### PR TITLE
:bug: Fix detaching a nested copy inside a main component

### DIFF
--- a/common/src/app/common/files/repair.cljc
+++ b/common/src/app/common/files/repair.cljc
@@ -320,6 +320,31 @@
             (pcb/with-file-data file-data)
             (pcb/update-shapes shape-ids detach-shape))))))
 
+(defmethod repair-error :ref-shape-is-not-head
+  [_ {:keys [shape page-id] :as error} file-data _]
+  (let [repair-shape
+        (fn [shape]
+          ; Convert shape in a normal copy, removing nested copy status
+          (log/debug :hint "  -> unroot shape")
+          (ctk/unroot-shape shape))]
+
+    (log/dbg :hint "repairing shape :shape-ref-is-not-head" :id (:id shape) :name (:name shape) :page-id page-id)
+    (-> (pcb/empty-changes nil page-id)
+        (pcb/with-file-data file-data)
+        (pcb/update-shapes [(:id shape)] repair-shape))))
+
+(defmethod repair-error :ref-shape-is-head
+  [_ {:keys [shape page-id args] :as error} file-data _]
+  (let [repair-shape
+        (fn [shape]
+          ; Convert shape in a nested head, adding component info
+          (log/debug :hint "  -> reroot shape")
+          (ctk/reroot-shape shape false (:component-file args) (:component-id args)))]
+
+    (log/dbg :hint "repairing shape :shape-ref-is-head" :id (:id shape) :name (:name shape) :page-id page-id)
+    (-> (pcb/empty-changes nil page-id)
+        (pcb/with-file-data file-data)
+        (pcb/update-shapes [(:id shape)] repair-shape))))
 
 (defmethod repair-error :shape-ref-cycle
   [_ {:keys [shape args] :as error} file-data _]

--- a/common/src/app/common/files/repair.cljc
+++ b/common/src/app/common/files/repair.cljc
@@ -325,8 +325,8 @@
   (let [repair-shape
         (fn [shape]
           ; Convert shape in a normal copy, removing nested copy status
-          (log/debug :hint "  -> unroot shape")
-          (ctk/unroot-shape shape))]
+          (log/debug :hint "  -> unhead shape")
+          (ctk/unhead-shape shape))]
 
     (log/dbg :hint "repairing shape :shape-ref-is-not-head" :id (:id shape) :name (:name shape) :page-id page-id)
     (-> (pcb/empty-changes nil page-id)
@@ -339,7 +339,7 @@
         (fn [shape]
           ; Convert shape in a nested head, adding component info
           (log/debug :hint "  -> reroot shape")
-          (ctk/reroot-shape shape false (:component-file args) (:component-id args)))]
+          (ctk/rehead-shape shape (:component-file args) (:component-id args)))]
 
     (log/dbg :hint "repairing shape :shape-ref-is-head" :id (:id shape) :name (:name shape) :page-id page-id)
     (-> (pcb/empty-changes nil page-id)

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -47,6 +47,8 @@
     :should-be-component-root
     :should-not-be-component-root
     :ref-shape-not-found
+    :ref-shape-is-head
+    :ref-shape-is-not-head
     :shape-ref-in-main
     :root-main-not-allowed
     :nested-main-not-allowed
@@ -305,6 +307,28 @@
                   "Shape inside main instance should not have shape-ref"
                   shape file page)))
 
