### PR TITLE
:bug: Fix position data not reseting for non-text shapes on update-attrs

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1782,8 +1782,7 @@
                 ;; :geometry-group and :content-group so, if the position-data
                 ;; changes but the geometry is touched we need to reset the position-data
                 ;; so it's calculated again
-                reset-pos-data? (and (cfh/text-shape? origin-shape)
-                                     (= attr :position-data)
+                reset-pos-data? (and (= attr :position-data)
                                      (not= (:position-data origin-shape) (:position-data dest-shape))
                                      (touched :geometry-group))
 


### PR DESCRIPTION
### Related Ticket



### Summary

Fix bug: Position data was only resetting for texts

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
