### PR TITLE
:bug: Don't allow letter-spacing value with %

### DIFF
--- a/frontend/src/app/main/data/style_dictionary.cljs
+++ b/frontend/src/app/main/data/style_dictionary.cljs
@@ -133,7 +133,6 @@
 
           :else {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value value)]})))
 
-
 (defn- parse-sd-token-stroke-width-value
   "Parses `value` of a dimensions `sd-token` into a map like `{:value 1 :unit \"px\"}`.
   If the `value` is not parseable and/or has missing references returns a map with `:errors`.
@@ -157,6 +156,15 @@
       (assoc parsed-value :warnings [(wtw/warning-with-value :warning.style-dictionary/invalid-referenced-token-value-stroke-width value)])
 
       :else {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value value)]})))
+
+(defn- parse-sd-token-letter-spacing-value
+  "Parses `value` of a text-case `sd-token` into a map like `{:value \"1\"}`.
+  If the `value` is not parseable and/or has missing references returns a map with `:errors`."
+  [value]
+  (let [parsed-value (parse-sd-token-general-value value)]
+    (if (= (:unit parsed-value) "%")
+      {:errors [(wte/error-with-value :error.style-dictionary/value-with-percent value)]}
+      parsed-value)))
 
 (defn- parse-sd-token-text-case-value
   "Parses `value` of a text-case `sd-token` into a map like `{:value \"uppercase\"}`.
@@ -253,6 +261,7 @@
                                 :opacity (parse-sd-token-opacity-value value has-references?)
                                 :stroke-width (parse-sd-token-stroke-width-value value has-references?)
                                 :text-case (parse-sd-token-text-case-value value)
+                                :letter-spacing (parse-sd-token-letter-spacing-value value)
                                 :text-decoration (parse-sd-token-text-decoration-value value)
                                 :font-weight (parse-sd-token-font-weight-value value)
                                 :number (parse-sd-token-number-value value)

--- a/frontend/src/app/main/data/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/errors.cljs
@@ -64,6 +64,10 @@
    {:error/code :error.style-dictionary/value-with-units
     :error/fn #(str (tr "workspace.tokens.value-with-units"))}
 
+   :error.style-dictionary/value-with-percent
+   {:error/code :error.style-dictionary/value-with-percent
+    :error/fn #(str (tr "workspace.tokens.value-with-percent"))}
+
    :error.style-dictionary/invalid-token-value-opacity
    {:error/code :error.style-dictionary/invalid-token-value-opacity
     :error/fn #(str/join "\n" [(str (tr "workspace.tokens.invalid-value" %) ".") (tr "workspace.tokens.opacity-range")])}

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7622,6 +7622,10 @@ msgstr "Right click to see options"
 msgid "workspace.tokens.value-with-units"
 msgstr "Invalid value: Units are not allowed."
 
+#: src/app/main/data/workspace/tokens/errors.cljs:61
+msgid "workspace.tokens.value-with-percent"
+msgstr "Invalid value: % is not allowed."
+
 #: src/app/main/ui/workspace/tokens/form.cljs:555
 msgid "workspace.tokens.warning-name-change"
 msgstr "Renaming this token will break any reference to its old name."


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/126

### Summary

- Disallows `%` suffix for letter-spacing token

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
