### PR TITLE
:tada: Add the ability to create variants from a selection

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -530,15 +530,17 @@
           (rx/of (dwl/rename-component-and-main-instance component-id name)))))))
 
 
-(defn- bounding-rect [shapes]
-  (let [xs   (map :x shapes)
-        ys   (map :y shapes)
-        x2s  (map #(+ (:x %) (:width %)) shapes)
-        y2s  (map #(+ (:y %) (:height %)) shapes)
+(defn- bounding-rect [frames]
+  (let [xs   (map :x frames)
+        ys   (map :y frames)
+        x2s  (map #(+ (:x %) (:width %)) frames)
+        y2s  (map #(+ (:y %) (:height %)) frames)
         min-x (apply min xs)
         min-y (apply min ys)
         max-x (apply max x2s)
         max-y (apply max y2s)]
+    "Receives a list of frames (with X, y, width and height)
+     and calculates a rect that contains them all"
     {:x min-x
      :y min-y
      :width (- max-x min-x)

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -530,7 +530,10 @@
           (rx/of (dwl/rename-component-and-main-instance component-id name)))))))
 
 
-(defn- bounding-rect [frames]
+(defn- bounding-rect
+  "Receives a list of frames (with X, y, width and height) and
+  calculates a rect that contains them all"
+  [frames]
   (let [xs   (map :x frames)
         ys   (map :y frames)
         x2s  (map #(+ (:x %) (:width %)) frames)
@@ -539,14 +542,13 @@
         min-y (apply min ys)
         max-x (apply max x2s)
         max-y (apply max y2s)]
-    "Receives a list of frames (with X, y, width and height)
-     and calculates a rect that contains them all"
     {:x min-x
      :y min-y
      :width (- max-x min-x)
      :height (- max-y min-y)}))
 
-(defn common-prefix [paths]
+(defn- common-prefix
+  [paths]
   (->> (apply map vector paths)
        (take-while #(apply = %))
        (map first)

--- a/frontend/src/app/main/ui/components/context_menu_a11y.cljs
+++ b/frontend/src/app/main/ui/components/context_menu_a11y.cljs
@@ -42,6 +42,8 @@
                [:map
                 [:name :string]
                 [:id :string]
+                [:title {:optional true} [:maybe :string]]
+                [:disabled {:optional true} [:maybe :boolean]]
                 [:handler {:optional true} fn?]
                 [:options {:optional true}
                  [:sequential [:ref ::option]]]]
@@ -258,7 +260,9 @@
              (let [name        (:name option)
                    id          (:id option)
                    sub-options (:options option)
-                   handler     (:handler option)]
+                   handler     (:handler option)
+                   title       (:title option)
+                   disabled    (:disabled option)]
                (when name
                  (if (= name :separator)
                    [:li {:key (dm/str "context-item-" index)
@@ -273,10 +277,12 @@
                          :role "menuitem"
                          :on-key-down dom/prevent-default}
                     (if-not sub-options
-                      [:a {:class (stl/css :context-menu-action)
+                      [:a {:class (stl/css-case :context-menu-action true :context-menu-action-disabled disabled)
+                           :title title
                            :on-click #(do (dom/stop-propagation %)
-                                          (on-close %)
-                                          (handler %))
+                                          (when-not disabled
+                                            (on-close %)
+                                            (handler %)))
                            :data-testid id}
                        (if (and in-dashboard? (= name "Default"))
                          (tr "dashboard.default-team-name")

--- a/frontend/src/app/main/ui/components/context_menu_a11y.scss
+++ b/frontend/src/app/main/ui/components/context_menu_a11y.scss
@@ -105,6 +105,11 @@
         }
       }
 
+      .context-menu-action-disabled,
+      &:hover .context-menu-action-disabled {
+        color: var(--color-foreground-secondary);
+      }
+
       &:focus {
         outline: none;
       }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -778,6 +778,9 @@
         copies          (filter ctk/in-component-copy? shapes)
         can-swap?       (boolean (seq copies))
 
+        all-main?       (every? ctk/main-instance? shapes)
+        any-variant?    (some ctk/is-variant? shapes)
+
         ;; For when it's only one shape
         shape           (first shapes)
         id              (:id shape)
@@ -790,6 +793,7 @@
         data            (dm/get-in libraries [(:component-file shape) :data])
         variants?       (features/use-feature "variants/v1")
         is-variant?     (when variants? (ctk/is-variant? component))
+
         main-instance?  (ctk/main-instance? shape)
 
         components      (mapv #(ctf/resolve-component %
@@ -829,6 +833,9 @@
            (let [search-id "swap-component-search-filter"]
              (when can-swap? (st/emit! (dwsp/open-specialized-panel :component-swap)))
              (tm/schedule-on-idle #(dom/focus! (dom/get-element search-id))))))
+
+        on-combine-as-variants
+        #(st/emit! (dwv/combine-as-variants))
 
         ;; NOTE: function needed for force rerender from the bottom
         ;; components. This is because `component-annotation`
@@ -936,6 +943,11 @@
             [:> component-variant-main-instance* {:components components
                                                   :shapes shapes
                                                   :data data}])
+
+          (when (and multi all-main? (not any-variant?))
+            [:button {:class (stl/css :combine-variant-button)
+                      :on-click on-combine-as-variants}
+             [:span (tr "workspace.shape.menu.combine-as-variants")]])
 
           (when (dbg/enabled? :display-touched)
             [:div ":touched " (str (:touched shape))])])])))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -808,3 +808,22 @@
   right: $s-2;
   top: $s-2;
 }
+
+.combine-variant-button {
+  @include buttonStyle;
+  @include uppercaseTitleTipography;
+  cursor: default;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: $s-8;
+  border-radius: $br-8;
+  background-color: var(--assets-item-background-color);
+  color: var(--color-foreground-secondary);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--assets-item-background-color-hover);
+    color: var(--color-foreground-primary);
+  }
+}

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -933,7 +933,7 @@
 
                  :else
                  (let [child-id (obj/get child "$id")]
-                   (st/emit! (dw/relocate-shapes #{child-id} id 0))))))
+                   (st/emit! (dwsh/relocate-shapes #{child-id} id 0))))))
 
            :insertChild
            (fn [index child]
@@ -953,7 +953,7 @@
 
                  :else
                  (let [child-id (obj/get child "$id")]
-                   (st/emit! (dw/relocate-shapes #{child-id} id index))))))
+                   (st/emit! (dwsh/relocate-shapes #{child-id} id index))))))
 
            ;; Only for frames
            :addFlexLayout

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6872,6 +6872,13 @@ msgstr "Create annotation"
 msgid "workspace.shape.menu.create-artboard-from-selection"
 msgstr "Selection to board"
 
+#: src/app/main/ui/workspace/context_menu.cljs:385
+msgid "workspace.shape.menu.combine-as-variants"
+msgstr "Combine as variants"
+
+msgid "workspace.shape.menu.combine-as-variants-error"
+msgstr "Components need to be in the same page"
+
 #: src/app/main/ui/workspace/context_menu.cljs:573
 msgid "workspace.shape.menu.create-component"
 msgstr "Create component"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6850,6 +6850,13 @@ msgstr "Crear una nota"
 msgid "workspace.shape.menu.create-artboard-from-selection"
 msgstr "Tablero de selección"
 
+#: src/app/main/ui/workspace/context_menu.cljs:385
+msgid "workspace.shape.menu.combine-as-variants"
+msgstr "Combinar como variantes"
+
+msgid "workspace.shape.menu.combine-as-variants-error"
+msgstr "Los componentes tienen que estar en la misma página"
+
 #: src/app/main/ui/workspace/context_menu.cljs:573
 msgid "workspace.shape.menu.create-component"
 msgstr "Crear componente"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/7926

### Summary

Create variants in bulk

### Steps to reproduce 

1. Create two components
2. Select both of them
3. On the contextual menu, you should see an entry "create variants in bulk". Select it.
4. Both components should combine into a variant

On Taiga there are several test cases about their names and properties

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
