### PR TITLE
:bug: Fix menu entry not showing on assets tab

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -172,6 +172,20 @@
           [:span {:class (stl/css-case :variant-mark-cell listing-thumbs? :variant-mark true :component-icon true)
                   :title (tr "workspace.assets.components.num-variants" num-variants)} i/variant])])]))
 
+
+(defn- count-leaves
+  "Counts the total number of leaf elements in a nested map structure.
+     A leaf element is considered any element inside a vector."
+  [m]
+  (reduce
+   (fn [acc v]
+     (cond
+       (map? v) (+ acc (count-leaves v))
+       (vector? v) (+ acc (count v))
+       :else acc))
+   0
+   (vals m)))
+
 (mf/defc components-group
   {::mf/wrap-props false}
   [{:keys [file-id prefix groups open-groups force-open? renaming listing-thumbs? selected on-asset-click
@@ -193,7 +207,7 @@
 
         components     (not-empty (get groups "" []))
         can-combine?   (and is-local
-                            (> (count components) 1)
+                            (> (count-leaves groups) 1)
                             (not-any? ctc/is-variant? components)
                             (apply = (map :main-instance-page components)))
         on-drag-enter

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -177,14 +177,13 @@
   "Counts the total number of leaf elements in a nested map structure.
      A leaf element is considered any element inside a vector."
   [m]
-  (reduce
-   (fn [acc v]
-     (cond
-       (map? v) (+ acc (count-leaves v))
-       (vector? v) (+ acc (count v))
-       :else acc))
-   0
-   (vals m)))
+  (reduce-kv (fn [acc _ v]
+               (cond
+                 (map? v) (+ acc (count-leaves v))
+                 (vector? v) (+ acc (count v))
+                 :else acc))
+             0
+             m))
 
 (mf/defc components-group
   {::mf/wrap-props false}
@@ -206,10 +205,11 @@
                                selected-full))
 
         components     (not-empty (get groups "" []))
-        can-combine?   (and is-local
-                            (> (count-leaves groups) 1)
-                            (not-any? ctc/is-variant? components)
-                            (apply = (map :main-instance-page components)))
+        can-combine?   (mf/with-memo [is-local groups components]
+                         (and is-local
+                              (> (count-leaves groups) 1)
+                              (not-any? ctc/is-variant? components)
+                              (apply = (map :main-instance-page components))))
         on-drag-enter
         (mf/use-fn
          (mf/deps dragging* prefix selected-paths is-local drag-data*)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11769

### Summary

Menu entry 'Combine as variants' missing when there is only one component that is a direct child of the group

### Steps to reproduce 
1. Create a component named "a/one"
2. Create a component named "a/b/two"
3. On assets tab, on the contextual menu of the group "a" you should see the entry 'Combine as variants' 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