+(defn- check-ref-is-not-head
+  "Validate that the referenced shape is not a nested copy root."
+  [shape file page libraries]
+  (let [ref-shape (ctf/find-ref-shape file page libraries shape :include-deleted? true)]
+    (when (and (some? ref-shape)
+               (ctk/instance-head? ref-shape))
+      (report-error :ref-shape-is-head
+                    (str/ffmt "Referenced shape % is a component, so the copy must also be" (:shape-ref shape))
+                    shape file page))))
+
+(defn- check-ref-is-head
+  "Validate that the referenced shape is a nested copy root."
+  [shape file page libraries]
+  (let [ref-shape (ctf/find-ref-shape file page libraries shape :include-deleted? true)]
+    (when (and (some? ref-shape)
+               (not (ctk/instance-head? ref-shape)))
+      (report-error :ref-shape-is-not-head
+                    (str/ffmt "Referenced shape % of a head copy must also be a head" (:shape-ref shape))
+                    shape file page
+                    :component-file (:component-file ref-shape)
+                    :component-id (:component-id ref-shape)))))
+
 (defn- check-empty-swap-slot
   "Validate that this shape does not have any swap slot."
   [shape file page]
@@ -382,6 +406,7 @@
     (check-component-not-main-head shape file page libraries)
     (check-component-root shape file page)
     (check-component-ref shape file page libraries)
+    (check-ref-is-head shape file page libraries)
     (check-empty-swap-slot shape file page)
     (check-duplicate-swap-slot shape file page)
     (check-valid-touched shape file page)
@@ -399,7 +424,8 @@
   ;; We can have situations where the nested copy and the ancestor copy come from different libraries and some of them have been dettached
   ;; so we only validate the shape-ref if the ancestor is from a valid library
   (when library-exists
-    (check-component-ref shape file page libraries))
+    (check-component-ref shape file page libraries)
+    (check-ref-is-head shape file page libraries))
   (run! #(check-shape % file page libraries :context :copy-nested) (:shapes shape)))
 
 (defn- check-shape-main-not-root
@@ -417,6 +443,7 @@
   (check-component-not-main-not-head shape file page)
   (check-component-not-root shape file page)
   (check-component-ref shape file page libraries)
+  (check-ref-is-not-head shape file page libraries)
   (check-empty-swap-slot shape file page)
   (check-valid-touched shape file page)
   (run! #(check-shape % file page libraries :context :copy-any) (:shapes shape)))

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1736,12 +1736,12 @@
 (defn- check-detached-main
   [changes dest-shape origin-shape]
   ;; Only for direct updates (from main to copy). Check if the main shape
-  ;; has been detached. If so, the copy shape must be unrooted (i.e. converted
+  ;; has been detached. If so, the copy shape must be unheaded (i.e. converted
   ;; into a normal copy and not a nested instance).
   (if (and (= (:shape-ref dest-shape) (:id origin-shape))
            (ctk/subcopy-head? dest-shape)
            (not (ctk/instance-head? origin-shape)))
-    (pcb/update-shapes changes [(:id dest-shape)] ctk/unroot-shape {:ignore-touched true})
+    (pcb/update-shapes changes [(:id dest-shape)] ctk/unhead-shape {:ignore-touched true})
     changes))
 
 (defn- update-attrs

--- a/common/src/app/common/test_helpers/files.cljc
+++ b/common/src/app/common/test_helpers/files.cljc
@@ -108,7 +108,8 @@
         page      (if (some? page-label)
                     (:id (get-page file page-label))
                     (current-page-id file))
-        libraries (or libraries {})]
+        libraries (or libraries
+                      {(:id file) file})]
 
     (ctf/dump-tree file page libraries params)))
 

--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -310,8 +310,8 @@
           :shape-ref
           :touched))
 
