### PR TITLE
Bugfixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Fix zoom context menu in viewer [Taiga #2041](https://tree.taiga.io/project/penpot/issue/2041)
 - Fix stroke caps adjustments in relation with stroke size [Taiga #2123](https://tree.taiga.io/project/penpot/issue/2123)
 - Fix problem duplicating paths [Taiga #2147](https://tree.taiga.io/project/penpot/issue/2147)
+- Fix problem inheriting attributes from SVG root when importing [Taiga #2124](https://tree.taiga.io/project/penpot/issue/2124)
 
 ### :arrow_up: Deps updates
 ### :boom: Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,15 @@
 ## :rocket: Next
 
 ### :boom: Breaking changes
+
+- Some stroke-caps can change behaviour
+- Text display bug fix could potentialy make some texts jump a line
+
 ### :sparkles: New features
 
 - Add boolean shapes: intersections, unions, difference and exclusions.
 - Add advanced prototyping [#244](https://tree.taiga.io/project/penpot/us/244).
+- Change order of the teams menu so it's in the joined time order
 
 ### :bug: Bugs fixed
 
@@ -32,10 +37,6 @@
 - Fix shift+wheel to horizontal scrolling in MacOS [#1217](https://github.com/penpot/penpot/issues/1217)
 
 ### :arrow_up: Deps updates
-### :boom: Breaking changes
-
-- Some stroke-caps can change behaviour
-- Text display bug fix could potentialy make some texts jump a line
 
 ### :heart: Community contributions by (Thank you!)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 - Fix problem inheriting attributes from SVG root when importing [Taiga #2124](https://tree.taiga.io/project/penpot/issue/2124)
 - Fix problem with lines and inside/outside stroke [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
 - Add stroke width in selection calculation [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
+- Fix shift+wheel to horizontal scrolling in MacOS [#1217](https://github.com/penpot/penpot/issues/1217)
 
 ### :arrow_up: Deps updates
 ### :boom: Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - Fix problem with lines and inside/outside stroke [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
 - Add stroke width in selection calculation [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
 - Fix shift+wheel to horizontal scrolling in MacOS [#1217](https://github.com/penpot/penpot/issues/1217)
+- Fix path stroke is not working properly with high thickness [Taiga #2154](https://tree.taiga.io/project/penpot/issue/2154)
 
 ### :arrow_up: Deps updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 - Fix problem duplicating paths [Taiga #2147](https://tree.taiga.io/project/penpot/issue/2147)
 - Fix problem inheriting attributes from SVG root when importing [Taiga #2124](https://tree.taiga.io/project/penpot/issue/2124)
 - Fix problem with lines and inside/outside stroke [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
+- Add stroke width in selection calculation [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
 
 ### :arrow_up: Deps updates
 ### :boom: Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Fix stroke caps adjustments in relation with stroke size [Taiga #2123](https://tree.taiga.io/project/penpot/issue/2123)
 - Fix problem duplicating paths [Taiga #2147](https://tree.taiga.io/project/penpot/issue/2147)
 - Fix problem inheriting attributes from SVG root when importing [Taiga #2124](https://tree.taiga.io/project/penpot/issue/2124)
+- Fix problem with lines and inside/outside stroke [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
 
 ### :arrow_up: Deps updates
 ### :boom: Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 - Add stroke width in selection calculation [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
 - Fix shift+wheel to horizontal scrolling in MacOS [#1217](https://github.com/penpot/penpot/issues/1217)
 - Fix path stroke is not working properly with high thickness [Taiga #2154](https://tree.taiga.io/project/penpot/issue/2154)
+- Fix bug with transformation operations [Taiga #2155](https://tree.taiga.io/project/penpot/issue/2155)
 
 ### :arrow_up: Deps updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 - Fix shift+wheel to horizontal scrolling in MacOS [#1217](https://github.com/penpot/penpot/issues/1217)
 - Fix path stroke is not working properly with high thickness [Taiga #2154](https://tree.taiga.io/project/penpot/issue/2154)
 - Fix bug with transformation operations [Taiga #2155](https://tree.taiga.io/project/penpot/issue/2155)
+- Fix bug in firefox when a text box is inside a mask [Taiga #2152](https://tree.taiga.io/project/penpot/issue/2152)
 
 ### :arrow_up: Deps updates
 

--- a/backend/src/app/rpc/queries/teams.clj
+++ b/backend/src/app/rpc/queries/teams.clj
@@ -58,7 +58,7 @@
      join team as t on (t.id = tp.team_id)
     where t.deleted_at is null
       and tp.profile_id = ?
-    order by t.created_at asc")
+    order by tp.created_at asc")
 
 (defn retrieve-teams
   [conn profile-id]

--- a/common/src/app/common/geom/shapes.cljc
+++ b/common/src/app/common/geom/shapes.cljc
@@ -160,6 +160,7 @@
 ;; PATHS
 (d/export gsp/content->selrect)
 (d/export gsp/transform-content)
+(d/export gsp/open-path?)
 
 ;; Intersection
 (d/export gin/overlaps?)

--- a/common/src/app/common/geom/shapes/intersect.cljc
+++ b/common/src/app/common/geom/shapes/intersect.cljc
@@ -284,12 +284,19 @@
 (defn overlaps?
   "General case to check for overlaping between shapes and a rectangle"
   [shape rect]
-  (or (not shape)
-      (let [path? (= :path (:type shape))
-            circle? (= :circle (:type shape))]
-        (and (overlaps-rect-points? rect (:points shape))
-             (or (not path?)   (overlaps-path? shape rect))
-             (or (not circle?) (overlaps-ellipse? shape rect))))))
+  (let [stroke-width (/ (or (:stroke-width shape) 0) 2)
+        rect (-> rect
+                 (update :x - stroke-width)
+                 (update :y - stroke-width)
+                 (update :width + (* 2 stroke-width))
+                 (update :height + (* 2 stroke-width))
+                 )]
+    (or (not shape)
+        (let [path? (= :path (:type shape))
+              circle? (= :circle (:type shape))]
+          (and (overlaps-rect-points? rect (:points shape))
+               (or (not path?)   (overlaps-path? shape rect))
+               (or (not circle?) (overlaps-ellipse? shape rect)))))))
 
 (defn has-point-rect?
   [rect point]

--- a/common/src/app/common/geom/shapes/path.cljc
+++ b/common/src/app/common/geom/shapes/path.cljc
@@ -948,3 +948,14 @@
                     (gsc/transform-points points-center transform-inverse)
                     (gpr/points->selrect))]
     [points selrect]))
+
+
+(defn open-path?
+  [shape]
+
+  (and (= :path (:type shape))
+       (not (->> shape
+                 :content
+                 (sp/close-subpaths)
+                 (sp/get-subpaths)
+                 (every? sp/is-closed?)))))

--- a/common/src/app/common/geom/shapes/path.cljc
+++ b/common/src/app/common/geom/shapes/path.cljc
@@ -126,8 +126,8 @@
 
   (let [tangent (curve-tangent curve t)]
     (cond
-      (> (:y tangent) 0)  1
-      (< (:y tangent) 0) -1
+      (> (:y tangent) 0) -1
+      (< (:y tangent) 0)  1
       :else               0)))
 
 (defn curve-split
@@ -822,30 +822,27 @@
   (let [selrect (content->selrect content)
         ray-line [point (gpt/point (inc (:x point)) (:y point))]
 
-        closed-subpaths
-        (->> content
-             (sp/close-subpaths)
-             (sp/get-subpaths)
-             (filterv sp/is-closed?))
+        closed-content
+        (into []
+              (comp  (filter sp/is-closed?)
+                     (mapcat :data))
+              (->> content
+                   (sp/close-subpaths)
+                   (sp/get-subpaths)))
 
         cast-ray
         (fn [cmd]
           (case (:command cmd)
             :line-to  (ray-line-intersect  point (command->line cmd))
             :curve-to (ray-curve-intersect ray-line (command->bezier cmd))
-            #_:else   []))
-
-        is-point-in-subpath?
-        (fn [subpath]
-          (and (gpr/contains-point? (content->selrect (:data subpath)) point)
-               (->> (:data subpath)
-                    (mapcat cast-ray)
-                    (map second)
-                    (reduce +)
-                    (not= 0))))]
+            #_:else   []))]
 
     (and (gpr/contains-point? selrect point)
-         (some is-point-in-subpath? closed-subpaths))))
+         (->> closed-content
+              (mapcat cast-ray)
+              (map second)
+              (reduce +)
+              (not= 0)))))
 
 (defn split-line-to
   "Given a point and a line-to command will create a two new line-to commands

--- a/common/src/app/common/path/subpaths.cljc
+++ b/common/src/app/common/path/subpaths.cljc
@@ -73,9 +73,15 @@
         (fn [subpaths current]
           (let [is-move? (= :move-to (:command current))
                 last-idx (dec (count subpaths))]
-            (if is-move?
+            (cond
+              is-move?
               (conj subpaths (make-subpath current))
-              (update subpaths last-idx add-subpath-command current))))]
+
+              (>= last-idx 0)
+              (update subpaths last-idx add-subpath-command current)
+
+              :else
+              subpaths)))]
     (->> content
          (reduce reduce-subpath []))))
 

--- a/frontend/src/app/main/ui/shapes/attrs.cljs
+++ b/frontend/src/app/main/ui/shapes/attrs.cljs
@@ -14,12 +14,14 @@
    [rumext.alpha :as mf]))
 
 (defn- stroke-type->dasharray
-  [style]
-  (case style
-    :mixed "5,5,1,5"
-    :dotted "5,5"
-    :dashed "10,10"
-    nil))
+  [width style]
+  (let [values (case style
+                 :mixed [5 5 1 5]
+                 :dotted [5 5]
+                 :dashed [10 10]
+                 nil)]
+
+    (->> values (map #(+ % width)) (str/join ","))))
 
 (defn- truncate-side
   [shape ra-attr rb-attr dimension-attr]
@@ -102,10 +104,11 @@
 
 (defn add-stroke [attrs shape render-id]
   (let [stroke-style (:stroke-style shape :none)
-        stroke-color-gradient-id (str "stroke-color-gradient_" render-id)]
+        stroke-color-gradient-id (str "stroke-color-gradient_" render-id)
+        stroke-width (:stroke-width shape 1)]
     (if (not= stroke-style :none)
       (let [stroke-attrs
-            (cond-> {:strokeWidth (:stroke-width shape 1)}
+            (cond-> {:strokeWidth stroke-width}
               (:stroke-color-gradient shape)
               (assoc :stroke (str/format "url(#%s)" stroke-color-gradient-id))
 
@@ -118,7 +121,7 @@
               (assoc :strokeOpacity (:stroke-opacity shape nil))
 
               (not= stroke-style :svg)
-              (assoc :strokeDasharray (stroke-type->dasharray stroke-style))
+              (assoc :strokeDasharray (stroke-type->dasharray stroke-width stroke-style))
 
               ;; For simple line caps we use svg stroke-line-cap attribute. This
               ;; only works if all caps are the same and we are not using the tricks

--- a/frontend/src/app/main/ui/shapes/group.cljs
+++ b/frontend/src/app/main/ui/shapes/group.cljs
@@ -27,21 +27,31 @@
                              [(first childs) (rest childs)]
                              [nil childs])
 
+            ;; We need to separate mask and clip into two because a bug in Firefox
+            ;; breaks when the group has clip+mask+foreignObject
+            ;; Clip and mask separated will work in every platform
+            ;  Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1734805
+            [clip-wrapper clip-props]
+            (if masked-group?
+              ["g" (-> (obj/new)
+                       (obj/set! "clipPath" (clip-url render-id mask)))]
+              [mf/Fragment nil])
+
             [mask-wrapper mask-props]
             (if masked-group?
               ["g" (-> (obj/new)
-                       (obj/set! "clipPath" (clip-url render-id mask))
                        (obj/set! "mask"     (mask-url render-id mask)))]
               [mf/Fragment nil])]
 
-        [:> mask-wrapper mask-props
-         (when masked-group?
-           [:> render-mask #js {:frame frame :mask mask}])
+        [:> clip-wrapper clip-props
+         [:> mask-wrapper mask-props
+          (when masked-group?
+            [:> render-mask #js {:frame frame :mask mask}])
 
-         (for [item childs]
-           [:& shape-wrapper {:frame frame
-                              :shape item
-                              :key (:id item)}])]))))
+          (for [item childs]
+            [:& shape-wrapper {:frame frame
+                               :shape item
+                               :key (:id item)}])]]))))
 
 
 

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -363,12 +363,14 @@
                delta-y (-> (.-deltaY ^js event)
                            (* unit)
                            (/ zoom))
+
                delta-x (-> (.-deltaX ^js event)
                            (* unit)
                            (/ zoom))]
            (dom/prevent-default event)
            (dom/stop-propagation event)
-           (if (kbd/shift? event)
+           (if (and (not (cfg/check-platform? :macos)) ;; macos sends delta-x automaticaly, don't need to do it
+                    (kbd/shift? event))
              (st/emit! (dw/update-viewport-position {:x #(+ % delta-y)}))
              (st/emit! (dw/update-viewport-position {:x #(+ % delta-x)
                                                      :y #(+ % delta-y)})))))))))

--- a/frontend/src/app/main/ui/workspace/viewport/selection.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/selection.cljs
@@ -229,7 +229,12 @@
         current-transform (mf/deref refs/current-transform)
 
         selrect (:selrect shape)
-        transform (geom/transform-matrix shape {:no-flip true})]
+        transform (geom/transform-matrix shape {:no-flip true})
+
+        rotation (-> (gpt/point 1 0)
+                     (gpt/transform (:transform shape))
+                     (gpt/angle)
+                     (mod 360))]
 
     (when (not (#{:move :rotate} current-transform))
       [:g.controls {:pointer-events (if disable-handlers "none" "visible")}
@@ -249,7 +254,7 @@
                              :on-rotate on-rotate
                              :on-resize (partial on-resize position)
                              :transform transform
-                             :rotation (:rotation shape)
+                             :rotation rotation
                              :color color
                              :overflow-text overflow-text}
                props (map->obj (merge common-props props))]


### PR DESCRIPTION
Closes #1217 

- Fix problem inheriting attributes from SVG root when importing [Taiga #2124](https://tree.taiga.io/project/penpot/issue/2124)
- Fix problem with lines and inside/outside stroke [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
- Add stroke width in selection calculation [Taiga #2146](https://tree.taiga.io/project/penpot/issue/2146)
- Fix shift+wheel to horizontal scrolling in MacOS [#1217](https://github.com/penpot/penpot/issues/1217)
- Fix path stroke is not working properly with high thickness [Taiga #2154](https://tree.taiga.io/project/penpot/issue/2154)
- Fix bug with transformation operations [Taiga #2155](https://tree.taiga.io/project/penpot/issue/2155)
- Fix bug in firefox when a text box is inside a mask [Taiga #2152](https://tree.taiga.io/project/penpot/issue/2152)