### PR TITLE
:wrench: Add vertical alignment for text shape

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -236,6 +236,7 @@
 
 (defn set-shape-text-images
   [shape-id content]
+
   (let [paragraph-set (first (get content :children))
         paragraphs (get paragraph-set :children)]
     (->> paragraphs
@@ -356,6 +357,10 @@
   ;; These values correspond to skia::BlendMode representation
   ;; https://rust-skia.github.io/doc/skia_safe/enum.BlendMode.html
   (h/call wasm/internal-module "_set_shape_blend_mode" (sr/translate-blend-mode blend-mode)))
+
+(defn set-shape-vertical-align
+  [vertical-align]
+  (h/call wasm/internal-module "_set_shape_vertical_align" (sr/serialize-vertical-align vertical-align)))
 
 (defn set-shape-opacity
   [opacity]
@@ -630,6 +635,8 @@
 (defn set-shape-text-content
   [shape-id content]
   (h/call wasm/internal-module "_clear_shape_text")
+  (set-shape-vertical-align (dm/get-prop content :vertical-align))
+
   (let [paragraph-set (first (dm/get-prop content :children))
         paragraphs (dm/get-prop paragraph-set :children)
         fonts (fonts/get-content-fonts content)
@@ -752,6 +759,7 @@
     (when (some? shadows) (set-shape-shadows shadows))
     (when (= type :text)
       (set-shape-grow-type grow-type))
+
     (when (or (ctl/any-layout? shape)
               (ctl/any-layout-immediate-child? objects shape))
       (set-layout-child shape))

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -295,6 +295,10 @@
   [value enum-map]
   (get enum-map value 0))
 
+(defn serialize-vertical-align
+  [vertical-align]
+  (serialize-enum vertical-align {"top" 0 "center" 1 "bottom" 2}))
+
 (defn serialize-text-align
   [text-align]
   (serialize-enum text-align {"left" 0 "center" 1 "right" 2 "justify" 3}))

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -19,6 +19,7 @@ use math::{Bounds, Matrix};
 use mem::SerializableResult;
 use shapes::{
     BoolType, ConstraintH, ConstraintV, StructureEntry, StructureEntryType, TransformEntry, Type,
+    VerticalAlign,
 };
 use skia_safe as skia;
 use state::State;
@@ -343,6 +344,13 @@ pub extern "C" fn set_shape_svg_raw_content() {
 pub extern "C" fn set_shape_blend_mode(mode: i32) {
     with_current_shape!(state, |shape: &mut Shape| {
         shape.set_blend_mode(render::BlendMode::from(mode));
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn set_shape_vertical_align(align: u8) {
+    with_current_shape!(state, |shape: &mut Shape| {
+        shape.set_vertical_align(VerticalAlign::from(align));
     });
 }
 

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -1,4 +1,5 @@
 use super::{RenderState, Shape, SurfaceId};
+use crate::shapes::VerticalAlign;
 use skia_safe::{textlayout::Paragraph, Paint, Path};
 
 pub fn render(
@@ -11,8 +12,16 @@ pub fn render(
         .surfaces
         .canvas(surface_id.unwrap_or(SurfaceId::Fills));
 
+    let container_height = shape.selrect().height();
     for group in paragraphs {
-        let mut offset_y = 0.0;
+        let total_paragraphs_height: f32 = group.iter().map(|p| p.height()).sum();
+
+        let mut offset_y = match shape.vertical_align() {
+            VerticalAlign::Center => (container_height - total_paragraphs_height) / 2.0,
+            VerticalAlign::Bottom => container_height - total_paragraphs_height,
+            _ => 0.0,
+        };
+
         for skia_paragraph in group {
             let xy = (shape.selrect().x(), shape.selrect.y() + offset_y);
             skia_paragraph.paint(canvas, xy);

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -157,6 +157,24 @@ impl ConstraintH {
 }
 
 #[derive(Debug, Clone, PartialEq, Copy)]
+pub enum VerticalAlign {
+    Top,
+    Center,
+    Bottom,
+}
+
+impl VerticalAlign {
+    pub fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Top,
+            1 => Self::Center,
+            2 => Self::Bottom,
+            _ => Self::Top,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum ConstraintV {
     Top,
     Bottom,
@@ -195,6 +213,7 @@ pub struct Shape {
     pub fills: Vec<Fill>,
     pub strokes: Vec<Stroke>,
     pub blend_mode: BlendMode,
+    pub vertical_align: VerticalAlign,
     pub blur: Blur,
     pub opacity: f32,
     pub hidden: bool,
@@ -221,6 +240,7 @@ impl Shape {
             fills: Vec::with_capacity(1),
             strokes: Vec::with_capacity(1),
             blend_mode: BlendMode::default(),
+            vertical_align: VerticalAlign::Top,
             opacity: 1.,
             hidden: false,
             blur: Blur::default(),
@@ -310,6 +330,14 @@ impl Shape {
 
     pub fn set_opacity(&mut self, opacity: f32) {
         self.opacity = opacity;
+    }
+
+    pub fn set_vertical_align(&mut self, align: VerticalAlign) {
+        self.vertical_align = align;
+    }
+
+    pub fn vertical_align(&self) -> VerticalAlign {
+        self.vertical_align
     }
 
     pub fn set_constraint_h(&mut self, constraint: Option<ConstraintH>) {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10901

### Summary

`vertical-align` is a `content` property that applies to all the paragraphs of the shape, so it's a "shape" property that all paragraphs should take into account.

![image](https://github.com/user-attachments/assets/16aa6970-1b36-4013-8eb3-114b0565832e)

### Steps to reproduce 

Create different texts with different vertical-align position

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
