### PR TITLE
:bug: Fix position of annotation for variants

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -1016,12 +1016,6 @@
           (when swap-opened?
             [:> component-swap* {:shapes copies}])
 
-          (when (and (not swap-opened?) (not multi))
-            [:> component-annotation* {:id id
-                                       :shape shape
-                                       :component component
-                                       :rerender-fn rerender-fn}])
-
           (when (and is-variant?
                      (not main-instance?)
                      (not (:deleted component))
@@ -1036,6 +1030,12 @@
             [:> component-variant-main-instance* {:components components
                                                   :shapes shapes
                                                   :data data}])
+
+          (when (and (not swap-opened?) (not multi))
+            [:> component-annotation* {:id id
+                                       :shape shape
+                                       :component component
+                                       :rerender-fn rerender-fn}])
 
           (when (and multi all-main? (not any-variant?))
             [:button {:class (stl/css :combine-variant-button)


### PR DESCRIPTION
### Related Ticket

Taiga [#12075](https://tree.taiga.io/project/penpot/issue/12075)

### Summary

The annotation section must appear below the properties for a variant.

### Steps to reproduce 

Select a variant, add an annotation, and check that it appears below the properties in the design tab.