### PR TITLE
:recycle: Refactor rendering surfaces

### DIFF
--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -17,13 +17,14 @@ fn render_debug_view(render_state: &mut RenderState) {
     scaled_rect.set_xywh(x, y, width, height);
 
     render_state
-        .debug_surface
+        .surfaces
+        .debug
         .canvas()
         .draw_rect(scaled_rect, &paint);
 }
 
 pub fn render_wasm_label(render_state: &mut RenderState) {
-    let canvas = render_state.render_surface.canvas();
+    let canvas = render_state.surfaces.current.canvas();
 
     let skia::ISize { width, height } = canvas.base_layer_size();
     let p = skia::Point::new(width as f32 - 100.0, height as f32 - 25.0);
@@ -57,7 +58,8 @@ pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, inter
     scaled_rect.set_xywh(x, y, width, height);
 
     render_state
-        .debug_surface
+        .surfaces
+        .debug
         .canvas()
         .draw_rect(scaled_rect, &paint);
 }
@@ -65,10 +67,10 @@ pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, inter
 pub fn render(render_state: &mut RenderState) {
     let paint = skia::Paint::default();
     render_debug_view(render_state);
-    render_state.debug_surface.draw(
-        &mut render_state.render_surface.canvas(),
+    render_state.surfaces.debug.draw(
+        &mut render_state.surfaces.current.canvas(),
         (0.0, 0.0),
-        skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Nearest),
+        render_state.sampling_options,
         Some(&paint),
     );
 }

--- a/render-wasm/src/render/fills.rs
+++ b/render-wasm/src/render/fills.rs
@@ -15,7 +15,7 @@ fn draw_image_fill_in_container(
     }
 
     let size = image_fill.size();
-    let canvas = render_state.drawing_surface.canvas();
+    let canvas = render_state.surfaces.shape.canvas();
     let kind = &shape.kind;
     let container = &shape.selrect;
     let path_transform = shape.to_path_transform();
@@ -91,7 +91,7 @@ fn draw_image_fill_in_container(
  * This SHOULD be the only public function in this module.
  */
 pub fn render(render_state: &mut RenderState, shape: &Shape, fill: &Fill) {
-    let canvas = render_state.drawing_surface.canvas();
+    let canvas = render_state.surfaces.shape.canvas();
     let selrect = shape.selrect;
     let path_transform = shape.to_path_transform();
     let kind = &shape.kind;

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -5,22 +5,23 @@ use crate::shapes::Shadow;
 
 pub fn render_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
     let shadow_paint = shadow.to_paint(scale);
-    render_state.drawing_surface.draw(
-        &mut render_state.shadow_surface.canvas(),
+    render_state.surfaces.shape.draw(
+        &mut render_state.surfaces.shadow.canvas(),
         (0.0, 0.0),
-        skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Nearest),
+        render_state.sampling_options,
         Some(&shadow_paint),
     );
 
-    render_state.shadow_surface.draw(
-        &mut render_state.render_surface.canvas(),
+    render_state.surfaces.shadow.draw(
+        &mut render_state.surfaces.current.canvas(),
         (0.0, 0.0),
-        skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Nearest),
+        render_state.sampling_options,
         Some(&skia::Paint::default()),
     );
 
     render_state
-        .shadow_surface
+        .surfaces
+        .shadow
         .canvas()
         .clear(skia::Color::TRANSPARENT);
 }
@@ -28,22 +29,23 @@ pub fn render_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale
 pub fn render_inner_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
     let shadow_paint = shadow.to_paint(scale);
 
-    render_state.drawing_surface.draw(
-        render_state.shadow_surface.canvas(),
+    render_state.surfaces.shape.draw(
+        render_state.surfaces.shadow.canvas(),
         (0.0, 0.0),
-        skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Nearest),
+        render_state.sampling_options,
         Some(&shadow_paint),
     );
 
-    render_state.shadow_surface.draw(
-        &mut render_state.overlay_surface.canvas(),
+    render_state.surfaces.shadow.draw(
+        &mut render_state.surfaces.overlay.canvas(),
         (0.0, 0.0),
-        skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Nearest),
+        render_state.sampling_options,
         None,
     );
 
     render_state
-        .shadow_surface
+        .surfaces
+        .shadow
         .canvas()
         .clear(skia::Color::TRANSPARENT);
 }

--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -335,7 +335,7 @@ fn draw_image_stroke_in_container(
     }
 
     let size = image_fill.size();
-    let canvas = render_state.drawing_surface.canvas();
+    let canvas = render_state.surfaces.shape.canvas();
     let kind = &shape.kind;
     let container = &shape.selrect;
     let path_transform = shape.to_path_transform();
@@ -429,7 +429,7 @@ fn draw_image_stroke_in_container(
  * This SHOULD be the only public function in this module.
  */
 pub fn render(render_state: &mut RenderState, shape: &Shape, stroke: &Stroke) {
-    let canvas = render_state.drawing_surface.canvas();
+    let canvas = render_state.surfaces.shape.canvas();
     let dpr_scale = render_state.viewbox.zoom * render_state.options.dpr();
     let selrect = shape.selrect;
     let path_transform = shape.to_path_transform();

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -1,0 +1,51 @@
+use super::gpu_state::GpuState;
+use skia_safe as skia;
+
+pub struct Surfaces {
+    // is the final destination surface, the one that it is represented in the canvas element.
+    pub target: skia::Surface,
+    // keeps the current render
+    pub current: skia::Surface,
+    // keeps the current shape
+    pub shape: skia::Surface,
+    // used for rendering shadows
+    pub shadow: skia::Surface,
+    // for drawing the things that are over shadows.
+    pub overlay: skia::Surface,
+    // for drawing debug info.
+    pub debug: skia::Surface,
+}
+
+impl Surfaces {
+    pub fn new(gpu_state: &mut GpuState, (width, height): (i32, i32)) -> Self {
+        let mut target = gpu_state.create_target_surface(width, height);
+        let current = target.new_surface_with_dimensions((width, height)).unwrap();
+        let shadow = target.new_surface_with_dimensions((width, height)).unwrap();
+        let overlay = target.new_surface_with_dimensions((width, height)).unwrap();
+        let shape = target.new_surface_with_dimensions((width, height)).unwrap();
+        let debug = target.new_surface_with_dimensions((width, height)).unwrap();
+
+        Surfaces {
+            target,
+            current,
+            shadow,
+            overlay,
+            shape,
+            debug,
+        }
+    }
+
+    pub fn set(&mut self, new_surface: skia::Surface) {
+        let dim = (new_surface.width(), new_surface.height());
+        self.target = new_surface;
+        self.current = self.target.new_surface_with_dimensions(dim).unwrap();
+        self.overlay = self.target.new_surface_with_dimensions(dim).unwrap();
+        self.shadow = self.target.new_surface_with_dimensions(dim).unwrap();
+        self.shape = self.target.new_surface_with_dimensions(dim).unwrap();
+        self.debug = self.target.new_surface_with_dimensions(dim).unwrap();
+    }
+
+    pub fn resize(&mut self, gpu_state: &mut GpuState, new_width: i32, new_height: i32) {
+        self.set(gpu_state.create_target_surface(new_width, new_height));
+    }
+}


### PR DESCRIPTION
This refactor introduces a new structure called `Surfaces` that keeps all the needed surfaces to the `RenderState`.