### PR TITLE
:bug: Update rotation or line height depending shape type on apply nu…

### DIFF
--- a/frontend/src/app/main/data/helpers.cljs
+++ b/frontend/src/app/main/data/helpers.cljs
@@ -78,6 +78,23 @@
              (filter selectable?)
              selected)))))
 
+(defn split-text-shapes
+  "Split text shapes from non-text shapes"
+  [objects ids]
+  (loop [ids (seq ids)
+         text-ids []
+         shape-ids []]
+    (if-let [id (first ids)]
+      (let [shape (get objects id)]
+        (if (cfh/text-shape? shape)
+          (recur (rest ids)
+                 (conj text-ids id)
+                 shape-ids)
+          (recur (rest ids)
+                 text-ids
+                 (conj shape-ids id))))
+      [text-ids shape-ids])))
+
 ;; DEPRECATED
 (defn lookup-selected-raw
   [state]

--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -83,24 +83,6 @@
           (assoc-in [:workspace-global :picked-color-select] value)
           (assoc-in [:workspace-global :picked-shift?] shift?)))))
 
-
-(defn- split-text-shapes
-  "Split text shapes from non-text shapes"
-  [objects ids]
-  (loop [ids (seq ids)
-         text-ids []
-         shape-ids []]
-    (if-let [id (first ids)]
-      (let [shape (get objects id)]
-        (if (cfh/text-shape? shape)
-          (recur (rest ids)
-                 (conj text-ids id)
-                 shape-ids)
-          (recur (rest ids)
-                 text-ids
-                 (conj shape-ids id))))
-      [text-ids shape-ids])))
-
 (defn assoc-shape-fill
   [shape position fill]
   (update shape :fills
@@ -111,13 +93,13 @@
 
 (defn transform-fill*
   "A lower-level companion function for `transform-fill`"
-  [state ids  transform options]
+  [state ids transform options]
   (let [page-id (or (get options :page-id)
                     (get state :current-page-id))
         objects (dsh/lookup-page-objects state page-id)
 
         [text-ids shape-ids]
-        (split-text-shapes objects ids)]
+        (dsh/split-text-shapes objects ids)]
 
     (rx/concat
      (->> (rx/from text-ids)


### PR DESCRIPTION
…meric token

### Related Ticket

https://tree.taiga.io/project/penpot/task/11331

### Summary

When applying a numeric token and the selected layer is a text, it should be applied to the line height by default.

### Tecnical notes

- Moved `split-text-shapes` fn from colors to helpers so it can be used in `application.cljs` to discern shapes and text shapes.
- Created an `update-numeric` fn to abstract token type from shape attributes. An applied token must be able to update different attributes, or many of them. `update-attribute-*` fn should work as attribute application helpers. 

### Steps to reproduce 

1. Create two shapes: one must be a common shape and the other a text.
2. Create a numeric token with a value (e.g. `20`)
3. Select both shapes and apply token

Current: both shapes change rotation
Expected: text shapes get a line-height tokens and other shapes update its rotation

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
