### PR TITLE
:bug: Fix absolute position tooltip message

### DIFF
--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -148,7 +148,7 @@
              (ts/dispose! schedule)
              (mf/set-ref-val! schedule-ref nil))
            (when-let [tooltip (dom/get-element id)]
-             (let [trigger-rect (->> (dom/get-current-target event)
+             (let [trigger-rect (->> (dom/get-target event)
                                      (dom/get-bounding-rect))]
                (mf/set-ref-val!
                 schedule-ref

--- a/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
@@ -49,28 +49,27 @@
 
 (mf/defc theme-options
   [{:keys [active-theme-paths themes on-close]}]
-  (let []
-    (let [on-edit-click #(modal/show! :tokens/themes {})]
-      [:ul {:class (stl/css :theme-options :custom-select-dropdown)
-            :role "listbox"}
-       (for [[group themes] themes]
-         [:li {:key group
-               :aria-labelledby (dm/str group "-label")
-               :role "group"}
-          (when (seq group)
-            [:> text* {:as "span" :typography "headline-small" :class (stl/css :group) :id (dm/str (str/kebab group) "-label") :title group} group])
-          [:& themes-list {:themes themes
-                           :active-theme-paths active-theme-paths
-                           :on-close on-close
-                           :grouped? true}]])
-       [:li {:class (stl/css :separator)
-             :aria-hidden true}]
-       [:li {:class (stl/css-case :checked-element true
-                                  :checked-element-button true)
-             :role "option"
-             :on-click on-edit-click}
-        [:> text* {:as "span" :typography "body-small"} (tr "workspace.tokens.edit-themes")]
-        [:> icon* {:icon-id i/arrow-right :aria-hidden true}]]])))
+  (let [on-edit-click #(modal/show! :tokens/themes {})]
+    [:ul {:class (stl/css :theme-options :custom-select-dropdown)
+          :role "listbox"}
+     (for [[group themes] themes]
+       [:li {:key group
+             :aria-labelledby (dm/str group "-label")
+             :role "group"}
+        (when (seq group)
+          [:> text* {:as "span" :typography "headline-small" :class (stl/css :group) :id (dm/str (str/kebab group) "-label") :title group} group])
+        [:& themes-list {:themes themes
+                         :active-theme-paths active-theme-paths
+                         :on-close on-close
+                         :grouped? true}]])
+     [:li {:class (stl/css :separator)
+           :aria-hidden true}]
+     [:li {:class (stl/css-case :checked-element true
+                                :checked-element-button true)
+           :role "option"
+           :on-click on-edit-click}
+      [:> text* {:as "span" :typography "body-small"} (tr "workspace.tokens.edit-themes")]
+      [:> icon* {:icon-id i/arrow-right :aria-hidden true}]]]))
 
 (mf/defc theme-select
   [{:keys []}]


### PR DESCRIPTION
### Related Ticket

This PR fixes this issue https://tree.taiga.io/project/penpot/issue/11300

### Summary

The close button on modal had its tooltip misplaced

### Steps to reproduce 

1. Go to token section (i.e.)
2. Open a create token modal
3. place mouse over X button, tooltip must be over button.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
