### PR TITLE
:wrench: Fix extrect and selrect debug interactivity

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -808,9 +808,9 @@ impl RenderState {
 
         if self.options.is_debug_visible() {
             let shape_selrect_bounds = self.get_shape_selrect_bounds(&shape);
-            let shape_extrect_bounds = self.get_shape_extrect_bounds(&shape, shapes, modifiers);
-            debug::render_debug_shape(self, shape_selrect_bounds, shape_extrect_bounds);
+            debug::render_debug_shape(self, Some(shape_selrect_bounds), None);
         }
+
         if apply_to_current_surface {
             self.apply_drawing_to_render_canvas(Some(&shape));
         }
@@ -1293,6 +1293,12 @@ impl RenderState {
                         tree,
                         modifiers,
                     );
+
+                if self.options.is_debug_visible() {
+                    let shape_extrect_bounds =
+                        self.get_shape_extrect_bounds(&transformed_element, tree, modifiers);
+                    debug::render_debug_shape(self, None, Some(shape_extrect_bounds));
+                }
 
                 if !is_visible {
                     continue;

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -147,8 +147,8 @@ pub fn render_workspace_current_tile(
 
 pub fn render_debug_shape(
     render_state: &mut RenderState,
-    shape_selrect: skia::Rect,
-    shape_extrect: skia::Rect,
+    shape_selrect: Option<skia::Rect>,
+    shape_extrect: Option<skia::Rect>,
 ) {
     let canvas = render_state.surfaces.canvas(SurfaceId::Debug);
 
@@ -157,11 +157,13 @@ pub fn render_debug_shape(
     paint.set_color(skia::Color::RED);
     paint.set_stroke_width(1.);
 
-    canvas.draw_rect(shape_selrect, &paint);
+    if let Some(rect) = shape_selrect {
+        canvas.draw_rect(rect, &paint);
+    }
 
-    if shape_extrect != shape_selrect {
+    if let Some(rect) = shape_extrect {
         paint.set_color(skia::Color::BLUE);
-        canvas.draw_rect(shape_extrect, &paint);
+        canvas.draw_rect(rect, &paint);
     }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12292

### Summary

Improve extrect debug rendering. This is a follow up for https://github.com/penpot/penpot/pull/7500  

### Steps to reproduce 

https://github.com/user-attachments/assets/4fff1dda-b236-480d-ac86-bd7a10612fd0

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.

