### PR TITLE
:sparkles: Set explicit no-buffering for sse responses

### DIFF
--- a/backend/src/app/http/sse.clj
+++ b/backend/src/app/http/sse.clj
@@ -44,7 +44,8 @@
 (def default-headers
   {"Content-Type" "text/event-stream;charset=UTF-8"
    "Cache-Control" "no-cache, no-store, max-age=0, must-revalidate"
-   "Pragma" "no-cache"})
+   "Pragma" "no-cache"
+   "X-Accel-Buffering" "no"})
 
 (defn response
   [handler & {:keys [buf] :or {buf 32} :as opts}]

--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -118,7 +118,6 @@ http {
 
         location /api {
             proxy_pass http://127.0.0.1:6060/api;
-            proxy_buffering off;
             proxy_http_version 1.1;
         }
 


### PR DESCRIPTION
### Summary

This removes the need to have `proxy_buffering off` for all methods under `/api` that can imply several implications already explained in nginx documentation. This change enables buffering only for SSE responses and is controlled from backend code instead of nginx configuration.

### How to test

No specific tests are required.

