### PR TITLE
:recycle: Sanitize heap write and read operations

### DIFF
--- a/common/src/app/common/buffer.cljc
+++ b/common/src/app/common/buffer.cljc
@@ -127,6 +127,18 @@
          (finally
            (.order ~target ByteOrder/LITTLE_ENDIAN))))))
 
+(defn wrap
+  [data]
+  #?(:clj (let [buffer (ByteBuffer/wrap ^bytes data)]
+            (.order buffer ByteOrder/LITTLE_ENDIAN))
+     :cljs
+     (cond
+       (instance? js/Uint8Array data)
+       (new js/DataView (.-buffer ^js data))
+
+       :else
+       (throw (js/Error. "unexpected type")))))
+
 (defn allocate
   [size]
   #?(:clj (let [buffer (ByteBuffer/allocate (int size))]

--- a/common/src/app/common/buffer.cljc
+++ b/common/src/app/common/buffer.cljc
@@ -129,15 +129,9 @@
 
 (defn wrap
   [data]
-  #?(:clj (let [buffer (ByteBuffer/wrap ^bytes data)]
-            (.order buffer ByteOrder/LITTLE_ENDIAN))
-     :cljs
-     (cond
-       (instance? js/Uint8Array data)
-       (new js/DataView (.-buffer ^js data))
-
-       :else
-       (throw (js/Error. "unexpected type")))))
+  #?(:clj  (let [buffer (ByteBuffer/wrap ^bytes data)]
+             (.order buffer ByteOrder/LITTLE_ENDIAN))
+     :cljs (new js/DataView (.-buffer ^js data))))
 
 (defn allocate
   [size]

--- a/common/src/app/common/types/path/impl.cljc
+++ b/common/src/app/common/types/path/impl.cljc
@@ -29,6 +29,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (def ^:const SEGMENT-U8-SIZE 28)
+(def ^:const SEGMENT-U32-SIZE (/ SEGMENT-U8-SIZE 4))
 
 (defprotocol IPathData
   (-write-to [_ buffer offset] "write the content to the specified buffer")

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -530,25 +530,24 @@
                   nil)))))))
    modif-tree))
 
+
+(def ^:private xf:parse-geometry-modifier
+  (let [default-transform (gmt/matrix)]
+    (keep (fn [[id data]]
+            (cond
+              (= id uuid/zero)
+              nil
+
+              (ctm/has-geometry? (:modifiers data))
+              (d/vec2 id (ctm/modifiers->transform (:modifiers data)))
+
+              ;; Unit matrix is used for reflowing
+              :else
+              (d/vec2 id default-transform))))))
+
 (defn- parse-geometry-modifiers
   [modif-tree]
-  (into
-   []
-   (keep
-    (fn [[id data]]
-      (cond
-        (= id uuid/zero)
-        nil
-
-        (ctm/has-geometry? (:modifiers data))
-        {:id id
-         :transform (ctm/modifiers->transform (:modifiers data))}
-
-        ;; Unit matrix is used for reflowing
-        :else
-        {:id id
-         :transform (gmt/matrix)})))
-   modif-tree))
+  (into [] xf:parse-geometry-modifier modif-tree))
 
 (defn- extract-property-changes
   [modif-tree]
@@ -573,6 +572,8 @@
     (update [_ state]
       (assoc state :workspace-wasm-modifiers modifiers))))
 
