### PR TITLE
:sparkles: Find closest font weight when switching font family

### DIFF
--- a/common/src/app/common/types/shape/token.cljc
+++ b/common/src/app/common/types/shape/token.cljc
@@ -1,0 +1,7 @@
+(ns app.common.types.shape.token)
+
+(defn font-weight-applied?
+  [shape]
+  (or
+   (get-in shape [:applied-tokens :font-weight])
+   (get-in shape [:applied-tokens :typography :font-weight])))

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -469,7 +469,7 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
                                              {:name final-name
                                               :value (:value valid-token)
                                               :description final-description}))
-                        (dwtp/propagate-workspace-tokens)
+                        (dwtp/propagate-workspace-tokens :interactive? true)
                         (modal/hide)))))))))
 
         on-delete-token

--- a/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
@@ -908,7 +908,7 @@
              (t/is (= (:typography (:applied-tokens text-1')) "typography.heading"))
 
              (t/is (= (:font-size style-text-blocks) "24"))
-             (t/is (= (:font-weight style-text-blocks) "400"))
+             (t/is (= (:font-weight style-text-blocks) "700"))
              (t/is (= (:font-family style-text-blocks) "sourcesanspro"))
              (t/is (= (:letter-spacing style-text-blocks) "2"))
              (t/is (= (:text-transform style-text-blocks) "uppercase"))


### PR DESCRIPTION
### Related Ticket

- https://github.com/tokens-studio/penpot/issues/139

### Summary


https://github.com/user-attachments/assets/d3cb9384-2079-4c44-831c-8347db358bef


- Unapply font-weight token when `font-family` or `font-weight` attributes change
- Show warning when `font-weight` for a `font-family` token can't be found and pick the closest one
- Only show warnings on user actions (editing via form, applying/unapplying via pill)

### Steps to reproduce

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
