### PR TITLE
:bug: Fix you can add a rect into a variant container

### DIFF
--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -389,12 +389,13 @@
      [(remap-ids new-shape)
       (map remap-ids new-shapes)])))
 
-(defn get-first-not-copy-parent
-  "Go trough the parents until we find a shape that is not a copy of a component."
+(defn get-first-valid-parent
+  "Go trough the parents until we find a shape that is not a copy of a component nor
+   a variant container."
   [objects id]
   (let [shape (get objects id)]
-    (if (ctk/in-component-copy? shape)
-      (get-first-not-copy-parent objects (:parent-id shape))
+    (if (or (ctk/in-component-copy? shape) (ctk/is-variant-container? shape))
+      (get-first-valid-parent objects (:parent-id shape))
       shape)))
 
 (defn has-any-copy-parent?

--- a/frontend/src/app/main/data/workspace/drawing/box.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/box.cljs
@@ -91,7 +91,7 @@
             focus        (:workspace-focus-selected state)
 
             fid          (->> (ctst/top-nested-frame objects initial)
-                              (ctn/get-first-not-copy-parent objects) ;; We don't want to change the structure of component copies
+                              (ctn/get-first-valid-parent objects) ;; We don't want to change the structure of component copies
                               :id)
 
             flex-layout? (ctl/flex-layout? objects fid)

--- a/frontend/src/app/main/data/workspace/drawing/curve.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/curve.cljs
@@ -36,7 +36,7 @@
             position     (path.segment/get-handler-point content 0 nil)
 
             frame-id     (->> (ctst/top-nested-frame objects position)
-                              (ctn/get-first-not-copy-parent objects) ;; We don't want to change the structure of component copies
+                              (ctn/get-first-valid-parent objects) ;; We don't want to change the structure of component copies
                               :id)
 
             flex-layout? (ctl/flex-layout? objects frame-id)

--- a/frontend/src/app/main/data/workspace/path/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/path/drawing.cljs
@@ -286,7 +286,7 @@
                              (gpt/point))
 
             frame-id     (->> (ctst/top-nested-frame objects position)
-                              (ctn/get-first-not-copy-parent objects) ;; We don't want to change the structure of component copies
+                              (ctn/get-first-valid-parent objects) ;; We don't want to change the structure of component copies
                               :id)
             flex-layout? (ctl/flex-layout? objects frame-id)
             drop-index   (when flex-layout? (gsl/get-drop-index frame-id objects position))]

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -232,8 +232,8 @@
                         (:parent-id base))
 
             ;; If the parent-id or the frame-id are component-copies, we need to get the first not copy parent
-            parent-id (:id (ctn/get-first-not-copy-parent objects parent-id))   ;; We don't want to change the structure of component copies
-            frame-id  (:id (ctn/get-first-not-copy-parent objects frame-id))
+            parent-id (:id (ctn/get-first-valid-parent objects parent-id))   ;; We don't want to change the structure of component copies
+            frame-id  (:id (ctn/get-first-valid-parent objects frame-id))
 
 
             shape     (cts/setup-shape


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11846

### Summary

You can add a rect to a variant container, getting a crash

### Steps to reproduce 
1. Create a variant
2. Make the variant container bigger
3. Create a rect on the empty space of the variant container


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
