### PR TITLE
:bug: Fix font-family being split up when restoring from backup value

### DIFF
--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -960,6 +960,12 @@ test.describe("Tokens: Themes modal", () => {
         name: /save/i,
       });
 
+      // Fill font-family to verify to verify that input value doesn't get split into list of characters
+      const fontFamilyField = tokensUpdateCreateModal
+        .getByLabel("Font family")
+        .first();
+      await fontFamilyField.fill("OneWord");
+
       // Invalidate incorrect values for font size
       const fontSizeField = tokensUpdateCreateModal.getByLabel(/Font Size/i);
       await fontSizeField.fill("invalid");
@@ -975,9 +981,6 @@ test.describe("Tokens: Themes modal", () => {
       // Fill in values for all fields and verify they persist when switching tabs
       await fontSizeField.fill("16");
 
-      const fontFamilyField = tokensUpdateCreateModal
-        .getByLabel(/Font Family/i)
-        .first();
       const fontWeightField =
         tokensUpdateCreateModal.getByLabel(/Font Weight/i);
       const letterSpacingField =

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -1024,7 +1024,11 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
          (fn [e]
            (if reference-tab-active?
              (swap! backup-state-ref assoc :reference (dom/get-target-val e))
-             (swap! backup-state-ref assoc-in [:composite (obj/get e "tokenType")] (dom/get-target-val e)))
+             (let [token-type (obj/get e "tokenType")
+                   token-value (dom/get-target-val e)
+                   token-value (cond-> token-value
+                                 (= :font-family token-type) (ctt/split-font-family))]
+               (swap! backup-state-ref assoc-in [:composite token-type] token-value)))
            (on-update-value e)))
 
         input-props (mf/spread-props props {:default-value default-value


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/148

### Summary

Fixes font-family value being split up when restoring the value.

The issue was that we dont handle the case for a string in the form setup logic, and the string value gets split up in when submitting the token.
So we had to bring that logic to the backup value.

### Steps to reproduce

See issue

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
