### PR TITLE
:bug: Change independent corner radius input tooltips

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -412,7 +412,7 @@
 
             (= radius-mode :radius-4)
             [:*
-             [:div.input-element.mini {:title (tr "workspace.options.radius")}
+             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-top-left")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
@@ -420,7 +420,7 @@
                 :on-change on-radius-r1-change
                 :value (:r1 values)}]]
 
-             [:div.input-element.mini {:title (tr "workspace.options.radius")}
+             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-top-right")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
@@ -428,7 +428,7 @@
                 :on-change on-radius-r2-change
                 :value (:r2 values)}]]
 
-             [:div.input-element.mini {:title (tr "workspace.options.radius")}
+             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-bottom-right")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
@@ -436,7 +436,7 @@
                 :on-change on-radius-r3-change
                 :value (:r3 values)}]]
 
-             [:div.input-element.mini {:title (tr "workspace.options.radius")}
+             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-bottom-left")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -412,7 +412,7 @@
 
             (= radius-mode :radius-4)
             [:*
-             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-top-left")}
+             [:div.input-element.mini {:title (tr "workspace.options.radius-top-left")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
@@ -420,7 +420,7 @@
                 :on-change on-radius-r1-change
                 :value (:r1 values)}]]
 
-             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-top-right")}
+             [:div.input-element.mini {:title (tr "workspace.options.radius-top-right")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
@@ -428,7 +428,7 @@
                 :on-change on-radius-r2-change
                 :value (:r2 values)}]]
 
-             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-bottom-right")}
+             [:div.input-element.mini {:title (tr "workspace.options.radius-bottom-right")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
@@ -436,7 +436,7 @@
                 :on-change on-radius-r3-change
                 :value (:r3 values)}]]
 