+(def ^:private xf:map-key (map key))
+
 #_:clj-kondo/ignore
 (defn set-wasm-modifiers
   [modif-tree & {:keys [ignore-constraints ignore-snap-pixel]
@@ -591,16 +592,17 @@
     (watch [_ state _]
       (wasm.api/clean-modifiers)
       (let [prev-wasm-props (:prev-wasm-props state)
-            wasm-props (:wasm-props state)
-            objects (dsh/lookup-page-objects state)
+            wasm-props      (:wasm-props state)
+            objects         (dsh/lookup-page-objects state)
             pixel-precision false]
         (set-wasm-props! objects prev-wasm-props wasm-props)
         (let [structure-entries (parse-structure-modifiers modif-tree)]
           (wasm.api/set-structure-modifiers structure-entries)
           (let [geometry-entries (parse-geometry-modifiers modif-tree)
-                modifiers (wasm.api/propagate-modifiers geometry-entries pixel-precision)]
+                modifiers        (wasm.api/propagate-modifiers geometry-entries pixel-precision)]
             (wasm.api/set-modifiers modifiers)
-            (let [selrect (wasm.api/get-selection-rect (->> geometry-entries (map :id)))]
+            (let [ids     (into [] xf:map-key geometry-entries)
+                  selrect (wasm.api/get-selection-rect ids)]
               (rx/of (set-temporary-selrect selrect)
                      (set-temporary-modifiers modifiers)))))))))
 
@@ -649,16 +651,14 @@
                 ;; way we don't have to check all the attributes
                 (assoc :attrs transform-attrs))
 
-            geometry-entries (parse-geometry-modifiers modif-tree)
+            geometry-entries
+            (parse-geometry-modifiers modif-tree)
 
             snap-pixel?
             (and (not ignore-snap-pixel) (contains? (:workspace-layout state) :snap-pixel-grid))
 
             transforms
-            (into
-             {}
-             (map (fn [{:keys [id transform]}] [id transform]))
-             (wasm.api/propagate-modifiers geometry-entries snap-pixel?))
+            (into {} (wasm.api/propagate-modifiers geometry-entries snap-pixel?))
 
             modif-tree
             (propagate-structure-modifiers modif-tree (dsh/lookup-page-objects state))
@@ -709,10 +709,9 @@
                  (gm/set-objects-modifiers objects))
 
              modifiers
-             (->> modif-tree
-                  (map (fn [[id {:keys [modifiers]}]]
-                         {:id id
-                          :transform (ctm/modifiers->transform modifiers)})))]
+             (mapv (fn [[id {:keys [modifiers]}]]
+                     (d/vec2 id (ctm/modifiers->transform modifiers)))
+                   modif-tree)]
 
          (wasm.api/set-modifiers modifiers))))))
 

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -390,11 +390,11 @@
         row-gap    (get gap :row-gap 0)
         column-gap (get gap :column-gap 0)
 
-        align-items     (-> (get shape :layout-align-items :start) sr/translate-layout-align-items)
-        align-content   (-> (get shape :layout-align-content :stretch) sr/translate-layout-align-content)
-        justify-items   (-> (get shape :layout-justify-items :start) sr/translate-layout-justify-items)
-        justify-content (-> (get shape :layout-justify-content :stretch) sr/translate-layout-justify-content)
-        wrap-type       (-> (get shape :layout-wrap-type :nowrap) sr/translate-layout-wrap-type)
+        align-items     (-> (get shape :layout-align-items) sr/translate-layout-align-items)
+        align-content   (-> (get shape :layout-align-content) sr/translate-layout-align-content)
+        justify-items   (-> (get shape :layout-justify-items) sr/translate-layout-justify-items)
+        justify-content (-> (get shape :layout-justify-content) sr/translate-layout-justify-content)
+        wrap-type       (-> (get shape :layout-wrap-type) sr/translate-layout-wrap-type)
 
         padding         (get shape :layout-padding)
         padding-top     (get padding :p1 0)
@@ -425,10 +425,10 @@
         row-gap    (get gap :row-gap 0)
         column-gap (get gap :column-gap 0)
 
