### PR TITLE
:recycle: Fix component schemas

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/utilities/hint_message.cljs
+++ b/frontend/src/app/main/ui/ds/controls/utilities/hint_message.cljs
@@ -13,7 +13,7 @@
 
 (def ^:private schema::hint-message
   [:map
-   [:message :string]
+   [:message [:or fn? :string]]
    [:id :string]
    [:type {:optional true} [:enum "hint" "error" "warning"]]
    [:class {:optional true} :string]])

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -172,9 +172,7 @@
    [:id {:optional true} :string]
    [:offset {:optional true} :int]
    [:delay {:optional true} :int]
-   ;; TODO: Review why html element crash schema
-   ;; https://tree.taiga.io/project/penpot/task/12039
-   ;; [:content [:or fn? :string [:fn mf/element?]]]
+   [:content [:or fn? :string]]
    [:placement {:optional true}
     [:maybe [:enum "top" "bottom" "left" "right" "top-right" "bottom-right" "bottom-left" "top-left"]]]])
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -104,10 +104,10 @@
                                has-errors
                                (tr "color-row.token-color-row.deleted-token")
                                :else
-                               (mf/html
-                                [:div
-                                 [:span (dm/str (tr "workspace.tokens.token-name") ": ")]
-                                 [:span {:class (stl/css :token-name-tooltip)} color-token]]))]
+                               #(mf/html
+                                 [:div
+                                  [:span (dm/str (tr "workspace.tokens.token-name") ": ")]
+                                  [:span {:class (stl/css :token-name-tooltip)} color-token]]))]
 
     [:div {:class (stl/css :color-info)}
      [:div {:class (stl/css-case :token-color-wrapper true


### PR DESCRIPTION
### Related Ticket

This PR solves this 2 PR
- https://tree.taiga.io/project/penpot/task/12016
- https://tree.taiga.io/project/penpot/task/12039

### Summary

We need to review the schemas of some components to admit html elements as children.

Note: mf/element is not working properly so, we can't use it for now, instead we will use fn? and we will send the html elemenet as a function `#(mf/html.....)`

### Steps to reproduce 
The tooltip on the color row should not crash.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
