### PR TITLE
:bug: Fix tooltip position after click

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,7 @@ on-premises instances** that want to keep up to date.
 - Fix shortcut error pressing G+W from the View Mode [Taiga #11061](https://tree.taiga.io/project/penpot/issue/11061)
 - Fix entering long project name [Taiga #11417](https://tree.taiga.io/project/penpot/issue/11417)
 - Fix slow color picker [Taiga #11019](https://tree.taiga.io/project/penpot/issue/11019)
+- Fix tooltip position after click [Taiga #11405](https://tree.taiga.io/project/penpot/issue/11405)
 
 ## 2.7.2
 

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.scss
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.scss
@@ -19,6 +19,12 @@ $arrow-side: 12px;
   block-size: fit-content;
 }
 
+.tooltip-content-wrapper {
+  display: grid;
+  inline-size: fit-content;
+  block-size: fit-content;
+}
+
 .tooltip-arrow {
   background-color: var(--color-background-primary);
   border-radius: var(--sp-xs);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11405

### Summary

When clicking fast or repeatedly a small button with an icon the tooltip en appearing misplaced. 

### Steps to reproduce 

https://github.com/user-attachments/assets/e712690b-159c-4c00-83b3-69ebe36c0970


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
