### PR TITLE
:sparkles: Make component path attr mandatory

### DIFF
--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -317,8 +317,7 @@
      [:type [:= :add-component]]
      [:id ::sm/uuid]
      [:name :string]
-     [:shapes {:optional true} [:vector {:gen/max 3} ::sm/any]]
-     [:path {:optional true} :string]
+     [:path :string]
      [:main-instance-id ::sm/uuid]
      [:main-instance-page ::sm/uuid]
      ;; Only used by external processes (like Penpot SDK)
@@ -331,7 +330,6 @@
      [:id ::sm/uuid]
      [:name {:optional true} :string]
      [:path {:optional true} :string]
-     [:shapes {:optional true} [:vector {:gen/max 3} ::sm/any]]
      [:variant-id {:optional true} ::sm/uuid]
      [:variant-properties {:optional true} [:vector ctv/schema:variant-property]]]]
 

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1605,6 +1605,13 @@
         (update :pages-index d/update-vals update-container)
         (d/update-when :components d/update-vals update-container))))
 
+(defmethod migrate-data "0013-fix-component-path"
+  [data _]
+  (let [update-component
+        (fn [component]
+          (update component :path #(d/nilv % "")))]
+    (d/update-when data :components d/update-vals update-component)))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1673,4 +1680,5 @@
          "0009-add-partial-text-touched-flags"
          "0010-fix-swap-slots-pointing-non-existent-shapes"
          "0011-fix-invalid-text-touched-flags"
-         "0012-fix-position-data"]))
+         "0012-fix-position-data"
+         "0013-fix-component-path"]))

--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -23,7 +23,7 @@
    [:map
     [:id ::sm/uuid]
     [:name :string]
-    [:path {:optional true} [:maybe :string]]
+    [:path :string]
     [:modified-at {:optional true} ::ct/inst]
     [:objects {:gen/max 10 :optional true} ctp/schema:objects]
     [:main-instance-id ::sm/uuid]

--- a/common/src/app/common/types/components_list.cljc
+++ b/common/src/app/common/types/components_list.cljc
@@ -8,7 +8,6 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
-   [app.common.features :as cfeat]
    [app.common.time :as dt]
    [app.common.types.component :as ctk]
    [clojure.set :as set]))
@@ -43,55 +42,53 @@
 
 (defn mod-component
   [file-data {:keys [id name path main-instance-id main-instance-page objects annotation variant-id variant-properties modified-at]}]
-  (let [wrap-objects-fn cfeat/*wrap-with-objects-map-fn*]
-    (d/update-in-when file-data [:components id]
-                      (fn [component]
-                        (let [objects  (some-> objects wrap-objects-fn)
-                              new-comp (cond-> component
-                                         (some? name)
-                                         (assoc :name name)
+  (d/update-in-when file-data [:components id]
+                    (fn [component]
+                      (let [new-comp (cond-> component
+                                       (some? name)
+                                       (assoc :name name)
 
-                                         (some? path)
-                                         (assoc :path path)
+                                       (some? path)
+                                       (assoc :path path)
 
-                                         (some? main-instance-id)
-                                         (assoc :main-instance-id main-instance-id)
+                                       (some? main-instance-id)
+                                       (assoc :main-instance-id main-instance-id)
 
-                                         (some? main-instance-page)
-                                         (assoc :main-instance-page main-instance-page)
+                                       (some? main-instance-page)
+                                       (assoc :main-instance-page main-instance-page)
 
-                                         (some? objects)
-                                         (assoc :objects objects)
+                                       (some? objects)
+                                       (assoc :objects objects)
 
-                                         (some? modified-at)
-                                         (assoc :modified-at modified-at)
+                                       (some? modified-at)
+                                       (assoc :modified-at modified-at)
 
-                                         (some? annotation)
-                                         (assoc :annotation annotation)
+                                       (some? annotation)
+                                       (assoc :annotation annotation)
 
-                                         (nil? annotation)
-                                         (dissoc :annotation)
+                                       (nil? annotation)
+                                       (dissoc :annotation)
 
-                                         (some? variant-id)
-                                         (assoc :variant-id variant-id)
+                                       (some? variant-id)
+                                       (assoc :variant-id variant-id)
 
-                                         (nil? variant-id)
-                                         (dissoc :variant-id)
+                                       (nil? variant-id)
+                                       (dissoc :variant-id)
 
-                                         (some? variant-properties)
-                                         (assoc :variant-properties variant-properties)
+                                       (some? variant-properties)
+                                       (assoc :variant-properties variant-properties)
 
-                                         (nil? variant-properties)
-                                         (dissoc :variant-properties))
+                                       (nil? variant-properties)
+                                       (dissoc :variant-properties))
 
-                              ;; The set of properties that doesn't mark a component as touched
-                              diff     (set/difference
-                                        (ctk/diff-components component new-comp)
-                                        #{:annotation :modified-at :variant-id :variant-properties})]
+                            ;; The set of properties that doesn't mark a component as touched
+                            diff     (set/difference
+                                      (ctk/diff-components component new-comp)
+                                      #{:annotation :modified-at :variant-id :variant-properties})]
 
-                          (if (empty? diff)
-                            new-comp
-                            (touch new-comp)))))))
+                        (if (empty? diff)
+                          new-comp
+                          (touch new-comp))))))
 
 (defn get-component
   ([file-data component-id]


### PR DESCRIPTION
### Summary

Make component path attr mandatory and add migration for ensure existing files have a correct value for it.

**Merge with "rebase and merge"** 