### PR TITLE
:bug: Fix internal error on missing theme setting in profile

### DIFF
--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -172,7 +172,9 @@
                                    current)]
                      (case current
                        "dark"   "light"
-                       "light"  "dark")))))
+                       "light"  "dark"
+                       ; Failsafe for missing data
+                       "dark")))))
 
     ptk/WatchEvent
     (watch [it state _]


### PR DESCRIPTION
### Summary

This PR fixes a problem whereby a missing `:profile :theme` value will result in "Internal Error" because of a missing default case clause.

### Steps to reproduce 

Go to design.penpot.app. Switch the theme to dark or light. For some users (like mine) this results in an  Internal error with output:

```
Hint:    No matching clause: 
Prof ID: 749aaa04-8836-81c6-8006-1125d2b8f1a5
Team ID: --

Data:
{:hint "No matching clause: "}

Trace:
Error: No matching clause: 
....
```

This fix adds a default "dark" value to work around this situation.


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