-(defn unroot-shape
-  "Make the shape not be a component root, but keep its :shape-ref and :touched if it was a nested copy"
+(defn unhead-shape
+  "Make the shape not be a component head, but keep its :shape-ref and :touched if it was a nested copy"
   [shape]
   (dissoc shape
           :component-root
@@ -319,11 +319,10 @@
           :component-id
           :main-instance))
 
-(defn reroot-shape
-  "Make the shape a component root, by adding component info"
-  [shape component-root? component-file component-id]
+(defn rehead-shape
+  "Make the shape a component head, by adding component info"
+  [shape component-file component-id]
   (assoc shape
-         :component-root component-root?
          :component-file component-file
          :component-id component-id))
 

--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -145,9 +145,12 @@
 (defn component-attr?
   "Check if some attribute is one that is involved in component syncrhonization.
    Note that design tokens also are involved, although they go by an alternate
-   route and thus they are not part of :sync-attrs."
+   route and thus they are not part of :sync-attrs.
+   Also when detaching a nested copy it also needs to trigger a synchronization,
+   even though :shape-ref is not a synced attribute per se"
   [attr]
   (or (get sync-attrs attr)
+      (= :shape-ref attr)
       (= :applied-tokens attr)))
 
 (defn instance-root?
@@ -217,18 +220,15 @@
   (and (= shape-id (:main-instance-id component))
        (= page-id (:main-instance-page component))))
 
-
 (defn is-variant?
   "Check if this shape or component is a variant component"
   [item]
   (some? (:variant-id item)))
 
-
 (defn is-variant-container?
   "Check if this shape is a variant container"
   [shape]
   (:is-variant-container shape))
-
 
 (defn set-touched-group
   [touched group]
@@ -309,6 +309,23 @@
           :remote-synced
           :shape-ref
           :touched))
+
+(defn unroot-shape
+  "Make the shape not be a component root, but keep its :shape-ref and :touched if it was a nested copy"
+  [shape]
+  (dissoc shape
+          :component-root
+          :component-file
+          :component-id
+          :main-instance))
+
+(defn reroot-shape
+  "Make the shape a component root, by adding component info"
+  [shape component-root? component-file component-id]
+  (assoc shape
+         :component-root component-root?
+         :component-file component-file
+         :component-id component-id))
 
 (defn- extract-ids [shape]
   (if (map? shape)

--- a/common/test/common_tests/logic/comp_detach_with_nested_test.cljc
+++ b/common/test/common_tests/logic/comp_detach_with_nested_test.cljc
@@ -475,6 +475,6 @@
 
     ;; ==== Check
 
-    ;; When the nested copy inside the main is detached, their copies are unrooted.
+    ;; When the nested copy inside the main is detached, their copies are unheaded.
     (t/is (not (ctk/subcopy-head? nested2-h-ellipse)))
     (t/is (not (ctk/subcopy-head? copy-nested2-h-ellipse)))))

--- a/common/test/common_tests/logic/comp_detach_with_nested_test.cljc
+++ b/common/test/common_tests/logic/comp_detach_with_nested_test.cljc
@@ -446,3 +446,35 @@
     (t/is (= (count fills') 1))
     (t/is (= (:fill-color fill') "#fabada"))
     (t/is (= (:fill-opacity fill') 1))))
+
+(t/deftest test-detach-copy-in-main
+  (let [;; ==== Setup
+        file (-> (setup-file)
+                 (thc/instantiate-component :c-big-board
+                                            :copy-big-board
+                                            :children-labels [:copy-h-board-with-ellipse
+                                                              :copy-nested-h-ellipse
+                                                              :copy-nested-ellipse]))
+
+        page (thf/current-page file)
+
+        ;; ==== Action
+        changes (cll/generate-detach-instance (-> (pcb/empty-changes nil)
+                                                  (pcb/with-page page)
+                                                  (pcb/with-objects (:objects page)))
+                                              page
+                                              {(:id file) file}
+                                              (thi/id :nested-h-ellipse))
+        file'   (-> (thf/apply-changes file changes)
+                    (tho/propagate-component-changes :c-board-with-ellipse)
+                    (tho/propagate-component-changes :c-big-board))
+
+        ;; ==== Get
+        nested2-h-ellipse (ths/get-shape file' :nested-h-ellipse)
+        copy-nested2-h-ellipse (ths/get-shape file' :copy-nested-h-ellipse)]
+
+    ;; ==== Check
+
+    ;; When the nested copy inside the main is detached, their copies are unrooted.
+    (t/is (not (ctk/subcopy-head? nested2-h-ellipse)))
+    (t/is (not (ctk/subcopy-head? copy-nested2-h-ellipse)))))


### PR DESCRIPTION
### Related Ticket

This was detected here https://tree.taiga.io/project/penpot/issue/11364 but actually it was a different bug, that showed up after fixing the mentioned issue.

### Summary

When a nested instance inside a main component is detached, its copies are left in an inconsistent state that causes a validation error when the copies are detached in turn.

### Steps to reproduce 

1.- Create a component A, and another component B that contains a nested copy of A.
2.- Create a copy of B.
3.- Inside the main of B, detach the nested copy of A.
(at this point the file gets into a broken state)
4.- Detach the copy of B.
(at this point Penpot crashes with a validation error).

This PR fixes the bug that causes the file corruption at step 3. Also adds a validator that detects the problem before it's persisted, and a repair script that can fix the broken files.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
