### PR TITLE
:bug: Fix double click on set name input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@
 - Add the ability to show login dialog on profile settings [Github #6871](https://github.com/penpot/penpot/pull/6871)
 - Improve the application of tokens with object specific tokens [Taiga #10209](https://tree.taiga.io/project/penpot/us/10209)
 - Add info to apply-token event [Taiga #11710](https://tree.taiga.io/project/penpot/task/11710)
+- Fix double click on set name input [Taiga #11747](https://tree.taiga.io/project/penpot/issue/11747)
+
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -59,7 +59,7 @@
       :type "text"
       :on-blur on-submit
       :on-key-down on-key-down
-      :maxlength "256"
+      :max-length "256"
       :auto-focus true
       :placeholder (tr "workspace.tokens.set-edit-placeholder")
       :default-value default-value}]))
@@ -210,7 +210,7 @@
 
 (mf/defc sets-tree-set*
   [{:keys [id set label tree-depth tree-path tree-index is-selected is-active is-draggable is-editing
-           on-select on-drop on-toggle on-start-edition on-reset-edition on-edit-submit]}]
+           on-select on-drop on-toggle on-start-edition on-reset-edition on-edit-submit is-new]}]
 
   (let [set-name  (ctob/get-name set)
         can-edit? (mf/use-ctx ctx/can-edit?)
@@ -239,7 +239,11 @@
                          :path tree-path})))))
 
         on-double-click
-        (mf/use-fn (mf/deps id) #(on-start-edition id))
+        (mf/use-fn
+         (mf/deps id is-new)
+         (fn []
+           (when-not is-new
+             (on-start-edition id))))
 
         on-checkbox-click
         (mf/use-fn
@@ -392,7 +396,7 @@
           :is-editing true
           :is-active true
           :is-selected true
-
+          :is-new true
           :tree-path path
           :tree-depth depth
           :tree-index index
@@ -416,6 +420,7 @@
           :tree-path path
           :tree-depth depth
           :tree-index index
+          :is-new false
           :tree-parent-path parent-path
           :on-toggle on-toggle-set
           :edition-id edition-id


### PR DESCRIPTION
### Related Ticket

[Taiga 11747](https://tree.taiga.io/project/penpot/issue/11747)

### Summary
Double click on set name input while editing crash the app.
### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
