### PR TITLE
:bug: Fix frame clipping

### DIFF
--- a/frontend/resources/wasm-playground/clips.html
+++ b/frontend/resources/wasm-playground/clips.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>WASM + WebGL2 Canvas</title>
+  <style>
+    body {
+      margin: 0;
+      background: #111;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      overflow: hidden;
+    }
+    canvas {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="canvas"></canvas>
+  <script type="module">
+    import initWasmModule from '/js/render_wasm.js';
+    import {
+      init, addShapeSolidFill, assignCanvas, hexToU32ARGB, getRandomInt, getRandomColor,
+      getRandomFloat, useShape, setShapeChildren, setupInteraction, addShapeSolidStrokeFill,
+      set_parent
+    } from './js/lib.js';
+
+    const canvas = document.getElementById("canvas");
+    canvas.width =  window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    initWasmModule().then(Module => {
+      init(Module);
+      assignCanvas(canvas);
+      Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
+      Module._set_view(1, 0, 0);
+      Module._init_shapes_pool(10);
+      setupInteraction(canvas);
+
+      const rectUuid1 = crypto.randomUUID();
+      const rectUuid2 = crypto.randomUUID();
+      const frameUuid = crypto.randomUUID();
+
+      // Create Rect 1
+      useShape(rectUuid1);
+      set_parent(frameUuid);
+      Module._set_shape_type(3);
+      Module._set_shape_selrect(100, 100, 300, 300);
+      Module._set_shape_blur(1, 100, 40);
+      addShapeSolidFill(hexToU32ARGB("#003DF7", 1));
+
+      // Create Rect 2
+      useShape(rectUuid2);
+      set_parent(frameUuid);
+      Module._set_shape_type(3);
+      Module._set_shape_selrect(200, 200, 400, 400);
+      addShapeSolidFill(1870806498)
+
+      // Create Frame
+      useShape(frameUuid);
+      Module._set_parent(0, 0, 0, 0);
+      Module._set_shape_type(0);
+      Module._set_shape_selrect(200, 200, 450, 450);
+      Module._set_shape_corners(50, 50, 50, 50);
+      addShapeSolidFill(hexToU32ARGB("#ee0d32", 1))
+      Module._add_shape_center_stroke(25, 0,  0, 0);
+      addShapeSolidStrokeFill(hexToU32ARGB("#000000", 1));
+      Module._set_shape_blur(1, 100, 4);
+      Module._add_shape_shadow(hexToU32ARGB("#000000", .2), 4, 40, 80, 80, 2, false);
+
+      setShapeChildren([rectUuid1]);
+
+      useShape("00000000-0000-0000-0000-000000000000");
+      setShapeChildren([frameUuid]);
+
+      performance.mark('render:begin');
+      Module._render(Date.now());
+      performance.mark('render:end');
+      const { duration } = performance.measure('render', 'render:begin', 'render:end');
+      // alert(`render time: ${duration.toFixed(2)}ms`);
+    });
+    
+  </script>
+</body>
+</html>

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -307,8 +307,14 @@ impl Surfaces {
         self.tiles.remove(tile)
     }
 
-    pub fn draw_cached_tile_surface(&mut self, tile: Tile, rect: skia::Rect) {
+    pub fn draw_cached_tile_surface(&mut self, tile: Tile, rect: skia::Rect, color: skia::Color) {
         let image = self.tiles.get(tile).unwrap();
+
+        let mut paint = skia::Paint::default();
+        paint.set_color(color);
+
+        self.target.canvas().draw_rect(rect, &paint);
+
         self.target
             .canvas()
             .draw_image_rect(&image, None, rect, &skia::Paint::default());

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -4,7 +4,7 @@ use indexmap::IndexSet;
 use skia_safe as skia;
 use std::collections::{HashMap, HashSet};
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct Tile(pub i32, pub i32);
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11294
https://tree.taiga.io/project/penpot/issue/11501

The top-left rectangle has a blur effect and actually is rendered this way:
![2](https://github.com/user-attachments/assets/46050ea1-0090-4865-aec5-a2d53b037255)


It should be rendered like this:
![2](https://github.com/user-attachments/assets/6adaf8c9-090e-489a-b930-d2f8d025fa6b)



## NOTE
This PR breaks drop shadows for frames with clipping. A new task/issue for this should be created in Taiga when merged

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
