### PR TITLE
:bug: Fix shadow serialization

### DIFF
--- a/render-wasm/src/wasm/shadows.rs
+++ b/render-wasm/src/wasm/shadows.rs
@@ -8,8 +8,9 @@ use crate::{with_current_shape_mut, STATE};
 #[repr(u8)]
 #[allow(dead_code)]
 pub enum RawShadowStyle {
-    Drop = 0,
-    Inner = 1,
+    // NOTE: Odd naming to comply with cljs value
+    DropShadow = 0,
+    InnerShadow = 1,
 }
 
 impl From<u8> for RawShadowStyle {
@@ -21,8 +22,8 @@ impl From<u8> for RawShadowStyle {
 impl From<RawShadowStyle> for ShadowStyle {
     fn from(value: RawShadowStyle) -> Self {
         match value {
-            RawShadowStyle::Drop => Self::Drop,
-            RawShadowStyle::Inner => Self::Inner,
+            RawShadowStyle::DropShadow => Self::Drop,
+            RawShadowStyle::InnerShadow => Self::Inner,
         }
     }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12209

### Summary

This fixes the bug of inner shadows being rendered as drop shadows.

<img width="695" height="284" alt="Screenshot 2025-10-02 at 2 35 22 PM" src="https://github.com/user-attachments/assets/f12237b6-e9e2-4cca-9752-803d80e54944" />

### Steps to reproduce 

1. Create a shape and add an inner shadow to it.

Expected behavior (with this bug fix):

- The shadow is rendered correctly as an inner shadow

Actual behavior (without this patch):

- The shadow is rendered as a drop shadow.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

