### PR TITLE
:wrench: Add ff for typography composite token

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -120,6 +120,7 @@
     :tiered-file-data-storage
     :token-units
     :token-typography-types
+    :token-typography-composite
     :transit-readable-response
     :user-feedback
     ;; TODO: remove this flag.

--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -84,7 +84,10 @@ const setupTypographyTokensFile = async (page, options = {}) => {
   return setupTokensFile(page, {
     file: "workspace/get-file-typography-tokens.json",
     fileFragment: "workspace/get-file-fragment-typography-tokens.json",
-    flags: ["enable-token-typography-types"],
+    flags: [
+      "enable-token-typography-types",
+      "enable-token-typography-composite",
+    ],
     ...options,
   });
 };

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -32,9 +32,11 @@
   If `:token-units` is not in cf/flags, number tokens are excluded."
   [tokens-by-type]
   (let [token-units? (contains? cf/flags :token-units)
+        token-typography-composite-types? (contains? cf/flags :token-typography-composite)
         token-typography-types? (contains? cf/flags :token-typography-types)
         all-types (cond-> dwta/token-properties
                     (not token-units?) (dissoc :number)
+                    (not token-typography-composite-types?) (remove-keys ctt/typography-token-keys)
                     (not token-typography-types?) (remove-keys ctt/ff-typography-keys))
         all-types (-> all-types keys seq)]
     (loop [empty  #js []


### PR DESCRIPTION
### Related Ticket

### Summary

Adds FF for typography composite token `enable-token-typography-composite`
This one is depending on `enable-token-typography-types`

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
