### PR TITLE
:bug: Fix visual glitch in transparent background for swatch component

### DIFF
--- a/frontend/src/app/main/ui/ds/utilities/swatch.cljs
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.cljs
@@ -93,6 +93,8 @@
         image          (:image background)
         format         (if id? "rounded" "square")
         element-id     (mf/use-id)
+        has-opacity?  (and (some? (:color background))
+                           (< (:opacity background) 1))
         on-click
         (mf/use-fn
          (mf/deps background on-click)
@@ -124,18 +126,20 @@
      [:> element-type props
       (cond
         (some? gradient-type)
-        [:span {:class (stl/css :swatch-gradient)
-                :style {:background-image (str (uc/gradient->css gradient-data) ", repeating-conic-gradient(lightgray 0% 25%, white 0% 50%)")}}]
+        [:div {:class (stl/css :swatch-gradient)
+               :style {:background-image (str (uc/gradient->css gradient-data) ", repeating-conic-gradient(lightgray 0% 25%, white 0% 50%)")}}]
 
         (some? image)
         (let [uri (cfg/resolve-file-media image)]
-          [:span {:class (stl/css :swatch-image)
-                  :style {:background-image (str/ffmt "url(%)" uri)}}])
+          [:div {:class (stl/css :swatch-image)
+                 :style {:background-image (str/ffmt "url(%)" uri)}}])
         has-errors
-        [:span {:class (stl/css :swatch-error)}]
+        [:div {:class (stl/css :swatch-error)}]
         :else
-        [:span {:class (stl/css :swatch-opacity)}
-         [:span {:class (stl/css :swatch-solid-side)
-                 :style {:background (uc/color->background (assoc background :opacity 1))}}]
-         [:span {:class (stl/css :swatch-opacity-side)
-                 :style {"--solid-color-overlay" (str (uc/color->background background))}}]])]]))
+        [:div {:class (stl/css :swatch-opacity)}
+         [:div {:class (stl/css :swatch-solid-side)
+                :style {:background (uc/color->background (assoc background :opacity 1))}}]
+         [:div {:class (stl/css-case :swatch-opacity-side true
+                                     :swatch-opacity-side-transparency has-opacity?
+                                     :swatch-opacity-side-solid-color (not has-opacity?))
+                :style {"--solid-color-overlay" (str (uc/color->background background))}}]])]]))

--- a/frontend/src/app/main/ui/ds/utilities/swatch.scss
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.scss
@@ -105,10 +105,11 @@
 }
 
 .swatch-opacity {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto;
 }
 
-.swatch-opacity-side {
+.swatch-opacity-side-transparency {
   background-image:
   /* solid‑colour overlay */
   /* checkerboard pattern */
@@ -117,6 +118,12 @@
   background-size: cover, var(--checkerboard-size);
   background-position: center, center;
   background-repeat: no-repeat, repeat;
+  clip-path: inset(0 0 0 0 round 0 #{$br-4} #{$br-4} 0);
+}
+
+.swatch-opacity-side-solid-color {
+  background: var(--solid-color-overlay);
+  background-size: cover;
 }
 
 .swatch-solid-side,


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/12264

### Summary

A visual glitch happens in the border radius when multiple gradient backgrounds are stacked. A few pixels from the bottom layer are being displayed. See image

<img width="104" height="39" alt="image" src="https://github.com/user-attachments/assets/a10d7673-dcad-4bde-8abe-264c6462e620" />


### Steps to reproduce 

Any swatch with a transparent color or even a solid one has a small glitch at the edges.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
