### PR TITLE
:tada: Inspect styles tab: layout element panel

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
@@ -1,0 +1,51 @@
+(ns app.main.ui.inspect.styles.panels.layout-element
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [app.common.data.macros :as dm]
+   [app.common.types.shape.layout :as ctl]
+   [app.main.ui.inspect.attributes.common :as cmm]
+   [app.main.ui.inspect.styles.properties-row :refer [properties-row*]]
+   [app.util.code-gen.style-css :as css]
+   [rumext.v2 :as mf]))
+
+(def ^:private shape-prop->margin-prop
+  {:margin-block-start :m1
+   :margin-inline-end :m2
+   :margin-block-end :m3
+   :margin-inline-start :m4
+   :max-block-size :layout-item-max-h ;; :max-height
+   :min-block-size :layout-item-min-h ;; :min-height
+   :max-inline-size :layout-item-max-w ;; :max-width
+   :min-inline-size :layout-item-min-w ;; :min-width
+   })
+
+(defn- get-applied-margins-in-shape
+  [shape-tokens property]
+  (if-let [margin-prop (get shape-prop->margin-prop property)]
+    (get shape-tokens margin-prop)
+    (get shape-tokens property)))
+
+(defn- get-resolved-tokens
+  [property shape resolved-tokens]
+  (when-let [shape-tokens (:applied-tokens shape)]
+    (let [applied-tokens-in-shape (get-applied-margins-in-shape shape-tokens property)
+          token (get resolved-tokens applied-tokens-in-shape)]
+      token)))
+
+(mf/defc layout-element-panel*
+  [{:keys [shapes objects resolved-tokens layout-element-properties]}]
+  (let [shapes (->> shapes (filter #(ctl/any-layout-immediate-child? objects %)))]
+    [:div {:class (stl/css :layout-element-panel)}
+     (for [shape shapes]
+       [:div {:key (:id shape) :class "layout-element-shape"}
+        (for [property layout-element-properties]
+          (when-let [value (css/get-css-value objects shape property)]
+            (let [property-name (cmm/get-css-rule-humanized property)
+                  resolved-token (get-resolved-tokens property shape resolved-tokens)
+                  property-value (if (not resolved-token) (css/get-css-property objects shape property) "")]
+              [:> properties-row* {:key (dm/str "layout-element-property-" property)
+                                   :term property-name
+                                   :detail (str value)
+                                   :token resolved-token
+                                   :property property-value
+                                   :copiable true}])))])]))

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -20,7 +20,9 @@
     :blur       (tr "labels.blur")
     :shadow     (tr "labels.shadow")
     :layout     (tr "labels.layout")
-    :layout-element (tr "inspect.tabs.styles.panel.layout-element")
+    :flex-element "Flex element"
+    :grid-element "Grid element"
+    :layout-element "Layout Element"
     :visibility (tr "labels.visibility")
     :svg        (tr "labels.svg")
     nil))

--- a/frontend/src/app/util/code_gen/style_css.cljs
+++ b/frontend/src/app/util/code_gen/style_css.cljs
@@ -113,10 +113,18 @@ body {
    ;; Flex/grid self properties
    :flex-shrink
    :margin
+   :margin-block-start
+   :margin-block-end
+   :margin-inline-start
+   :margin-inline-end
    :max-height
+   :max-block-size
    :min-height
+   :min-block-size
    :max-width
+   :max-inline-size
    :min-width
+   :min-inline-size
    :align-self
    :justify-self
 

--- a/frontend/src/app/util/code_gen/style_css_formats.cljs
+++ b/frontend/src/app/util/code_gen/style_css_formats.cljs
@@ -18,10 +18,14 @@
    :top                       :position
    :width                     :size
    :height                    :size
-   :min-width                 :size
-   :min-height                :size
-   :max-width                 :size
    :max-height                :size
+   :max-block-size            :size
+   :min-height                :size
+   :min-block-size            :size
+   :max-width                 :size
+   :max-inline-size           :size
+   :min-width                 :size
+   :min-inline-size           :size
    :background                :color
    :border                    :border
    :border-radius             :string-or-size-array
@@ -42,6 +46,10 @@
    :padding-block-start       :size-array
    :padding-block-end         :size-array
    :margin                    :size-array
+   :margin-block-start        :size-array
+   :margin-block-end          :size-array
+   :margin-inline-start       :size-array
+   :margin-inline-end         :size-array
    :grid-template-rows        :tracks
    :grid-template-columns     :tracks})
 

