### PR TITLE
:bug: Fix use a pointer cursor for adding variant from the viewport

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/widgets.scss
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.scss
@@ -71,6 +71,7 @@
   --button-add-background-color-hover: var(--color-accent-action-hover);
   --button-add-icon-color: var(--color-static-white);
 
+  cursor: pointer;
   fill: var(--button-add-background-color);
   &:hover {
     --button-add-background-color: var(--button-add-background-color-hover);


### PR DESCRIPTION
### Related Ticket

Taiga [#12197](https://tree.taiga.io/project/penpot/task/12197)

### Summary

The mouse cursor when hovering the viewport button for adding a new variant must be a hand. This is consistent with the behavior of the button's pointer for adding a new grid section, also in the viewport.

### Steps to reproduce 

Move the cursor over the button and check that it turns into a hand.