### PR TITLE
:recycle: Refactor single set import functionality

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -803,7 +803,7 @@
          (map-indexed (fn [index item]
                         (assoc item :index index))))))
 
-(defn- flatten-nested-tokens-json
+(defn flatten-nested-tokens-json
   "Recursively flatten the dtcg token structure, joining keys with '.'."
   [tokens token-path]
   (reduce-kv
@@ -830,7 +830,7 @@
 
 (declare make-tokens-lib)
 
-(defn- legacy-nodes->dtcg-nodes [sets-data]
+(defn legacy-nodes->dtcg-nodes [sets-data]
   (walk/postwalk
    (fn [node]
      (cond-> node
@@ -866,8 +866,6 @@ Will return a value that matches this schema:
   (get-active-themes-set-tokens [_] "set of set names that are active in the the active themes")
   (encode-dtcg [_] "Encodes library to a dtcg compatible json string")
   (decode-dtcg-json [_ parsed-json] "Decodes parsed json containing tokens and converts to library")
-  (decode-single-set-json [_ set-name tokens] "Decodes parsed json containing single token set and converts to library")
-  (decode-single-set-legacy-json [_ set-name tokens] "Decodes parsed legacy json containing single token set and converts to library")
   (decode-legacy-json [_ parsed-json] "Decodes parsed legacy json containing tokens and converts to library")
   (get-all-tokens [_] "all tokens in the lib")
   (validate [_]))
@@ -1310,17 +1308,6 @@ Will return a value that matches this schema:
           (assoc-in ["$metadata" "tokenSetOrder"] ordered-set-names)
           (assoc-in ["$metadata" "activeThemes"] active-themes-clear)
           (assoc-in ["$metadata" "activeSets"] active-sets))))
-
-  (decode-single-set-json [this set-name tokens]
-    (assert (map? tokens) "expected a map data structure for `data`")
-
-    (add-set this (make-token-set :name (normalize-set-name set-name)
-                                  :tokens (flatten-nested-tokens-json tokens ""))))
-
-
-  (decode-single-set-legacy-json [this set-name tokens]
-    (assert (map? tokens) "expected a map data structure for `data`")
-    (decode-single-set-json this set-name (legacy-nodes->dtcg-nodes tokens)))
 
   (decode-dtcg-json [_ data]
     (assert (map? data) "expected a map data structure for `data`")

--- a/common/test/common_tests/types/data/legacy-single-set.json
+++ b/common/test/common_tests/types/data/legacy-single-set.json
@@ -1,6 +1,0 @@
-{"color":
- {"red":
-  {"100":
-   {"value":"red",
-    "type":"color",
-    "description":""}}}}

--- a/common/test/common_tests/types/data/single-set.json
+++ b/common/test/common_tests/types/data/single-set.json
@@ -1,6 +1,0 @@
-{"color":
- {"red":
-  {"100":
-   {"$value":"red",
-    "$type":"color",
-    "$description":""}}}}

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1372,30 +1372,6 @@
          (t/is (nil? (get-set-token "typography" "H1.Bold")))))))
 
 #?(:clj
-   (t/deftest single-set-legacy-json-decoding
-     (let [json (-> (slurp "test/common_tests/types/data/legacy-single-set.json")
-                    (tr/decode-str))
-           lib (ctob/decode-single-set-legacy-json (ctob/ensure-tokens-lib nil) "single_set" json)
-           get-set-token (fn [set-name token-name]
-                           (some-> (ctob/get-set lib set-name)
-                                   (ctob/get-token token-name)))]
-       (t/is (= '("single_set") (ctob/get-ordered-set-names lib)))
-       (t/testing "token added"
-         (t/is (some? (get-set-token "single_set" "color.red.100")))))))
-
-#?(:clj
-   (t/deftest single-set-dtcg-json-decoding
-     (let [json (-> (slurp "test/common_tests/types/data/single-set.json")
-                    (tr/decode-str))
-           lib (ctob/decode-single-set-json (ctob/ensure-tokens-lib nil) "single_set" json)
-           get-set-token (fn [set-name token-name]
-                           (some-> (ctob/get-set lib set-name)
-                                   (ctob/get-token token-name)))]
-       (t/is (= '("single_set") (ctob/get-ordered-set-names lib)))
-       (t/testing "token added"
-         (t/is (some? (get-set-token "single_set" "color.red.100")))))))
-
-#?(:clj
    (t/deftest dtcg-encoding-decoding-json
      (let [json (-> (slurp "test/common_tests/types/data/tokens-multi-set-example.json")
                     (tr/decode-str))

--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -240,7 +240,21 @@
 
 ;; === Import
 
-(defn reference-errors
+(defn- decode-single-set-json
+  "Decodes parsed json containing single token set and converts to library"
+  [this set-name tokens]
+  (assert (map? tokens) "expected a map data structure for `data`")
+
+  (ctob/add-set this (ctob/make-token-set :name (ctob/normalize-set-name set-name)
+                                          :tokens (ctob/flatten-nested-tokens-json tokens ""))))
+
+(defn- decode-single-set-legacy-json
+  "Decodes parsed legacy json containing single token set and converts to library"
+  [this set-name tokens]
+  (assert (map? tokens) "expected a map data structure for `data`")
+  (decode-single-set-json this set-name (ctob/legacy-nodes->dtcg-nodes tokens)))
+
+(defn- reference-errors
   "Extracts reference errors from StyleDictionary."
   [err]
   (let [[header-1 header-2 & errors] (str/split err "\n")]
@@ -267,11 +281,11 @@
                         (cond
                           (and single-set?
                                (= :json-format/legacy json-format))
-                          (ctob/decode-single-set-legacy-json (ctob/ensure-tokens-lib nil) file-name json-data)
+                          (decode-single-set-legacy-json (ctob/ensure-tokens-lib nil) file-name json-data)
 
                           (and single-set?
                                (= :json-format/dtcg json-format))
-                          (ctob/decode-single-set-json (ctob/ensure-tokens-lib nil) file-name json-data)
+                          (decode-single-set-json (ctob/ensure-tokens-lib nil) file-name json-data)
 
                           (= :json-format/legacy json-format)
                           (ctob/decode-legacy-json (ctob/ensure-tokens-lib nil) json-data)

--- a/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
+++ b/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
@@ -133,3 +133,29 @@ color.value tries to reference missing, which is not defined.")))
               (fn [err]
                 (t/is (= :error.import/style-dictionary-reference-errors (:error/code (ex-data err))))
                 (done))))))))
+
+(t/deftest single-set-legacy-json-decoding
+  (let [decode-single-set-legacy-json #'sd/decode-single-set-legacy-json
+        json {"color" {"red" {"100" {"value" "red"
+                                     "type" "color"
+                                     "description" ""}}}}
+        lib (decode-single-set-legacy-json (ctob/ensure-tokens-lib nil) "single_set" json)
+        get-set-token (fn [set-name token-name]
+                        (some-> (ctob/get-set lib set-name)
+                                (ctob/get-token token-name)))]
+    (t/is (= '("single_set") (ctob/get-ordered-set-names lib)))
+    (t/testing "token added"
+      (t/is (some? (get-set-token "single_set" "color.red.100"))))))
+
+(t/deftest single-set-dtcg-json-decoding
+  (let [decode-single-set-json #'sd/decode-single-set-json
+        json (-> {"color" {"red" {"100" {"$value" "red"
+                                         "$type" "color"
+                                         "$description" ""}}}})
+        lib (decode-single-set-json (ctob/ensure-tokens-lib nil) "single_set" json)
+        get-set-token (fn [set-name token-name]
+                        (some-> (ctob/get-set lib set-name)
+                                (ctob/get-token token-name)))]
+    (t/is (= '("single_set") (ctob/get-ordered-set-names lib)))
+    (t/testing "token added"
+      (t/is (some? (get-set-token "single_set" "color.red.100"))))))


### PR DESCRIPTION
A refactoring for PR that adds Single set import functionality.
Closes https://github.com/tokens-studio/penpot/issues/95
Conversation with the request to move functions from TokenLib - https://github.com/penpot/penpot/pull/6197#discussion_r2022269435