### PR TITLE
:sparkles: Add line height token

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -110,11 +110,10 @@
 (def spacing-keys (schema-keys schema:spacing))
 
 (def ^:private schema:dimensions
-  [:merge
-   schema:sizing
-   schema:spacing
-   schema:stroke-width
-   schema:border-radius])
+  (reduce mu/union [schema:sizing
+                    schema:spacing
+                    schema:stroke-width
+                    schema:border-radius]))
 
 (def dimensions-keys (schema-keys schema:dimensions))
 
@@ -139,9 +138,8 @@
 (def typography-keys (set/union font-size-keys line-height-keys))
 
 (def ^:private schema:number
-  [:merge
-   [:map [:rotation {:optional true} token-name-ref]]
-   schema:line-height])
+  (reduce mu/union [schema:line-height
+                    schema:rotation]))
 
 (def number-keys (schema-keys schema:number))
 

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -34,6 +34,7 @@
    :color         "color"
    :dimensions    "dimension"
    :font-size     "fontSizes"
+   :line-height   "lineHeights"
    :number        "number"
    :opacity       "opacity"
    :other         "other"
@@ -129,12 +130,18 @@
 
 (def font-size-keys (schema-keys schema:font-size))
 
-(def typography-keys (set/union font-size-keys))
+(def ^:private schema:line-height
+  [:map
+   [:line-height {:optional true} token-name-ref]])
+
+(def line-height-keys (schema-keys schema:line-height))
+
+(def typography-keys (set/union font-size-keys line-height-keys))
 
 (def ^:private schema:number
-  [:map
-   [:rotation {:optional true} token-name-ref]
-   [:line-height {:optional true} token-name-ref]])
+  [:merge
+   [:map [:rotation {:optional true} token-name-ref]]
+   schema:line-height])
 
 (def number-keys (schema-keys schema:number))
 
@@ -147,6 +154,7 @@
                          dimensions-keys
                          rotation-keys
                          typography-keys
+                         line-height-keys
                          number-keys))
 
 (def ^:private schema:tokens
@@ -161,6 +169,7 @@
    schema:rotation
    schema:number
    schema:font-size
+   schema:line-height
    schema:dimensions])
 
 (defn shape-attr->token-attrs
@@ -189,6 +198,7 @@
        #{:m1 :m2 :m3 :m4})
 
      (font-size-keys shape-attr) #{shape-attr}
+     (line-height-keys shape-attr) #{shape-attr}
      (border-radius-keys shape-attr) #{shape-attr}
      (sizing-keys shape-attr) #{shape-attr}
      (opacity-keys shape-attr) #{shape-attr}

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -391,6 +391,14 @@
             :fields [{:label "Font Size"
                       :key :font-size}]}}
 
+   :line-height
+   {:title "Line Height"
+    :attributes ctt/line-height-keys
+    :on-update-shape update-line-height
+    :modal {:key :tokens/line-height
+            :fields [{:label "Line Height"
+                      :key :line-height}]}}
+
    :stroke-width
    {:title "Stroke Width"
     :attributes ctt/stroke-width-keys

--- a/frontend/src/app/main/ui/workspace/tokens/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals.cljs
@@ -185,3 +185,9 @@
    ::mf/register-as :tokens/font-size}
   [properties]
   [:& token-update-create-modal properties])
+
+(mf/defc line-height-modal
+  {::mf/register modal/components
+   ::mf/register-as :tokens/line-height}
+  [properties]
+  [:& token-update-create-modal properties])

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data :as d]
+   [app.common.types.token :as ctt]
    [app.common.types.tokens-lib :as ctob]
    [app.config :as cf]
    [app.main.data.modal :as modal]
@@ -143,6 +144,9 @@
               :on-click on-token-pill-click
               :on-context-menu on-context-menu}])]])]]))
 
+(defn- remove-keys [m ks]
+  (d/removem (comp ks key) m))
+
 (defn- get-sorted-token-groups
   "Separate token-types into groups of `empty` or `filled` depending if
   tokens exist for that type. Sort each group alphabetically (by their type).
@@ -152,7 +156,7 @@
         token-typography-types? (contains? cf/flags :token-typography-types)
         all-types (cond-> dwta/token-properties
                     (not token-units?) (dissoc :number)
-                    (not token-typography-types?) (dissoc :font-size))
+                    (not token-typography-types?) (remove-keys ctt/typography-keys))
         all-types (-> all-types keys seq)]
     (loop [empty  #js []
            filled #js []

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -52,6 +52,7 @@
     :color "drop"
     :boolean "boolean-difference"
     :font-size "text-font-size"
+    :line-height "drop"
     :opacity "percentage"
     :number "number"
     :rotation "rotation"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/109

### Summary

- Adds line-height token
- Fixes `:merge` schema not actually working with `mu/keys`

### Steps to reproduce 

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [X] Include screenshots or videos, if applicable.
- [X] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Check CI passes successfully.
- [X] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->

