### PR TITLE
:recycle: Revert trigger interactive via actionize and propagation

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -469,7 +469,7 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
                                              {:name final-name
                                               :value (:value valid-token)
                                               :description final-description}))
-                        (dwtp/propagate-workspace-tokens :interactive? true)
+                        (dwtp/propagate-workspace-tokens)
                         (modal/hide)))))))))
 
         on-delete-token


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/143

### Summary

Simplifies when the warning is shown.
Font weight warnings will now only be show when applying a token via a token pill click.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
