### PR TITLE
:bug: Unapply layout item tokens when moving out of a layout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@
 - Fix typo [Taiga #11970](https://tree.taiga.io/project/penpot/issue/11970)
 - Fix typos [Taiga #11971](https://tree.taiga.io/project/penpot/issue/11971)
 - Fix inconsistent naming for "Flatten" [Taiga #8371](https://tree.taiga.io/project/penpot/issue/8371)
+- Layout item tokens should be unapplied when moving out of a layout [Taiga #11012](https://tree.taiga.io/project/penpot/issue/11012)
 
 ## 2.9.0
 

--- a/common/src/app/common/logic/shapes.cljc
+++ b/common/src/app/common/logic/shapes.cljc
@@ -405,9 +405,10 @@
                             (remove #(= % parent-id) all-parents))]
 
     (-> changes
-        ;; Remove layout-item properties when moving a shape outside a layout
+        ;; Remove layout-item properties and tokens when moving a shape outside a layout
         (cond-> (not (ctl/any-layout? parent))
-          (pcb/update-shapes ids ctl/remove-layout-item-data))
+          (-> (pcb/update-shapes ids ctl/remove-layout-item-data)
+              (pcb/update-shapes ids cto/unapply-layout-item-tokens)))
 
         ;; Remove the hide in viewer flag
         (cond-> (and (not= uuid/zero parent-id) (cfh/frame-shape? parent))

--- a/common/src/app/common/test_helpers/tokens.cljc
+++ b/common/src/app/common/test_helpers/tokens.cljc
@@ -77,22 +77,25 @@
   [file shape-label token-name token-attrs shape-attrs resolved-value]
   (let [page   (thf/current-page file)
         shape  (ths/get-shape file shape-label)
-        shape' (as-> shape $
-                 (cto/apply-token-to-shape {:shape $
-                                            :token {:name token-name}
-                                            :attributes token-attrs})
-                 (reduce (fn [shape attr]
-                           (case attr
-                             :stroke-width (set-stroke-width shape resolved-value)
-                             :stroke-color (set-stroke-color shape resolved-value)
-                             :fill (set-fill-color shape resolved-value)
-                             (ctn/set-shape-attr shape attr resolved-value {:ignore-touched true})))
-                         $
-                         shape-attrs))]
+        shape' (when shape
+                 (as-> shape $
+                   (cto/apply-token-to-shape {:shape $
+                                              :token {:name token-name}
+                                              :attributes token-attrs})
+                   (reduce (fn [shape attr]
+                             (case attr
+                               :stroke-width (set-stroke-width shape resolved-value)
+                               :stroke-color (set-stroke-color shape resolved-value)
+                               :fill (set-fill-color shape resolved-value)
+                               (ctn/set-shape-attr shape attr resolved-value {:ignore-touched true})))
+                           $
+                           shape-attrs)))]
 
-    (ctf/update-file-data
-     file
-     (fn [file-data]
-       (ctpl/update-page file-data
-                         (:id page)
-                         #(ctst/set-shape % shape'))))))
+    (if shape'
+      (ctf/update-file-data
+       file
+       (fn [file-data]
+         (ctpl/update-page file-data
+                           (:id page)
+                           #(ctst/set-shape % shape'))))
+      file)))

--- a/common/src/app/common/types/shape/layout.cljc
+++ b/common/src/app/common/types/shape/layout.cljc
@@ -14,22 +14,22 @@
    [app.common.schema :as sm]
    [app.common.uuid :as uuid]))
 
-;; :layout                 ;; :flex, :grid in the future
-;; :layout-flex-dir        ;; :row, :row-reverse, :column, :column-reverse
-;; :layout-gap-type        ;; :simple, :multiple
-;; :layout-gap             ;; {:row-gap number , :column-gap number}
+;; :layout                  ;; :flex, :grid in the future
+;; :layout-flex-dir         ;; :row, :row-reverse, :column, :column-reverse
+;; :layout-gap-type         ;; :simple, :multiple
+;; :layout-gap              ;; {:row-gap number , :column-gap number}
 
-;; :layout-align-items     ;; :start :end :center :stretch
-;; :layout-align-content   ;; :start :center :end :space-between :space-around :space-evenly :stretch (by default)
+;; :layout-align-items      ;; :start :end :center :stretch
+;; :layout-align-content    ;; :start :center :end :space-between :space-around :space-evenly :stretch (by default)
 ;; :layout-justify-items    ;; :start :center :end :space-between :space-around :space-evenly
-;; :layout-justify-content ;; :start :center :end :space-between :space-around :space-evenly
-;; :layout-wrap-type       ;; :wrap, :nowrap
-;; :layout-padding-type    ;; :simple, :multiple
-;; :layout-padding         ;; {:p1 num :p2 num :p3 num :p4 num} number could be negative
+;; :layout-justify-content  ;; :start :center :end :space-between :space-around :space-evenly
+;; :layout-wrap-type        ;; :wrap, :nowrap
+;; :layout-padding-type     ;; :simple, :multiple
+;; :layout-padding          ;; {:p1 num :p2 num :p3 num :p4 num} number could be negative
 
-;; layout-grid-rows        ;; vector of grid-track
-;; layout-grid-columns     ;; vector of grid-track
-;; layout-grid-cells       ;; map of id->grid-cell
+;; layout-grid-rows         ;; vector of grid-track
+;; layout-grid-columns      ;; vector of grid-track
+;; layout-grid-cells        ;; map of id->grid-cell
 
 ;; ITEMS
 ;; :layout-item-margin      ;; {:m1 0 :m2 0 :m3 0 :m4 0}

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -83,14 +83,24 @@
 
 (def stroke-width-keys (schema-keys schema:stroke-width))
 
-(def ^:private schema:sizing
-  [:map {:title "SizingTokenAttrs"}
+(def ^:private schema:sizing-base
+  [:map {:title "SizingBaseTokenAttrs"}
    [:width {:optional true} token-name-ref]
-   [:height {:optional true} token-name-ref]
+   [:height {:optional true} token-name-ref]])
+
+(def ^:private schema:sizing-layout-item
+  [:map {:title "SizingLayoutItemTokenAttrs"}
    [:layout-item-min-w {:optional true} token-name-ref]
    [:layout-item-max-w {:optional true} token-name-ref]
    [:layout-item-min-h {:optional true} token-name-ref]
    [:layout-item-max-h {:optional true} token-name-ref]])
+
+(def ^:private schema:sizing
+  (-> (reduce mu/union [schema:sizing-base
+                        schema:sizing-layout-item])
+      (mu/update-properties assoc :title "SizingTokenAttrs")))
+
+(def sizing-layout-item-keys (schema-keys schema:sizing-layout-item))
 
 (def sizing-keys (schema-keys schema:sizing))
 
@@ -377,6 +387,13 @@
 
 (defn unapply-token-id [shape attributes]
   (update shape :applied-tokens d/without-keys attributes))
+
+(defn unapply-layout-item-tokens
+  "Unapplies all layout item related tokens from shape."
+  [shape]
+  (let [layout-item-attrs (set/union sizing-layout-item-keys
+                                     spacing-margin-keys)]
+    (unapply-token-id shape layout-item-attrs)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TYPOGRAPHY

--- a/common/test/common_tests/logic/move_shapes_test.cljc
+++ b/common/test/common_tests/logic/move_shapes_test.cljc
@@ -12,6 +12,8 @@
    [app.common.test-helpers.files :as thf]
    [app.common.test-helpers.ids-map :as thi]
    [app.common.test-helpers.shapes :as ths]
+   [app.common.test-helpers.tokens :as tht]
+   [app.common.types.tokens-lib :as ctob]
    [app.common.uuid :as uuid]
    [clojure.test :as t]))
 
@@ -47,7 +49,6 @@
     (t/is (= (:parent-id frame-to-move) uuid/zero))
     (t/is (= (:parent-id frame-to-move') (:id frame-parent')))))
 
-
 (t/deftest test-relocate-shape-out-of-group
   (let [;; ==== Setup
         file                   (-> (thf/sample-file :file1)
@@ -68,7 +69,6 @@
                                                       0                     ;; to-index
                                                       #{(:id circle)})      ;; ids
 
-
         file'                  (thf/apply-changes file changes)
 
         ;; ==== Get
@@ -82,3 +82,133 @@
     (t/is (= (:parent-id circle') uuid/zero))
     (t/is group)
     (t/is (nil? group'))))
+
+(t/deftest test-relocate-shape-out-of-layout-manual
+  (let [;; ==== Setup
+        file (-> (thf/sample-file :file1)
+                 (tho/add-frame :frame-1
+                                :layout                 :flex     ;; TODO: those values come from main.data.workspace.shape_layout/default-layout-params
+                                :layout-flex-dir        :row      ;;       it should be good to use it directly, but first it should be moved to common.logic
+                                :layout-gap-type        :multiple
+                                :layout-gap             {:row-gap 0 :column-gap 0}
+                                :layout-align-items     :start
+                                :layout-justify-content :start
+                                :layout-align-content   :stretch
+                                :layout-wrap-type       :nowrap
+                                :layout-padding-type    :simple
+                                :layout-padding         {:p1 0 :p2 0 :p3 0 :p4 0})
+                 (ths/add-sample-shape :circle-1 :parent-label :frame-1
+                                       :layout-item-margin      {:m1 10 :m2 10 :m3 10 :m4 10}
+                                       :layout-item-margin-type :multiple
+                                       :layout-item-h-sizing    :auto
+                                       :layout-item-v-sizing    :auto
+                                       :layout-item-max-h       1000
+                                       :layout-item-min-h       100
+                                       :layout-item-max-w       2000
+                                       :layout-item-min-w       200
+                                       :layout-item-absolute    false
+                                       :layout-item-z-index     10))
+
+        page   (thf/current-page file)
+        circle (ths/get-shape file :circle-1)
+
+        ;; ==== Action
+
+        changes (cls/generate-relocate (-> (pcb/empty-changes nil)
+                                           (pcb/with-page-id (:id page))
+                                           (pcb/with-objects (:objects page)))
+                                       uuid/zero             ;; parent-id
+                                       0                     ;; to-index
+                                       #{(:id circle)})      ;; ids
+
+        ;; ==== Get
+        file'   (thf/apply-changes file changes)
+        circle' (ths/get-shape file' :circle-1)]
+
+    ;; ==== Check
+
+    ;; the layout item attributes are removed
+    (t/is (nil? (:layout-item-margin circle')))
+    (t/is (nil? (:layout-item-margin-type circle')))
+    (t/is (nil? (:layout-item-h-sizing circle')))
+    (t/is (nil? (:layout-item-v-sizing circle')))
+    (t/is (nil? (:layout-item-max-h circle')))
+    (t/is (nil? (:layout-item-min-h circle')))
+    (t/is (nil? (:layout-item-max-w circle')))
+    (t/is (nil? (:layout-item-min-w circle')))
+    (t/is (nil? (:layout-item-absolute circle')))
+    (t/is (nil? (:layout-item-z-index circle')))))
+
+(t/deftest test-relocate-shape-out-of-layout-with-tokens
+  (let [;; ==== Setup
+        file (-> (thf/sample-file :file1)
+                 (tht/add-tokens-lib)
+                 (tht/update-tokens-lib #(-> %
+                                             (ctob/add-set (ctob/make-token-set :name "test-token-set"))
+                                             (ctob/add-theme (ctob/make-token-theme :name "test-theme"
+                                                                                    :sets #{"test-token-set"}))
+                                             (ctob/set-active-themes #{"/test-theme"})
+                                             (ctob/add-token-in-set "test-token-set"
+                                                                    (ctob/make-token :id (thi/new-id! :token-sizing)
+                                                                                     :name "token-sizing"
+                                                                                     :type :sizing
+                                                                                     :value 10))
+                                             (ctob/add-token-in-set "test-token-set"
+                                                                    (ctob/make-token :id (thi/new-id! :token-spacing)
+                                                                                     :name "token-spacing"
+                                                                                     :type :spacing
+                                                                                     :value 30))))
+                 (tho/add-frame :frame-1
+                                :layout                 :flex     ;; TODO: those values come from main.data.workspace.shape_layout/default-layout-params
+                                :layout-flex-dir        :row      ;;       it should be good to use it directly, but first it should be moved to common.logic
+                                :layout-gap-type        :multiple
+                                :layout-gap             {:row-gap 0 :column-gap 0}
+                                :layout-align-items     :start
+                                :layout-justify-content :start
+                                :layout-align-content   :stretch
+                                :layout-wrap-type       :nowrap
+                                :layout-padding-type    :simple
+                                :layout-padding         {:p1 0 :p2 0 :p3 0 :p4 0})
+                 (ths/add-sample-shape :circle-1 :parent-label :frame-1)
+                 (tht/apply-token-to-shape :circle-1
+                                           "token-sizing"
+                                           [:layout-item-max-h :layout-item-max-w :layout-item-min-h :layout-item-min-w]
+                                           [:layout-item-max-h :layout-item-max-w :layout-item-min-h :layout-item-min-w]
+                                           10)
+                 (tht/apply-token-to-shape :circle-1
+                                           "token-spacing"
+                                           [:m1 :m2 :m3 :m4]
+                                           [:layout-item-margin]
+                                           {:m1 30 :m2 30 :m3 30 :m4 30}))
+
+        page   (thf/current-page file)
+        circle (ths/get-shape file :circle-1)
+
+        ;; ==== Action
+
+        changes (cls/generate-relocate (-> (pcb/empty-changes nil)
+                                           (pcb/with-page-id (:id page))
+                                           (pcb/with-objects (:objects page)))
+                                       uuid/zero             ;; parent-id
+                                       0                     ;; to-index
+                                       #{(:id circle)})      ;; ids
+
+
+        ;; ==== Get
+        file'   (thf/apply-changes file changes)
+        circle' (ths/get-shape file' :circle-1)]
+
+    ;; ==== Check
+
+    ;; the layout item attributes and tokens are removed
+    (t/is (empty? (:applied-tokens circle')))
+    (t/is (nil? (:layout-item-margin circle')))
+    (t/is (nil? (:layout-item-margin-type circle')))
+    (t/is (nil? (:layout-item-h-sizing circle')))
+    (t/is (nil? (:layout-item-v-sizing circle')))
+    (t/is (nil? (:layout-item-max-h circle')))
+    (t/is (nil? (:layout-item-min-h circle')))
+    (t/is (nil? (:layout-item-max-w circle')))
+    (t/is (nil? (:layout-item-min-w circle')))
+    (t/is (nil? (:layout-item-absolute circle')))
+    (t/is (nil? (:layout-item-z-index circle')))))

--- a/common/test/common_tests/logic/token_apply_test.cljc
+++ b/common/test/common_tests/logic/token_apply_test.cljc
@@ -75,8 +75,29 @@
                                                          (ctob/make-token :id (thi/new-id! :token-font-family)
                                                                           :name "token-font-family"
                                                                           :type :font-family
-                                                                          :value ["Helvetica" "Arial" "sans-serif"]))))
-      (tho/add-frame :frame1)
+                                                                          :value ["Helvetica" "Arial" "sans-serif"]))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :id (thi/new-id! :token-sizing)
+                                                                          :name "token-sizing"
+                                                                          :type :sizing
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :id (thi/new-id! :token-spacing)
+                                                                          :name "token-spacing"
+                                                                          :type :spacing
+                                                                          :value 30))))
+      (tho/add-frame :frame1
+                     :layout                 :flex     ;; TODO: those values come from main.data.workspace.shape_layout/default-layout-params
+                     :layout-flex-dir        :row      ;;       it should be good to use it directly, but first it should be moved to common.logic
+                     :layout-gap-type        :multiple
+                     :layout-gap             {:row-gap 0 :column-gap 0}
+                     :layout-align-items     :start
+                     :layout-justify-content :start
+                     :layout-align-content   :stretch
+                     :layout-wrap-type       :nowrap
+                     :layout-padding-type    :simple
+                     :layout-padding         {:p1 0 :p2 0 :p3 0 :p4 0})
+      (ths/add-sample-shape :circle1 :parent-label :frame-1)
       (tho/add-text :text1 "Hello World!")))
 
 (defn- apply-all-tokens
@@ -91,7 +112,17 @@
       (tht/apply-token-to-shape :frame1 "token-dimensions" [:width :height] [:width :height] 100)
       (tht/apply-token-to-shape :text1 "token-font-size" [:font-size] [:font-size] 24)
       (tht/apply-token-to-shape :text1 "token-letter-spacing" [:letter-spacing] [:letter-spacing] 2)
-      (tht/apply-token-to-shape :text1 "token-font-family" [:font-family] [:font-family] ["Helvetica" "Arial" "sans-serif"])))
+      (tht/apply-token-to-shape :text1 "token-font-family" [:font-family] [:font-family] ["Helvetica" "Arial" "sans-serif"])
+      (tht/apply-token-to-shape :circle1
+                                "token-sizing"
+                                [:layout-item-max-h :layout-item-max-w :layout-item-min-h :layout-item-min-w]
+                                [:layout-item-max-h :layout-item-max-w :layout-item-min-h :layout-item-min-w]
+                                10)
+      (tht/apply-token-to-shape :circle1
+                                "token-spacing"
+                                [:m1 :m2 :m3 :m4]
+                                [:layout-item-margin]
+                                {:m1 30 :m2 30 :m3 30 :m4 30})))
 
 (t/deftest apply-tokens-to-shape
   (let [;; ==== Setup
@@ -99,6 +130,7 @@
         page                 (thf/current-page file)
         frame1               (ths/get-shape file :frame1)
         text1                (ths/get-shape file :text1)
+        circle1              (ths/get-shape file :circle1)
         token-radius         (tht/get-token file "test-token-set" (thi/id :token-radius))
         token-rotation       (tht/get-token file "test-token-set" (thi/id :token-rotation))
         token-opacity        (tht/get-token file "test-token-set" (thi/id :token-opacity))
@@ -108,6 +140,8 @@
         token-font-size      (tht/get-token file "test-token-set" (thi/id :token-font-size))
         token-letter-spacing (tht/get-token file "test-token-set" (thi/id :token-letter-spacing))
         token-font-family    (tht/get-token file "test-token-set" (thi/id :token-font-family))
+        token-sizing         (tht/get-token file "test-token-set" (thi/id :token-sizing))
+        token-spacing        (tht/get-token file "test-token-set" (thi/id :token-spacing))
 
         ;; ==== Action
         changes (-> (-> (pcb/empty-changes nil)
@@ -152,33 +186,57 @@
                                                                                :shape $
                                                                                :attributes [:font-family]})))
                                                 (:objects page)
+                                                {})
+                    (cls/generate-update-shapes [(:id circle1)]
+                                                (fn [shape]
+                                                  (as-> shape $
+                                                    (cto/apply-token-to-shape {:token token-sizing
+                                                                               :shape $
+                                                                               :attributes [:layout-item-max-h :layout-item-max-w :layout-item-min-h :layout-item-min-w]})
+                                                    (cto/apply-token-to-shape {:token token-spacing
+                                                                               :shape $
+                                                                               :attributes [:m1 :m2 :m3 :m4]})))
+                                                (:objects page)
                                                 {}))
 
         file' (thf/apply-changes file changes)
 
         ;; ==== Get
-        frame1'              (ths/get-shape file' :frame1)
-        applied-tokens'      (:applied-tokens frame1')
-        text1'               (ths/get-shape file' :text1)
-        text1-applied-tokens (:applied-tokens text1')]
+        frame1'                  (ths/get-shape file' :frame1)
+        frame1'-applied-tokens   (:applied-tokens frame1')
+        text1'                   (ths/get-shape file' :text1)
+        text1'-applied-tokens    (:applied-tokens text1')
+        circle1'                 (ths/get-shape file' :circle1)
+        circle1'-applied-tokens  (:applied-tokens circle1')]
 
     ;; ==== Check
-    (t/is (= (count applied-tokens') 11))
-    (t/is (= (:r1 applied-tokens') "token-radius"))
-    (t/is (= (:r2 applied-tokens') "token-radius"))
-    (t/is (= (:r3 applied-tokens') "token-radius"))
-    (t/is (= (:r4 applied-tokens') "token-radius"))
-    (t/is (= (:rotation applied-tokens') "token-rotation"))
-    (t/is (= (:opacity applied-tokens') "token-opacity"))
-    (t/is (= (:stroke-width applied-tokens') "token-stroke-width"))
-    (t/is (= (:stroke-color applied-tokens') "token-color"))
-    (t/is (= (:fill applied-tokens') "token-color"))
-    (t/is (= (:width applied-tokens') "token-dimensions"))
-    (t/is (= (:height applied-tokens') "token-dimensions"))
-    (t/is (= (count text1-applied-tokens) 3))
-    (t/is (= (:font-size text1-applied-tokens) "token-font-size"))
-    (t/is (= (:letter-spacing text1-applied-tokens) "token-letter-spacing"))
-    (t/is (= (:font-family text1-applied-tokens) "token-font-family"))))
+    (t/is (= (count frame1'-applied-tokens) 11))
+    (t/is (= (:r1 frame1'-applied-tokens) "token-radius"))
+    (t/is (= (:r2 frame1'-applied-tokens) "token-radius"))
+    (t/is (= (:r3 frame1'-applied-tokens) "token-radius"))
+    (t/is (= (:r4 frame1'-applied-tokens) "token-radius"))
+    (t/is (= (:rotation frame1'-applied-tokens) "token-rotation"))
+    (t/is (= (:opacity frame1'-applied-tokens) "token-opacity"))
+    (t/is (= (:stroke-width frame1'-applied-tokens) "token-stroke-width"))
+    (t/is (= (:stroke-color frame1'-applied-tokens) "token-color"))
+    (t/is (= (:fill frame1'-applied-tokens) "token-color"))
+    (t/is (= (:width frame1'-applied-tokens) "token-dimensions"))
+    (t/is (= (:height frame1'-applied-tokens) "token-dimensions"))
+
+    (t/is (= (count text1'-applied-tokens) 3))
+    (t/is (= (:font-size text1'-applied-tokens) "token-font-size"))
+    (t/is (= (:letter-spacing text1'-applied-tokens) "token-letter-spacing"))
+    (t/is (= (:font-family text1'-applied-tokens) "token-font-family"))
+
+    (t/is (= (count circle1'-applied-tokens) 8))
+    (t/is (= (:layout-item-max-h circle1'-applied-tokens) "token-sizing"))
+    (t/is (= (:layout-item-min-h circle1'-applied-tokens) "token-sizing"))
+    (t/is (= (:layout-item-max-w circle1'-applied-tokens) "token-sizing"))
+    (t/is (= (:layout-item-min-w circle1'-applied-tokens) "token-sizing"))
+    (t/is (= (:m1 circle1'-applied-tokens) "token-spacing"))
+    (t/is (= (:m2 circle1'-applied-tokens) "token-spacing"))
+    (t/is (= (:m3 circle1'-applied-tokens) "token-spacing"))
+    (t/is (= (:m4 circle1'-applied-tokens) "token-spacing"))))
 
 (t/deftest unapply-tokens-from-shape
   (let [;; ==== Setup
@@ -187,6 +245,7 @@
         page    (thf/current-page file)
         frame1  (ths/get-shape file :frame1)
         text1   (ths/get-shape file :text1)
+        circle1 (ths/get-shape file :circle1)
 
         ;; ==== Action
         changes (-> (-> (pcb/empty-changes nil)
@@ -211,19 +270,29 @@
                                                       (cto/unapply-token-id [:letter-spacing])
                                                       (cto/unapply-token-id [:font-family])))
                                                 (:objects page)
+                                                {})
+                    (cls/generate-update-shapes [(:id circle1)]
+                                                (fn [shape]
+                                                  (-> shape
+                                                      (cto/unapply-token-id [:layout-item-max-h :layout-item-min-h :layout-item-max-w :layout-item-min-w])
+                                                      (cto/unapply-token-id [:m1 :m2 :m3 :m4])))
+                                                (:objects page)
                                                 {}))
 
         file' (thf/apply-changes file changes)
 
         ;; ==== Get
-        frame1'              (ths/get-shape file' :frame1)
-        applied-tokens'      (:applied-tokens frame1')
-        text1'               (ths/get-shape file' :text1)
-        text1-applied-tokens (:applied-tokens text1')]
+        frame1'                 (ths/get-shape file' :frame1)
+        frame1'-applied-tokens  (:applied-tokens frame1')
+        text1'                  (ths/get-shape file' :text1)
+        text1'-applied-tokens   (:applied-tokens text1')
+        circle1'                (ths/get-shape file' :circle1)
+        circle1'-applied-tokens (:applied-tokens circle1')]
 
     ;; ==== Check
-    (t/is (= (count applied-tokens') 0))
-    (t/is (= (count text1-applied-tokens) 0))))
+    (t/is (= (count frame1'-applied-tokens) 0))
+    (t/is (= (count text1'-applied-tokens) 0))
+    (t/is (= (count circle1'-applied-tokens) 0))))
 
 (t/deftest unapply-tokens-automatic
   (let [;; ==== Setup
@@ -232,6 +301,7 @@
         page    (thf/current-page file)
         frame1  (ths/get-shape file :frame1)
         text1   (ths/get-shape file :text1)
+        circle1 (ths/get-shape file :circle1)
 
         ;; ==== Action
         changes (-> (-> (pcb/empty-changes nil)
@@ -263,16 +333,29 @@
                                                     :letter-spacing "0"
                                                     :font-family "Arial"}))
                                                 (:objects page)
+                                                {})
+                    (cls/generate-update-shapes [(:id circle1)]
+                                                (fn [shape]
+                                                  (-> shape
+                                                      (ctn/set-shape-attr :layout-item-max-h 0)
+                                                      (ctn/set-shape-attr :layout-item-min-h 0)
+                                                      (ctn/set-shape-attr :layout-item-max-w 0)
+                                                      (ctn/set-shape-attr :layout-item-min-w 0)
+                                                      (ctn/set-shape-attr :layout-item-margin {})))
+                                                (:objects page)
                                                 {}))
 
         file' (thf/apply-changes file changes)
 
         ;; ==== Get
-        frame1'               (ths/get-shape file' :frame1)
-        text1'                (ths/get-shape file' :text1)
-        applied-tokens-frame' (:applied-tokens frame1')
-        applied-tokens-text'  (:applied-tokens text1')]
+        frame1'                 (ths/get-shape file' :frame1)
+        text1'                  (ths/get-shape file' :text1)
+        circle1'                (ths/get-shape file' :circle1)
+        applied-tokens-frame'   (:applied-tokens frame1')
+        applied-tokens-text'    (:applied-tokens text1')
+        applied-tokens-circle'  (:applied-tokens circle1')]
 
     ;; ==== Check
     (t/is (= (count applied-tokens-frame') 0))
-    (t/is (= (count applied-tokens-text') 0))))
+    (t/is (= (count applied-tokens-text') 0))
+    (t/is (= (count applied-tokens-circle') 0))))


### PR DESCRIPTION
### Related Ticket

[Layout item tokens should be unapplied when moving out of a layout](https://tree.taiga.io/project/penpot/issue/11012)

### Summary

When a layer that has a token applied to a layout item property (e.g. margin) is moved outside the layout, the token should be unapplied, as the property no longer exists.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
