### PR TITLE
:bug: Fix when retrieving a variant from several with same props, it get the last one

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -368,7 +368,8 @@
                                     (update pos assoc :value val))
                    valid-comps  (->> variant-components
                                      (remove #(= (:id %) component-id))
-                                     (filter #(= (dm/get-in % [:variant-properties pos :value]) val)))
+                                     (filter #(= (dm/get-in % [:variant-properties pos :value]) val))
+                                     (reverse))
                    nearest-comp (apply min-key #(ctv/distance target-props (:variant-properties %)) valid-comps)]
                (when nearest-comp
                  (st/emit! (dwl/component-swap shape (:component-file shape) (:id nearest-comp) true)))))))]


### PR DESCRIPTION
…

### Related Ticket

https://tree.taiga.io/project/penpot/task/11133

### Summary

Fix: If the user creates a variant with the same value for all properties, we should retrieve only one of the variants, the first in order. But we are retrieving the last one.

### Steps to reproduce 
1. Create a variant with three components. 
2. Set the same properties to two of them
3. Make a copy of the different one
4. Make a switch to select the common properties
5. You switch to the last one, you should switch to the first one

### Checklist

- [X ] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.


