### PR TITLE
:sparkles: Add import error event

### DIFF
--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -170,6 +170,9 @@
          (rx/filter some?)
          (rx/subs!
           (fn [message]
+            (when (some? (:error message))
+              (st/emit! (ptk/data-event ::ev/event {::ev/name "import-files-error"
+                                                    :error (:error message)})))
             (swap! state update-with-analyze-result message))))))
 
 (defn- import-files


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/11004

### Summary

Add Posthog evento to track import penpot file error, which is needed to better identify friction points during onboarding.

### Checklist

- [x] Choose the correct target branch.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.