### PR TITLE
:sparkles: Compact fill serialization (opacity + flags)

### DIFF
--- a/common/src/app/common/buffer.cljc
+++ b/common/src/app/common/buffer.cljc
@@ -21,6 +21,13 @@
     (let [target (with-meta target {:tag 'java.nio.ByteBuffer})]
       `(long (.get ~target ~offset)))))
 
+(defmacro read-unsigned-byte
+  [target offset]
+  (if (:ns &env)
+    `(.getUint8 ~target ~offset true)
+    (let [target (with-meta target {:tag 'java.nio.ByteBuffer})]
+      `(bit-and (long (.get ~target ~offset)) 0xff))))
+
 (defmacro read-bool
   [target offset]
   (if (:ns &env)

--- a/render-wasm/src/wasm/fills/gradient.rs
+++ b/render-wasm/src/wasm/fills/gradient.rs
@@ -10,7 +10,8 @@ pub struct RawGradientData {
     start_y: f32,
     end_x: f32,
     end_y: f32,
-    opacity: f32,
+    opacity: u8,
+    // 24-bit padding here, reserved for future use
     width: f32,
     stop_count: u8,
     stops: [RawStopData; MAX_GRADIENT_STOPS],
@@ -55,7 +56,7 @@ impl From<RawGradientData> for Gradient {
         Gradient::new(
             raw_gradient.start(),
             raw_gradient.end(),
-            (raw_gradient.opacity * 255.) as u8,
+            raw_gradient.opacity,
             raw_gradient.width,
             &stops,
         )

--- a/render-wasm/src/wasm/fills/image.rs
+++ b/render-wasm/src/wasm/fills/image.rs
@@ -12,7 +12,7 @@ pub struct RawImageFillData {
     d: u32,
     opacity: u8,
     flags: u8,
-    _padding: u16, // reserved for future use
+    // 16-bit padding here, reserved for future use
     width: i32,
     height: i32,
 }

--- a/render-wasm/src/wasm/fills/image.rs
+++ b/render-wasm/src/wasm/fills/image.rs
@@ -1,5 +1,7 @@
 use crate::{shapes::ImageFill, utils::uuid_from_u32_quartet};
 
+const FLAG_KEEP_ASPECT_RATIO: u8 = 1 << 0;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 #[repr(align(4))]
@@ -8,23 +10,24 @@ pub struct RawImageFillData {
     b: u32,
     c: u32,
     d: u32,
-    opacity: f32,
+    opacity: u8,
+    flags: u8,
+    _padding: u16, // reserved for future use
     width: i32,
     height: i32,
-    keep_aspect_ratio: i32,
 }
 
 impl From<RawImageFillData> for ImageFill {
     fn from(value: RawImageFillData) -> Self {
         let id = uuid_from_u32_quartet(value.a, value.b, value.c, value.d);
-        let opacity = (value.opacity * 255.).floor() as u8;
+        let keep_aspect_ratio = value.flags & FLAG_KEEP_ASPECT_RATIO != 0;
 
         Self::new(
             id,
-            opacity,
+            value.opacity,
             value.width,
             value.height,
-            value.keep_aspect_ratio != 0,
+            keep_aspect_ratio,
         )
     }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11678

### Summary

This PR makes `opacity` take only 1 byte in gradient and image fills. This way, we can store flags (like `keep_aspect_ratio`) in the resulting free space rather than use another 32-bit value.

<img width="915" height="473" alt="Screenshot 2025-08-04 at 2 14 15 PM" src="https://github.com/user-attachments/assets/b8e92b16-c9be-4bd1-a18f-ff0b422b2e99" />

### Steps to reproduce 

Load a file with shapes with different types of fills and tweak the opacity value in them. Everything should work as normal.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable~~.
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
