### PR TITLE
:bug: Remove duplicated token set ids

### DIFF
--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -33,6 +33,7 @@
    [app.common.types.shape.shadow :as ctss]
    [app.common.types.shape.text :as ctst]
    [app.common.types.text :as types.text]
+   [app.common.types.tokens-lib :as types.tokens-lib]
    [app.common.uuid :as uuid]
    [clojure.set :as set]
    [cuerdas.core :as str]))
@@ -1612,6 +1613,10 @@
           (update component :path #(d/nilv % "")))]
     (d/update-when data :components d/update-vals update-component)))
 
+(defmethod migrate-data "0014-fix-tokens-lib-duplicate-ids"
+  [data _]
+  (update data :tokens-lib types.tokens-lib/fix-duplicate-token-set-ids))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1681,4 +1686,5 @@
          "0010-fix-swap-slots-pointing-non-existent-shapes"
          "0011-fix-invalid-text-touched-flags"
          "0012-fix-position-data"
-         "0013-fix-component-path"]))
+         "0013-fix-component-path"
+         "0014-fix-tokens-lib-duplicate-ids"]))

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -855,7 +855,9 @@
 
 (t/deftest transit-serialization
   (let [tokens-lib  (-> (ctob/make-tokens-lib)
-                        (ctob/add-set (ctob/make-token-set :name "test-token-set"))
+                        (ctob/add-set (ctob/make-token-set
+                                       :id (thi/new-id! :test-token-set)
+                                       :name "test-token-set"))
                         (ctob/add-token (thi/id :test-token-set)
                                         (ctob/make-token :name "test-token"
                                                          :type :boolean


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12243

### Summary

There are files with several token sets with the same id. This is invalid, so we add a validation check to avoid this occurs again, and a migration to fix it if it's already occuring in a file.

### Steps to reproduce 

This bug cannot be reproduced, since we don't know the cause of the duplication. We have detected it in two files, linked in the issue. But once those two have been repaired, there is no known way of reproducing.

When the files are exported and reimported, all ids are regenerated, cleaning the failure. But if you duplicate the penpot files, the error persists.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
