### PR TITLE
:sparkles: Switch auto-width to auto-height on horizontal resize on text shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - New typography token type - font size token [Taiga #10938](https://tree.taiga.io/project/penpot/us/10938)
 - Hide bounding box while editing visual effects [Taiga #11576](https://tree.taiga.io/project/penpot/issue/11576)
 - Improved text layer resizing: Allow double-click on text bounding box to set auto-width/auto-height [Taiga #11577](https://tree.taiga.io/project/penpot/issue/11577)
+- Improve text layer auto-resize: auto-width switches to auto-height on horizontal resize, and only switches to fixed on vertical resize [Taiga #11578](https://tree.taiga.io/project/penpot/issue/11578)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -847,3 +847,25 @@
           (if undo-transation?
             (rx/of (dwu/commit-undo-transaction undo-id))
             (rx/empty))))))))
+
+;; Pure function to determine next grow-type for text layers
+(defn next-grow-type [current-grow-type resize-direction]
+  (cond
+    (= current-grow-type :fixed)
+    :fixed
+
+    (and (= resize-direction :horizontal)
+         (= current-grow-type :auto-width))
+    :auto-height
+
+    (and (= resize-direction :horizontal)
+         (= current-grow-type :auto-height))
+    :auto-height
+
+    (and (= resize-direction :vertical)
+         (or (= current-grow-type :auto-width)
+             (= current-grow-type :auto-height)))
+    :fixed
+
+    :else
+    current-grow-type))


### PR DESCRIPTION
Improve text layer auto-resize: auto-width switches to auto-height on horizontal resize

### Related Ticket

https://tree.taiga.io/project/penpot/issue/11578

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
