### PR TITLE
:tada: Update Typography palette order

### DIFF
--- a/frontend/src/app/main/ui/workspace/textpalette.cljs
+++ b/frontend/src/app/main/ui/workspace/textpalette.cljs
@@ -68,8 +68,8 @@
         current-typographies
         (case @selected
           :recent []
-          :file (vals file-typographies)
-          (vals (get-in shared-libs [@selected :data :typographies])))
+          :file (sort-by #(str/lower (:name %)) (vals file-typographies))
+          (sort-by #(str/lower (:name %)) (vals (get-in shared-libs [@selected :data :typographies]))))
 
         container (mf/use-ref nil)
 


### PR DESCRIPTION
 🎉 Update Typography palette order #2523 

* The order of the assets at the typography palette is updated to be alphabetical, from left to right
* It shall be consistent with their order at the assets panel