### PR TITLE
:wrench: Replace ADD with COPY in Dockerfiles to fix hadolint warnings

### DIFF
--- a/docker/images/Dockerfile.backend
+++ b/docker/images/Dockerfile.backend
@@ -128,7 +128,7 @@ COPY --from=build /opt/node /opt/node
 COPY --from=penpotapp/imagemagick:7.1.2-0 /opt/imagick /opt/imagick
 
 ARG BUNDLE_PATH="./bundle-backend/"
-ADD --chown=penpot:penpot $BUNDLE_PATH /opt/penpot/backend/
+COPY --chown=penpot:penpot $BUNDLE_PATH /opt/penpot/backend/
 
 USER penpot:penpot
 WORKDIR /opt/penpot/backend

--- a/docker/images/Dockerfile.exporter
+++ b/docker/images/Dockerfile.exporter
@@ -90,7 +90,7 @@ RUN set -eux; \
     chown -R penpot:penpot /opt/penpot;
 
 ARG BUNDLE_PATH="./bundle-exporter/"
-ADD --chown=penpot:penpot $BUNDLE_PATH /opt/penpot/exporter/
+COPY --chown=penpot:penpot $BUNDLE_PATH /opt/penpot/exporter/
 
 WORKDIR /opt/penpot/exporter
 USER penpot:penpot

--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -12,13 +12,13 @@ RUN set -ex; \
     mkdir -p /etc/nginx/overrides/location.d/;
 
 ARG BUNDLE_PATH="./bundle-frontend/"
-ADD $BUNDLE_PATH /var/www/app/
-ADD ./files/config.js /var/www/app/js/config.js
-ADD ./files/nginx.conf.template /tmp/nginx.conf.template
-ADD ./files/nginx-resolvers.conf.template /tmp/resolvers.conf.template
-ADD ./files/nginx-mime.types /etc/nginx/mime.types
-ADD ./files/nginx-external-locations.conf /etc/nginx/overrides/location.d/external-locations.conf
-ADD ./files/nginx-entrypoint.sh /entrypoint.sh
+COPY $BUNDLE_PATH /var/www/app/
+COPY ./files/config.js /var/www/app/js/config.js
+COPY ./files/nginx.conf.template /tmp/nginx.conf.template
+COPY ./files/nginx-resolvers.conf.template /tmp/resolvers.conf.template
+COPY ./files/nginx-mime.types /etc/nginx/mime.types
+COPY ./files/nginx-external-locations.conf /etc/nginx/overrides/location.d/external-locations.conf
+COPY ./files/nginx-entrypoint.sh /entrypoint.sh
 
 RUN chown -R 1001:0 /var/cache/nginx; \
     chmod -R g+w /var/cache/nginx; \


### PR DESCRIPTION
![cleaning gif](https://media.giphy.com/media/l2Je66zG6mAAZxgqI/giphy.gif)

Switched all ADD instructions to COPY across Dockerfiles to comply with **Hadolint**.
While functionally identical, this change improves clarity, build reproducibility, and keeps our Docker setup clean and consistent. 🧽✨