### PR TITLE
:bug: Fix :show-content wasn't on components sync-attrs

### DIFF
--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -99,6 +99,8 @@
    :exports                 :exports-group
    :grids                   :grids-group
 
+   :show-content            :show-content
+
    :layout                  :layout-container
 
    :layout-align-content    :layout-align-content


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11822

### Summary
When I have a variant copy and I change its “Clip content” property, when I switch to another variant, this override is not preserved

### Steps to reproduce 

See Taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
