### PR TITLE
:bug: Enable switch to system theme on options menu

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@
 ### :bug: Bugs fixed
 
 - Fix unexpected exception on processing old texts [Github #6889](https://github.com/penpot/penpot/pull/6889)
+- Fix UI theme selection from main menu [Taiga #11567](https://tree.taiga.io/project/penpot/issue/11567)
 
 ## 2.8.0
 

--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -20,7 +20,6 @@
    [app.plugins.register :as plugins.register]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.storage :as storage]
-   [app.util.theme :as theme]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -159,9 +158,6 @@
       (update-in state [:profile :theme]
                  (fn [current]
                    (let [current (cond
-                                   (= current "system")
-                                   (theme/get-system-theme)
-
                                    ;; NOTE: this is a workaround for
                                    ;; the old data on the database
                                    ;; where whe have `default` value
@@ -172,7 +168,8 @@
                                    current)]
                      (case current
                        "dark"   "light"
-                       "light"  "dark"
+                       "light"  "system"
+                       "system" "dark"
                        ; Failsafe for missing data
                        "dark")))))
 

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -280,8 +280,8 @@
                               :data-testid   "toggle-theme"
                               :id          "file-menu-toggle-theme"}
       [:span {:class (stl/css :item-name)}
-       (case (:theme profile)  ;; default = dark -> light -> system -> dark and so on
-         "default" (tr "workspace.header.menu.toggle-light-theme")
+       (case (:theme profile)  ;; dark -> light -> system -> dark and so on
+         "dark" (tr "workspace.header.menu.toggle-light-theme")
          "light"   (tr "workspace.header.menu.toggle-system-theme")
          "system" (tr "workspace.header.menu.toggle-dark-theme")
          (tr "workspace.header.menu.toggle-light-theme"))]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11567

### Summary

This PR fixes UI theme rotation from the options menu to include the system's theme

### Steps to reproduce 

https://github.com/user-attachments/assets/47ab6ff9-46c6-43b8-92a6-fa2e93e1a67c

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
