### PR TITLE
:recycle: Add shortcut to scss import  paths

### DIFF
--- a/docs/technical-guide/developer/ui.md
+++ b/docs/technical-guide/developer/ui.md
@@ -234,7 +234,7 @@ Use variables from `frontend/src/app/main/ui/ds/spacing.scss`. These are predefi
 For fixed dimensions (e.g., modals' widths) defined by design and not layout-driven, use or define variables in `frontend/src/app/main/ui/ds/_sizes.scss`. To use them:
 
 ```scss
-@use "../_sizes.scss" as *;
+@use "ds/_sizes.scss" as *;
 ```
 Note: Since these values haven't been semantically defined yet, we’re temporarily using SASS variables instead of named CSS custom properties.
 
@@ -242,7 +242,7 @@ Note: Since these values haven't been semantically defined yet, we’re temporar
 Use border thickness variables from `frontend/src/app/main/ui/ds/_borders.scss`. To import:
 
 ```scss
-@use "../_borders.scss" as *;
+@use "ds/_borders.scss" as *;
 ```
 
 Avoid using sass variables defined on `frontend/resources/styles/common/refactor/spacing.scss` that are deprecated.
@@ -314,7 +314,7 @@ When applying typography in SCSS, use the proper mixin from the Design System.
 
 ✅ **DO: Use the DS mixin**
 ```scss
-@use "../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 
 .class {
   @include t.use-typography("body-small");

--- a/frontend/scripts/_worker.js
+++ b/frontend/scripts/_worker.js
@@ -24,6 +24,7 @@ async function compileFile(path) {
           "node_modules/animate.css",
           "resources/styles/common/",
           "resources/styles",
+          "src/app/main/ui/",
         ],
         sourceMap: false,
       });

--- a/frontend/src/app/main/ui/components/code_block.scss
+++ b/frontend/src/app/main/ui/components/code_block.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/typography.scss" as t;
-@use "../ds/borders" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_borders.scss" as *;
 
 .code-display {
   @include t.use-typography("code-font");

--- a/frontend/src/app/main/ui/components/title_bar.scss
+++ b/frontend/src/app/main/ui/components/title_bar.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 @use "refactor/common-refactor.scss" as *;
 
 .title-bar {

--- a/frontend/src/app/main/ui/dashboard/placeholder.scss
+++ b/frontend/src/app/main/ui/dashboard/placeholder.scss
@@ -6,7 +6,7 @@
 
 @use "common/refactor/common-refactor.scss" as *;
 @use "./grid.scss" as g;
-@use "../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 
 .grid-empty-placeholder {
   border-radius: $br-12;

--- a/frontend/src/app/main/ui/dashboard/sidebar.scss
+++ b/frontend/src/app/main/ui/dashboard/sidebar.scss
@@ -4,13 +4,13 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/typography.scss" as t;
-@use "../ds/colors.scss" as *;
-@use "../ds/spacing.scss" as *;
-@use "../ds/_borders.scss" as *;
-@use "../ds/_sizes.scss" as *;
-@use "../ds/_utils.scss" as *;
-@use "../ds/z-index.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/colors.scss" as *;
+@use "ds/spacing.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
+@use "ds/z-index.scss" as *;
 @use "common/refactor/common-dashboard";
 @use "common/refactor/common-refactor.scss" as deprecated;
 

--- a/frontend/src/app/main/ui/dashboard/subscription.scss
+++ b/frontend/src/app/main/ui/dashboard/subscription.scss
@@ -1,8 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
 @use "common/refactor/common-refactor.scss" as *;
 @use "common/refactor/common-dashboard";
-@use "../ds/typography.scss" as t;
-@use "../ds/_borders.scss" as *;
-@use "../ds/spacing.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_borders.scss" as *;
+@use "ds/spacing.scss" as *;
 
 .cta-power-up {
   display: flex;

--- a/frontend/src/app/main/ui/ds/_borders.scss
+++ b/frontend/src/app/main/ui/ds/_borders.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "./utils.scss" as *;
+@use "ds/_utils.scss" as *;
 
 // TODO: create actual tokens once we have them from design
 $br-8: px2rem(8);

--- a/frontend/src/app/main/ui/ds/_sizes.scss
+++ b/frontend/src/app/main/ui/ds/_sizes.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "./utils.scss" as *;
+@use "ds/_utils.scss" as *;
 
 // TODO: create actual tokens once we have them from design
 $sz-1: px2rem(1);

--- a/frontend/src/app/main/ui/ds/buttons/_buttons.scss
+++ b/frontend/src/app/main/ui/ds/buttons/_buttons.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_borders.scss" as *;
-@use "../_sizes.scss" as *;
-@use "../utils.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
 
 %base-button {
   --button-bg-color: initial;

--- a/frontend/src/app/main/ui/ds/buttons/button.scss
+++ b/frontend/src/app/main/ui/ds/buttons/button.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../typography.scss" as *;
+@use "ds/typography.scss" as *;
 @use "./buttons" as *;
 
 .button {

--- a/frontend/src/app/main/ui/ds/buttons/icon_button.scss
+++ b/frontend/src/app/main/ui/ds/buttons/icon_button.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../typography.scss" as *;
-@use "../_sizes.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/_sizes.scss" as *;
 @use "./buttons" as *;
 
 .icon-button {

--- a/frontend/src/app/main/ui/ds/controls/combobox.scss
+++ b/frontend/src/app/main/ui/ds/controls/combobox.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_borders.scss" as *;
-@use "../_sizes.scss" as *;
-@use "../typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
 
 .wrapper {
   --combobox-icon-color: var(--color-icon-default);

--- a/frontend/src/app/main/ui/ds/controls/input.scss
+++ b/frontend/src/app/main/ui/ds/controls/input.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../spacing.scss" as *;
+@use "ds/spacing.scss" as *;
 
 .input-wrapper {
   display: flex;

--- a/frontend/src/app/main/ui/ds/controls/numeric_input.scss
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../spacing.scss" as *;
-@use "../borders.scss" as *;
-@use "../sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/spacing.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 .input-wrapper {
   --opacity-button: 0;

--- a/frontend/src/app/main/ui/ds/controls/select.scss
+++ b/frontend/src/app/main/ui/ds/controls/select.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_borders.scss" as *;
-@use "../_sizes.scss" as *;
-@use "../typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
 
 .select-wrapper {
   --select-icon-color: var(--color-icon-default);

--- a/frontend/src/app/main/ui/ds/controls/shared/option.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/option.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../_borders.scss" as *;
-@use "../../_sizes.scss" as *;
-@use "../../typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
 
 .option {
   --options-fg-color: var(--color-foreground-primary);

--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../_borders.scss" as *;
-@use "../../_sizes.scss" as *;
-@use "../../typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
 
 .option-list {
   --options-dropdown-icon-fg-color: var(--color-foreground-secondary);

--- a/frontend/src/app/main/ui/ds/controls/shared/token_option.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/token_option.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../_borders.scss" as *;
-@use "../../_sizes.scss" as *;
-@use "../../typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
 
 .token-option {
   --token-options-fg-color: var(--color-foreground-primary);

--- a/frontend/src/app/main/ui/ds/controls/utilities/hint_message.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/hint_message.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../typography.scss" as *;
-@use "../../colors.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/colors.scss" as *;
 
 .hint-message {
   --hint-color: var(--color-foreground-secondary);

--- a/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
@@ -4,10 +4,10 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../_borders.scss" as *;
-@use "../../_sizes.scss" as *;
-@use "../../typography.scss" as *;
-@use "../../colors.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/colors.scss" as *;
 
 .input-wrapper {
   --input-bg-color: var(--color-background-tertiary);

--- a/frontend/src/app/main/ui/ds/controls/utilities/label.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/label.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../typography.scss" as *;
-@use "../../colors.scss" as *;
-@use "../../spacing.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/colors.scss" as *;
+@use "ds/spacing.scss" as *;
 
 .label {
   --label-color: var(--color-foreground-primary);

--- a/frontend/src/app/main/ui/ds/controls/utilities/token_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/token_field.scss
@@ -4,10 +4,10 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../_borders.scss" as *;
-@use "../../_sizes.scss" as *;
-@use "../../typography.scss" as t;
-@use "../../colors.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/colors.scss" as *;
 
 .token-field {
   --token-field-bg-color: var(--color-background-tertiary);

--- a/frontend/src/app/main/ui/ds/foundations/typography/heading.scss
+++ b/frontend/src/app/main/ui/ds/foundations/typography/heading.scss
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) KALEIDOS INC
-@use "../../typography.scss" as t;
+@use "ds/typography.scss" as t;
 
 .display-typography {
   @include t.use-typography("display");

--- a/frontend/src/app/main/ui/ds/foundations/typography/text.scss
+++ b/frontend/src/app/main/ui/ds/foundations/typography/text.scss
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) KALEIDOS INC
-@use "../../typography.scss" as t;
+@use "ds/typography.scss" as t;
 
 .display-typography {
   @include t.use-typography("display");

--- a/frontend/src/app/main/ui/ds/layout/tab_switcher.scss
+++ b/frontend/src/app/main/ui/ds/layout/tab_switcher.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
-@use "../typography.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as *;
 
 .tabs {
   --tabs-bg-color: var(--color-background-secondary);

--- a/frontend/src/app/main/ui/ds/notifications/actionable.scss
+++ b/frontend/src/app/main/ui/ds/notifications/actionable.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_borders.scss" as *;
-@use "../typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as *;
 
 .notification {
   @include use-typography("body-medium");

--- a/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.scss
+++ b/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../_sizes.scss" as *;
-@use "../../_borders.scss" as *;
-@use "../../typography.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as *;
 
 .notification-pill {
   @include use-typography("body-medium");

--- a/frontend/src/app/main/ui/ds/notifications/toast.scss
+++ b/frontend/src/app/main/ui/ds/notifications/toast.scss
@@ -4,11 +4,11 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
-@use "../typography.scss" as *;
-@use "../spacing.scss" as *;
-@use "../z-index.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/spacing.scss" as *;
+@use "ds/z-index.scss" as *;
 
 .toast {
   --toast-icon-color: var(--color-foreground-secondary);

--- a/frontend/src/app/main/ui/ds/product/avatar.scss
+++ b/frontend/src/app/main/ui/ds/product/avatar.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .avatar {
   border-radius: $br-circle;

--- a/frontend/src/app/main/ui/ds/product/cta.scss
+++ b/frontend/src/app/main/ui/ds/product/cta.scss
@@ -4,10 +4,10 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../colors.scss" as *;
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
-@use "../typography.scss" as t;
+@use "ds/colors.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
 
 .cta {
   border-radius: $br-8;

--- a/frontend/src/app/main/ui/ds/product/empty_placeholder.scss
+++ b/frontend/src/app/main/ui/ds/product/empty_placeholder.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .empty-placeholder {
   display: grid;

--- a/frontend/src/app/main/ui/ds/product/input_with_meta.scss
+++ b/frontend/src/app/main/ui/ds/product/input_with_meta.scss
@@ -4,10 +4,10 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_borders.scss" as *;
-@use "../spacing.scss" as *;
-@use "../_sizes.scss" as *;
-@use "../typography.scss" as t;
+@use "ds/_borders.scss" as *;
+@use "ds/spacing.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/typography.scss" as t;
 
 .input-with-meta-container {
   --input-meta-value: var(--color-foreground-primary);

--- a/frontend/src/app/main/ui/ds/product/milestone.scss
+++ b/frontend/src/app/main/ui/ds/product/milestone.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
-@use "../typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
 
 .milestone {
   border: $b-1 solid var(--border-color, transparent);

--- a/frontend/src/app/main/ui/ds/product/milestone_group.scss
+++ b/frontend/src/app/main/ui/ds/product/milestone_group.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
-@use "../typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
 
 .milestone {
   border: $b-1 solid var(--border-color, transparent);

--- a/frontend/src/app/main/ui/ds/spacing.scss
+++ b/frontend/src/app/main/ui/ds/spacing.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "./utils.scss" as *;
+@use "ds/_utils.scss" as *;
 
 $_sp-2: px2rem(2);
 $_sp-4: px2rem(4);

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.scss
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_sizes.scss" as *;
-@use "../_borders.scss" as *;
-@use "../typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
 
 $arrow-side: 12px;
 

--- a/frontend/src/app/main/ui/ds/typography.scss
+++ b/frontend/src/app/main/ui/ds/typography.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "./utils.scss" as *;
+@use "ds/_utils.scss" as *;
 
 $_font-weight-regular: 400;
 $_font-weight-medium: 500;

--- a/frontend/src/app/main/ui/ds/utilities/swatch.scss
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../_borders.scss" as *;
-@use "../_sizes.scss" as *;
-@use "../colors.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/colors.scss" as *;
 
 .swatch {
   --border-color: var(--color-accent-primary-muted);

--- a/frontend/src/app/main/ui/inspect/attributes.scss
+++ b/frontend/src/app/main/ui/inspect/attributes.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/_sizes.scss" as *;
-@use "../ds/utils" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
 
 .element-options {
   display: flex;

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/typography.scss" as *;
+@use "ds/typography.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .settings-bar-right {

--- a/frontend/src/app/main/ui/inspect/styles/properties_row.scss
+++ b/frontend/src/app/main/ui/inspect/styles/properties_row.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
-@use "../../ds/_sizes.scss" as *;
-@use "../../ds/_borders.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 // TOKENS ROW
 

--- a/frontend/src/app/main/ui/inspect/styles/property_detail_copiable.scss
+++ b/frontend/src/app/main/ui/inspect/styles/property_detail_copiable.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
-@use "../../ds/_sizes.scss" as *;
-@use "../../ds/_borders.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .property-detail-copiable {
   --detail-color: var(--color-foreground-primary);

--- a/frontend/src/app/main/ui/inspect/styles/style_box.scss
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
+@use "ds/typography.scss" as *;
 
 .style-box {
   --title-gap: var(--sp-xs);

--- a/frontend/src/app/main/ui/settings/subscription.scss
+++ b/frontend/src/app/main/ui/settings/subscription.scss
@@ -5,9 +5,9 @@
 // Copyright (c) KALEIDOS INC
 
 @use "common/refactor/common-refactor.scss" as *;
-@use "../ds/typography.scss" as t;
-@use "../ds/_borders.scss" as *;
-@use "../ds/spacing.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_borders.scss" as *;
+@use "ds/spacing.scss" as *;
 
 .dashboard-section {
   display: flex;

--- a/frontend/src/app/main/ui/workspace/colorpicker.scss
+++ b/frontend/src/app/main/ui/workspace/colorpicker.scss
@@ -4,11 +4,11 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/typography.scss" as t;
-@use "../ds/spacing.scss";
-@use "../ds/_borders.scss" as *;
-@use "../ds/_sizes.scss" as *;
-@use "../ds/utils" as *;
+@use "ds/typography.scss" as t;
+@use "ds/spacing.scss";
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
 @use "refactor/basic-rules.scss" as *;
 
 .colorpicker-tooltip {

--- a/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.scss
+++ b/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as t;
-@use "../../ds/_borders.scss" as *;
-@use "../../ds/_sizes.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 .color-token-list {
   display: flex;

--- a/frontend/src/app/main/ui/workspace/palette.scss
+++ b/frontend/src/app/main/ui/workspace/palette.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/spacing.scss" as *;
-@use "../ds/z-index.scss" as *;
-@use "../ds/_sizes.scss" as *;
+@use "ds/spacing.scss" as *;
+@use "ds/z-index.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 @use "refactor/common-refactor.scss" as *;
 

--- a/frontend/src/app/main/ui/workspace/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../ds/_sizes.scss" as *;
+@use "ds/_sizes.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 $width-settings-bar: $sz-318;

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 @use "refactor/common-refactor.scss" as *;
 .tool-window {
   padding: 0 0 $s-24 $s-12;

--- a/frontend/src/app/main/ui/workspace/sidebar/options.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/_sizes.scss" as *;
+@use "ds/_sizes.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .tool-window {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/drawing/frame.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/drawing/frame.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../../ds/_sizes.scss" as *;
+@use "ds/_sizes.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .presets {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 @use "refactor/common-refactor.scss" as *;
 
 .element-set {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../../ds/_sizes.scss" as *;
+@use "ds/_sizes.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .element-set {

--- a/frontend/src/app/main/ui/workspace/sidebar/versions.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/versions.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 @use "refactor/common-refactor.scss" as *;
 
 .version-toolbox {

--- a/frontend/src/app/main/ui/workspace/tokens/export.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/export.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as t;
-@use "../../ds/_sizes.scss" as *;
-@use "../../ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .modal-overlay {

--- a/frontend/src/app/main/ui/workspace/tokens/export/modal.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/export/modal.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as t;
-@use "../../../ds/_sizes.scss" as *;
-@use "../../../ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .export-modal-wrapper {
   display: flex;

--- a/frontend/src/app/main/ui/workspace/tokens/import/modal.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/import/modal.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as t;
-@use "../../../ds/_borders.scss" as *;
-@use "../../../ds/_sizes.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 .import-modal-wrapper {
   display: flex;

--- a/frontend/src/app/main/ui/workspace/tokens/management.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
+@use "ds/typography.scss" as *;
 
 .sets-header-container {
   @include use-typography("headline-small");

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as *;
+@use "ds/typography.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .token-context-menu {

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../../ds/typography.scss" as t;
-@use "../../../../ds/_sizes.scss" as *;
-@use "../../../../ds/_borders.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .form-wrapper {
   width: $sz-384;

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/input_token_color_bullet.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/input_token_color_bullet.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../../ds/_sizes.scss" as *;
-@use "../../../../ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .input-token-color-bullet {
   --bullet-size: var(--sp-l);

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/input_tokens_value.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/input_tokens_value.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../../ds/typography.scss" as *;
-@use "../../../../ds/_sizes.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 @use "refactor/common-refactor.scss" as *;
 

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as *;
-@use "../../../ds/borders.scss" as *;
-@use "../../../ds/sizes.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 .token-pill {
   @include use-typography("code-font");

--- a/frontend/src/app/main/ui/workspace/tokens/sets.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
+@use "ds/typography.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .sets-list {

--- a/frontend/src/app/main/ui/workspace/tokens/sets/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/context_menu.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as t;
+@use "ds/typography.scss" as t;
 @use "refactor/common-refactor.scss" as *;
 
 .token-set-context-menu {

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/typography.scss" as *;
+@use "ds/typography.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .sets-list {

--- a/frontend/src/app/main/ui/workspace/tokens/settings/menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/settings/menu.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/spacing.scss" as *;
+@use "ds/spacing.scss" as *;
 
 @use "refactor/common-refactor.scss" as *;
 

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
@@ -4,8 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
-@use "../../ds/spacing.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/spacing.scss" as *;
 @use "refactor/common-refactor.scss" as *;
 
 .sidebar-wrapper {

--- a/frontend/src/app/main/ui/workspace/tokens/themes.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/themes.scss
@@ -4,9 +4,9 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../ds/typography.scss" as *;
-@use "../../ds/_sizes" as *;
-@use "../../ds/spacing.scss" as *;
+@use "ds/typography.scss" as *;
+@use "ds/_sizes" as *;
+@use "ds/spacing.scss" as *;
 
 .themes-wrapper {
   padding: var(--sp-m) 0 0 var(--sp-m);

--- a/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.scss
@@ -4,7 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "../../../ds/_sizes.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 @use "refactor/common-refactor.scss" as *;
 


### PR DESCRIPTION
### Related Ticket

This PR complete [this task](https://tree.taiga.io/project/penpot/task/12145)

### Summary

We want to import DS files easily, we don't want to write the complete path to import a DS scss file. 

### Steps to reproduce 

Using the shortcut "ds/spacing.scss" should work in any file on the frontend folder. 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
