### PR TITLE
:tada: Add base font size flag

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -119,6 +119,7 @@
     ;; Only for developtment.
     :tiered-file-data-storage
     :token-units
+    :token-base-font-size
     :token-typography-types
     :token-typography-composite
     :transit-readable-response

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -137,7 +137,7 @@
        (tr "labels.export")]]
 
 
-     (when (and can-edit? (contains? cf/flags :token-units))
+     (when (and can-edit? (contains? cf/flags :token-base-font-size))
        [:> icon-button* {:variant "secondary"
                          :icon "settings"
                          :aria-label "Settings"


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/task/12009


### Summary
Add a new config flag to distinguish between the token number (which should be visible) and the base font size (which should be hidden).

Flags stay like this:
token-unit -> for token number (should be activated on hourly and pre)
token-base-font-size -> for base font size button (should be activated on hourly but NOT activated on pre)
There is no changes needed on flag.

### Steps to reproduce 
- Open any file
- Go to tokens panel
- Look at the bottom (next to "tools" button) should not be visible unless you activate the flag.

With flag activated

<img width="708" height="237" alt="Screenshot from 2025-09-05 13-17-02" src="https://github.com/user-attachments/assets/08ea7239-3a49-415e-8daa-1c708facddad" />

Withou flag activated

<img width="708" height="237" alt="Screenshot from 2025-09-05 13-16-53" src="https://github.com/user-attachments/assets/7a4b16cd-863c-4e03-928a-1441eaea2541" />

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
