### PR TITLE
:sparkles: Add referer field to binfile v3

### DIFF
--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -54,7 +54,7 @@
   [:map {:title "Manifest"}
    [:version ::sm/int]
    [:type :string]
-
+   [:referer {:optional true} :string]
    [:generated-by {:optional true} :string]
 
    [:files

--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -12,7 +12,6 @@
    [app.binfile.common :as bfc]
    [app.binfile.migrations :as bfm]
    [app.common.data :as d]
-   [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
    [app.common.features :as cfeat]
    [app.common.files.migrations :as-alias fmg]
@@ -373,6 +372,7 @@
           params {:type "penpot/export-files"
                   :version 1
                   :generated-by (str "penpot/" (:full cf/version))
+                  :refer "penpot"
                   :files (vec (vals files))
                   :relations rels}]
       (write-entry! output "manifest.json" params))))
@@ -878,13 +878,8 @@
 (defn- import-files
   [{:keys [::bfc/timestamp ::bfc/input ::bfc/name] :or {timestamp (dt/now)} :as cfg}]
 
-  (dm/assert!
-   "expected zip file"
-   (instance? ZipFile input))
-
-  (dm/assert!
-   "expected valid instant"
-   (dt/instant? timestamp))
+  (assert (instance? ZipFile input) "expected zip file")
+  (assert (dt/instant? timestamp) "expected valid instant")
 
   (let [manifest (-> (read-manifest input)
                      (validate-manifest))
@@ -895,6 +890,7 @@
                 :code :invalid-binfile-v3-manifest
                 :hint "unexpected type on manifest"
                 :manifest manifest))
+
 
     ;; Check if all files referenced on manifest are present
     (doseq [{file-id :id features :features} (:files manifest)]
@@ -956,14 +952,13 @@
 
   [{:keys [::bfc/ids] :as cfg} output]
 
-  (dm/assert!
-   "expected a set of uuid's for `::bfc/ids` parameter"
-   (and (set? ids)
-        (every? uuid? ids)))
+  (assert
+   (and (set? ids) (every? uuid? ids))
+   "expected a set of uuid's for `::bfc/ids` parameter")
 
-  (dm/assert!
-   "expected instance of jio/IOFactory for `input`"
-   (satisfies? jio/IOFactory output))
+  (assert
+   (satisfies? jio/IOFactory output)
+   "expected instance of jio/IOFactory for `input`")
 
   (let [id (uuid/next)
         tp (dt/tpoint)
@@ -1002,14 +997,14 @@
 (defn import-files!
   [{:keys [::bfc/input] :as cfg}]
 
-  (dm/assert!
-   "expected valid profile-id and project-id on `cfg`"
+  (assert
    (and (uuid? (::bfc/profile-id cfg))
-        (uuid? (::bfc/project-id cfg))))
+        (uuid? (::bfc/project-id cfg)))
+   "expected valid profile-id and project-id on `cfg`")
 
-  (dm/assert!
-   "expected instance of jio/IOFactory for `input`"
-   (io/coercible? input))
+  (assert
+   (io/coercible? input)
+   "expected instance of jio/IOFactory for `input`")
 
   (let [id (uuid/next)
         tp (dt/tpoint)
@@ -1029,3 +1024,9 @@
                 :id (str id)
                 :elapsed (dt/format-duration (tp))
                 :error? (some? @cs))))))
+
+(defn get-manifest
+  [path]
+  (with-open [input (ZipFile. (fs/file path))]
+    (-> (read-manifest input)
+        (validate-manifest))))

--- a/library/CHANGES.md
+++ b/library/CHANGES.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 1.0.7
+
+- Add the ability to provide refereron creating build context
+
+```js
+const context = penpot.createBuildContext({referer:"my-referer"});
+```
+
+The referer will be added as an additional field on the manifest.json
+
+
 ## 1.0.6
 
 - Fix unexpected issue on library color decoding

--- a/library/deps.edn
+++ b/library/deps.edn
@@ -21,11 +21,10 @@
   :dev
   {:extra-paths ["dev"]
    :extra-deps
-   {thheller/shadow-cljs {:mvn/version "3.1.4"}
+   {thheller/shadow-cljs {:mvn/version "3.1.7"}
     com.bhauman/rebel-readline {:mvn/version "RELEASE"}
     org.clojure/tools.namespace {:mvn/version "RELEASE"}
-    criterium/criterium {:mvn/version "RELEASE"}
-    cider/cider-nrepl {:mvn/version "0.48.0"}}}
+    criterium/criterium {:mvn/version "RELEASE"}}}
 
   :shadow-cljs
   {:main-opts ["-m" "shadow.cljs.devtools.cli"]

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penpot/library",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MPL-2.0",
   "author": "Kaleidos INC",
   "packageManager": "yarn@4.9.1+sha512.f95ce356460e05be48d66401c1ae64ef84d163dd689964962c6888a9810865e39097a5e9de748876c2e0bf89b232d583c33982773e9903ae7a76257270986538",
@@ -40,8 +40,7 @@
     "@zip.js/zip.js": "patch:@zip.js/zip.js@npm%3A2.7.60#~/.yarn/patches/@zip.js-zip.js-npm-2.7.60-b6b814410b.patch",
     "concurrently": "^9.1.2",
     "luxon": "^3.6.1",
-    "nodemon": "^3.1.9",
-    "shadow-cljs": "3.1.4"
+    "nodemon": "^3.1.9"
   },
   "dependencies": {
     "source-map-support": "^0.5.21"

--- a/library/playground/sample-fill-stroke-and-media.js
+++ b/library/playground/sample-fill-stroke-and-media.js
@@ -6,7 +6,7 @@ import { Writable } from "stream";
 // console.log(penpot);
 
 (async function () {
-  const context = penpot.createBuildContext();
+  const context = penpot.createBuildContext({referer:"playground"});
 
   {
     context.addFile({ name: "Test File 1" });

--- a/library/src/lib/builder.cljs
+++ b/library/src/lib/builder.cljs
@@ -271,11 +271,19 @@
     (fn []
       (json/->js @state))))
 
+(def ^:private schema:context-options
+  [:map {:title "ContextOptions"}
+   [:referer {:optional true} ::sm/text]])
+
+(def ^:private decode-context-options
+  (sm/decoder schema:context-options sm/json-transformer))
+
 (defn create-build-context
   "Create an empty builder state context."
-  []
-  (let [state (atom {})
-        api   (create-builder-api state)]
+  [options]
+  (let [options (some-> options decode-params decode-context-options)
+        state   (atom {:options options})
+        api     (create-builder-api state)]
 
     (specify! api
       cljs.core/IDeref

--- a/library/src/lib/export.cljs
+++ b/library/src/lib/export.cljs
@@ -183,17 +183,22 @@
 
 (defn- generate-manifest-procs
   [state]
-  (let [files (->> (get state ::fb/files)
-                   (mapv (fn [[file-id file]]
-                           {:id file-id
-                            :name (:name file)
-                            :features (:features file)})))
+  (let [opts   (get state :options)
+        files  (->> (get state ::fb/files)
+                    (mapv (fn [[file-id file]]
+                            {:id file-id
+                             :name (:name file)
+                             :features (:features file)})))
         params {:type "penpot/export-files"
                 :version 1
                 :generated-by "penpot-library/%version%"
+                :referer (get opts :referer)
                 :files files
-                :relations []}]
-    ["manifest.json" (delay (json/encode params))]))
+                :relations []}
+        params (d/without-nils params)]
+
+    ["manifest.json"
+     (delay (json/encode params))]))
 
 (defn- generate-procs
   [state]


### PR DESCRIPTION
### Summary

On this PR: 
- add optional referer to the binfile-v3 ouput
- emit referer and generated-by fields on audit log events
- add the ability to pass referer on create build context on penpot library

### Steps to reproduce

- use library playground for generate a file: `playground/sample-fill-stroke-and-media.js`
- upload the file to penpot
- check on audit_log table you have the corresponding fields for referer and generated-by