-             [:div.input-element.mini {:title (tr "workspace.options.interaction-pos-bottom-left")}
+             [:div.input-element.mini {:title (tr "workspace.options.radius-bottom-left")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -3458,6 +3458,22 @@ msgstr "Tots els cantons"
 msgid "workspace.options.radius.single-corners"
 msgstr "Cantons individuals"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Superior esquerra"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Superior dreta"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Inferior esquerra"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Inferior dreta"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Recent"
 

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -3525,6 +3525,22 @@ msgstr "Všechny rohy"
 msgid "workspace.options.radius.single-corners"
 msgstr "Jednotlivé rohy"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Nahoře vlevo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Nahoře vpravo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Dole vlevo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Dole vpravo"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Nedávné"
 

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -3893,6 +3893,22 @@ msgstr "Alle Ecken"
 msgid "workspace.options.radius.single-corners"
 msgstr "Individuelle Ecken"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Oben links"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Oben rechts"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Unten links"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Unten rechts"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Aktuell"
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -4025,6 +4025,22 @@ msgstr "All corners"
 msgid "workspace.options.radius.single-corners"
 msgstr "Independent corners"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Top left"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Top right"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Bottom left"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Bottom right"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Recent"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -4122,6 +4122,22 @@ msgstr "Todas las esquinas"
 msgid "workspace.options.radius.single-corners"
 msgstr "Esquinas individuales"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Arriba izquierda"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Arriba derecha"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Abajo izquierda"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Abajo derecha"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Recientes"
 

--- a/frontend/translations/eu.po
+++ b/frontend/translations/eu.po
@@ -3635,6 +3635,22 @@ msgstr "Ertz guztiak"
 msgid "workspace.options.radius.single-corners"
 msgstr "Ertz bakarrak"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Goian ezkerrean"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Goian eskuman"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Behean ezkerrean"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Behean eskuman"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Azkenak"
 

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -3479,6 +3479,22 @@ msgstr "Tous les coins"
 msgid "workspace.options.radius.single-corners"
 msgstr "Coins individuels"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "En haut à gauche"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "En haut à droite"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "En bas à gauche"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "En bas à droite"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/exports.cljs, src/app/main/ui/inspect/exports.cljs, src/app/main/ui/workspace/header.cljs
 msgid "workspace.options.retry"
 msgstr "Réessayer"

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -3830,6 +3830,22 @@ msgstr "כל הפינות"
 msgid "workspace.options.radius.single-corners"
 msgstr "פינות עצמאיות"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "בראש משמאל"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "בראש מימין"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "בתחתית משמאל"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "בתחתית מימין"
+
 msgid "workspace.options.recent-fonts"
 msgstr "אחרונים"
 

--- a/frontend/translations/hr.po
+++ b/frontend/translations/hr.po
@@ -3645,6 +3645,22 @@ msgstr "Svi kutevi"
 msgid "workspace.options.radius.single-corners"
 msgstr "Jednostruki kutovi"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Gore lijevo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Gore desno"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Dolje lijevo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Dolje desno"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Nedavni"
 

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -3780,6 +3780,22 @@ msgstr "Semua sudut"
 msgid "workspace.options.radius.single-corners"
 msgstr "Sudut individu"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Kiri atas"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Kanan atas"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Kiri bawah"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Kanan bawah"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Terkini"
 

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -3815,6 +3815,22 @@ msgstr "Visi stūri"
 msgid "workspace.options.radius.single-corners"
 msgstr "Atsevišķie stūri"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Augšā pa kreisi"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Augšā pa labi"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Apakšā pa kreisi"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Apakšā pa labi"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Pēdējie"
 

--- a/frontend/translations/pl.po
+++ b/frontend/translations/pl.po
@@ -3842,6 +3842,22 @@ msgstr "Wszystkie rogi"
 msgid "workspace.options.radius.single-corners"
 msgstr "Poszczególne narożniki"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Górne lewo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Górne prawo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Dolne lewo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Dolne prawo"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Bieżące"
 

--- a/frontend/translations/pt_BR.po
+++ b/frontend/translations/pt_BR.po
@@ -3782,6 +3782,22 @@ msgstr "Todos os cantos"
 msgid "workspace.options.radius.single-corners"
 msgstr "Cantos individuais"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Superior (a esquerda)"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Superior (a direita)"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Inferior esquerdo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Inferior direito"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Recente"
 

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -3632,6 +3632,22 @@ msgstr "Todos os cantos"
 msgid "workspace.options.radius.single-corners"
 msgstr "Cantos individuais"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Superior esquerdo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Superior direito"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Inferior esquerdo"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Inferior direito"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Recente"
 

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -3807,6 +3807,22 @@ msgstr "Toate colţurile"
 msgid "workspace.options.radius.single-corners"
 msgstr "Colțuri individuale"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Stânga sus"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Dreapta sus"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Stânga jos"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Dreapta jos"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Recente"
 

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -3957,6 +3957,22 @@ msgstr "Tüm köşeler"
 msgid "workspace.options.radius.single-corners"
 msgstr "Bireysel köşeler"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "Sol üst"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "Sağ üst"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "Sol alt"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "Sağ alt"
+
 msgid "workspace.options.recent-fonts"
 msgstr "Son kullanılanlar"
 

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -3668,6 +3668,22 @@ msgstr "所有角"
 msgid "workspace.options.radius.single-corners"
 msgstr "单个角"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-left"
+msgstr "左上角"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-top-right"
+msgstr "右上角"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-left"
+msgstr "左下角"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+msgid "workspace.options.radius-bottom-right"
+msgstr "右下角"
+
 msgid "workspace.options.recent-fonts"
 msgstr "最近的"
 


### PR DESCRIPTION
Make the inputs show a tooltip for the relevant corner(e.g. "Top left") instead of "Radius".
Completes #3305 ([Taiga #5486](https://tree.taiga.io/project/penpot/issue/5486))
This pull request does not introduce breaking changes.

After the change the tooltips are shown like this:
![image](https://github.com/penpot/penpot/assets/95227070/35572ea8-8167-4d95-9e46-ff34dc47d5c2)