--- a/frontend/src/app/util/code_gen/style_css_values.cljs
+++ b/frontend/src/app/util/code_gen/style_css_values.cljs
@@ -410,6 +410,26 @@
       (when (or (not= m1 0) (not= m2 0) (not= m3 0) (not= m4 0))
         [m1 m2 m3 m4]))))
 
+(defmethod get-value :margin-block-start
+  [_ {:keys [layout-item-margin] :as shape} objects _]
+  (when (and (ctl/any-layout-immediate-child? objects shape) (:m1 layout-item-margin) (not= (:m1 layout-item-margin) 0))
+    [(:m1 layout-item-margin)]))
+
+(defmethod get-value :margin-inline-end
+  [_ {:keys [layout-item-margin] :as shape} objects _]
+  (when (and (ctl/any-layout-immediate-child? objects shape) (:m2 layout-item-margin) (not= (:m2 layout-item-margin) 0))
+    [(:m2 layout-item-margin)]))
+
+(defmethod get-value :margin-block-end
+  [_ {:keys [layout-item-margin] :as shape} objects _]
+  (when (and (ctl/any-layout-immediate-child? objects shape) (:m3 layout-item-margin) (not= (:m3 layout-item-margin) 0))
+    [(:m3 layout-item-margin)]))
+
+(defmethod get-value :margin-inline-start
+  [_ {:keys [layout-item-margin] :as shape} objects _]
+  (when (and (ctl/any-layout-immediate-child? objects shape) (:m4 layout-item-margin) (not= (:m4 layout-item-margin) 0))
+    [(:m4 layout-item-margin)]))
+
 (defmethod get-value :z-index
   [_ {:keys [layout-item-z-index] :as shape} objects _]
   (cond
@@ -425,6 +445,10 @@
     (ctl/any-layout-immediate-child? objects shape)
     (:layout-item-max-h shape)))
 
+(defmethod get-value :max-block-size
+  [_ shape objects _]
+  (get-value :max-height shape objects))
+
 (defmethod get-value :min-height
   [_ shape objects _]
   (cond
@@ -434,11 +458,19 @@
     (and (ctl/auto-height? shape) (cfh/frame-shape? shape) (not (:show-content shape)))
     (-> shape :selrect :height)))
 
+(defmethod get-value :min-block-size
+  [_ shape objects _]
+  (get-value :min-height shape objects))
+
 (defmethod get-value :max-width
   [_ shape objects _]
   (cond
     (ctl/any-layout-immediate-child? objects shape)
     (:layout-item-max-w shape)))
+
+(defmethod get-value :max-inline-size
+  [_ shape objects _]
+  (get-value :max-width shape objects))
 
 (defmethod get-value :min-width
   [_ shape objects _]
@@ -448,6 +480,10 @@
 
     (and (ctl/auto-width? shape) (cfh/frame-shape? shape) (not (:show-content shape)))
     (-> shape :selrect :width)))
+
+(defmethod get-value :min-inline-size
+  [_ shape objects _]
+  (get-value :min-width shape objects))
 
 (defmethod get-value :align-self
   [_ shape objects _]

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1878,10 +1878,6 @@ msgid "inspect.tabs.styles.panel.geometry"
 msgstr "Size & Position"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:12
-msgid "inspect.tabs.styles.panel.layout-element"
-msgstr "Layout Element"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:12
 msgid "inspect.tabs.styles.panel.toggle-style"
 msgstr "Toggle panel %s"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1884,10 +1884,6 @@ msgid "inspect.tabs.styles.panel.geometry"
 msgstr "Tamaño y posición"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:12
-msgid "inspect.tabs.styles.panel.layout-element"
-msgstr "Layout de elemento"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:12
 msgid "inspect.tabs.styles.panel.toggle-style"
 msgstr "Alternar panel %s"
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12052

### Summary

Create panel for layout children elements

### Steps to reproduce 

- Create a layout (e. g. flex layout)
- Add two rects inside it
- Add some properties as [margin-left, max-width,justify-self]
- Ensure that those properties are displayed in the styles tab as logical properties
- test again using tokens

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
