### PR TITLE
:sparkles: Implement text-decoration token type

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -35,6 +35,7 @@
    :dimensions    "dimension"
    :font-size     "fontSizes"
    :letter-spacing "letterSpacing"
+   :text-decoration "textDecoration"
    :number        "number"
    :opacity       "opacity"
    :other         "other"
@@ -133,7 +134,13 @@
 
 (def letter-spacing-keys (schema-keys schema:letter-spacing))
 
-(def typography-keys (set/union font-size-keys letter-spacing-keys))
+(def ^:private schema:text-decoration
+  [:map
+   [:text-decoration {:optional true} token-name-ref]])
+
+(def text-decoration-keys (schema-keys schema:text-decoration))
+
+(def typography-keys (set/union font-size-keys letter-spacing-keys text-decoration-keys))
 
 (def ^:private schema:number
   (reduce mu/union [[:map [:line-height {:optional true} token-name-ref]]
@@ -165,6 +172,7 @@
    schema:number
    schema:font-size
    schema:letter-spacing
+   schema:text-decoration
    schema:dimensions])
 
 (defn shape-attr->token-attrs
@@ -194,6 +202,7 @@
 
      (font-size-keys shape-attr) #{shape-attr}
      (letter-spacing-keys shape-attr) #{shape-attr}
+     (text-decoration-keys shape-attr) #{shape-attr}
      (border-radius-keys shape-attr) #{shape-attr}
      (sizing-keys shape-attr) #{shape-attr}
      (opacity-keys shape-attr) #{shape-attr}

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -380,6 +380,19 @@
                            {:ignore-touched true
                             :page-id page-id})))))
 
+(defn update-text-decoration
+  ([value shape-ids attributes] (update-text-decoration value shape-ids attributes nil))
+  ([value shape-ids _attributes page-id]
+   (let [update-node? (fn [node]
+                        (or (txt/is-text-node? node)
+                            (txt/is-paragraph-node? node)))]
+     (when (string? value)
+       (dwsh/update-shapes shape-ids
+                           #(txt/update-text-content % update-node? d/txt-merge {:text-decoration value})
+                           {:ignore-touched true
+                            :page-id page-id})))))
+
+
 ;; Map token types to different properties used along the cokde ---------------------------------------------
 
 ;; FIXME: the values should be lazy evaluated, probably a function,
@@ -420,6 +433,14 @@
     :modal {:key :tokens/letter-spacing
             :fields [{:label "Letter Spacing"
                       :key :letter-spacing}]}}
