### PR TITLE
:bug: Fix share button being displayed with no permissions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 - Fix problem while syncing library colors and typographies [Taiga #11068](https://tree.taiga.io/project/penpot/issue/11068)
 - Fix problem with path edition of shapes [Taiga #9496](https://tree.taiga.io/project/penpot/issue/9496)
 - Fix exception on paste invalid html [Taiga #11047](https://tree.taiga.io/project/penpot/issue/11047)
+- Fix share button being displayed with no permissions [Taiga #11086](https://tree.taiga.io/project/penpot/issue/11086)
 
 ## 2.6.2
 

--- a/frontend/src/app/main/ui/workspace/right_header.cljs
+++ b/frontend/src/app/main/ui/workspace/right_header.cljs
@@ -7,6 +7,7 @@
 (ns app.main.ui.workspace.right-header
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data :as d]
    [app.main.data.common :as dcm]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
@@ -128,7 +129,20 @@
 
         input-ref         (mf/use-ref nil)
 
+        profile           (mf/deref refs/profile)
         team              (mf/deref refs/team)
+
+        team-profile
+        (mf/use-memo
+         (mf/deps profile team)
+         #(->> (:members team)
+               (d/seek (fn [{:keys [id]}] (= id (:id profile))))))
+
+        display-share-button?
+        (and (not (:is-default team))
+             (some? team-profile)
+             (or (:is-admin team-profile)
+                 (:is-owner team-profile)))
 
         nav-to-viewer
         (mf/use-fn
@@ -216,7 +230,7 @@
           :on-click toggle-history}
          i/history]])
 
-     (when  (not (:is-default team))
+     (when display-share-button?
        [:a {:class (stl/css :viewer-btn)
             :title (tr "workspace.header.share")
             :on-click open-share-dialog}

--- a/frontend/src/app/main/ui/workspace/right_header.cljs
+++ b/frontend/src/app/main/ui/workspace/right_header.cljs
@@ -7,7 +7,6 @@
 (ns app.main.ui.workspace.right-header
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.data :as d]
    [app.main.data.common :as dcm]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
@@ -129,20 +128,13 @@
 
         input-ref         (mf/use-ref nil)
 
-        profile           (mf/deref refs/profile)
         team              (mf/deref refs/team)
-
-        team-profile
-        (mf/use-memo
-         (mf/deps profile team)
-         #(->> (:members team)
-               (d/seek (fn [{:keys [id]}] (= id (:id profile))))))
+        permissions       (get team :permissions)
 
         display-share-button?
         (and (not (:is-default team))
-             (some? team-profile)
-             (or (:is-admin team-profile)
-                 (:is-owner team-profile)))
+             (or (:is-admin permissions)
+                 (:is-owner permissions)))
 
         nav-to-viewer
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/11086

### Summary
Share button is being displayed without the necessary permissions.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
