### PR TITLE
:sparkles: Add additional http middlewares

### DIFF
--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -146,7 +146,6 @@
     [:quotes-team-access-requests-per-team {:optional true} ::sm/int]
     [:quotes-team-access-requests-per-requester {:optional true} ::sm/int]
 
-    [:auth-data-cookie-domain {:optional true} :string]
     [:auth-token-cookie-name {:optional true} :string]
     [:auth-token-cookie-max-age {:optional true} ::ct/duration]
 

--- a/backend/src/app/http.clj
+++ b/backend/src/app/http.clj
@@ -19,6 +19,7 @@
    [app.http.errors :as errors]
    [app.http.management :as mgmt]
    [app.http.middleware :as mw]
+   [app.http.security :as sec]
    [app.http.session :as session]
    [app.http.websocket :as-alias ws]
    [app.main :as-alias main]
@@ -167,6 +168,7 @@
   [_ cfg]
   (rr/router
    [["" {:middleware [[mw/server-timing]
+                      [sec/sec-fetch-metadata]
                       [mw/params]
                       [mw/format-response]
                       [session/soft-auth cfg]

--- a/backend/src/app/http.clj
+++ b/backend/src/app/http.clj
@@ -189,7 +189,8 @@
 
      (::ws/routes cfg)
 
-     ["/api" {:middleware [[mw/cors]]}
+     ["/api" {:middleware [[mw/cors]
+                           [sec/client-header-check]]}
       (::oidc/routes cfg)
       (::rpc.doc/routes cfg)
       (::rpc/routes cfg)]]]))

--- a/backend/src/app/http/security.clj
+++ b/backend/src/app/http/security.clj
@@ -37,3 +37,19 @@
    :compile (fn [_ _]
               (when (contains? cf/flags :sec-fetch-metadata-middleware)
                 wrap-sec-fetch-metadata))})
+
+(defn- wrap-client-header-check
+  "Check for a penpot custom header to be present as additional CSRF
+  protection"
+  [handler]
+  (fn [request]
+    (let [client (yreq/get-header request "x-client")]
+      (if (some? client)
+        (handler request)
+        {::yres/status 403}))))
+
+(def client-header-check
+  {:name ::client-header-check
+   :compile (fn [_ _]
+              (when (contains? cf/flags :client-header-check-middleware)
+                wrap-client-header-check))})

--- a/backend/src/app/http/security.clj
+++ b/backend/src/app/http/security.clj
@@ -1,0 +1,39 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.http.security
+  "Additional security layer middlewares"
+  (:require
+   [app.config :as cf]
+   [yetti.request :as yreq]
+   [yetti.response :as yres]))
+
+(def ^:private safe-methods
+  #{:get :head :options})
+
+(defn- wrap-sec-fetch-metadata
+  "Sec-Fetch metadata security layer middleware"
+  [handler]
+  (fn [request]
+    (let [site (yreq/get-header request "sec-fetch-site")]
+      (cond
+        (= site "same-origin")
+        (handler request)
+
+        (or (= site "same-site")
+            (= site "cross-site"))
+        (if (contains? safe-methods (yreq/method request))
+          (handler request)
+          {::yres/status 403})
+
+        :else
+        (handler request)))))
+
+(def sec-fetch-metadata
+  {:name ::sec-fetch-metadata
+   :compile (fn [_ _]
+              (when (contains? cf/flags :sec-fetch-metadata-middleware)
+                wrap-sec-fetch-metadata))})

--- a/backend/test/backend_tests/http_middleware_security.clj
+++ b/backend/test/backend_tests/http_middleware_security.clj
@@ -1,0 +1,47 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns backend-tests.http-middleware-security
+  (:require
+   [app.http.security :as sec]
+   [clojure.test :as t]
+   [yetti.request :as yreq]
+   [yetti.response :as yres]))
+
+(defn- mock-request
+  [method value]
+  (reify yreq/IRequest
+    (method [_]
+      method)
+    (get-header [_ _]
+      value)))
+
+(t/deftest sec-fetch-metadata
+  (let [request1 (mock-request :get "same-origin")
+        request2 (mock-request :post "same-origin")
+        request3 (mock-request :get "same-site")
+        request4 (mock-request :post "same-site")
+        request5 (mock-request :get "cross-site")
+        request6 (mock-request :post "cross-site")
+
+        handler  (fn [request]
+                   {::yres/status 200})
+        handler  (#'sec/wrap-sec-fetch-metadata handler)
+        resp1    (handler request1)
+        resp2    (handler request2)
+        resp3    (handler request3)
+        resp4    (handler request4)
+        resp5    (handler request5)
+        resp6    (handler request6)]
+
+    (t/is (= 200 (::yres/status resp1)))
+    (t/is (= 200 (::yres/status resp2)))
+    (t/is (= 200 (::yres/status resp3)))
+    (t/is (= 403 (::yres/status resp4)))
+    (t/is (= 200 (::yres/status resp5)))
+    (t/is (= 403 (::yres/status resp6)))))
+
+

--- a/backend/test/backend_tests/http_middleware_security.clj
+++ b/backend/test/backend_tests/http_middleware_security.clj
@@ -44,4 +44,16 @@
     (t/is (= 200 (::yres/status resp5)))
     (t/is (= 403 (::yres/status resp6)))))
 
+(t/deftest client-header-check
+  (let [request1 (mock-request :get "some")
+        request2 (mock-request :post nil)
+
+        handler  (fn [request]
+                   {::yres/status 200})
+        handler  (#'sec/wrap-client-header-check handler)
+        resp1    (handler request1)
+        resp2    (handler request2)]
+
+    (t/is (= 200 (::yres/status resp1)))
+    (t/is (= 403 (::yres/status resp2)))))
 

--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -135,7 +135,11 @@
     :subscriptions
     :subscriptions-old
     :frontend-binary-fills
-    :inspect-styles})
+    :inspect-styles
+
+    ;; Security layer middleware that filters request by fetch
+    ;; metadata headers
+    :sec-fetch-metadata-middleware})
 
 (def all-flags
   (set/union email login varia))

--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -139,7 +139,11 @@
 
     ;; Security layer middleware that filters request by fetch
     ;; metadata headers
-    :sec-fetch-metadata-middleware})
+    :sec-fetch-metadata-middleware
+
+    ;; Security layer middleware that check the precense of x-client
+    ;; http headers and enables an addtional csrf protection
+    :client-header-check-middleware})
 
 (def all-flags
   (set/union email login varia))

--- a/frontend/src/app/util/http.cljs
+++ b/frontend/src/app/util/http.cljs
@@ -51,7 +51,8 @@
 
 (defn default-headers
   []
-  {"x-frontend-version" (:full cfg/version)})
+  {"x-frontend-version" (:full cfg/version)
+   "x-client" (str "penpot-frontend/" (:full cfg/version))})
 
 (defn fetch
   [{:keys [method uri query headers body mode omit-default-headers credentials]


### PR DESCRIPTION
### Summary

On this PR:
- A middleware for to filter requests using the sec-fetch metadata headers (additional csrf protection)
- A middleware for to filter requests that includes x-client http header (additional csrf protection)
- Remove unused code from sessions

All the middleware are disabled by default and will be enabled on our hourly for first tests.

### How to test
No specific tests required, unit tests included.

### Merge stragegy

**Merge with merge-with-merge-commit or with merge-with-rebase** 
