### PR TITLE
:sparkles: Add missing variant-switch tracking event

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -715,7 +715,9 @@
                 (do
                   (on-error)
                   (rx/empty))
-                (rx/of (dwl/component-swap shape (:component-file shape) (:id nearest-comp) true))))))))))
+                (rx/of
+                 (dwl/component-swap shape (:component-file shape) (:id nearest-comp) true)
+                 (ev/event {::ev/name "variant-switch" ::ev/origin "workspace:design-tab"}))))))))))
 
 (defn variants-switch
   "Switch each shape (that must be a variant copy head) for the closest one with the property value passed as parameter"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12104

### Summary

The tracking event "variant-switch" is not triggered when the user makes a switch

### Steps to reproduce 

1. Make a switch
2. Check that no push-audit-event call is made

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
