### PR TITLE
:bug: Fix component number has no singular translation string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 - Fix error updating library [Taiga #12218](https://tree.taiga.io/project/penpot/issue/12218)
 - Fix restoring a variant in another file makes it overlap the existing variant [Taiga #12049](https://tree.taiga.io/project/penpot/issue/12049)
 - Fix auto-width changes to fixed when switching variants [Taiga #12172](https://tree.taiga.io/project/penpot/issue/12172)
+- Fix component number has no singular translation string [Taiga #12106](https://tree.taiga.io/project/penpot/issue/12106)
 
 
 ## 2.10.1 (Unreleased)

--- a/frontend/src/app/main/ui/workspace/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/libraries.cljs
@@ -37,7 +37,7 @@
    [app.main.ui.icons :as deprecated-icon]
    [app.util.color :as uc]
    [app.util.dom :as dom]
-   [app.util.i18n :as i18n :refer [tr]]
+   [app.util.i18n :refer [c tr]]
    [app.util.strings :refer [matches-search]]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
@@ -98,16 +98,16 @@
      (str/join " · "
                (cond-> []
                  (or all-zero? (pos? components-count))
-                 (conj (tr "workspace.libraries.components" components-count))
+                 (conj (tr "workspace.libraries.components" (c components-count)))
 
                  (or all-zero? (pos? graphics-count))
-                 (conj (tr "workspace.libraries.graphics" graphics-count))
+                 (conj (tr "workspace.libraries.graphics" (c graphics-count)))
 
                  (or all-zero? (pos? colors-count))
-                 (conj (tr "workspace.libraries.colors" colors-count))
+                 (conj (tr "workspace.libraries.colors" (c colors-count)))
 
                  (or all-zero? (pos? typography-count))
-                 (conj (tr "workspace.libraries.typography" typography-count))))
+                 (conj (tr "workspace.libraries.typography" (c typography-count)))))
      "\u00A0")))
 
 (mf/defc library-description*
@@ -122,19 +122,19 @@
     [:*
      (when (pos? components-count)
        [:li {:class (stl/css :element-count)}
-        (tr "workspace.libraries.components" components-count)])
+        (tr "workspace.libraries.components" (c components-count))])
 
      (when (pos? graphics-count)
        [:li {:class (stl/css :element-count)}
-        (tr "workspace.libraries.graphics" graphics-count)])
+        (tr "workspace.libraries.graphics" (c graphics-count))])
 
      (when (pos? colors-count)
        [:li {:class (stl/css :element-count)}
-        (tr "workspace.libraries.colors" colors-count)])
+        (tr "workspace.libraries.colors" (c colors-count))])
 
      (when (pos? typography-count)
        [:li {:class (stl/css :element-count)}
-        (tr "workspace.libraries.typography" typography-count)])]))
+        (tr "workspace.libraries.typography" (c typography-count))])]))
 
 (mf/defc sample-library-entry*
   {::mf/props :obj

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5488,7 +5488,9 @@ msgstr "Add"
 
 #: src/app/main/ui/workspace/libraries.cljs:107, src/app/main/ui/workspace/libraries.cljs:133
 msgid "workspace.libraries.colors"
-msgstr "%s colors"
+msgid_plural "workspace.libraries.colors" 
+msgstr[0] "1 color" 
+msgstr[1] "%s colors"
 
 #: src/app/main/ui/workspace/color_palette.cljs:147
 msgid "workspace.libraries.colors.empty-palette"
@@ -5526,7 +5528,9 @@ msgstr "Save color style"
 
 #: src/app/main/ui/workspace/libraries.cljs:101, src/app/main/ui/workspace/libraries.cljs:125
 msgid "workspace.libraries.components"
-msgstr "%s components"
+msgid_plural "workspace.libraries.components" 
+msgstr[0] "1 component" 
+msgstr[1] "%s components"
 
 #: src/app/main/ui/workspace/libraries.cljs:349
 msgid "workspace.libraries.connected-to"
@@ -5550,7 +5554,9 @@ msgstr "File library"
 
 #: src/app/main/ui/workspace/libraries.cljs:104, src/app/main/ui/workspace/libraries.cljs:129
 msgid "workspace.libraries.graphics"
-msgstr "%s graphics"
+msgid_plural "workspace.libraries.graphics" 
+msgstr[0] "1 graphic" 
+msgstr[1] "%s graphics"
 
 #: src/app/main/ui/workspace/libraries.cljs:316
 msgid "workspace.libraries.in-this-file"
@@ -5608,7 +5614,9 @@ msgstr "Unlink all typographies"
 
 #: src/app/main/ui/workspace/libraries.cljs:110, src/app/main/ui/workspace/libraries.cljs:137
 msgid "workspace.libraries.typography"
-msgstr "%s typographies"
+msgid_plural "workspace.libraries.typography" 
+msgstr[0] "1 typography" 
+msgstr[1] "%s typographies"
 
 #: src/app/main/ui/workspace/libraries.cljs:354
 msgid "workspace.libraries.unlink-library-btn"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5467,7 +5467,9 @@ msgstr "Añadir"
 
 #: src/app/main/ui/workspace/libraries.cljs:107, src/app/main/ui/workspace/libraries.cljs:133
 msgid "workspace.libraries.colors"
-msgstr "%s colores"
+msgid_plural "workspace.libraries.colors" 
+msgstr[0] "1 color" 
+msgstr[1] "%s colores"
 
 #: src/app/main/ui/workspace/color_palette.cljs:147
 msgid "workspace.libraries.colors.empty-palette"
@@ -5505,7 +5507,9 @@ msgstr "Guardar estilo de color"
 
 #: src/app/main/ui/workspace/libraries.cljs:101, src/app/main/ui/workspace/libraries.cljs:125
 msgid "workspace.libraries.components"
-msgstr "%s componentes"
+msgid_plural "workspace.libraries.components" 
+msgstr[0] "1 componente" 
+msgstr[1] "%s componentes"
 
 #: src/app/main/ui/workspace/libraries.cljs:349
 msgid "workspace.libraries.connected-to"
@@ -5529,7 +5533,9 @@ msgstr "Biblioteca del archivo"
 
 #: src/app/main/ui/workspace/libraries.cljs:104, src/app/main/ui/workspace/libraries.cljs:129
 msgid "workspace.libraries.graphics"
-msgstr "%s gráficos"
+msgid_plural "workspace.libraries.graphics" 
+msgstr[0] "1 gráfico" 
+msgstr[1] "%s gráficos"
 
 #: src/app/main/ui/workspace/libraries.cljs:316
 msgid "workspace.libraries.in-this-file"
@@ -5587,7 +5593,9 @@ msgstr "Desvincular todas las tipografías"
 
 #: src/app/main/ui/workspace/libraries.cljs:110, src/app/main/ui/workspace/libraries.cljs:137
 msgid "workspace.libraries.typography"
-msgstr "%s tipografías"
+msgid_plural "workspace.libraries.typography" 
+msgstr[0] "1 tipografía" 
+msgstr[1] "%s tipografías"
 
 #: src/app/main/ui/workspace/libraries.cljs:354
 msgid "workspace.libraries.unlink-library-btn"


### PR DESCRIPTION
### Related Ticket

Taiga [#12106](https://tree.taiga.io/project/penpot/issue/12106)

### Summary

Add singular translation strings for some items that describe a library.

### Steps to reproduce 

Open the "Manage library" modal. Check that "component/s", "color/s", "graphic/s" and "typography/es" are properly translated depending on if they refer to one or more items.