### PR TITLE
:tada: Add debug and alert when WebGL is unsupported

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -296,8 +296,9 @@
         (->> wasm.api/module
              (p/fmap (fn [ready?]
                        (when ready?
-                         (reset! canvas-init? true)
-                         (wasm.api/assign-canvas canvas)))))
+                         (let [init? (wasm.api/init-canvas-context canvas)]
+                           (reset! canvas-init? init?)
+                           (when-not init? (js/alert "WebGL not supported")))))))
         (fn []
           (wasm.api/clear-canvas))))
 

--- a/frontend/src/app/util/debug.cljs
+++ b/frontend/src/app/util/debug.cljs
@@ -96,8 +96,11 @@
     ;; Show some information about the WebGL context.
     :gl-context
 
-    ;; Show viewbox
+    ;; Show viewbox.
     :wasm-viewbox
+
+    ;; Makes the GL context to fail on initialization.
+    :wasm-gl-context-init-error
 
     ;; Event times
     :events-times})


### PR DESCRIPTION
### Summary

Adds a debug option to test when WebGL is unsupported.
<img width="270" height="138" alt="image" src="https://github.com/user-attachments/assets/d1245f64-8ade-45c2-8229-72ef0a9ca2d7" />

Adds an alert when canvas initialization fails.
<img width="647" height="300" alt="image" src="https://github.com/user-attachments/assets/a0d81e89-e33d-438e-9c2e-d7704cb2f800" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
