### PR TITLE
:bug: Fix duplicate a variant when all have bad formulae crashes

### DIFF
--- a/common/src/app/common/logic/variants.cljc
+++ b/common/src/app/common/logic/variants.cljc
@@ -31,9 +31,11 @@
                                  component-id
                                  new-component-id
                                  {:new-shape-id new-shape-id :apply-changes-local-library? true}))]
-    (-> changes
-        (clvp/generate-update-property-value new-component-id prop-num value)
-        (pcb/change-parent (:parent-id shape) [new-shape] 0))))
+    (cond-> changes
+      (>= prop-num 0)
+      (clvp/generate-update-property-value new-component-id prop-num value)
+      :always
+      (pcb/change-parent (:parent-id shape) [new-shape] 0))))
 
 (defn- generate-path
   [path objects base-id shape]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11843

### Summary

Duplicate a variant when all have bad formulae crashes

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