+
+   :text-decoration
+   {:title "Text Decoration"
+    :attributes ctt/text-decoration-keys
+    :on-update-shape update-text-decoration
+    :modal {:key :tokens/text-case
+            :fields [{:label "Text Decoration"
+                      :key :text-case}]}}
 
    :stroke-width
    {:title "Stroke Width"

--- a/frontend/src/app/main/data/workspace/tokens/propagation.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/propagation.cljs
@@ -35,6 +35,7 @@
    #{:line-height} dwta/update-line-height
    #{:font-size} dwta/update-font-size
    #{:letter-spacing} dwta/update-letter-spacing
+   #{:text-decoration} dwta/update-text-decoration
    #{:x :y} dwta/update-shape-position
    #{:p1 :p2 :p3 :p4} dwta/update-layout-padding
    #{:m1 :m2 :m3 :m4} dwta/update-layout-item-margin

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -260,6 +260,7 @@
 (def shape-attribute-actions-map
   (let [stroke-width (partial generic-attribute-actions #{:stroke-width} "Stroke Width")
         font-size (partial generic-attribute-actions #{:font-size} "Font Size")
+        text-decoration (partial generic-attribute-actions #{:text-decoration} "Text Decoration")
         line-height #(generic-attribute-actions #{:line-height} "Line Height" (assoc % :on-update-shape dwta/update-line-height))
         border-radius (partial all-or-separate-actions {:attribute-labels {:r1 "Top Left"
                                                                            :r2 "Top Right"
@@ -284,6 +285,7 @@
                   (when (seq line-height) line-height))))
      :stroke-width stroke-width
      :font-size font-size
+     :text-decoration text-decoration
      :dimensions (fn [context-data]
                    (-> (concat
                         (when (seq (sizing-attribute-actions context-data)) [{:title "Sizing" :submenu :sizing}])

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/modals.cljs
@@ -191,3 +191,9 @@
    ::mf/register-as :tokens/letter-spacing}
   [properties]
   [:& token-update-create-modal properties])
+
+(mf/defc text-decoration-modal
+  {::mf/register modal/components
+   ::mf/register-as :tokens/text-decoration}
+  [properties]
+  [:& token-update-create-modal properties])

--- a/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
@@ -29,6 +29,7 @@
     :boolean "boolean-difference"
     :font-size "text-font-size"
     :letter-spacing "text-letterspacing"
+    :text-decoration "text-underlined"
     :opacity "percentage"
     :number "number"
     :rotation "rotation"

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
@@ -170,7 +170,7 @@
         selected-shapes))
 
 (def token-types-with-status-icon
-  #{:color :border-radius :rotation :sizing :dimensions :opacity :spacing :stroke-width})
+  #{:color :border-radius :rotation :sizing :dimensions :opacity :spacing :stroke-width :text-decoration})
 
 (mf/defc token-pill*
   {::mf/wrap [mf/memo]}

--- a/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
@@ -556,6 +556,40 @@
              (t/is (= (:letter-spacing (:applied-tokens text-1')) (:name token-target')))
              (t/is (= (:letter-spacing style-text-blocks) "2")))))))))
 
+(t/deftest test-apply-text-decoration
+  (t/testing "applies text-decoration token and updates the text transform"
+    (t/async
+      done
+      (let [text-decoration-token {:name "underline-decoration"
+                                   :value "underline"
+                                   :type :text-decoration}
+            file (-> (setup-file-with-tokens)
+                     (update-in [:data :tokens-lib]
+                                #(ctob/add-token-in-set % "Set A" (ctob/make-token text-decoration-token))))
+            store (ths/setup-store file)
+            text-1 (cths/get-shape file :text-1)
+            events [(dwta/apply-token {:shape-ids [(:id text-1)]
+                                       :attributes #{:text-decoration}
+                                       :token (toht/get-token file "underline-decoration")
+                                       :on-update-shape dwta/update-text-decoration})]]
+        (tohs/run-store-async
+         store done events
+         (fn [new-state]
+           (let [file' (ths/get-file-from-state new-state)
+                 token-target' (toht/get-token file' "underline-decoration")
+                 text-1' (cths/get-shape file' :text-1)
+                 style-text-blocks (->> (:content text-1')
+                                        (txt/content->text+styles)
+                                        (remove (fn [[_ text]] (str/empty? (str/trim text))))
+                                        (mapv (fn [[style text]]
+                                                {:styles (merge txt/default-text-attrs style)
+                                                 :text-content text}))
+                                        (first)
+                                        (:styles))]
+             (t/is (some? (:applied-tokens text-1')))
+             (t/is (= (:text-decoration (:applied-tokens text-1')) (:name token-target')))
+             (t/is (= (:text-decoration style-text-blocks) "underline")))))))))
+
 (t/deftest test-toggle-token-none
   (t/testing "should apply token to all selected items, where no item has the token applied"
     (t/async

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7260,6 +7260,15 @@ msgstr "Multiple files"
 msgid "workspace.tokens.export.no-tokens-themes-sets"
 msgstr "There are no tokens, themes or sets to export."
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:602
+msgid "workspace.tokens.text-decoration-value-enter"
+msgstr "Enter text decoration: none | underline | strike-through"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:109
+msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgstr "Invalid token value: only none, underline and strike-through are accepted"
+
+
 #: src/app/main/ui/workspace/tokens/modals/export.cljs:33
 msgid "workspace.tokens.export.preview"
 msgstr "Preview:"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7232,6 +7232,10 @@ msgstr "Múltiples ficheros"
 msgid "workspace.tokens.export.no-tokens-themes-sets"
 msgstr "No existen tokens, temas o sets para exportar."
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:602
+msgid "workspace.tokens.text-decoration-value-enter"
+msgstr "Introduce text decoration: none | underline | strike-through"
+
 #: src/app/main/ui/workspace/tokens/modals/export.cljs:33
 msgid "workspace.tokens.export.preview"
 msgstr "Previsualizar:"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/113

### Summary

Adds text-decoration token type

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
