### PR TITLE
:bug: Fix error when there exists a tokens lib with no sets

### DIFF
--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -529,6 +529,14 @@ test.describe("Tokens: Sets Tab", () => {
     await changeSetInput(sidebar, setName, (finalKey = "Enter"));
   };
 
+  const assertEmptySetsList = async (el) => {
+    const buttons = await el.getByRole("button").allTextContents();
+    const filteredButtons = buttons.filter(
+      (text) => text === "Create one.",
+    );
+    await expect(filteredButtons.length).toEqual(2); // We assume there are no themes, so we have two "Create one" buttons.
+  };
+
   const assertSetsList = async (el, sets) => {
     const buttons = await el.getByRole("button").allTextContents();
     const filteredButtons = buttons.filter(
@@ -623,6 +631,15 @@ test.describe("Tokens: Sets Tab", () => {
       "sizes",
       "small",
     ]);
+
+    // User deletes all sets
+    await tokenThemesSetsSidebar
+      .getByRole("button", { name: "core" })
+      .click({ button: "right" });
+    await expect(tokenContextMenuForSet).toBeVisible();
+    await tokenContextMenuForSet.getByText("Delete").click();
+
+    await assertEmptySetsList(tokenThemesSetsSidebar);
   });
 
   test("User can create & edit sets and set groups with an identical name", async ({

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -123,9 +123,9 @@
                      (and selected-token-set-name
                           (not (ctob/get-set tokens-lib selected-token-set-name)))))
         (let [match (->> (ctob/get-sets tokens-lib)
-                         (first)
-                         (ctob/get-name))]
-          (st/emit! (dwtl/set-selected-token-set-name match)))))
+                         (first))]
+          (when match
+            (st/emit! (dwtl/set-selected-token-set-name (ctob/get-name match)))))))
 
     [:*
      [:& token-context-menu]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11533

### Summary

When there exists a tokens library but there is not any set, the UI crashes.

### Steps to reproduce 

a) In an empty file, create a set and then delete it.
b) In an empty file, create a new theme.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
