### PR TITLE
:bug: Fix add space between the name and the index of new properties

### DIFF
--- a/common/src/app/common/test_helpers/variants.cljc
+++ b/common/src/app/common/test_helpers/variants.cljc
@@ -22,9 +22,9 @@
         (ths/add-sample-shape root2-label :type :frame :parent-label variant-label :variant-id variant-id :variant-name "Value2")
         (ths/add-sample-shape root1-label :type :frame :parent-label variant-label :variant-id variant-id :variant-name "Value1")
         (thc/make-component component1-label root1-label)
-        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "Value1"}]})
+        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value1"}]})
         (thc/make-component component2-label root2-label)
-        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "Value2"}]}))))
+        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value2"}]}))))
 
 (defn add-variant-two-properties
   [file variant-label component1-label root1-label component2-label root2-label
@@ -36,9 +36,9 @@
         (ths/add-sample-shape root2-label :type :frame :parent-label variant-label :variant-id variant-id :variant-name "p1v2, p2v2")
         (ths/add-sample-shape root1-label :type :frame :parent-label variant-label :variant-id variant-id :variant-name "p1v1, p2v1")
         (thc/make-component component1-label root1-label)
-        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "p1v1"} {:name "Property2" :value "p2v1"}]})
+        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "p1v1"} {:name "Property 2" :value "p2v1"}]})
         (thc/make-component component2-label root2-label)
-        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "p1v2"} {:name "Property2" :value "p2v2"}]}))))
+        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "p1v2"} {:name "Property 2" :value "p2v2"}]}))))
 
 (defn add-variant-with-child
   [file variant-label component1-label root1-label component2-label root2-label child1-label child2-label
@@ -51,9 +51,9 @@
         (ths/add-sample-shape child1-label (assoc child1-params :parent-label root1-label))
         (ths/add-sample-shape child2-label (assoc child2-params :parent-label root2-label))
         (thc/make-component component1-label root1-label)
-        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "Value1"}]})
+        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value1"}]})
         (thc/make-component component2-label root2-label)
-        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "Value2"}]}))))
+        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value2"}]}))))
 
 
 (defn add-variant-with-text
@@ -81,6 +81,6 @@
                               (merge text2
                                      text2-params))
         (thc/make-component component1-label root1-label)
-        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "Value1"}]})
+        (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value1"}]})
         (thc/make-component component2-label root2-label)
-        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property1" :value "Value2"}]}))))
+        (thc/update-component component2-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value2"}]}))))

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -52,7 +52,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def property-prefix "Property")
+(def property-prefix "Property ")
 (def property-regex (re-pattern (str property-prefix "(\\d+)")))
 (def property-max-length 60)
 (def value-prefix "Value ")

--- a/common/test/common_tests/logic/variants_test.cljc
+++ b/common/test/common_tests/logic/variants_test.cljc
@@ -204,7 +204,7 @@
     (t/is (= (count (:variant-properties comp01')) 1))
     (t/is (= (count (:variant-properties comp02)) 2))
     (t/is (= (count (:variant-properties comp02')) 1))
-    (t/is (= (-> comp01' :variant-properties first :name) "Property2"))))
+    (t/is (= (-> comp01' :variant-properties first :name) "Property 2"))))
 
 (t/deftest test-update-property-value
   (let [;; ==== Setup

--- a/frontend/playwright/ui/specs/variants.spec.js
+++ b/frontend/playwright/ui/specs/variants.spec.js
@@ -107,7 +107,7 @@ test("User creates a variant", async ({ page }) => {
 
   // The design tab shows the variant properties
   await expect(
-    workspacePage.page.getByTitle("Property1: Value 1, Value 2"),
+    workspacePage.page.getByTitle("Property 1: Value 1, Value 2"),
   ).toBeVisible();
 });
 


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11770](https://tree.taiga.io/project/penpot/task/11770)

### Summary

When adding a new property, the name should be “Property X” instead of “PropertyX”, just like in values.