### PR TITLE
:wrench: Sanitize and check tokens when deserializing from db

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1769,7 +1769,7 @@ Will return a value that matches this schema:
             (fres/write-object! w (into {} o)))
      :rfn (fn [r]
             (let [obj (fres/read-object! r)]
-              (map->Token obj)))}
+              (make-token obj)))}
 
     {:name "penpot/token-set/v1"
      :class TokenSet
@@ -1787,7 +1787,7 @@ Will return a value that matches this schema:
             (fres/write-object! w (into {} o)))
      :rfn (fn [r]
             (let [obj (fres/read-object! r)]
-              (map->TokenTheme obj)))}
+              (make-token-theme obj)))}
 
     ;; LEGACY TOKENS LIB READERS (with migrations)
     {:name "penpot/tokens-lib/v1"


### PR DESCRIPTION
### Related Ticket

Part of https://tree.taiga.io/project/penpot/task/11489

### Summary

Sanitize token objects when deserializing from db. We have recently added more strict schema checks. There may be files that were created before the changes, and that have invalid data (e.g. descruption to nil instead of empty string).

With this PR, all data is sanitized when deserializing.

### Steps to reproduce 

Open [this file](https://early.penpot.dev/#/workspace?team-id=168cf05f-930a-8048-8005-908737914783&file-id=1dba7980-9f8c-8006-8006-676f436176b6&page-id=779e9c5e-93a5-8043-8003-c787b5e45532)

It gives an error with message "expected valid params for token-set".

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
