### PR TITLE
:bug: Fix case-sensitivity and multi word italic in font weight parsing

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -415,14 +415,19 @@
        (reduce (fn [acc [k vs]]
                  (into acc (zipmap vs (repeat k)))) {})))
 
+(defn parse-font-weight [font-weight]
+  (let [[_ variant italic] (->> (str/lower font-weight)
+                                (re-find #"^(.+?)\s*(italic)?$"))]
+    {:variant variant
+     :italic? (some? italic)}))
+
 (defn valid-font-weight-variant
   "Converts font-weight token value to a map like `{:weight \"100\" :style \"italic\"}`.
   Converts a weight alias like `regular` to a number, needs to be a regular number.
   Adds `italic` style when found in the `value` string."
   [value]
-  (let [[weight style] (->> (str/split value #"\s+")
-                            (map str/lower))
-        weight (get font-weight-map weight weight)]
+  (let [{:keys [variant italic?]} (parse-font-weight value)
+        weight (get font-weight-map variant variant)]
     (when (font-weight-values weight)
       (cond-> {:weight weight}
-        (= style "italic") (assoc :style "italic")))))
+        italic? (assoc :style "italic")))))

--- a/common/test/common_tests/token_test.cljc
+++ b/common/test/common_tests/token_test.cljc
@@ -1,0 +1,46 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.token-test
+  (:require
+   [app.common.types.token :as token]
+   [clojure.test :as t]))
+
+(t/deftest valid-font-weight-variant
+  (t/testing "numeric weights"
+    (t/is (= {:weight "400"} (token/valid-font-weight-variant "400")))
+    (t/is (= {:weight "700"} (token/valid-font-weight-variant "700")))
+    (t/is (= {:weight "100"} (token/valid-font-weight-variant "100")))
+    (t/is (= {:weight "900"} (token/valid-font-weight-variant "900"))))
+
+  (t/testing "weight aliases"
+    (t/is (= {:weight "400"} (token/valid-font-weight-variant "normal")))
+    (t/is (= {:weight "400"} (token/valid-font-weight-variant "regular")))
+    (t/is (= {:weight "700"} (token/valid-font-weight-variant "bold")))
+    (t/is (= {:weight "300"} (token/valid-font-weight-variant "light")))
+    (t/is (= {:weight "500"} (token/valid-font-weight-variant "medium")))
+    (t/is (= {:weight "600"} (token/valid-font-weight-variant "semibold")))
+    (t/is (= {:weight "600"} (token/valid-font-weight-variant "semi-bold")))
+    (t/is (= {:weight "800"} (token/valid-font-weight-variant "extrabold")))
+    (t/is (= {:weight "900"} (token/valid-font-weight-variant "black")))
+    (t/is (= {:weight "950"} (token/valid-font-weight-variant "extra black"))))
+
+  (t/testing "italic style"
+    (t/is (= {:weight "400" :style "italic"} (token/valid-font-weight-variant "normal italic")))
+    (t/is (= {:weight "700" :style "italic"} (token/valid-font-weight-variant "bold italic")))
+    (t/is (= {:weight "400" :style "italic"} (token/valid-font-weight-variant "400 italic")))
+    (t/is (= {:weight "950" :style "italic"} (token/valid-font-weight-variant "extra black italic"))))
+
+  (t/testing "case-insensitivity"
+    (t/is (= {:weight "700"} (token/valid-font-weight-variant "BOLD")))
+    (t/is (= {:weight "400"} (token/valid-font-weight-variant "Normal")))
+    (t/is (= {:weight "400" :style "italic"} (token/valid-font-weight-variant "NORMAL ITALIC"))))
+
+  (t/testing "invalid values"
+    (t/is (nil? (token/valid-font-weight-variant "invalid")))
+    (t/is (nil? (token/valid-font-weight-variant "invalid italic")))
+    (t/is (nil? (token/valid-font-weight-variant "999")))
+    (t/is (nil? (token/valid-font-weight-variant "")))))


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/138

### Summary

- Fixes case-sensitivity in font-weight parsing
- Fixes italic not being accepted for multi-word font-weights e.g.: "Extra black italic"

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
