### PR TITLE
:bug: Fix export button width on inspect tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@
 - Fix font selector highlight inconsistency when using keyboard navigation [Taiga #11668](https://tree.taiga.io/project/penpot/issue/11668)
 - Fix X & Y position do not sincronize with tokens [Taiga #11617](https://tree.taiga.io/project/penpot/issue/11617)
 - Fix tooltip position after first time [Taiga #11688](https://tree.taiga.io/project/penpot/issue/11688)
+- Fix export button width on inspect tab [Taiga #11394](https://tree.taiga.io/project/penpot/issue/11394)
 
 ## 2.8.1 (Unreleased)
 

--- a/frontend/src/app/main/ui/inspect/exports.scss
+++ b/frontend/src/app/main/ui/inspect/exports.scss
@@ -101,5 +101,5 @@
   @extend .button-secondary;
   @include uppercaseTitleTipography;
   height: $s-32;
-  width: $s-252;
+  width: 100%;
 }


### PR DESCRIPTION
### Related Ticket

This PR the comment on [this issue](https://tree.taiga.io/project/penpot/issue/11394)

### Summary

Export button width has no 100% width on inspect tab.

### Steps to reproduce 
1. Create some shapes
2. Add different export options for each shape
3. select all shapes
4. Go to inspect tab
5. check export button at the bottom, 

This button must be 100% width.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
