### PR TITLE
:bug: Fix reading text-decoration and text-transform from leaf, and fallback to paragraph values

### DIFF
--- a/frontend/src/app/render_wasm/api/texts.cljs
+++ b/frontend/src/app/render_wasm/api/texts.cljs
@@ -104,12 +104,17 @@
               font-id (f/serialize-font-id (:font-id leaf))
               font-family (hash (:font-family leaf))
               font-variant-id (sr/serialize-uuid (:font-variant-id leaf))
+              leaf-text-decoration (or (sr/serialize-text-decoration (:text-decoration leaf)) (sr/serialize-text-decoration (:text-decoration paragraph)))
+              leaf-text-transform (or (sr/serialize-text-transform (:text-transform leaf)) (sr/serialize-text-transform (:text-transform paragraph)))
               text-buffer (utf8->buffer (:text leaf))
               text-length (.-byteLength text-buffer)
               fills (:fills leaf)
               total-fills (count fills)]
 
           (.setUint8 dview offset font-style le?)
+          (.setUint8 dview (+ offset 1) leaf-text-decoration le?)
+          (.setUint8 dview (+ offset 2) leaf-text-transform le?)
+
           (.setFloat32 dview (+ offset 4) font-size le?)
           (.setUint32 dview (+ offset 8) font-weight le?)
           (.setUint32 dview (+ offset 12) (aget font-id 0) le?)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11214

### Summary

This PR fixes missing text decoration and transform properties from text leaves

### Steps to reproduce 

![image](https://github.com/user-attachments/assets/a2adf832-1cc5-4416-9735-c69430a54622)

Use different text decoration and text transform in a paragraph

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
