### PR TITLE
:bug: Fix touched component marker appearing when it's not needed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 - Fixed color palette outside viewport [Taiga #2715](https://tree.taiga.io/project/penpot/issue/2715)
 - Fixed missing translate string [Taiga #2780](https://tree.taiga.io/project/penpot/issue/2780)
 - Fixed handoff shadow type text [Taiga #2717](https://tree.taiga.io/project/penpot/issue/2717)
+- Fixed components get "dirty" marker when moved [Taiga #2764](https://tree.taiga.io/project/penpot/issue/2764)
 
 ### :arrow_up: Deps updates
 

--- a/common/src/app/common/pages/helpers.cljc
+++ b/common/src/app/common/pages/helpers.cljc
@@ -243,8 +243,7 @@
     shape
 
     (some? (:shape-ref shape))
-    (recur (get objects (:parent-id shape))
-           objects)))
+    (recur objects (get objects (:parent-id shape)))))
 
 (defn make-container
   [page-or-component type]


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/issue/2764