### PR TITLE
:bug: Add migrations for several fixes

### DIFF
--- a/backend/src/app/srepl/main.clj
+++ b/backend/src/app/srepl/main.clj
@@ -531,6 +531,18 @@
         (assoc :max-jobs 1)
         (process!))))
 
+
+(defn mark-file-as-trimmed
+  [id]
+  (let [id (h/parse-uuid id)]
+    (db/tx-run! main/system (fn [cfg]
+                              (-> (db/update! cfg :file
+                                              {:has-media-trimmed true}
+                                              {:id id}
+                                              {::db/return-keys false})
+                                  (db/get-update-count)
+                                  (pos?))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; DELETE/RESTORE OBJECTS (WITH CASCADE, SOFT)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/backend/src/app/srepl/main.clj
+++ b/backend/src/app/srepl/main.clj
@@ -15,7 +15,7 @@
    [app.common.features :as cfeat]
    [app.common.files.validate :as cfv]
    [app.common.logging :as l]
-   [app.common.pprint :as p]
+   [app.common.pprint :as pp]
    [app.common.schema :as sm]
    [app.common.spec :as us]
    [app.common.time :as ct]
@@ -58,7 +58,7 @@
 (defn print-tasks
   []
   (let [tasks (:app.worker/registry main/system)]
-    (p/pprint (keys tasks) :level 200)))
+    (pp/pprint (keys tasks) :level 200)))
 
 (defn run-task!
   ([tname]
@@ -130,18 +130,18 @@
 (defn reset-password!
   "Reset a password to a specific one for a concrete user or all users
   if email is `:all` keyword."
-  [& {:keys [email password] :or {password "123123"} :as params}]
-  (when-not email
-    (throw (IllegalArgumentException. "email is mandatory")))
+  [& {:keys [email password]}]
+  (assert (string? email) "expected email")
+  (assert (string? password) "expected password")
 
   (some-> main/system
           (db/tx-run!
            (fn [{:keys [::db/conn] :as system}]
-             (let [password (derive-password password)]
-               (if (= email :all)
-                 (db/exec! conn ["update profile set password=?" password])
-                 (let [email (str/lower email)]
-                   (db/exec! conn ["update profile set password=? where email=?" password email]))))))))
+             (let [password (derive-password password)
+                   email    (str/lower email)]
+               (-> (db/exec-one! conn ["update profile set password=? where email=?" password email])
+                   (db/get-update-count)
+                   (pos?)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; FEATURES

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -420,7 +420,7 @@
   :min 0
   :max 1
   :compile
-  (fn [{:keys [kind max min] :as props} children _]
+  (fn [{:keys [kind max min ordered] :as props} children _]
     (let [kind  (or (last children) kind)
 
           pred
@@ -456,18 +456,23 @@
             (fn [value]
               (every? pred value)))
 
+          empty-set
+          (if ordered
+            (d/ordered-set)
+            #{})
+
           decode
           (fn [v]
             (cond
               (string? v)
               (let [v  (str/split v #"[\s,]+")]
-                (into #{} xf:filter-word-strings v))
+                (into empty-set xf:filter-word-strings v))
 
               (set? v)
               v
 
               (coll? v)
-              (into #{} v)
+              (into empty-set v)
 
               :else
               v))

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -106,7 +106,7 @@
    [:version :int]
    [:features ::cfeat/features]
    [:migrations {:optional true}
-    [::sm/set :string]]])
+    [::sm/set {:ordered true} :string]]])
 
 (sm/register! ::data schema:data)
 (sm/register! ::file schema:file)


### PR DESCRIPTION
### Summary

#### Bug 1
We have several error reports when we have files with completly invalid shapes. Example:

<img width="796" height="182" alt="image" src="https://github.com/user-attachments/assets/948e044e-61a0-4ff1-a508-22c67ca0eed2" />

On this cases, the shape looks like a plan map with empty path content.

For solve this we have a migration that checks if the shape has correct type. If not, we try to preserve all the attributes on coercing the data to a shape but if incorrect state is generated, as the last resort we replace the shape with a dummy rect.

#### Bug 2

This also have several reports of local library containing components with objects to `nil`.

<img width="619" height="183" alt="image" src="https://github.com/user-attachments/assets/345f7631-e2aa-4b18-9392-b0e3293b15a7" />


Because of a old bug in migrations, several files have migrations applied in an incorrect order and because of other bug on old migrations, some files have components with `:objects` with `nil` as value; this migration fixes it.


### How to test

There are no way to test it correctly. **Ensure this migration does not removes correct data.**