### PR TITLE
:bug: Fix variant switch in another page

### DIFF
--- a/common/src/app/common/logic/variants.cljc
+++ b/common/src/app/common/logic/variants.cljc
@@ -91,11 +91,14 @@
         ;; shape on the main component
         orig-ref-shape     (ctf/find-ref-shape nil container libraries original-shape)
 
+        orig-ref-objects   (-> (ctf/get-component-container-from-head orig-ref-shape libraries)
+                               :objects)
+
         ;; Adds a :shape-path attribute to the children of the orig-ref-shape,
         ;; that contains the type of its ancestors and its name
         o-ref-shapes-wp    (add-unique-path
-                            (reverse (cfh/get-children-with-self objects (:id orig-ref-shape)))
-                            objects
+                            (reverse (cfh/get-children-with-self orig-ref-objects (:id orig-ref-shape)))
+                            orig-ref-objects
                             (:id orig-ref-shape))
 
         ;; Creates a map to quickly find a child of the orig-ref-shape by its shape-path

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -242,6 +242,13 @@
       (cfh/make-container component-page :page))
     (cfh/make-container component :component)))
 
+(defn get-component-container-from-head
+  [instance-head libraries & {:keys [include-deleted?] :or {include-deleted? true}}]
+  (let [library-data   (-> (get-component-library libraries instance-head)
+                           :data)
+        component (ctkl/get-component library-data (:component-id instance-head) include-deleted?)]
+    (get-component-container library-data component)))
+
 (defn get-component-root
   "Retrieve the root shape of the component."
   [file-data component]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11477

### Summary

When you try to make a variant switch, and the copy is in a different page than the main, it crashes

### Steps to reproduce 

1. Create a variant
2. Create a copy of the first component of the variant in another page
3. Switch the copy

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.


