### PR TITLE
:bug: Fix last migration of token sets

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1767,7 +1767,14 @@ Will return a value that matches this schema:
            themes        (fres/read-object! r)
            active-themes (fres/read-object! r)
 
-           sets (d/update-vals sets make-token-set)]
+           migrate-sets-node
+           (fn recurse [node]
+             (if (token-set-legacy? node)
+               (make-token-set node)
+               (d/update-vals node recurse)))
+
+           sets
+           (d/update-vals sets migrate-sets-node)]
 
        (->TokensLib sets themes active-themes))))
 


### PR DESCRIPTION
### Summary

Fix a bug introduced in https://github.com/penpot/penpot/pull/6952 when suppressing the intermediate type for migrating TokenSets.
