### PR TITLE
:bug: Fix image fill strokes are not rendered correctly for texts

### DIFF
--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -534,7 +534,10 @@ pub fn render(
     let path_transform = shape.to_path_transform();
     let svg_attrs = &shape.svg_attrs;
 
-    if shadow.is_none() && matches!(stroke.fill, Fill::Image(_)) {
+    if !matches!(shape.shape_type, Type::Text(_))
+        && shadow.is_none()
+        && matches!(stroke.fill, Fill::Image(_))
+    {
         if let Fill::Image(image_fill) = &stroke.fill {
             draw_image_stroke_in_container(render_state, shape, stroke, image_fill, antialias);
         }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11398

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
