### PR TITLE
:bug: Fix make-token throwing because of error in name

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -10,6 +10,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.tokens :as cft]
+   [app.common.schema :as sm]
    [app.common.types.color :as c]
    [app.common.types.token :as ctt]
    [app.common.types.tokens-lib :as ctob]
@@ -119,10 +120,10 @@
 (defn validate-resolve-token
   [token prev-token tokens]
   (let [token (cond-> token
-                ;; When creating a new token we dont have a name yet,
+                ;; When creating a new token we dont have a name yet or invalid name,
                 ;; but we still want to resolve the value to show in the form.
                 ;; So we use a temporary token name that hopefully doesn't clash with any of the users token names
-                (str/empty? (:name token)) (assoc :name "__PENPOT__TOKEN__NAME__PLACEHOLDER__"))
+                (not (sm/valid? ctt/token-name-ref (:name token))) (assoc :name "__PENPOT__TOKEN__NAME__PLACEHOLDER__"))
         tokens' (cond-> tokens
                   ;; Remove previous token when renaming a token
                   (not= (:name token) (:name prev-token))


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/149

### Summary

Fixes resolved value preview when the token name is invalid, caught by tokens-lib.
We still want to show the user the value, so we use an unchecked version of make-token.
The name will never be used in the final submitted token form the form.

### Checklist


- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
