### PR TITLE
:sparkles: Allow override java opts for build scripts

### DIFF
--- a/docker/devenv/files/bashrc
+++ b/docker/devenv/files/bashrc
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export PATH=/usr/lib/jvm/openjdk/bin:/usr/local/nodejs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
-export JAVA_OPTS="-Xmx1000m -Xms50m"
+export JAVA_OPTS=${JAVA_OPTS:-"-Xmx1000m -Xms200m"};
 
 alias l='ls --color -GFlh'
 alias rm='rm -r'

--- a/exporter/scripts/build
+++ b/exporter/scripts/build
@@ -10,7 +10,7 @@ rm -rf target
 export NODE_ENV=production;
 
 # Build the application
-clojure -J-Xms100M -J-Xmx1000M -J-XX:+UseSerialGC -M:dev:shadow-cljs release main;
+clojure -M:dev:shadow-cljs release main;
 
 # Remove source
 rm -rf target/app;

--- a/manage.sh
+++ b/manage.sh
@@ -7,6 +7,9 @@ export DEVENV_PNAME="penpotdev";
 export CURRENT_USER_ID=$(id -u);
 export CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD);
 
+# Set default java options
+export JAVA_OPTS=${JAVA_OPTS:-"-Xmx1000m -Xms50m"};
+
 set -e
 
 function print-current-version {
@@ -95,9 +98,11 @@ function run-devenv-shell {
     if [[ ! $(docker ps -f "name=penpot-devenv-main" -q) ]]; then
         start-devenv
     fi
-    docker exec -ti penpot-devenv-main sudo -EH -u penpot bash
+    docker exec -ti \
+           -e JAVA_OPTS="$JAVA_OPTS" \
+           -e EXTERNAL_UID=$CURRENT_USER_ID \
+           penpot-devenv-main sudo -EH -u penpot bash;
 }
-
 
 function build {
     echo ">> build start: $1"
@@ -111,6 +116,7 @@ function build {
            -e EXTERNAL_UID=$CURRENT_USER_ID \
            -e BUILD_STORYBOOK=$BUILD_STORYBOOK \
            -e SHADOWCLJS_EXTRA_PARAMS=$SHADOWCLJS_EXTRA_PARAMS \
+           -e JAVA_OPTS="$JAVA_OPTS" \
            -w /home/penpot/penpot/$1 \
            $DEVENV_IMGNAME:latest sudo -EH -u penpot ./scripts/build $version
 


### PR DESCRIPTION
A change that allows from build scripts overwrite the jvm heap and other jvm options for adapt the build process to the resources of the build machine.