### PR TITLE
:bug: Fix problem with component swapping panel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - Retrieve variants with nested components [Taiga #10277](https://tree.taiga.io/project/penpot/us/10277)
 - Create variants in bulk from existing components [Taiga #7926](https://tree.taiga.io/project/penpot/us/7926)
 - Alternative ways of creating variants - Button Design Tab [Taiga #10316](https://tree.taiga.io/project/penpot/us/10316)
+- Fix problem with component swapping panel [Taiga #12175](https://tree.taiga.io/project/penpot/issue/12175)
 
 ### :bug: Bugs fixed
 

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -77,11 +77,8 @@
 
 (defn get-shape
   [container shape-id]
-
-  (assert (check-container container))
   (assert (uuid? shape-id)
           "expected valid uuid for `shape-id`")
-
   (-> container
       (get :objects)
       (get shape-id)))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -266,6 +266,7 @@
            [:div {:class (stl/css-case :drop-space true
                                        :drop-space-small (not dragging?))}])
 
+         ;; FIXME: This could be in the thousands. We need to think about paginate this
          (for [component components]
            [:& components-item
             {:component component

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.cljs
@@ -363,13 +363,16 @@
          (fn []
            (st/emit! (dw/unselect-all-assets file-id))))
 
+        variants-counter
+        (mf/with-memo [library]
+          (-> (group-by :variant-id (ctkl/components-seq library))
+              (update-vals count)))
+
         count-variants
         (mf/use-fn
-         (mf/deps library)
+         (mf/deps variants-counter)
          (fn [variant-id]
-           (->> (ctkl/components-seq library)
-                (filterv #(= variant-id (:variant-id %)))
-                count)))]
+           (get variants-counter variant-id)))]
 
     [:div {:class (stl/css :tool-window)
            :on-context-menu dom/prevent-default

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -631,7 +631,13 @@
                               (str/upper (tr "workspace.assets.local-library"))
                               (dm/get-in libraries [current-library-id :name]))
 
-        current-lib-data    (get-in libraries [current-library-id :data])
+        current-lib-data    (mf/with-memo [libraries]
+                              (get-in libraries [current-library-id :data]))
+
+        current-lib-counts  (mf/with-memo [current-lib-data]
+                              (-> (group-by :variant-id
+                                            (ctkl/components-seq current-lib-data))
+                                  (update-vals count)))
 
         components          (->> (get-in libraries [current-library-id :data :components])
                                  vals
@@ -640,9 +646,7 @@
                                  (map #(assoc % :full-name (cfh/merge-path-item-with-dot (:path %) (:name %)))))
 
         count-variants      (fn [component]
-                              (->> (ctkl/components-seq current-lib-data)
-                                   (filterv #(= (:variant-id component) (:variant-id %)))
-                                   count))
+                              (get current-lib-counts (:variant-id component)))
 
         get-subgroups       (fn [path]
                               (let [split-path (cfh/split-path path)]
@@ -767,6 +771,7 @@
 
        [:div {:class (stl/css-case :component-grid (:listing-thumbs? filters)
                                    :component-list (not (:listing-thumbs? filters)))}
+        ;; FIXME: This could be in the thousands. We need to think about paginate this
         (for [item items]
           (if (:id item)
             (let [data       (dm/get-in libraries [current-library-id :data])


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12175

### Summary
There is a performance problem with libraries with thousands of icons. This problem solves the major issue introduced in 2.10.

### Steps to reproduce 
Load a library with lots of icons (for example, material design icons). The components assets side bar hangs and the right side panel when swapping components also hangs.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
