### PR TITLE
:bug: Fix use ellipsis when property names are too long

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -438,8 +438,10 @@
       (for [[pos prop] (map vector (range) properties)]
         [:div {:key (str (:id shape) pos) :class (stl/css :variant-property-container)}
          [:*
-          [:span {:class (stl/css :variant-property-name)}
-           (:name prop)]
+          [:div {:class (stl/css :variant-property-name-wrapper-copy)
+                 :title (:name prop)}
+           [:span {:class (stl/css :variant-property-name)}
+            (:name prop)]]
           [:> select* {:default-selected (:value prop)
                        :options (get-options (:name prop))
                        :empty-to-end true

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -746,24 +746,26 @@
   padding-right: var(--sp-xxs);
 }
 
-.variant-property-name {
-  color: var(--color-foreground-primary);
-  height: var(--sp-xxxl);
-  width: $s-104;
-
+.variant-property-name-wrapper-copy {
   display: flex;
   align-items: center;
   justify-content: center;
 
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  height: var(--sp-xxxl);
+  width: $s-104;
 }
 
 .variant-property-name-wrapper {
   display: flex;
   flex: 0 0 auto;
   width: $s-104;
+}
+
+.variant-property-name {
+  color: var(--color-foreground-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .variant-warning-wrapper {


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11743](https://tree.taiga.io/project/penpot/issue/11743)

### Summary

When the copy of a variant is selected:

- Show a tooltip that contains the whole text of the property name when hovering over it.
- Truncate the text with an ellipsis at the end if the text is too long.

### Steps to reproduce

Select a copy of a variant and take a look at the property names when they are too long.