### PR TITLE
:bug: Fix weird resizing on combine variants with constraints scale

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -605,6 +605,10 @@
                    (dwu/start-undo-transaction undo-id)
                    (transform-in-variant (first selected) variant-id delta prefix add-wrapper? false false)
                    (dwsh/relocate-shapes (into #{} (-> selected rest reverse)) variant-id 0)
+                   (dwsh/update-shapes selected #(-> %
+                                                     (assoc :constraints-h :left)
+                                                     (assoc :constraints-v :top)
+                                                     (assoc :fixed-scroll false)))
                    (dwt/update-dimensions [variant-id] :width (+ (:width rect) 60))
                    (dwt/update-dimensions [variant-id] :height (+ (:height rect) 60))
                    (dwsh/relocate-shapes #{variant-id} common-parent index)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11837

### Summary

If a component had a constraint-h or constraint-v of "scale", when combining it with other component to create a variant it resized weirdly

### Steps to reproduce 
1. Create a board
2. Create two components inside the board
3. Set the constraints of the components to "scale"
4. Select both components and combine them into a variant

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
