### PR TITLE
:bug: On variant create do not set sizing

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -380,16 +380,12 @@
                            :layout-item-v-sizing :auto
                            :layout-padding {:p1 30 :p2 30 :p3 30 :p4 30}
                            :layout-gap     {:row-gap 0 :column-gap 20}}
-             cont-props    (if flex?
-                             (into base-props flex-props)
-                             base-props)
-             m-base-props {:name name
+             cont-props   (if flex?
+                            (into base-props flex-props)
+                            base-props)
+             main-props   {:name name
                            :variant-id variant-id}
-             m-flex-props {:layout-item-h-sizing :fix
-                           :layout-item-v-sizing :fix}
-             main-props   (if flex?
-                            (into m-base-props m-flex-props)
-                            m-base-props)
+
              stroke-props {:stroke-alignment :inner
                            :stroke-style :solid
                            :stroke-color "#bb97d8" ;; todo use color var?


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11736

### Summary

When I create a variant it is automatically set up as fixed content

### Steps to reproduce 

1. Create a board with flex layout
2. Set sizing to fit content h and v
3. Make it a component
4. Make it a variant
5. Check its sizings


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
