### PR TITLE
:sparkles: Pixel precision for new renderer

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -262,10 +262,10 @@
 
         [x y width height]
         (if (features/active-feature? @st/state "render-wasm/v1")
-          (let [{:keys [width height]} (wasm.api/text-dimensions shape-id)
+          (let [{:keys [max-width height]} (wasm.api/text-dimensions shape-id)
                 {:keys [x y]} (:selrect shape)]
 
-            [x y width height])
+            [x y max-width height])
 
           (let [bounds (gst/shape->rect shape)
                 x      (mth/min (dm/get-prop bounds :x)

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -771,7 +771,7 @@
       (h/call wasm/internal-module "_set_structure_modifiers"))))
 
 (defn propagate-modifiers
-  [entries]
+  [entries pixel-precision]
   (when (d/not-empty? entries)
     (let [offset (mem/alloc-bytes-32 (modifier-get-entries-size entries))
           heapf32 (mem/get-heap-f32)
@@ -785,7 +785,7 @@
             (sr/heapf32-set-matrix transform heapf32 (+ current-offset (mem/ptr8->ptr32 MODIFIER-ENTRY-TRANSFORM-OFFSET)))
             (recur (rest entries) (+ current-offset (mem/ptr8->ptr32 MODIFIER-ENTRY-SIZE))))))
 
-      (let [result-offset (h/call wasm/internal-module "_propagate_modifiers")
+      (let [result-offset (h/call wasm/internal-module "_propagate_modifiers" pixel-precision)
             heapf32 (mem/get-heap-f32)
             heapu32 (mem/get-heap-u32)
             len (aget heapu32 (mem/ptr8->ptr32 result-offset))
@@ -797,7 +797,7 @@
         result))))
 
 (defn propagate-apply
-  [entries]
+  [entries pixel-precision]
   (when (d/not-empty? entries)
     (let [offset (mem/alloc-bytes-32 (modifier-get-entries-size entries))
           heapf32 (mem/get-heap-f32)
@@ -811,7 +811,7 @@
             (sr/heapf32-set-matrix transform heapf32 (+ current-offset (mem/ptr8->ptr32 MODIFIER-ENTRY-TRANSFORM-OFFSET)))
             (recur (rest entries) (+ current-offset (mem/ptr8->ptr32 MODIFIER-ENTRY-SIZE))))))
 
-      (let [offset (h/call wasm/internal-module "_propagate_apply")
+      (let [offset (h/call wasm/internal-module "_propagate_apply" pixel-precision)
             heapf32 (mem/get-heap-f32)
             width (aget heapf32 (mem/ptr8->ptr32 (+ offset 0)))
             height (aget heapf32 (mem/ptr8->ptr32 (+ offset 4)))

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -620,9 +620,10 @@
    (let [offset (h/call wasm/internal-module "_get_text_dimensions")
          heapf32 (mem/get-heap-f32)
          width (aget heapf32 (mem/ptr8->ptr32 offset))
-         height (aget heapf32 (mem/ptr8->ptr32 (+ offset 4)))]
+         height (aget heapf32 (mem/ptr8->ptr32 (+ offset 4)))
+         max-width (aget heapf32 (mem/ptr8->ptr32 (+ offset 8)))]
      (h/call wasm/internal-module "_free_bytes")
-     {:width width :height height})))
+     {:width width :height height :max-width max-width})))
 
 (defn set-view-box
   [zoom vbox]

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -389,7 +389,7 @@ pub extern "C" fn set_shape_path_attrs(num_attrs: u32) {
 }
 
 #[no_mangle]
-pub extern "C" fn propagate_modifiers() -> *mut u8 {
+pub extern "C" fn propagate_modifiers(pixel_precision: bool) -> *mut u8 {
     let bytes = mem::bytes();
 
     let entries: Vec<_> = bytes
@@ -398,13 +398,13 @@ pub extern "C" fn propagate_modifiers() -> *mut u8 {
         .collect();
 
     with_state!(state, {
-        let (result, _) = shapes::propagate_modifiers(state, &entries);
+        let (result, _) = shapes::propagate_modifiers(state, &entries, pixel_precision);
         mem::write_vec(result)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn propagate_apply() -> *mut u8 {
+pub extern "C" fn propagate_apply(pixel_precision: bool) -> *mut u8 {
     let bytes = mem::bytes();
 
     let entries: Vec<_> = bytes
@@ -413,7 +413,7 @@ pub extern "C" fn propagate_apply() -> *mut u8 {
         .collect();
 
     with_state!(state, {
-        let (result, bounds) = shapes::propagate_modifiers(state, &entries);
+        let (result, bounds) = shapes::propagate_modifiers(state, &entries, pixel_precision);
 
         for entry in result {
             state.modifiers.insert(entry.id, entry.transform);

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -210,6 +210,10 @@ pub fn propagate_modifiers(
                     shape_modif.post_concat(&transform);
                     modifiers.insert(shape.id, shape_modif);
 
+                    if shape.has_layout() {
+                        entries.push_back(Modifier::reflow(shape.id));
+                    }
+
                     if let Some(parent) = shape.parent_id.and_then(|id| shapes.get(&id)) {
                         if parent.has_layout() || parent.is_group_like() {
                             entries.push_back(Modifier::reflow(parent.id));

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -187,7 +187,7 @@ fn initialize_tracks(
     let mut children = modified_children_ids(shape, structure.get(&shape.id));
     let mut first = true;
 
-    if !flex_data.is_reverse() {
+    if flex_data.is_reverse() {
         children.reverse();
     }
 
@@ -497,6 +497,14 @@ fn next_anchor(
     prev_anchor: Point,
     total_shapes_size: f32,
 ) -> Point {
+    if layout_axis.is_auto_main {
+        let delta = child_axis.margin_main_start
+            + child_axis.margin_main_end
+            + child_axis.main_size
+            + layout_axis.gap_main;
+        return prev_anchor + layout_axis.main_v * delta;
+    }
+
     let delta = child_axis.margin_main_start
         + child_axis.margin_main_end
         + match layout_data.justify_content {

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -551,6 +551,13 @@ pub fn auto_width(paragraphs: &[Vec<skia::textlayout::Paragraph>]) -> f32 {
     })
 }
 
+pub fn max_width(paragraphs: &[Vec<skia::textlayout::Paragraph>]) -> f32 {
+    paragraphs
+        .iter()
+        .flatten()
+        .fold(0.0, |max_width, p| f32::max(p.max_width(), max_width))
+}
+
 pub fn auto_height(paragraphs: &[Vec<skia::textlayout::Paragraph>]) -> f32 {
     paragraphs
         .iter()


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/task/10730

### Summary
Add pixel snap in new render

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
