### PR TITLE
:bug: Fix several inconsistencies and duplicated shortcuts

### DIFF
--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -213,12 +213,12 @@
                           :fn #(emit-when-no-readonly (dw/vertical-order-selected :bottom))}
 
    :move-fast-up         {:tooltip (ds/shift ds/up-arrow)
-                          :command ["shift+up" "shift+alt+up" "alt+shift+up"]
+                          :command ["shift+up"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :up true))}
 
    :move-fast-down       {:tooltip (ds/shift ds/down-arrow)
-                          :command ["shift+down" "shift+alt+down" "alt+shift+down"]
+                          :command ["shift+down"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :down true))}
 
@@ -233,12 +233,12 @@
                           :fn #(emit-when-no-readonly (dwt/move-selected :left true))}
 
    :move-unit-up         {:tooltip ds/up-arrow
-                          :command ["up" "alt+up"]
+                          :command ["up"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :up false))}
 
    :move-unit-down       {:tooltip ds/down-arrow
-                          :command ["down" "alt+down"]
+                          :command ["down"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :down false))}
 

--- a/frontend/src/app/main/data/workspace/text/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/text/shortcuts.cljs
@@ -206,17 +206,13 @@
                          (filter cfh/text-shape?)
                          (not-empty))
 
-        ;; Check if we're actually editing text content (not just selecting text shapes)
-        ;; Handle both text-editor/v1 and text-editor/v2
-        editing-text? (if (features/active-feature? @st/state "text-editor/v2")
-                        (some? (deref refs/workspace-v2-editor-state))
-                        (some? (deref refs/workspace-editor)))
-
         props       (if (> (count text-shapes) 1)
                       (blend-props text-shapes props)
                       props)]
 
-    (when (and can-edit? (not read-only?) text-shapes editing-text?)
+    (when (and can-edit?
+               (not read-only?)
+               (some? text-shapes))
       (st/emit! (dwu/start-undo-transaction undo-id))
       (run! #(update-attrs % props) text-shapes)
       (st/emit! (dwu/commit-undo-transaction undo-id)))))


### PR DESCRIPTION
### Summary

This PR fixes several inconsistencies on text shortcuts what enter in conflict with general shortcuts.
It also revers a previous change (regression) that makes impossible to use text shortcuts outside of the editor.
