### PR TITLE
:bug: Display color swatch only on color type tokens

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/components/controls/input_tokens_value.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/components/controls/input_tokens_value.cljs
@@ -7,6 +7,7 @@
 (ns app.main.ui.workspace.tokens.components.controls.input-tokens-value
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.main.ui.ds.controls.utilities.input-field :refer [input-field*]]
    [app.main.ui.ds.controls.utilities.label :refer [label*]]
@@ -19,6 +20,7 @@
    [:placeholder {:optional true} :string]
    [:value {:optional true} [:maybe :string]]
    [:class {:optional true} :string]
+   [:is-color-token {:optional true} :boolean]
    [:color {:optional true} [:maybe :string]]
    [:display-colorpicker {:optional true} fn?]
    [:error {:optional true} :boolean]])
@@ -28,9 +30,10 @@
   {::mf/props :obj
    ::mf/forward-ref true
    ::mf/schema schema::input-tokens-value}
-  [{:keys [class label placeholder error value color display-colorpicker] :rest props} ref]
+  [{:keys [class label is-color-token placeholder error value color display-colorpicker] :rest props} ref]
   (let [id (mf/use-id)
         input-ref (mf/use-ref)
+        is-color-token (d/nilv is-color-token false)
         swatch
         (mf/html [:> input-token-color-bullet*
                   {:color color
@@ -44,7 +47,7 @@
                                       :value value
                                       :variant "comfortable"
                                       :hint-type (when error "error")
-                                      :slot-start swatch
+                                      :slot-start (when is-color-token swatch)
                                       :ref (or ref input-ref)})]
     [:div {:class (dm/str class " " (stl/css-case :wrapper true
                                                   :input-error error))}

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -560,7 +560,8 @@
          :label (tr "workspace.tokens.token-value")
          :default-value (mf/ref-val value-ref)
          :ref value-input-ref
-         :color (when is-color-token color)
+         :is-color-token is-color-token
+         :color color
          :on-change on-update-value
          :error (not (nil? (:errors token-resolve-result)))
          :display-colorpicker on-display-colorpicker'


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11168

### Summary

Currently, color swatch are being displayed on all types of tokens for creation and edition forms.
Color swatch must only be visible on token color types

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
