### PR TITLE
:bug: Fix broken layout when multiple fill/strokes with tokens

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -68,13 +68,13 @@
                 resolved-token (get-resolved-token property shape resolved-tokens)
                 has-token (has-token? resolved-token stroke-type idx)]
             (if (= property :border-color)
-              [:> color-properties-row* {:key (dm/str "stroke-" property "-" idx (:color stroke-type))
+              [:> color-properties-row* {:key (str idx property)
                                          :term property-name
                                          :color stroke-type
                                          :token (when has-token resolved-token)
                                          :format color-space
                                          :copiable true}]
-              [:> properties-row* {:key  (dm/str "stroke-" property "-" idx (:color stroke-type))
+              [:> properties-row* {:key  (str idx property)
                                    :term (d/name property-name)
                                    :detail (dm/str value)
                                    :token (when has-token resolved-token)


### PR DESCRIPTION
### Related Ticket

This PR fixes two bugs:

- [Put color row on top of the border properties](https://tree.taiga.io/project/penpot/task/12056)
- [Properties with multiple values display token in every row](https://tree.taiga.io/project/penpot/task/12216)

### Summary

In the stroke panel, color row must be the first property
In strokes/fill with multiple values and tokens, visualization was wrong

<img width="524" height="862" alt="image" src="https://github.com/user-attachments/assets/6422f49d-f77c-44ab-8146-7380b586342b" />

### Steps to reproduce 

Create a new stroke with multiple strokes. One of them must be a token

- Ensure that the first property is a color
- Ensure that all the properties are not displayed as if they were tokens

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
