### PR TITLE
:bug: Fix resize on blocked shapes from the viewport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ### :bug: Bugs fixed
 
 - Fix pan cursor not disabling viewport guides [Github #6985](https://github.com/penpot/penpot/issues/6985)
+- Fix viewport resize on locked shapes [Taiga #11974](https://tree.taiga.io/project/penpot/issue/11974)
 
 ## 2.11.0 (Unreleased)
 

--- a/frontend/playwright/ui/visual-specs/workspace.spec.js
+++ b/frontend/playwright/ui/visual-specs/workspace.spec.js
@@ -28,13 +28,29 @@ const setupFileWithAssets = async (workspace) => {
   return { fileId, pageId };
 };
 
-test("Shows the workspace correctly for a blank file", async ({ page }) => {
-  const workspace = new WorkspacePage(page);
-  await workspace.setupEmptyFile();
+test.describe("Viewport", () => {
+  test("Shows the workspace correctly for a blank file", async ({ page }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile();
 
-  await workspace.goToWorkspace();
+    await workspace.goToWorkspace();
 
-  await expect(workspace.page).toHaveScreenshot();
+    await expect(workspace.page).toHaveScreenshot();
+  });
+
+  test("User creates a rectangle and locks it", async ({ page }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile(page);
+    await workspace.goToWorkspace();
+
+    await workspace.rectShapeButton.click();
+    await workspace.clickWithDragViewportAt(128, 128, 200, 100);
+    await workspace.clickLeafLayer("Rectangle");
+
+    await page.keyboard.press("Shift+Control+L");
+
+    await expect(workspace.page).toHaveScreenshot();
+  });
 });
 
 test.describe("Design tab", () => {

--- a/frontend/src/app/main/ui/workspace/viewport/selection.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/selection.cljs
@@ -381,6 +381,7 @@
                            (and flip-y (not flip-x)))]
 
     (when (and (not ^boolean read-only?)
+               (not (:blocked shape))
                (not (or (= transform-type :move)
                         (= transform-type :rotate))))
 

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -100,9 +100,9 @@
 
         on-pointer-down
         (mf/use-fn
-         (mf/deps (:id frame) on-frame-select workspace-read-only?)
+         (mf/deps (:id frame) on-frame-select workspace-read-only? blocked?)
          (fn [event]
-           (when (dom/left-mouse? event)
+           (when (and (dom/left-mouse? event) (not blocked?))
              (dom/prevent-default event)
              (dom/stop-propagation event)
              (on-frame-select event (:id frame)))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11974

### Summary

Right now, it's possible to resize a shape using the viewport controls when it's blocked. We should not allow that, so this PR fixes the following:

- When a shape is blocked and has been selected from the left sidebar, the viewport controls box does not display the resize corners, and it's not possible to resize it directly from the viewport.
- This also applies on groups of shapes.
- Additionally, it should not be possible to select a board by clicking on its name in the viewport when it's blocked, so this is fixed now as well.

### Steps to reproduce 

Create different kind of shapes, including boards, groups and components, and try to resize them in the viewport when they're blocked.

[lock_and_resize.webm](https://github.com/user-attachments/assets/d104c6a4-4dc9-44f6-ab10-ce94bf05164e)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.