### PR TITLE
:bug: Fix scroll on token themes modal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### :bug: Bugs fixed
 
 - Increase the height of the right sidebar dropdowns [Taiga #10615](https://tree.taiga.io/project/penpot/issue/10615)
+- Fix scroll on token themes modal [Taiga #10745](https://tree.taiga.io/project/penpot/issue/10745)
 
 ## 2.6.1
 

--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.scss
@@ -190,6 +190,7 @@
   border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
   border-radius: $s-8;
   overflow-y: auto;
+  max-height: $s-452;
 }
 
 .sets-count-empty-button {

--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -171,6 +171,7 @@
         on-collapse-click
         (mf/use-fn
          (fn [event]
+           (dom/prevent-default event)
            (dom/stop-propagation event)
            (on-toggle-collapse tree-path)))
 


### PR DESCRIPTION
### Related Ticket

[This PR fixes this issue](https://tree.taiga.io/project/penpot/issue/10745)

### Summary

There is no scroll on theme modal when there are lots of sets

### Steps to reproduce 

1. Import token json from issue
2. Open theme creation modal

Scroll should appear on sets list

![Screenshot from 2025-04-09 11-41-58](https://github.com/user-attachments/assets/e8e846e8-5202-412b-a33c-692f202493c0)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
