### PR TITLE
:bug: Fix palette is over sidebar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,7 @@ A non exhaustive list of changes:
 - Fix spacing / sizes of different elements in the measurements section of the design tab [Taiga #11076](https://tree.taiga.io/project/penpot/issue/11076)
 - Fix selection of short paths [Github #4472](https://github.com/penpot/penpot/issues/4472)
 - Fix element positioning on the right side to adjust to grid [#11073](https://tree.taiga.io/project/penpot/issue/11073)
+- Fix palette is over sidebar [#11160](https://tree.taiga.io/project/penpot/issue/11160)
 
 ## 2.7.1
 

--- a/frontend/src/app/main/ui/workspace/palette.cljs
+++ b/frontend/src/app/main/ui/workspace/palette.cljs
@@ -40,12 +40,12 @@
         left-sidebar-size      (-> (dom/get-data left-sidebar "size")
                                    (d/parse-integer))
         rulers-width           (if rulers? 22 0)
-        min-left-sidebar-width 275
+        min-left-sidebar-width 318
         left-padding           4
         calculate-padding-left (+ rulers-width (or left-sidebar-size min-left-sidebar-width) left-padding 1)]
 
     #js {"paddingLeft" (dm/str calculate-padding-left "px")
-         "paddingRight" "280px"}))
+         "paddingRight" "322px"}))
 
 (mf/defc palette
   [{:keys [layout on-change-palette-size]}]

--- a/frontend/src/app/main/ui/workspace/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar.cljs
@@ -73,7 +73,7 @@
          on-pointer-move :on-pointer-move
          parent-ref :parent-ref
          size :size}
-        (use-resize-hook :left-sidebar 275 275 500 :x false :left)
+        (use-resize-hook :left-sidebar 318 318 500 :x false :left)
 
         {on-pointer-down-pages :on-pointer-down
          on-lost-pointer-capture-pages  :on-lost-pointer-capture


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11160

### Summary

The palette toolbar sits over the sidebar. The sidebars are now larger in their minimum size, but the padding for the palette has remained the same.

### Steps to reproduce 

Go to any file and check the palette toolbar's position. It should not overlap the sidebar.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] ~~Include screenshots or videos, if applicable.~~
- [ ] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.