### PR TITLE
:sparkles: Enable font-size token

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -135,6 +135,8 @@
 
 (def typography-keys (set/union font-size-keys letter-spacing-keys))
 
+(def ff-typography-keys (set/difference typography-keys font-size-keys))
+
 (def ^:private schema:number
   (reduce mu/union [[:map [:line-height {:optional true} token-name-ref]]
                     schema:rotation]))

--- a/frontend/src/app/main/data/workspace/tokens/import_export.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/import_export.cljs
@@ -70,7 +70,7 @@
                                                               (and (not (contains? cf/flags :token-units))
                                                                    (= dtcg-token-type "number"))
                                                               (and (not (contains? cf/flags :token-typography-types))
-                                                                   (contains? ctt/typography-keys dtcg-token-type)))
+                                                                   (contains? ctt/ff-typography-keys dtcg-token-type)))
                                                            nil
                                                            dtcg-token-type))})}
     (catch js/Error e

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -34,7 +34,7 @@
         token-typography-types? (contains? cf/flags :token-typography-types)
         all-types (cond-> dwta/token-properties
                     (not token-units?) (dissoc :number)
-                    (not token-typography-types?) (remove-keys ctt/typography-keys))
+                    (not token-typography-types?) (remove-keys ctt/ff-typography-keys))
         all-types (-> all-types keys seq)]
     (loop [empty  #js []
            filled #js []


### PR DESCRIPTION
### Related Ticket

### Summary

Enables font size token by excluding the keys from the typography-keys flag check

### Steps to reproduce 

1. Create/edit font-size token in sidebar

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