-        align-items     (-> (get shape :layout-align-items :start) sr/translate-layout-align-items)
-        align-content   (-> (get shape :layout-align-content :stretch) sr/translate-layout-align-content)
-        justify-items   (-> (get shape :layout-justify-items :start) sr/translate-layout-justify-items)
-        justify-content (-> (get shape :layout-justify-content :stretch) sr/translate-layout-justify-content)
+        align-items     (-> (get shape :layout-align-items) sr/translate-layout-align-items)
+        align-content   (-> (get shape :layout-align-content) sr/translate-layout-align-content)
+        justify-items   (-> (get shape :layout-justify-items) sr/translate-layout-justify-items)
+        justify-content (-> (get shape :layout-justify-content) sr/translate-layout-justify-content)
 
         padding         (get shape :layout-padding)
         padding-top     (get padding :p1 0)

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -383,22 +383,24 @@
 
 (defn set-flex-layout
   [shape]
-  (let [dir (-> (or (dm/get-prop shape :layout-flex-dir) :row) sr/translate-layout-flex-dir)
-        gap (dm/get-prop shape :layout-gap)
-        row-gap (or (dm/get-prop gap :row-gap) 0)
-        column-gap (or (dm/get-prop gap :column-gap) 0)
+  (let [dir        (-> (get shape :layout-flex-dir :row)
+                       (sr/translate-layout-flex-dir))
+        gap        (get shape :layout-gap)
+        row-gap    (get gap :row-gap 0)
+        column-gap (get gap :column-gap 0)
 
-        align-items (-> (or (dm/get-prop shape :layout-align-items) :start) sr/translate-layout-align-items)
-        align-content (-> (or (dm/get-prop shape :layout-align-content) :stretch) sr/translate-layout-align-content)
-        justify-items (-> (or (dm/get-prop shape :layout-justify-items) :start) sr/translate-layout-justify-items)
-        justify-content (-> (or (dm/get-prop shape :layout-justify-content) :stretch) sr/translate-layout-justify-content)
-        wrap-type (-> (or (dm/get-prop shape :layout-wrap-type) :nowrap) sr/translate-layout-wrap-type)
+        align-items     (-> (get shape :layout-align-items :start) sr/translate-layout-align-items)
+        align-content   (-> (get shape :layout-align-content :stretch) sr/translate-layout-align-content)
+        justify-items   (-> (get shape :layout-justify-items :start) sr/translate-layout-justify-items)
+        justify-content (-> (get shape :layout-justify-content :stretch) sr/translate-layout-justify-content)
+        wrap-type       (-> (get shape :layout-wrap-type :nowrap) sr/translate-layout-wrap-type)
 
-        padding (dm/get-prop shape :layout-padding)
-        padding-top (or (dm/get-prop padding :p1) 0)
-        padding-right (or (dm/get-prop padding :p2) 0)
-        padding-bottom (or (dm/get-prop padding :p3) 0)
-        padding-left (or (dm/get-prop padding :p4) 0)]
+        padding         (get shape :layout-padding)
+        padding-top     (get padding :p1 0)
+        padding-right   (get padding :p2 0)
+        padding-bottom  (get padding :p3 0)
+        padding-left    (get padding :p4 0)]
+
     (h/call wasm/internal-module
             "_set_flex_layout_data"
             dir

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -489,7 +489,7 @@
 (defn set-grid-layout-cells
   [cells]
   (let [entries (vals cells)
-        size    (mem/get-alloc-size entries GRID-LAYOUT-CELL-U8-SIZE)
+        size    (mem/get-alloc-size cells GRID-LAYOUT-CELL-U8-SIZE)
         offset  (mem/alloc size)
         heap    (-> (mem/get-heap-u8)
                     (mem/view offset size))]

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -418,21 +418,22 @@
 
 (defn set-grid-layout-data
   [shape]
-  (let [dir (-> (or (dm/get-prop shape :layout-grid-dir) :row) sr/translate-layout-grid-dir)
-        gap (dm/get-prop shape :layout-gap)
-        row-gap (or (dm/get-prop gap :row-gap) 0)
-        column-gap (or (dm/get-prop gap :column-gap) 0)
+  (let [dir        (-> (get shape :layout-grid-dir :row)
+                       (sr/translate-layout-grid-dir))
+        gap        (get shape :layout-gap)
+        row-gap    (get gap :row-gap 0)
+        column-gap (get gap :column-gap 0)
 
-        align-items (-> (or (dm/get-prop shape :layout-align-items) :start) sr/translate-layout-align-items)
-        align-content (-> (or (dm/get-prop shape :layout-align-content) :stretch) sr/translate-layout-align-content)
-        justify-items (-> (or (dm/get-prop shape :layout-justify-items) :start) sr/translate-layout-justify-items)
-        justify-content (-> (or (dm/get-prop shape :layout-justify-content) :stretch) sr/translate-layout-justify-content)
+        align-items     (-> (get shape :layout-align-items :start) sr/translate-layout-align-items)
+        align-content   (-> (get shape :layout-align-content :stretch) sr/translate-layout-align-content)
+        justify-items   (-> (get shape :layout-justify-items :start) sr/translate-layout-justify-items)
+        justify-content (-> (get shape :layout-justify-content :stretch) sr/translate-layout-justify-content)
 
-        padding (dm/get-prop shape :layout-padding)
-        padding-top (or (dm/get-prop padding :p1) 0)
-        padding-right (or (dm/get-prop padding :p2) 0)
-        padding-bottom (or (dm/get-prop padding :p3) 0)
-        padding-left (or (dm/get-prop padding :p4) 0)]
+        padding         (get shape :layout-padding)
+        padding-top     (get padding :p1 0)
+        padding-right   (get padding :p2 0)
+        padding-bottom  (get padding :p3 0)
+        padding-left    (get padding :p4 0)]
 
     (h/call wasm/internal-module
             "_set_grid_layout_data"

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -369,12 +369,17 @@
     (h/call wasm/internal-module "_set_shape_blur" type hidden value)))
 
 (defn set-shape-corners
-  [corners]
-  (let [r1 (or (get corners 0) 0)
-        r2 (or (get corners 1) 0)
-        r3 (or (get corners 2) 0)
-        r4 (or (get corners 3) 0)]
-    (h/call wasm/internal-module "_set_shape_corners" r1 r2 r3 r4)))
+  [shape]
+  (let [r1 (dm/get-prop shape :r1)]
+    (when (some? r1)
+      (let [r2 (dm/get-prop shape :r2)
+            r3 (dm/get-prop shape :r3)
+            r4 (dm/get-prop shape :r4)]
+        (h/call wasm/internal-module "_set_shape_corners"
+                (d/nilv r1 0)
+                (d/nilv r2 0)
+                (d/nilv r3 0)
+                (d/nilv r4 0))))))
 
 (defn set-flex-layout
   [shape]
@@ -685,11 +690,6 @@
         bool-type    (dm/get-prop shape :bool-type)
         grow-type    (dm/get-prop shape :grow-type)
         blur         (dm/get-prop shape :blur)
-        corners      (when (some? (dm/get-prop shape :r1))
-                       [(dm/get-prop shape :r1)
-                        (dm/get-prop shape :r2)
-                        (dm/get-prop shape :r3)
-                        (dm/get-prop shape :r4)])
         svg-attrs    (dm/get-prop shape :svg-attrs)
         shadows      (dm/get-prop shape :shadow)]
 
@@ -705,6 +705,7 @@
     (set-shape-opacity opacity)
     (set-shape-hidden hidden)
     (set-shape-children children)
+    (set-shape-corners shape)
     (when (and (= type :group) masked)
       (set-masked masked))
     (when (some? blur)
@@ -719,7 +720,6 @@
       (set-shape-path-content content))
     (when (and (some? content) (= type :svg-raw))
       (set-shape-svg-raw-content (get-static-markup shape)))
-    (when (some? corners) (set-shape-corners corners))
     (when (some? shadows) (set-shape-shadows shadows))
     (when (= type :text)
       (set-shape-grow-type grow-type))

--- a/frontend/src/app/render_wasm/deserializers.cljs
+++ b/frontend/src/app/render_wasm/deserializers.cljs
@@ -5,25 +5,44 @@
 ;; Copyright (c) KALEIDOS INC
 (ns app.render-wasm.deserializers
   (:require
+   [app.common.data :as d]
    [app.common.geom.matrix :as gmt]
+   [app.common.geom.point :as gpt]
    [app.common.uuid :as uuid]))
 
-(defn heap32->entry
+(defn read-modifier-entry
   [heapu32 heapf32 offset]
   (let [id1 (aget heapu32 (+ offset 0))
         id2 (aget heapu32 (+ offset 1))
         id3 (aget heapu32 (+ offset 2))
         id4 (aget heapu32 (+ offset 3))
 
-        a (aget heapf32 (+ offset 4))
-        b (aget heapf32 (+ offset 5))
-        c (aget heapf32 (+ offset 6))
-        d (aget heapf32 (+ offset 7))
-        e (aget heapf32 (+ offset 8))
-        f (aget heapf32 (+ offset 9))
+        a   (aget heapf32 (+ offset 4))
+        b   (aget heapf32 (+ offset 5))
+        c   (aget heapf32 (+ offset 6))
+        d   (aget heapf32 (+ offset 7))
+        e   (aget heapf32 (+ offset 8))
+        f   (aget heapf32 (+ offset 9))]
 
-        id (uuid/from-unsigned-parts id1 id2 id3 id4)]
+    (d/vec2 (uuid/from-unsigned-parts id1 id2 id3 id4)
+            (gmt/matrix a b c d e f))))
 
-    {:id id
+
+(defn read-selection-rect
+  [heapf32 offset]
+  (let [width  (aget heapf32 (+ offset 0))
+        height (aget heapf32 (+ offset 1))
+        cx     (aget heapf32 (+ offset 2))
+        cy     (aget heapf32 (+ offset 3))
+        a      (aget heapf32 (+ offset 4))
+        b      (aget heapf32 (+ offset 5))
+        c      (aget heapf32 (+ offset 6))
+        d      (aget heapf32 (+ offset 7))
+        e      (aget heapf32 (+ offset 8))
+        f      (aget heapf32 (+ offset 9))]
+    {:width width
+     :height height
+     :center (gpt/point cx cy)
      :transform (gmt/matrix a b c d e f)}))
+
 

--- a/frontend/src/app/render_wasm/mem.cljs
+++ b/frontend/src/app/render_wasm/mem.cljs
@@ -15,10 +15,12 @@
   ;; Divides the value by 4
   (bit-shift-right value 2))
 
-(defn get-list-size
-  "Returns the size of a list in bytes"
-  [list list-item-size]
-  (* list-item-size (count list)))
+(defn get-alloc-size
+  "Calculate allocation size for a sequential collection of identical
+  objects of the specified size."
+  [coll item-size]
+  (assert (counted? coll) "`coll` should be constant time countable")
+  (* item-size (count coll)))
 
 (defn alloc
   "Allocates an arbitrary amount of bytes (aligned to 4 bytes).
@@ -61,5 +63,11 @@
 (defn slice
   "Returns a copy of a portion of a typed array into a new typed array
   object selected from start to end."
-  [heap start end]
-  (.slice ^js heap start end))
+  [heap offset size]
+  (.slice ^js heap offset (+ offset size)))
+
+(defn view
+  "Returns a new typed array on the same ArrayBuffer store and with the
+  same element types as for this typed array."
+  [heap offset size]
+  (.subarray ^js heap offset (+ offset size)))

--- a/frontend/src/app/render_wasm/mem.cljs
+++ b/frontend/src/app/render_wasm/mem.cljs
@@ -6,6 +6,7 @@
 
 (ns app.render-wasm.mem
   (:require
+   [app.common.buffer :as buf]
    [app.render-wasm.helpers :as h]
    [app.render-wasm.wasm :as wasm]))
 
@@ -71,3 +72,18 @@
   same element types as for this typed array."
   [heap offset size]
   (.subarray ^js heap offset (+ offset size)))
+
+(defn get-data-view
+  "Returns a heap wrapped in a DataView for surgical write operations"
+  []
+  (buf/wrap (get-heap-u8)))
+
+(defn write-u8
+  "Write unsigned int8. Expects a DataView instance"
+  [target offset value]
+  (buf/write-byte target offset value))
+
+(defn write-f32
+  "Write float32. Expects a DataView instance"
+  [target offset value]
+  (buf/write-float target offset value))

--- a/frontend/src/app/render_wasm/mem/heap32.cljs
+++ b/frontend/src/app/render_wasm/mem/heap32.cljs
@@ -1,0 +1,51 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.render-wasm.mem.heap32
+  "A memory write helpers that uses 32 bits addressed offsets."
+  (:require
+   [app.common.data.macros :as dm]
+   [app.common.uuid :as uuid]))
+
+(defn write-u32
+  [offset heap value]
+  (assert (instance? js/Uint32Array heap) "expected Uint32Array instance for `heap`")
+  (aset heap offset value)
+  (inc offset))
+
+(defn write-f32
+  [offset heap value]
+  (assert (instance? js/Float32Array heap) "expected Float32Array instance for `heap`")
+  (aset heap offset value)
+  (inc offset))
+
+(defn write-uuid
+  "Write a uuid to 32 bits addressed heap and return the offset
+  after write."
+  [offset heap id]
+  (assert (instance? js/Uint32Array heap) "expected Uint32Array instance for `heap`")
+  (let [buffer (uuid/get-u32 id)]
+    (.set heap buffer offset)
+    (+ offset 4)))
+
+(defn write-matrix
+  "Write a matrix to 32 bits addressed heap and return the offset
+  after write."
+  [offset heap matrix]
+  (assert (instance? js/Float32Array heap) "expected Float32Array instance for `heap`")
+  (let [a (dm/get-prop matrix :a)
+        b (dm/get-prop matrix :b)
+        c (dm/get-prop matrix :c)
+        d (dm/get-prop matrix :d)
+        e (dm/get-prop matrix :e)
+        f (dm/get-prop matrix :f)]
+    (aset heap (+ offset 0) a)
+    (aset heap (+ offset 1) b)
+    (aset heap (+ offset 2) c)
+    (aset heap (+ offset 3) d)
+    (aset heap (+ offset 4) e)
+    (aset heap (+ offset 5) f)
+    (+ offset 6)))

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -6,7 +6,6 @@
 
 (ns app.render-wasm.serializers
   (:require
-   [app.common.data.macros :as dm]
    [app.common.uuid :as uuid]
    [cuerdas.core :as str]))
 

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -55,18 +55,32 @@
     (catch :default _e
       [uuid/zero])))
 
-(defn heapu32-set-u32
-  [value heap offset]
-  (aset heap offset value))
+(defn write-u32
+  [offset heap value]
+  (assert (instance? js/Uint32Array heap) "expected Uint32Array instance for `heap`")
+  (aset heap offset value)
+  (inc offset))
 
-(defn heapu32-set-uuid
-  [id heap offset]
+(defn write-f32
+  [offset heap value]
+  (assert (instance? js/Float32Array heap) "expected Float32Array instance for `heap`")
+  (aset heap offset value)
+  (inc offset))
+
+(defn write-uuid
+  "Write a uuid to 32 bits addressed heap and return the offset
+  after write."
+  [offset heap id]
+  (assert (instance? js/Uint32Array heap) "expected Uint32Array instance for `heap`")
   (let [buffer (uuid/get-u32 id)]
     (.set heap buffer offset)
-    buffer))
+    (+ offset 4)))
 
-(defn heapf32-set-matrix
-  [matrix heap offset]
+(defn write-matrix
+  "Write a matrix to 32 bits addressed heap and return the offset
+  after write."
+  [offset heap matrix]
+  (assert (instance? js/Float32Array heap) "expected Float32Array instance for `heap`")
   (let [a (dm/get-prop matrix :a)
         b (dm/get-prop matrix :b)
         c (dm/get-prop matrix :c)
@@ -78,7 +92,8 @@
     (aset heap (+ offset 2) c)
     (aset heap (+ offset 3) d)
     (aset heap (+ offset 4) e)
-    (aset heap (+ offset 5) f)))
+    (aset heap (+ offset 5) f)
+    (+ offset 6)))
 
 (defn translate-shape-type
   [type]

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -212,7 +212,8 @@
     :start   0
     :end     1
     :center  2
-    :stretch 3))
+    :stretch 3
+    0))
 
 (defn translate-layout-align-content
   [align-content]
@@ -223,7 +224,8 @@
     :space-between 3
     :space-around  4
     :space-evenly  5
-    :stretch       6))
+    :stretch       6
+    6))
 
 (defn translate-layout-justify-items
   [justify-items]
@@ -231,7 +233,8 @@
     :start   0
     :end     1
     :center  2
-    :stretch 3))
+    :stretch 3
+    0))
 
 (defn translate-layout-justify-content
   [justify-content]
@@ -242,13 +245,15 @@
     :space-between 3
     :space-around  4
     :space-evenly  5
-    :stretch       6))
+    :stretch       6
+    6))
 
 (defn translate-layout-wrap-type
   [wrap-type]
   (case wrap-type
     :wrap   0
-    :nowrap 1))
+    :nowrap 1
+    1))
 
 (defn translate-grid-track-type
   [type]

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -55,46 +55,6 @@
     (catch :default _e
       [uuid/zero])))
 
