### PR TITLE
:lipstick: Slightly reduce the width of the right sidebar

### DIFF
--- a/frontend/src/app/main/constants.cljs
+++ b/frontend/src/app/main/constants.cljs
@@ -15,7 +15,7 @@
 (def grid-x-axis 10)
 (def grid-y-axis 10)
 
-(def sidebar-default-width 318)
+(def sidebar-default-width 308)
 (def sidebar-default-max-width 768)
 
 (def page-metadata


### PR DESCRIPTION
### Related Ticket

No ticket.

### Summary

We have lots of buttons in the right sidebar. There are even rows made only of single icon buttons. These icons have a fixed width (32px) and the space between them is also fixed (4px). Since we have a padding of 12px on both ends, the total width necessary to fit a row of single icon buttons is:

`12 (padding-left) +  32*8 (column) + 7*4 (space) + 12 (padding-right) = 308px = 19.25rem`

So, if we want to keep them aligned vertically with other rows that contain items of various widths, this is the width that the sidebar needs to have. Setting a fixed width of 308px allows us to use flex, push some items to the end of the space, and they will still keep aligned on the right with the rest. And we can also do other simple things like assigning a width of 100% to items which need to occupy an entire row, keeping the correct alignment.

Otherwise we would have to use a fixed width for every component, or use always a grid layout of 8 columns. This is mostly adequate for a matrix of icon buttons, but for other cases  it's clearly overkill (i. e. a single item that needs to spread all along the 8 columns). Of course we can still do this if we want to specify the width of an item in terms of a number of columns, and it will work nicely.

This is why we have reduced the width from 318px to **308px**.

### Steps to reproduce 

Check that all the controls of the right sidebar fit properly and there are no misalignments on the right margin.