### PR TITLE
:bug: Fix variants nesting loops

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -436,6 +436,24 @@
         parent-components   (into #{} xf-get-component-id parents)]
     (seq (set/intersection child-components parent-components))))
 
+(defn variants-nesting-loop?
+  "Check if a variants nesting loop would be created if the given shape is moved below the given parent"
+  [objects libraries shape-id parent-id]
+  (let [get-variant-id #(or (:variant-id %)
+                            (when (:is-variant-container %) (:id %))
+                            (when (:component-id %)
+                              (dm/get-in libraries [(:component-file %)
+                                                    :data
+                                                    :components
+                                                    (:component-id %)
+                                                    :variant-id])))
+        child-variant-ids  (into #{} (keep get-variant-id)
+                                 (get-children-with-self objects shape-id))
+        parent-variant-ids (into #{} (keep get-variant-id)
+                                 (get-parents-with-self objects parent-id))]
+    (seq (set/intersection child-variant-ids parent-variant-ids))))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ALGORITHMS & TRANSFORMATIONS FOR SHAPES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -456,7 +456,11 @@
         parent-in-component?    (in-any-component? objects parent)
         comps-nesting-loop?     (not (->> children
                                           (map #(cfh/components-nesting-loop? objects (:id %) (:id parent)))
-                                          (every? nil?)))]
+                                          (every? nil?)))
+
+        variants-nesting-loop? (not (->> children
+                                         (map #(cfh/variants-nesting-loop? objects libraries (:id %) (:id parent)))
+                                         (every? nil?)))]
     (or
       ;;We don't want to change the structure of component copies
      (ctk/in-component-copy? parent)
@@ -465,7 +469,8 @@
      (and selected-main-instance? parent-in-component?)
       ;; Avoid placing a shape as a direct or indirect child of itself,
       ;; or inside its main component if it's in a copy.
-     comps-nesting-loop?)))
+     comps-nesting-loop?
+     variants-nesting-loop?)))
 
 (defn find-valid-parent-and-frame-ids
   "Navigate trough the ancestors until find one that is valid. Returns [ parent-id frame-id ]"

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -636,16 +636,17 @@
      ptk/WatchEvent
      (watch [_ state stream]
        (let [prev-cell-data (volatile! nil)
-             page-id (:current-page-id state)
-             objects (dsh/lookup-page-objects state page-id)
-             selected (dsh/lookup-selected state {:omit-blocked? true})
-             ids     (if (nil? ids) selected ids)
-             shapes  (into []
-                           (comp (map (d/getf objects))
-                                 (remove #(let [parent (get objects (:parent-id %))]
-                                            (and (ctk/in-component-copy? parent)
-                                                 (ctl/any-layout? parent)))))
-                           ids)
+             page-id   (:current-page-id state)
+             libraries (dsh/lookup-libraries state)
+             objects   (dsh/lookup-page-objects state page-id)
+             selected  (dsh/lookup-selected state {:omit-blocked? true})
+             ids       (if (nil? ids) selected ids)
+             shapes    (into []
+                             (comp (map (d/getf objects))
+                                   (remove #(let [parent (get objects (:parent-id %))]
+                                              (and (ctk/in-component-copy? parent)
+                                                   (ctl/any-layout? parent)))))
+                             ids)
 
              duplicate-move-started? (get-in state [:workspace-local :duplicate-move-started?] false)
 
@@ -696,7 +697,7 @@
                          (let [position         (gpt/add from-position move-vector)
                                exclude-frames   (if mod? exclude-frames exclude-frames-siblings)
                                target-frame     (ctst/top-nested-frame objects position exclude-frames)
-                               [target-frame _] (ctn/find-valid-parent-and-frame-ids target-frame objects shapes)
+                               [target-frame _] (ctn/find-valid-parent-and-frame-ids target-frame objects shapes false libraries)
                                flex-layout?     (ctl/flex-layout? objects target-frame)
                                grid-layout?     (ctl/grid-layout? objects target-frame)
                                drop-index       (when flex-layout? (gslf/get-drop-index target-frame objects position))

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -200,6 +200,9 @@
         read-only?        (mf/use-ctx ctx/workspace-read-only?)
         parent-board?     (and (cfh/frame-shape? item)
                                (= uuid/zero (:parent-id item)))
+
+        files             (mf/deref refs/files)
+
         toggle-collapse
         (mf/use-fn
          (mf/deps expanded?)
@@ -280,7 +283,7 @@
 
         on-drop
         (mf/use-fn
-         (mf/deps id index objects expanded? selected)
+         (mf/deps id index objects expanded? selected files)
          (fn [side _data]
            (let [single? (= (count selected) 1)
                  same?   (and single? (= (first selected) id))]
@@ -298,7 +301,7 @@
                        :else
                        (cfh/get-parent-id objects id))
 
-                     [parent-id _] (ctn/find-valid-parent-and-frame-ids parent-id objects (map #(get objects %) selected))
+                     [parent-id _] (ctn/find-valid-parent-and-frame-ids parent-id objects (map #(get objects %) selected) false files)
 
                      parent    (get objects parent-id)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -201,8 +201,6 @@
         parent-board?     (and (cfh/frame-shape? item)
                                (= uuid/zero (:parent-id item)))
 
-        files             (mf/deref refs/files)
-
         toggle-collapse
         (mf/use-fn
          (mf/deps expanded?)
@@ -283,12 +281,13 @@
 
         on-drop
         (mf/use-fn
-         (mf/deps id index objects expanded? selected files)
+         (mf/deps id index objects expanded? selected)
          (fn [side _data]
            (let [single? (= (count selected) 1)
                  same?   (and single? (= (first selected) id))]
              (when-not same?
-               (let [shape (get objects id)
+               (let [files (deref refs/files)
+                     shape (get objects id)
 
                      parent-id
                      (cond


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11734

### Summary

Fix error allowing cycles on variants

### Steps to reproduce 

1. Create a component with two variants
2. Place a copy of VariantA inside of variantB

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