-(defn write-u32
-  [offset heap value]
-  (assert (instance? js/Uint32Array heap) "expected Uint32Array instance for `heap`")
-  (aset heap offset value)
-  (inc offset))
-
-(defn write-f32
-  [offset heap value]
-  (assert (instance? js/Float32Array heap) "expected Float32Array instance for `heap`")
-  (aset heap offset value)
-  (inc offset))
-
-(defn write-uuid
-  "Write a uuid to 32 bits addressed heap and return the offset
-  after write."
-  [offset heap id]
-  (assert (instance? js/Uint32Array heap) "expected Uint32Array instance for `heap`")
-  (let [buffer (uuid/get-u32 id)]
-    (.set heap buffer offset)
-    (+ offset 4)))
-
-(defn write-matrix
-  "Write a matrix to 32 bits addressed heap and return the offset
-  after write."
-  [offset heap matrix]
-  (assert (instance? js/Float32Array heap) "expected Float32Array instance for `heap`")
-  (let [a (dm/get-prop matrix :a)
-        b (dm/get-prop matrix :b)
-        c (dm/get-prop matrix :c)
-        d (dm/get-prop matrix :d)
-        e (dm/get-prop matrix :e)
-        f (dm/get-prop matrix :f)]
-    (aset heap (+ offset 0) a)
-    (aset heap (+ offset 1) b)
-    (aset heap (+ offset 2) c)
-    (aset heap (+ offset 3) d)
-    (aset heap (+ offset 4) e)
-    (aset heap (+ offset 5) f)
-    (+ offset 6)))
-
 (defn translate-shape-type
   [type]
   (case type

--- a/render-wasm/src/shapes/layouts.rs
+++ b/render-wasm/src/shapes/layouts.rs
@@ -385,6 +385,7 @@ impl GridData {
     }
 }
 
+// FIXME: use transmute
 #[derive(Debug)]
 #[repr(C)]
 pub struct RawGridTrack {


### PR DESCRIPTION
Mainly improves the offset management making it less error prone, encapsulating the write operation and offset management into write-* operations with proper asserts for the expected heap type.
