### PR TITLE
:zap: Add minor comment threads queries optimization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 - Alternative ways of creating variants - Button Viewport [Taiga #11931](https://tree.taiga.io/project/penpot/us/11931)
 - Reorder properties for a component [Taiga #10225](https://tree.taiga.io/project/penpot/us/10225)
 - File Data storage layout refactor [Github #7345](https://github.com/penpot/penpot/pull/7345)
+- Make several queries optimization on comment threads [Github #7506](https://github.com/penpot/penpot/pull/7506)
 
 ### :bug: Bugs fixed
 


### PR DESCRIPTION
### Summary

This PR replaces the comment threads queries with more optimized versions of them.

The main problem with current queries is that they declare the main query under WITH clause, and then declares filtering as separate query; this forces postgres to materialize the query in WITH clause, and then proceed to filter. On small set of data that worked ok, but with files and teams with big amount of comment threads and comments this becomes a pretty slow query because of large sequential scans on materialized query.

Example: 

<img width="748" height="137" alt="image" src="https://github.com/user-attachments/assets/212f8be0-5b2f-4cb7-b782-98a17b99067f" />

That can be easily improved by moving several filtering conditions into the main query and making the resulting materialized view smaller and more amenable for filtering on things that can't be done directly on the main query (that depends on aggregation calculation, per example)

This reduces queries from several seconds to milliseconds in the worst case and reduces the load of database in general because this queries are executed each time user fetches dashboard or workspace.

### How to test

This mainly affects the comments queries. The comment queries can be tested navigating to comments on workspace and dashboard.

This already has several unit tests so the basic is also covered by tests.