### PR TITLE
:bug: Fix spacing menu not available in dimensions token

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -467,7 +467,7 @@
 
         is-selected-inside-layout
         (mf/with-memo [token-type selected-shapes objects]
-          (when (= :spacing token-type)
+          (when (contains? #{:spacing :dimensions} token-type)
             (some #(ctsl/any-layout-immediate-child? objects %) selected-shapes)))]
 
     [:ul {:class (stl/css :context-list)}


### PR DESCRIPTION
### Summary

Fixes spacing menu not showing up for the dimensions token for layout children

 
[New File 13 - Penpot.webm](https://github.com/user-attachments/assets/46cceb7c-a330-42ea-973c-8d8a3aa10bc0)


### Steps to reproduce 

1. Apply spacing via dimensions token on a child shape inside a layout
