### PR TITLE
:globe_with_meridians: Add font-style label on workspace assets

### DIFF
--- a/docs/technical-guide/developer/frontend.md
+++ b/docs/technical-guide/developer/frontend.md
@@ -217,7 +217,7 @@ repository:
 
 ```bash
 # cd <repo>/frontend
-yarn run validate-translations
+yarn run translations
 ```
 
 At Penpot core team we maintain manually the english and spanish .po files. All

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -515,7 +515,7 @@
             deprecated-icon/menu]]
 
           [:div {:class (stl/css :info-row)}
-           [:span {:class (stl/css :info-label)}  (tr "labels.variant")]
+           [:span {:class (stl/css :info-label)}  (tr "workspace.assets.typography.font-style")]
            [:span {:class (stl/css :info-content)} (:font-variant-id typography)]]
 
           [:div {:class (stl/css :info-row)}

--- a/frontend/translations/ar.po
+++ b/frontend/translations/ar.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Alejandro Alonso <alejandro.alonso@kaleidos.net>\n"
-"Language-Team: Arabic <https://hosted.weblate.org/projects/penpot/frontend/"
-"ar/>\n"
+"Language-Team: Arabic "
+"<https://hosted.weblate.org/projects/penpot/frontend/ar/>\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -2832,6 +2832,9 @@ msgstr "أسلوب الخط"
 msgid "workspace.assets.typography.font-size"
 msgstr "الحجم"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "نوع الخط"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "اذهب إلى تحرير نوع ملف المكتبة"
@@ -3826,7 +3829,7 @@ msgstr "أعلى"
 msgid "workspace.options.more-colors"
 msgstr "المزيد من الألوان"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "المزيد من ألوان المكتبة"
 

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Aryiu <aryiu@users.noreply.hosted.weblate.org>\n"
-"Language-Team: Catalan <https://hosted.weblate.org/projects/penpot/frontend/"
-"ca/>\n"
+"Language-Team: Catalan "
+"<https://hosted.weblate.org/projects/penpot/frontend/ca/>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -2790,6 +2790,9 @@ msgstr "Tipografia"
 msgid "workspace.assets.typography.font-size"
 msgstr "Mida"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Estil de la lletra"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Vés al fitxer de la biblioteca d'estils per a editar-lo"
@@ -3694,7 +3697,7 @@ msgstr "Dalt"
 msgid "workspace.options.more-colors"
 msgstr "Més colors"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Més llibreries de colors"
 

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: \"Amerey.eu\" <info@amerey.eu>\n"
-"Language-Team: Czech <https://hosted.weblate.org/projects/penpot/frontend/cs/"
-">\n"
+"Language-Team: Czech "
+"<https://hosted.weblate.org/projects/penpot/frontend/cs/>\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4278,6 +4278,9 @@ msgstr "Písmo"
 msgid "workspace.assets.typography.font-size"
 msgstr "Velikost"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Styl písma"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Chcete-li upravit, přejděte do souboru knihovny stylů"
@@ -5482,7 +5485,7 @@ msgstr "Nahoře"
 msgid "workspace.options.more-colors"
 msgstr "Více barev"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Více barev knihovny"
 

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Marius <hi@mariusscheel.de>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/penpot/frontend/"
-"de/>\n"
+"Language-Team: German "
+"<https://hosted.weblate.org/projects/penpot/frontend/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4779,6 +4779,9 @@ msgstr "Schriftart"
 msgid "workspace.assets.typography.font-size"
 msgstr "Größe"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Schriftschnitt"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Wechseln Sie zur Stilbibliotheksdatei, um sie zu bearbeiten"
@@ -6060,7 +6063,7 @@ msgstr "Oben"
 msgid "workspace.options.more-colors"
 msgstr "Weitere Farben"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Weitere Bibliotheksfarben"
 

--- a/frontend/translations/el.po
+++ b/frontend/translations/el.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Greek <https://hosted.weblate.org/projects/penpot/frontend/el/"
-">\n"
+"Language-Team: Greek "
+"<https://hosted.weblate.org/projects/penpot/frontend/el/>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -1273,6 +1273,9 @@ msgstr "Γραμματοσειρά"
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:522
 msgid "workspace.assets.typography.font-size"
 msgstr "Μέγεθος"
+
+msgid "workspace.assets.typography.font-style"
+msgstr "Στυλ γραμματοσειράς"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5111,6 +5111,9 @@ msgstr "Font"
 msgid "workspace.assets.typography.font-size"
 msgstr "Size"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Font Style"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Go to style library file to edit"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5095,6 +5095,9 @@ msgstr "Fuente"
 msgid "workspace.assets.typography.font-size"
 msgstr "Tamaño"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Estilo de fuente"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Ir al archivo de la biblioteca del estilo para editar"
@@ -5467,8 +5470,8 @@ msgstr "Añadir"
 
 #: src/app/main/ui/workspace/libraries.cljs:107, src/app/main/ui/workspace/libraries.cljs:133
 msgid "workspace.libraries.colors"
-msgid_plural "workspace.libraries.colors" 
-msgstr[0] "1 color" 
+msgid_plural "workspace.libraries.colors"
+msgstr[0] "1 color"
 msgstr[1] "%s colores"
 
 #: src/app/main/ui/workspace/color_palette.cljs:147
@@ -5507,8 +5510,8 @@ msgstr "Guardar estilo de color"
 
 #: src/app/main/ui/workspace/libraries.cljs:101, src/app/main/ui/workspace/libraries.cljs:125
 msgid "workspace.libraries.components"
-msgid_plural "workspace.libraries.components" 
-msgstr[0] "1 componente" 
+msgid_plural "workspace.libraries.components"
+msgstr[0] "1 componente"
 msgstr[1] "%s componentes"
 
 #: src/app/main/ui/workspace/libraries.cljs:349
@@ -5533,8 +5536,8 @@ msgstr "Biblioteca del archivo"
 
 #: src/app/main/ui/workspace/libraries.cljs:104, src/app/main/ui/workspace/libraries.cljs:129
 msgid "workspace.libraries.graphics"
-msgid_plural "workspace.libraries.graphics" 
-msgstr[0] "1 gráfico" 
+msgid_plural "workspace.libraries.graphics"
+msgstr[0] "1 gráfico"
 msgstr[1] "%s gráficos"
 
 #: src/app/main/ui/workspace/libraries.cljs:316
@@ -5593,8 +5596,8 @@ msgstr "Desvincular todas las tipografías"
 
 #: src/app/main/ui/workspace/libraries.cljs:110, src/app/main/ui/workspace/libraries.cljs:137
 msgid "workspace.libraries.typography"
-msgid_plural "workspace.libraries.typography" 
-msgstr[0] "1 tipografía" 
+msgid_plural "workspace.libraries.typography"
+msgstr[0] "1 tipografía"
 msgstr[1] "%s tipografías"
 
 #: src/app/main/ui/workspace/libraries.cljs:354
@@ -6457,13 +6460,13 @@ msgstr "Arriba"
 msgid "workspace.options.more-colors"
 msgstr "Más colores"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
-msgid "workspace.options.more-token-colors"
-msgstr "Más tokens de color"
-
 #: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Más colores de la biblioteca"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
+msgid "workspace.options.more-token-colors"
+msgstr "Más tokens de color"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:192
 msgid "workspace.options.opacity"

--- a/frontend/translations/eu.po
+++ b/frontend/translations/eu.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
-"Language-Team: Basque <https://hosted.weblate.org/projects/penpot/frontend/"
-"eu/>\n"
+"Language-Team: Basque "
+"<https://hosted.weblate.org/projects/penpot/frontend/eu/>\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3130,6 +3130,9 @@ msgstr "Letra-tipoak"
 msgid "workspace.assets.typography.font-size"
 msgstr "Tamaina"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Letra-tipoaren estiloa"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Joan estilo liburutegiaren fitxategira editatzeko"
@@ -4082,7 +4085,7 @@ msgstr "Goian"
 msgid "workspace.options.more-colors"
 msgstr "Kolore gehiago"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Liburutegiko kolore gehiago"
 

--- a/frontend/translations/fa.po
+++ b/frontend/translations/fa.po
@@ -2282,6 +2282,9 @@ msgstr "فونت"
 msgid "workspace.assets.typography.font-size"
 msgstr "اندازه"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "استایل فونت"
+
 #: src/app/main/ui/dashboard/grid.cljs:217, src/app/main/ui/workspace/libraries.cljs:579, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:480, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:506, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:613, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:633
 msgid "workspace.assets.typography.sample"
 msgstr "مثال"

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Pablo Alba <pablo.alba@kaleidos.net>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/penpot/frontend/"
-"fr/>\n"
+"Language-Team: French "
+"<https://hosted.weblate.org/projects/penpot/frontend/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4887,6 +4887,9 @@ msgstr "Police"
 msgid "workspace.assets.typography.font-size"
 msgstr "Taille"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Style de police"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Accéder au fichier de bibliothèque de styles à modifier"
@@ -6202,7 +6205,7 @@ msgstr "En haut"
 msgid "workspace.options.more-colors"
 msgstr "Plus de couleurs"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Plus de couleurs de la bibliothèque"
 

--- a/frontend/translations/ha.po
+++ b/frontend/translations/ha.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Alejandro Alonso <alejandro.alonso@kaleidos.net>\n"
-"Language-Team: Hausa <https://hosted.weblate.org/projects/penpot/frontend/ha/"
-">\n"
+"Language-Team: Hausa "
+"<https://hosted.weblate.org/projects/penpot/frontend/ha/>\n"
 "Language: ha\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3388,6 +3388,9 @@ msgstr "tsarin haruffa"
 msgid "workspace.assets.typography.font-size"
 msgstr "girma"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "tsarin salo"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "tafi zuwa salon dakin karatu don a tace"
@@ -4388,7 +4391,7 @@ msgstr "sama"
 msgid "workspace.options.more-colors"
 msgstr "kaloli masu yawa"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Ma'ajiyar kaloli masu yawa"
 

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
-"Language-Team: Hebrew <https://hosted.weblate.org/projects/penpot/frontend/"
-"he/>\n"
+"Language-Team: Hebrew "
+"<https://hosted.weblate.org/projects/penpot/frontend/he/>\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : "
-"((n > 10 && n % 10 == 0) ? 2 : 3));\n"
+"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
+"n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.14-dev\n"
 
 #: src/app/main/ui/auth/register.cljs:215, src/app/main/ui/static.cljs:153, src/app/main/ui/viewer/login.cljs:98
@@ -191,6 +191,16 @@ msgstr "דוא״ל עבודה"
 #, unused
 msgid "branding-illustrations-marketing-pieces"
 msgstr "…מיתוג, איורים, חומרים שיווקיים ועוד."
+
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
+msgid "color-row.token-color-row.deleted-token"
+msgstr "האסימון הזה לא קיים או שנמחק."
+
+#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
+msgid "color-token.empty-state"
+msgstr ""
+"אין אסימוני צבע זמינים. נא לבדוק ערכות/ערכות עיצוב פעילות או להוסיף "
+"אסימונים חדשים."
 
 #: src/app/main/ui/comments.cljs:530
 msgid "comments.mentions.not-found"
@@ -720,6 +730,22 @@ msgstr "הנתונים נשלחים לשרת (%s/%s)"
 msgid "dashboard.import.progress.upload-media"
 msgstr "נשלח קובץ: %s"
 
+#: src/app/main/ui/dashboard/team.cljs:765
+msgid "dashboard.invitation-modal.delete"
+msgstr "תימחקנה ההזמנות שמיועדות אל:"
+
+#: src/app/main/ui/dashboard/team.cljs:766
+msgid "dashboard.invitation-modal.resend"
+msgstr "תישלחנה מחדש ההזמנות שמיועדות אל:"
+
+#: src/app/main/ui/dashboard/team.cljs:756
+msgid "dashboard.invitation-modal.title.delete-invitations"
+msgstr "מחיקת הזמנות"
+
+#: src/app/main/ui/dashboard/team.cljs:757
+msgid "dashboard.invitation-modal.title.resend-invitations"
+msgstr "שליחת הזמנות מחדש"
+
 #: src/app/main/ui/dashboard/team.cljs:122, src/app/main/ui/dashboard/team.cljs:744
 msgid "dashboard.invite-profile"
 msgstr "הזמנת אנשים"
@@ -831,6 +857,14 @@ msgstr "פתיחת קובץ בלשונית חדשה"
 #: src/app/main/ui/dashboard/files.cljs:119, src/app/main/ui/dashboard/grid.cljs:425, src/app/main/ui/dashboard/projects.cljs:261, src/app/main/ui/dashboard/projects.cljs:262
 msgid "dashboard.options"
 msgstr "אפשרויות"
+
+#: src/app/main/ui/dashboard/team.cljs:949
+msgid "dashboard.order-invitations-by-role"
+msgstr "סידור לפי תפקיד"
+
+#: src/app/main/ui/dashboard/team.cljs:958
+msgid "dashboard.order-invitations-by-status"
+msgstr "סידור לפי מצב"
 
 #: src/app/main/ui/settings/password.cljs:94, src/app/main/ui/settings/password.cljs:107
 msgid "dashboard.password-change"
@@ -1827,6 +1861,38 @@ msgstr "מחושב"
 msgid "inspect.tabs.info"
 msgstr "מידע"
 
+#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
+msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgstr "העתקה ללוח הגזירים"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:22
+msgid "inspect.tabs.styles.panel.geometry"
+msgstr "גודל ומקום"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
+msgid "inspect.tabs.styles.panel.toggle-style"
+msgstr "החלפת חשיפת הלוח %s"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:21
+msgid "inspect.tabs.styles.panel.token"
+msgstr "ערכות אסימונים וערכות עיצוב"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
+msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgstr "ערכות פעילות"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
+msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgstr "ערכות עיצוב פעילות"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:20
+msgid "inspect.tabs.styles.panel.variant"
+msgstr "מאפייני הגוון"
+
+#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
+msgid "inspect.tabs.styles.token.resolved-value"
+msgstr "ערך פתור:"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
 msgid "inspect.tabs.switcher.label"
 msgstr "פרטי שכבה"
@@ -1838,6 +1904,10 @@ msgstr "לסמן הכול כנקרא"
 #: src/app/main/ui/workspace/main_menu.cljs:192
 msgid "label.shortcuts"
 msgstr "קיצורי דרך"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1043
+msgid "labels.about-penpot"
+msgstr "על Penpot"
 
 #: src/app/main/data/common.cljs:90, src/app/main/ui/dashboard/import.cljs:530
 msgid "labels.accept"
@@ -1894,6 +1964,10 @@ msgstr ""
 msgid "labels.bad-gateway.main-message"
 msgstr "שער גישה שגוי"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:26
+msgid "labels.blur"
+msgstr "טשטוש"
+
 #: src/app/main/data/common.cljs:129, src/app/main/ui/dashboard/change_owner.cljs:64, src/app/main/ui/dashboard/import.cljs:515, src/app/main/ui/dashboard/team.cljs:780, src/app/main/ui/dashboard/team.cljs:1122, src/app/main/ui/delete_shared.cljs:36, src/app/main/ui/exports/assets.cljs:162, src/app/main/ui/exports/files.cljs:191, src/app/main/ui/settings/access_tokens.cljs:175, src/app/main/ui/viewer/share_link.cljs:205, src/app/main/ui/workspace/sidebar/assets/groups.cljs:159, src/app/main/ui/workspace/tokens/export/modal.cljs:44, src/app/main/ui/workspace/tokens/import/modal.cljs:269, src/app/main/ui/workspace/tokens/management/create/form.cljs:632, src/app/main/ui/workspace/tokens/settings/menu.cljs:104, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:228
 msgid "labels.cancel"
 msgstr "ביטול"
@@ -1910,6 +1984,10 @@ msgstr "סגירה"
 msgid "labels.collapse"
 msgstr "צמצום"
 
+#: src/app/main/ui/workspace/colorpicker.cljs:427
+msgid "labels.color"
+msgstr "צבע"
+
 #: src/app/main/ui/comments.cljs:913
 msgid "labels.comment"
 msgstr "הערה"
@@ -1925,6 +2003,10 @@ msgstr "הערות"
 #: src/app/main/ui/dashboard/sidebar.cljs:840, src/app/main/ui/workspace/main_menu.cljs:144
 msgid "labels.community"
 msgstr "קהילה"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1030
+msgid "labels.community-contributions"
+msgstr "קהילה ותרומות"
 
 #: src/app/main/ui/settings/password.cljs:91
 msgid "labels.confirm-password"
@@ -2064,6 +2146,10 @@ msgstr "המשוב נשלח"
 msgid "labels.figma"
 msgstr "Figma"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:23
+msgid "labels.fill"
+msgstr "מילוי"
+
 #: src/app/main/ui/dashboard/fonts.cljs:430
 msgid "labels.font-family"
 msgstr "משפחת גופנים"
@@ -2110,6 +2196,10 @@ msgstr "עיצוב גרפי"
 msgid "labels.help-center"
 msgstr "מרכז העזרה"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:1019
+msgid "labels.help-learning"
+msgstr "עזרה ולמידה"
+
 #: src/app/main/ui/dashboard/templates.cljs:91
 msgid "labels.hide"
 msgstr "הסתרה"
@@ -2151,6 +2241,14 @@ msgstr "הזמנות"
 #: src/app/main/ui/settings/options.cljs:53
 msgid "labels.language"
 msgstr "שפה"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:28
+msgid "labels.layout"
+msgstr "פריסה"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:798
+msgid "labels.learning-center"
+msgstr "מרכז הלמידה"
 
 #: src/app/main/ui/workspace/main_menu.cljs:168
 msgid "labels.libraries-and-templates"
@@ -2294,6 +2392,14 @@ msgstr "סיסמה"
 msgid "labels.pending-invitation"
 msgstr "בהמתנה"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:878
+msgid "labels.penpot-changelog"
+msgstr "יומן השינויים של Penpot"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:804
+msgid "labels.penpot-hub"
+msgstr "המרכז של Penpot"
+
 #: src/app/main/ui/dashboard/sidebar.cljs:751
 msgid "labels.pinned-projects"
 msgstr "מיזמים נעוצים"
@@ -2321,6 +2427,10 @@ msgstr "פרופיל"
 #: src/app/main/ui/dashboard/sidebar.cljs:718
 msgid "labels.projects"
 msgstr "מיזמים"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
+msgid "labels.reference"
+msgstr "הפניה"
 
 #: src/app/main/data/common.cljs:83
 msgid "labels.refresh"
@@ -2371,6 +2481,10 @@ msgstr "תגובה חדשה"
 #: src/app/main/ui/comments.cljs:722
 msgid "labels.reply.thread"
 msgstr "תגובה"
+
+#: src/app/main/ui/dashboard/team.cljs:788
+msgid "labels.resend"
+msgstr "שליחה מחדש"
 
 #: src/app/main/ui/dashboard/team.cljs:938
 msgid "labels.resend-invitation"
@@ -2428,6 +2542,10 @@ msgstr "סדרות"
 msgid "labels.settings"
 msgstr "הגדרות"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:27
+msgid "labels.shadow"
+msgstr "צל"
+
 #: src/app/main/ui/viewer/header.cljs:204
 msgid "labels.share"
 msgstr "שיתוף"
@@ -2476,9 +2594,21 @@ msgstr "התחלה"
 msgid "labels.status"
 msgstr "מצב"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
+msgid "labels.stroke"
+msgstr "קו מתאר"
+
 #: src/app/main/ui/onboarding/questions.cljs:87
 msgid "labels.student-teacher"
 msgstr "סטודנט/ית או מרצה"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
+msgid "labels.styles"
+msgstr "סגנונות"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:33
+msgid "labels.svg"
+msgstr "SVG"
 
 #: src/app/main/ui/onboarding/questions.cljs:256
 #, unused
@@ -2490,6 +2620,10 @@ msgstr "מוביל או מובילת צוות"
 msgid "labels.team-member"
 msgstr "חבר או חברת צוות"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:25
+msgid "labels.text"
+msgstr "טקסט"
+
 #: src/app/main/ui/workspace/tokens/themes.cljs:36
 msgid "labels.themes"
 msgstr "ערכות עיצוב"
@@ -2497,6 +2631,10 @@ msgstr "ערכות עיצוב"
 #: src/app/main/ui/workspace/main_menu.cljs:152
 msgid "labels.tutorials"
 msgstr "מדריכים"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
+msgid "labels.typography"
+msgstr "טיפוגרפיה"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101
 msgid "labels.unknown-error"
@@ -2530,6 +2668,14 @@ msgstr "העלאת גופנים משלך"
 msgid "labels.uploading"
 msgstr "מתבצעת העלאה…"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
+msgid "labels.variant"
+msgstr "הגוון"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:872
+msgid "labels.version-notes"
+msgstr "הערות לגרסה %s"
+
 #: src/app/main/ui/workspace/sidebar/sitemap.cljs:246
 msgid "labels.view-only"
 msgstr "תצוגה בלבד"
@@ -2537,6 +2683,10 @@ msgstr "תצוגה בלבד"
 #: src/app/main/ui/dashboard/team.cljs:131, src/app/main/ui/dashboard/team.cljs:314, src/app/main/ui/dashboard/team.cljs:567, src/app/main/ui/dashboard/team.cljs:603, src/app/main/ui/onboarding/team_choice.cljs:56
 msgid "labels.viewer"
 msgstr "מציג"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:32
+msgid "labels.visibility"
+msgstr "חשיפה"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:441, src/app/main/ui/dashboard/team.cljs:103, src/app/main/ui/dashboard/team.cljs:113, src/app/main/ui/dashboard/team.cljs:1134
 msgid "labels.webhooks"
@@ -3260,6 +3410,10 @@ msgstr "הפסקת תחזוקה: המערכת תושבת לעבודת תחזוק
 msgid "notifications.by-code.upgrade-version"
 msgstr "יש גרסה חדשה, נא לרענן את העמוד"
 
+#: src/app/main/ui/dashboard/team.cljs:825
+msgid "notifications.invitation-deleted"
+msgstr "ההזמנה נמחקה בהצלחה"
+
 #: src/app/main/ui/dashboard/team.cljs:170, src/app/main/ui/dashboard/team.cljs:867
 msgid "notifications.invitation-email-sent"
 msgstr "ההזמנה נשלחה בהצלחה"
@@ -3820,6 +3974,10 @@ msgstr "העתקת קישור ללוח הגזירים"
 msgid "shortcuts.copy-props"
 msgstr "העתקת מאפיינים"
 
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
+msgid "shortcuts.create-component-variant"
+msgstr "יצירת רכיב / הגוון"
+
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:98
 msgid "shortcuts.create-new-project"
 msgstr "יצירת חדש"
@@ -4374,6 +4532,12 @@ msgstr ""
 "נא לשדרג כעת כדי לעמוד במכסת העורכים הנוכחית שלך. [להירשם "
 "כעת.|target:self](%s)"
 
+#: src/app/main/ui/dashboard/subscription.cljs:156
+msgid "subscription.dashboard.unlimited-members-extra-editors-cta-text"
+msgstr ""
+"רק עורכים חדשים על פני הצוותים שבבעלותך מחושבים בחיובים העתידיים. 175$ "
+"בחודש בלי תוספות עדיין חלים על ‎25+‎ עורכים."
+
 #: src/app/main/ui/dashboard/subscription.cljs:152
 msgid "subscription.dashboard.unlimited-members-extra-editors-cta-title"
 msgstr "הזמנת אנשים תוך השתתפות בתוכנית הבלתי מוגבלת"
@@ -4532,6 +4696,7 @@ msgid "subscription.settings.sucess.dialog.title"
 msgstr "התוכנית שלך היא %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:413
+#, fuzzy
 msgid "subscription.settings.support-us-since"
 msgstr "תמכת בנו עם התוכנית הזאת מאז: %s"
 
@@ -4907,6 +5072,9 @@ msgstr "גופן"
 msgid "workspace.assets.typography.font-size"
 msgstr "גודל"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "סגנון גופן"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "מעבר לקובץ ספריית סגנון כדי לערוך"
@@ -4934,6 +5102,18 @@ msgstr "התמרת טקסט"
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:70
 msgid "workspace.assets.ungroup"
 msgstr "פירוק קבוצה"
+
+#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
+msgid "workspace.colorpicker.color-tokens"
+msgstr "אסימוני צבע"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
+msgid "workspace.component.swap.loop-error"
+msgstr "אי אפשר לקנן את הרכיבים בתוך עצמם."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
+msgid "workspace.component.switch.loop-error-multi"
+msgstr "לא ניתן לכבות/להדליק חלק מהעותקים. אי אפשר לקנן את הרכיבים בתוך עצמם."
 
 #: src/app/main/ui/workspace/context_menu.cljs:794
 msgid "workspace.context-menu.grid-cells.area"
@@ -5301,6 +5481,10 @@ msgstr "RGBA"
 #: src/app/main/ui/workspace/colorpicker.cljs:557
 msgid "workspace.libraries.colors.save-color"
 msgstr "שמירת סגנון צבע"
+
+#: src/app/main/ui/workspace/libraries.cljs:349
+msgid "workspace.libraries.connected-to"
+msgstr "מחובר אל"
 
 #: src/app/main/ui/workspace/libraries.cljs:404
 msgid "workspace.libraries.empty.add-some"
@@ -6262,7 +6446,7 @@ msgstr "עליון"
 msgid "workspace.options.more-colors"
 msgstr "צבעים נוספים"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "צבעי ספרייה נוספים"
 
@@ -7201,6 +7385,10 @@ msgstr "בחירת תיקייה"
 msgid "workspace.tokens.color"
 msgstr "צבע"
 
+#: src/app/main/data/workspace/tokens/errors.cljs:97
+msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgstr "גובה השורה תלוי בגודל הגופן. יש להוסיף גודל גופן כדי לקבל את הערך הפתור."
+
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:53
 msgid "workspace.tokens.create-new-theme"
 msgstr "אפשר ליצור את ערכת העיצוב הראשונה שלך עכשיו."
@@ -7240,6 +7428,10 @@ msgstr "עריכת ערכת עיצוב"
 #: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:74
 msgid "workspace.tokens.edit-themes"
 msgstr "עריכת ערכות עיצוב"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
+msgid "workspace.tokens.edit-token"
+msgstr "עריכת אסימון %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
 msgid "workspace.tokens.empty-input"
@@ -7350,6 +7542,10 @@ msgstr ""
 "הסדרה הזאת לא פעילה. יש להחליף את ערכת העיצוב או להפעיל את הסדרה הזאת כדי "
 "לראות את השינויים באשנב"
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:711
+msgid "workspace.tokens.individual-tokens"
+msgstr "להשתמש באסימונים עצמאיים"
+
 #: src/app/main/data/workspace/tokens/errors.cljs:49
 msgid "workspace.tokens.invalid-color"
 msgstr "ערך צבע שגוי: %s"
@@ -7368,6 +7564,10 @@ msgstr ""
 "„%s” אינו שם תקף לאסימון.\n"
 "שמות האסימונים יכולים להכיל אותיות וספרות מופרדים בתווי . ואסור שיתחילו "
 "בדולר ($)."
+
+#: src/app/main/data/workspace/tokens/errors.cljs:93
+msgid "workspace.tokens.invalid-token-value-typography"
+msgstr "ערך שגוי: חייב להפנות לאסימון טיפוגרפיה מרוכב."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
 msgid "workspace.tokens.invalid-value"
@@ -7388,6 +7588,10 @@ msgstr "ערכת עיצוב"
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:200
 msgid "workspace.tokens.label.theme-placeholder"
 msgstr "הוספת ערכת עיצוב (למשל: בהירה)"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1047
+msgid "workspace.tokens.letter-spacing-value-enter-composite"
+msgstr "הוספת ריווח תווים או {alias}"
 
 #: src/app/main/ui/workspace/tokens/management/context_menu.cljs:220
 msgid "workspace.tokens.margins"
@@ -7458,6 +7662,7 @@ msgid "workspace.tokens.opacity-range"
 msgstr "שקיפות צריכה להיות בין 0 ל־100% או 0 ו־1 (כלומר 50% או 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:120
+#, fuzzy
 msgid "workspace.tokens.original-value"
 msgstr "ערך מקורי: %s"
 
@@ -7473,12 +7678,17 @@ msgstr "רדיוס"
 msgid "workspace.tokens.ref-not-valid"
 msgstr "ההפניה לא תקפה או שאינה באף סדרה פעילה"
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:744
+msgid "workspace.tokens.reference-composite"
+msgstr "נא למלא כינוי לטיפוגרפיית אסימון"
+
 #: src/app/main/ui/workspace/tokens/style_dictionary.cljs
 #, unused
 msgid "workspace.tokens.reference-error"
 msgstr "שגיאות הפניה: "
 
 #: src/app/main/data/workspace/tokens/warnings.cljs:15, src/app/main/data/workspace/tokens/warnings.cljs:19, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:56, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:84, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:100, src/app/main/ui/workspace/tokens/management/create/input_tokens_value.cljs:41, src/app/main/ui/workspace/tokens/management/create/input_tokens_value.cljs:46, src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
+#, fuzzy
 msgid "workspace.tokens.resolved-value"
 msgstr "ערך פתור: %s"
 
@@ -7546,6 +7756,7 @@ msgid "workspace.tokens.themes-list"
 msgstr "רשימת ערכות עיצוב"
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:608, src/app/main/ui/workspace/tokens/management/create/form.cljs:609
+#, fuzzy
 msgid "workspace.tokens.token-description"
 msgstr "תיאור"
 
@@ -7600,6 +7811,10 @@ msgstr "הייבוא הצליח. חלק מהאסימונים לא נכללו."
 #: src/app/main/data/workspace/tokens/import_export.cljs:49
 msgid "workspace.tokens.unknown-token-type-section"
 msgstr "הסוג ‚%s’ לא נתמך (%s)\n"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:715
+msgid "workspace.tokens.use-reference"
+msgstr "להשתמש בהפניה"
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:131
 msgid "workspace.tokens.value-not-valid"
@@ -7944,212 +8159,3 @@ msgstr "גרסאות שנשמרו אוטומטית תישמרנה למשך %s י
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "לחיצה תסגור את הנתיב"
-
-#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
-msgid "color-row.token-color-row.deleted-token"
-msgstr "האסימון הזה לא קיים או שנמחק."
-
-#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
-msgid "color-token.empty-state"
-msgstr ""
-"אין אסימוני צבע זמינים. נא לבדוק ערכות/ערכות עיצוב פעילות או להוסיף אסימונים "
-"חדשים."
-
-#: src/app/main/ui/dashboard/team.cljs:765
-msgid "dashboard.invitation-modal.delete"
-msgstr "תימחקנה ההזמנות שמיועדות אל:"
-
-#: src/app/main/ui/dashboard/team.cljs:766
-msgid "dashboard.invitation-modal.resend"
-msgstr "תישלחנה מחדש ההזמנות שמיועדות אל:"
-
-#: src/app/main/ui/dashboard/team.cljs:756
-msgid "dashboard.invitation-modal.title.delete-invitations"
-msgstr "מחיקת הזמנות"
-
-#: src/app/main/ui/dashboard/team.cljs:757
-msgid "dashboard.invitation-modal.title.resend-invitations"
-msgstr "שליחת הזמנות מחדש"
-
-#: src/app/main/ui/dashboard/team.cljs:949
-msgid "dashboard.order-invitations-by-role"
-msgstr "סידור לפי תפקיד"
-
-#: src/app/main/ui/dashboard/team.cljs:958
-msgid "dashboard.order-invitations-by-status"
-msgstr "סידור לפי מצב"
-
-#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
-msgstr "העתקה ללוח הגזירים"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
-msgstr "גודל ומקום"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
-msgstr "החלפת חשיפת הלוח %s"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
-msgstr "ערכות אסימונים וערכות עיצוב"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
-msgstr "ערכות פעילות"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
-msgstr "ערכות עיצוב פעילות"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
-msgstr "מאפייני הגוון"
-
-#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
-msgstr "ערך פתור:"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1043
-msgid "labels.about-penpot"
-msgstr "על Penpot"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:26
-msgid "labels.blur"
-msgstr "טשטוש"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:427
-msgid "labels.color"
-msgstr "צבע"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1030
-msgid "labels.community-contributions"
-msgstr "קהילה ותרומות"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:23
-msgid "labels.fill"
-msgstr "מילוי"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1019
-msgid "labels.help-learning"
-msgstr "עזרה ולמידה"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:28
-msgid "labels.layout"
-msgstr "פריסה"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:798
-msgid "labels.learning-center"
-msgstr "מרכז הלמידה"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:878
-msgid "labels.penpot-changelog"
-msgstr "יומן השינויים של Penpot"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:804
-msgid "labels.penpot-hub"
-msgstr "המרכז של Penpot"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
-msgid "labels.reference"
-msgstr "הפניה"
-
-#: src/app/main/ui/dashboard/team.cljs:788
-msgid "labels.resend"
-msgstr "שליחה מחדש"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:27
-msgid "labels.shadow"
-msgstr "צל"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
-msgid "labels.stroke"
-msgstr "קו מתאר"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
-msgid "labels.styles"
-msgstr "סגנונות"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:33
-msgid "labels.svg"
-msgstr "SVG"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:25
-msgid "labels.text"
-msgstr "טקסט"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
-msgid "labels.typography"
-msgstr "טיפוגרפיה"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
-msgid "labels.variant"
-msgstr "הגוון"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:872
-msgid "labels.version-notes"
-msgstr "הערות לגרסה %s"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:32
-msgid "labels.visibility"
-msgstr "חשיפה"
-
-#: src/app/main/ui/dashboard/team.cljs:825
-msgid "notifications.invitation-deleted"
-msgstr "ההזמנה נמחקה בהצלחה"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
-msgid "shortcuts.create-component-variant"
-msgstr "יצירת רכיב / הגוון"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:715
-msgid "workspace.tokens.use-reference"
-msgstr "להשתמש בהפניה"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:744
-msgid "workspace.tokens.reference-composite"
-msgstr "נא למלא כינוי לטיפוגרפיית אסימון"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1047
-msgid "workspace.tokens.letter-spacing-value-enter-composite"
-msgstr "הוספת ריווח תווים או {alias}"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-token-value-typography"
-msgstr "ערך שגוי: חייב להפנות לאסימון טיפוגרפיה מרוכב."
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:711
-msgid "workspace.tokens.individual-tokens"
-msgstr "להשתמש באסימונים עצמאיים"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
-msgid "workspace.tokens.edit-token"
-msgstr "עריכת אסימון %s"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.composite-line-height-needs-font-size"
-msgstr ""
-"גובה השורה תלוי בגודל הגופן. יש להוסיף גודל גופן כדי לקבל את הערך הפתור."
-
-#: src/app/main/ui/workspace/libraries.cljs:349
-msgid "workspace.libraries.connected-to"
-msgstr "מחובר אל"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
-msgid "workspace.component.switch.loop-error-multi"
-msgstr "לא ניתן לכבות/להדליק חלק מהעותקים. אי אפשר לקנן את הרכיבים בתוך עצמם."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
-msgid "workspace.component.swap.loop-error"
-msgstr "אי אפשר לקנן את הרכיבים בתוך עצמם."
-
-#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
-msgid "workspace.colorpicker.color-tokens"
-msgstr "אסימוני צבע"
-
-#: src/app/main/ui/dashboard/subscription.cljs:156
-msgid "subscription.dashboard.unlimited-members-extra-editors-cta-text"
-msgstr ""
-"רק עורכים חדשים על פני הצוותים שבבעלותך מחושבים בחיובים העתידיים. 175$ בחודש "
-"בלי תוספות עדיין חלים על ‎25+‎ עורכים."

--- a/frontend/translations/hi.po
+++ b/frontend/translations/hi.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: VKing9 <vaibhavrathod2282@gmail.com>\n"
-"Language-Team: Hindi <https://hosted.weblate.org/projects/penpot/frontend/hi/"
-">\n"
+"Language-Team: Hindi "
+"<https://hosted.weblate.org/projects/penpot/frontend/hi/>\n"
 "Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4754,6 +4754,9 @@ msgstr "फ़ॉन्ट"
 msgid "workspace.assets.typography.font-size"
 msgstr "आकार"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "फ़ॉन्ट शैली"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "संपादन के लिए स्टाइल लाइब्रेरी फ़ाइल पर जाएँ"
@@ -6033,7 +6036,7 @@ msgstr "शीर्ष"
 msgid "workspace.options.more-colors"
 msgstr "और अधिक रंग"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "और लाइब्रेरी रंग"
 

--- a/frontend/translations/hr.po
+++ b/frontend/translations/hr.po
@@ -2,15 +2,14 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Zvonimir Juranko <zjuranko@gmail.com>\n"
-"Language-Team: Croatian <https://hosted.weblate.org/projects/penpot/frontend/"
-"hr/>\n"
+"Language-Team: Croatian "
+"<https://hosted.weblate.org/projects/penpot/frontend/hr/>\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural="
-"(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? "
-"1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.14-dev\n"
 
 #: src/app/main/ui/auth/register.cljs:215, src/app/main/ui/static.cljs:153, src/app/main/ui/viewer/login.cljs:98
@@ -4278,6 +4277,9 @@ msgstr "Font"
 msgid "workspace.assets.typography.font-size"
 msgstr "Veličina"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Stil fonta"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Idi na datoteku biblioteke stilova za uređivanje"
@@ -5494,7 +5496,7 @@ msgstr "Vrh"
 msgid "workspace.options.more-colors"
 msgstr "Više boja"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Više boja iz biblioteke"
 

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Linerly <linerly@proton.me>\n"
-"Language-Team: Indonesian <https://hosted.weblate.org/projects/penpot/"
-"frontend/id/>\n"
+"Language-Team: Indonesian "
+"<https://hosted.weblate.org/projects/penpot/frontend/id/>\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4476,6 +4476,9 @@ msgstr "Fon"
 msgid "workspace.assets.typography.font-size"
 msgstr "Ukuran"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Gaya Fon"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Pergi ke berkas pustaka untuk menyunting"
@@ -5714,7 +5717,7 @@ msgstr "Atas"
 msgid "workspace.options.more-colors"
 msgstr "Lebih banyak warna"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Lebih banyak warna pustaka"
 

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Nicola Bortoletto <nicola.bortoletto@live.com>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/penpot/frontend/"
-"it/>\n"
+"Language-Team: Italian "
+"<https://hosted.weblate.org/projects/penpot/frontend/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -200,6 +200,16 @@ msgstr "Email di lavoro"
 #, unused
 msgid "branding-illustrations-marketing-pieces"
 msgstr "…branding, illustrazione, materiali di marketing, etc."
+
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
+msgid "color-row.token-color-row.deleted-token"
+msgstr "Questo token non esiste o è stato eliminato."
+
+#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
+msgid "color-token.empty-state"
+msgstr ""
+"Nessun token colore disponibile. Controlla i set o i temi attivi oppure "
+"aggiungi nuovi token."
 
 #: src/app/main/ui/comments.cljs:530
 msgid "comments.mentions.not-found"
@@ -750,6 +760,22 @@ msgstr "Caricamento dei dati sul server (%s/%s)"
 msgid "dashboard.import.progress.upload-media"
 msgstr "Caricamento file: %s"
 
+#: src/app/main/ui/dashboard/team.cljs:765
+msgid "dashboard.invitation-modal.delete"
+msgstr "Stai per eliminare gli inviti a:"
+
+#: src/app/main/ui/dashboard/team.cljs:766
+msgid "dashboard.invitation-modal.resend"
+msgstr "Stai per reinviare gli inviti a:"
+
+#: src/app/main/ui/dashboard/team.cljs:756
+msgid "dashboard.invitation-modal.title.delete-invitations"
+msgstr "Elimina inviti"
+
+#: src/app/main/ui/dashboard/team.cljs:757
+msgid "dashboard.invitation-modal.title.resend-invitations"
+msgstr "Reinvia inviti"
+
 #: src/app/main/ui/dashboard/team.cljs:122, src/app/main/ui/dashboard/team.cljs:744
 msgid "dashboard.invite-profile"
 msgstr "Invita nel team"
@@ -863,6 +889,14 @@ msgstr "Apri file in una nuova scheda"
 #: src/app/main/ui/dashboard/files.cljs:119, src/app/main/ui/dashboard/grid.cljs:425, src/app/main/ui/dashboard/projects.cljs:261, src/app/main/ui/dashboard/projects.cljs:262
 msgid "dashboard.options"
 msgstr "Opzioni"
+
+#: src/app/main/ui/dashboard/team.cljs:949
+msgid "dashboard.order-invitations-by-role"
+msgstr "Ordina per ruolo"
+
+#: src/app/main/ui/dashboard/team.cljs:958
+msgid "dashboard.order-invitations-by-status"
+msgstr "Ordina per stato"
 
 #: src/app/main/ui/settings/password.cljs:94, src/app/main/ui/settings/password.cljs:107
 msgid "dashboard.password-change"
@@ -1880,6 +1914,38 @@ msgstr "Calcolato"
 msgid "inspect.tabs.info"
 msgstr "Informazione"
 
+#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
+msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgstr "Copia negli appunti"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:22
+msgid "inspect.tabs.styles.panel.geometry"
+msgstr "Dimensione e posizione"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
+msgid "inspect.tabs.styles.panel.toggle-style"
+msgstr "Attiva/disattiva pannello %s"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:21
+msgid "inspect.tabs.styles.panel.token"
+msgstr "Set di token e temi"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
+msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgstr "Set attivi"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
+msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgstr "Temi attivi"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:20
+msgid "inspect.tabs.styles.panel.variant"
+msgstr "Proprietà delle varianti"
+
+#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
+msgid "inspect.tabs.styles.token.resolved-value"
+msgstr "Valore risolto:"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
 msgid "inspect.tabs.switcher.label"
 msgstr "Informazioni livello"
@@ -1891,6 +1957,10 @@ msgstr "Contassegna tutto come letto"
 #: src/app/main/ui/workspace/main_menu.cljs:192
 msgid "label.shortcuts"
 msgstr "Scorciatoie"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1043
+msgid "labels.about-penpot"
+msgstr "Informazioni su Penpot"
 
 #: src/app/main/data/common.cljs:90, src/app/main/ui/dashboard/import.cljs:530
 msgid "labels.accept"
@@ -1947,6 +2017,10 @@ msgstr ""
 msgid "labels.bad-gateway.main-message"
 msgstr "Gateway non corretto"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:26
+msgid "labels.blur"
+msgstr "Sfocatura"
+
 #: src/app/main/data/common.cljs:129, src/app/main/ui/dashboard/change_owner.cljs:64, src/app/main/ui/dashboard/import.cljs:515, src/app/main/ui/dashboard/team.cljs:780, src/app/main/ui/dashboard/team.cljs:1122, src/app/main/ui/delete_shared.cljs:36, src/app/main/ui/exports/assets.cljs:162, src/app/main/ui/exports/files.cljs:191, src/app/main/ui/settings/access_tokens.cljs:175, src/app/main/ui/viewer/share_link.cljs:205, src/app/main/ui/workspace/sidebar/assets/groups.cljs:159, src/app/main/ui/workspace/tokens/export/modal.cljs:44, src/app/main/ui/workspace/tokens/import/modal.cljs:269, src/app/main/ui/workspace/tokens/management/create/form.cljs:632, src/app/main/ui/workspace/tokens/settings/menu.cljs:104, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:228
 msgid "labels.cancel"
 msgstr "Annulla"
@@ -1963,6 +2037,10 @@ msgstr "Chiudi"
 msgid "labels.collapse"
 msgstr "Comprimi"
 
+#: src/app/main/ui/workspace/colorpicker.cljs:427
+msgid "labels.color"
+msgstr "Colore"
+
 #: src/app/main/ui/comments.cljs:913
 msgid "labels.comment"
 msgstr "Commenta"
@@ -1978,6 +2056,10 @@ msgstr "Commenti"
 #: src/app/main/ui/dashboard/sidebar.cljs:840, src/app/main/ui/workspace/main_menu.cljs:144
 msgid "labels.community"
 msgstr "Community"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1030
+msgid "labels.community-contributions"
+msgstr "Comunità e contributi"
 
 #: src/app/main/ui/settings/password.cljs:91
 msgid "labels.confirm-password"
@@ -2117,6 +2199,10 @@ msgstr "Feedback inviato"
 msgid "labels.figma"
 msgstr "Figma"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:23
+msgid "labels.fill"
+msgstr "Riempimento"
+
 #: src/app/main/ui/dashboard/fonts.cljs:430
 msgid "labels.font-family"
 msgstr "Famiglia di caratteri"
@@ -2163,6 +2249,10 @@ msgstr "Graphic design"
 msgid "labels.help-center"
 msgstr "Supporto"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:1019
+msgid "labels.help-learning"
+msgstr "Aiuto e apprendimento"
+
 #: src/app/main/ui/dashboard/templates.cljs:91
 msgid "labels.hide"
 msgstr "Nascondi"
@@ -2204,6 +2294,14 @@ msgstr "Inviti"
 #: src/app/main/ui/settings/options.cljs:53
 msgid "labels.language"
 msgstr "Lingua"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:28
+msgid "labels.layout"
+msgstr "Layout"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:798
+msgid "labels.learning-center"
+msgstr "Centro di apprendimento"
 
 #: src/app/main/ui/workspace/main_menu.cljs:168
 msgid "labels.libraries-and-templates"
@@ -2341,6 +2439,14 @@ msgstr "Password"
 msgid "labels.pending-invitation"
 msgstr "In attesa"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:878
+msgid "labels.penpot-changelog"
+msgstr "Registro delle modifiche di Penpot"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:804
+msgid "labels.penpot-hub"
+msgstr "Hub di Penpot"
+
 #: src/app/main/ui/dashboard/sidebar.cljs:751
 msgid "labels.pinned-projects"
 msgstr "Progetti in evidenza"
@@ -2368,6 +2474,10 @@ msgstr "Profilo"
 #: src/app/main/ui/dashboard/sidebar.cljs:718
 msgid "labels.projects"
 msgstr "Progetti"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
+msgid "labels.reference"
+msgstr "Riferimento"
 
 #: src/app/main/data/common.cljs:83
 msgid "labels.refresh"
@@ -2418,6 +2528,10 @@ msgstr "nuova risposta"
 #: src/app/main/ui/comments.cljs:722
 msgid "labels.reply.thread"
 msgstr "Rispondi"
+
+#: src/app/main/ui/dashboard/team.cljs:788
+msgid "labels.resend"
+msgstr "Reinvia"
 
 #: src/app/main/ui/dashboard/team.cljs:938
 msgid "labels.resend-invitation"
@@ -2475,6 +2589,10 @@ msgstr "Set"
 msgid "labels.settings"
 msgstr "Configurazione"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:27
+msgid "labels.shadow"
+msgstr "Ombra"
+
 #: src/app/main/ui/viewer/header.cljs:204
 msgid "labels.share"
 msgstr "Condividi"
@@ -2523,9 +2641,21 @@ msgstr "Inizia"
 msgid "labels.status"
 msgstr "Stato"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
+msgid "labels.stroke"
+msgstr "Traccia"
+
 #: src/app/main/ui/onboarding/questions.cljs:87
 msgid "labels.student-teacher"
 msgstr "Studente o docente"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
+msgid "labels.styles"
+msgstr "Stili"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:33
+msgid "labels.svg"
+msgstr "SVG"
 
 #: src/app/main/ui/onboarding/questions.cljs:256
 #, unused
@@ -2537,6 +2667,10 @@ msgstr "Capo del team"
 msgid "labels.team-member"
 msgstr "Membro del team"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:25
+msgid "labels.text"
+msgstr "Testo"
+
 #: src/app/main/ui/workspace/tokens/themes.cljs:36
 msgid "labels.themes"
 msgstr "Temi"
@@ -2544,6 +2678,10 @@ msgstr "Temi"
 #: src/app/main/ui/workspace/main_menu.cljs:152
 msgid "labels.tutorials"
 msgstr "Tutorial"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
+msgid "labels.typography"
+msgstr "Tipografia"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101
 msgid "labels.unknown-error"
@@ -2577,6 +2715,14 @@ msgstr "Carica caratteri personalizzati"
 msgid "labels.uploading"
 msgstr "Caricamento…"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
+msgid "labels.variant"
+msgstr "Variante"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:872
+msgid "labels.version-notes"
+msgstr "Note della versione %s"
+
 #: src/app/main/ui/workspace/sidebar/sitemap.cljs:246
 msgid "labels.view-only"
 msgstr "Solo visualizzazione"
@@ -2584,6 +2730,10 @@ msgstr "Solo visualizzazione"
 #: src/app/main/ui/dashboard/team.cljs:131, src/app/main/ui/dashboard/team.cljs:314, src/app/main/ui/dashboard/team.cljs:567, src/app/main/ui/dashboard/team.cljs:603, src/app/main/ui/onboarding/team_choice.cljs:56
 msgid "labels.viewer"
 msgstr "Visualizzatore"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:32
+msgid "labels.visibility"
+msgstr "Visibilità"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:441, src/app/main/ui/dashboard/team.cljs:103, src/app/main/ui/dashboard/team.cljs:113, src/app/main/ui/dashboard/team.cljs:1134
 msgid "labels.webhooks"
@@ -3314,6 +3464,10 @@ msgstr ""
 msgid "notifications.by-code.upgrade-version"
 msgstr "Una nuova versione è disponibile, si prega di ricaricare la pagina"
 
+#: src/app/main/ui/dashboard/team.cljs:825
+msgid "notifications.invitation-deleted"
+msgstr "Invito eliminato con successo"
+
 #: src/app/main/ui/dashboard/team.cljs:170, src/app/main/ui/dashboard/team.cljs:867
 msgid "notifications.invitation-email-sent"
 msgstr "Invito inviato con successo"
@@ -3880,6 +4034,10 @@ msgstr "Copia link negli appunti"
 #, unused
 msgid "shortcuts.copy-props"
 msgstr "Copia proprietà"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
+msgid "shortcuts.create-component-variant"
+msgstr "Crea componente / variante"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:98
 msgid "shortcuts.create-new-project"
@@ -4992,6 +5150,9 @@ msgstr "Carattere"
 msgid "workspace.assets.typography.font-size"
 msgstr "Dimensione"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Stile del carattere"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Vai alla libreria dello stile del file per modificare"
@@ -5019,6 +5180,20 @@ msgstr "Trasforma testo"
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:70
 msgid "workspace.assets.ungroup"
 msgstr "Separa"
+
+#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
+msgid "workspace.colorpicker.color-tokens"
+msgstr "Token colore"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
+msgid "workspace.component.swap.loop-error"
+msgstr "I componenti non possono essere annidati dentro sé stessi."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
+msgid "workspace.component.switch.loop-error-multi"
+msgstr ""
+"Alcune copie non possono essere sostituite. I componenti non possono essere "
+"annidati dentro sé stessi."
 
 #: src/app/main/ui/workspace/context_menu.cljs:794
 msgid "workspace.context-menu.grid-cells.area"
@@ -5386,6 +5561,10 @@ msgstr "RGBA"
 #: src/app/main/ui/workspace/colorpicker.cljs:557
 msgid "workspace.libraries.colors.save-color"
 msgstr "Salva stile di colore"
+
+#: src/app/main/ui/workspace/libraries.cljs:349
+msgid "workspace.libraries.connected-to"
+msgstr "Connesso a"
 
 #: src/app/main/ui/workspace/libraries.cljs:404
 msgid "workspace.libraries.empty.add-some"
@@ -6356,7 +6535,7 @@ msgstr "In alto"
 msgid "workspace.options.more-colors"
 msgstr "Più colori"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Più librerie colori"
 
@@ -7305,6 +7484,12 @@ msgstr "Scegli cartella"
 msgid "workspace.tokens.color"
 msgstr "Colore"
 
+#: src/app/main/data/workspace/tokens/errors.cljs:97
+msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgstr ""
+"L'interlinea dipende dalla dimensione del carattere. Aggiungi una "
+"dimensione carattere per ottenere il valore risolto."
+
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:53
 msgid "workspace.tokens.create-new-theme"
 msgstr "Crea ora il tuo prima tema."
@@ -7344,6 +7529,10 @@ msgstr "Modifica tema"
 #: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:74
 msgid "workspace.tokens.edit-themes"
 msgstr "Modifica temi"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
+msgid "workspace.tokens.edit-token"
+msgstr "Modifica token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
 msgid "workspace.tokens.empty-input"
@@ -7466,6 +7655,10 @@ msgstr ""
 "Questo set non è attivo. Cambia tema o attiva questo set per vedere "
 "modifiche nell'anteprima"
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:711
+msgid "workspace.tokens.individual-tokens"
+msgstr "Utilizza token individuali"
+
 #: src/app/main/data/workspace/tokens/errors.cljs:49
 msgid "workspace.tokens.invalid-color"
 msgstr "Valore colore invalido: %s"
@@ -7504,6 +7697,10 @@ msgstr ""
 "Valore del token non valido: sono accettati solo none, underline e "
 "strike-through"
 
+#: src/app/main/data/workspace/tokens/errors.cljs:93
+msgid "workspace.tokens.invalid-token-value-typography"
+msgstr "Valore non valido: deve fare riferimento a un token tipografico composito."
+
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
 msgid "workspace.tokens.invalid-value"
 msgstr "Valore token non valido: %s"
@@ -7523,6 +7720,14 @@ msgstr "Tema"
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:200
 msgid "workspace.tokens.label.theme-placeholder"
 msgstr "Aggiungi un tema (es. Chiaro)"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1047
+msgid "workspace.tokens.letter-spacing-value-enter-composite"
+msgstr "Aggiungi spaziatura tra lettere o {alias"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1043
+msgid "workspace.tokens.line-height-value-enter"
+msgstr "Inserisci interlinea — moltiplicatore, px, %, o {alias}"
 
 #: src/app/main/ui/workspace/tokens/management/context_menu.cljs:220
 msgid "workspace.tokens.margins"
@@ -7610,6 +7815,10 @@ msgstr "Raggio"
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:128
 msgid "workspace.tokens.ref-not-valid"
 msgstr "Il riferimento non è valido o non è presente in nessun set attivo"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:744
+msgid "workspace.tokens.reference-composite"
+msgstr "Inserisci un alias tipografico del token"
 
 #: src/app/main/ui/workspace/tokens/style_dictionary.cljs
 #, unused
@@ -7748,6 +7957,10 @@ msgstr ""
 #: src/app/main/data/workspace/tokens/import_export.cljs:49
 msgid "workspace.tokens.unknown-token-type-section"
 msgstr "Il tipo '%s' non è supportato (%s)\n"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:715
+msgid "workspace.tokens.use-reference"
+msgstr "Utilizza un riferimento"
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:131
 msgid "workspace.tokens.value-not-valid"
@@ -8125,214 +8338,3 @@ msgstr "Clicca per chiudere il tracciato"
 
 #~ msgid "onboarding.slide.1.desc1"
 #~ msgstr "Crea interazioni complete per imitare al meglio il prodotto finale."
-
-#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
-msgid "color-row.token-color-row.deleted-token"
-msgstr "Questo token non esiste o è stato eliminato."
-
-#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
-msgid "color-token.empty-state"
-msgstr ""
-"Nessun token colore disponibile. Controlla i set o i temi attivi oppure "
-"aggiungi nuovi token."
-
-#: src/app/main/ui/dashboard/team.cljs:765
-msgid "dashboard.invitation-modal.delete"
-msgstr "Stai per eliminare gli inviti a:"
-
-#: src/app/main/ui/dashboard/team.cljs:766
-msgid "dashboard.invitation-modal.resend"
-msgstr "Stai per reinviare gli inviti a:"
-
-#: src/app/main/ui/dashboard/team.cljs:756
-msgid "dashboard.invitation-modal.title.delete-invitations"
-msgstr "Elimina inviti"
-
-#: src/app/main/ui/dashboard/team.cljs:757
-msgid "dashboard.invitation-modal.title.resend-invitations"
-msgstr "Reinvia inviti"
-
-#: src/app/main/ui/dashboard/team.cljs:949
-msgid "dashboard.order-invitations-by-role"
-msgstr "Ordina per ruolo"
-
-#: src/app/main/ui/dashboard/team.cljs:958
-msgid "dashboard.order-invitations-by-status"
-msgstr "Ordina per stato"
-
-#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
-msgstr "Copia negli appunti"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
-msgstr "Dimensione e posizione"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
-msgstr "Attiva/disattiva pannello %s"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
-msgstr "Set di token e temi"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
-msgstr "Set attivi"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
-msgstr "Temi attivi"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
-msgstr "Proprietà delle varianti"
-
-#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
-msgstr "Valore risolto:"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1043
-msgid "labels.about-penpot"
-msgstr "Informazioni su Penpot"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:26
-msgid "labels.blur"
-msgstr "Sfocatura"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:427
-msgid "labels.color"
-msgstr "Colore"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1030
-msgid "labels.community-contributions"
-msgstr "Comunità e contributi"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:23
-msgid "labels.fill"
-msgstr "Riempimento"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1019
-msgid "labels.help-learning"
-msgstr "Aiuto e apprendimento"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:28
-msgid "labels.layout"
-msgstr "Layout"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:798
-msgid "labels.learning-center"
-msgstr "Centro di apprendimento"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:878
-msgid "labels.penpot-changelog"
-msgstr "Registro delle modifiche di Penpot"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:804
-msgid "labels.penpot-hub"
-msgstr "Hub di Penpot"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
-msgid "labels.reference"
-msgstr "Riferimento"
-
-#: src/app/main/ui/dashboard/team.cljs:788
-msgid "labels.resend"
-msgstr "Reinvia"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:27
-msgid "labels.shadow"
-msgstr "Ombra"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
-msgid "labels.stroke"
-msgstr "Traccia"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
-msgid "labels.styles"
-msgstr "Stili"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:33
-msgid "labels.svg"
-msgstr "SVG"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:25
-msgid "labels.text"
-msgstr "Testo"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
-msgid "labels.typography"
-msgstr "Tipografia"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
-msgid "labels.variant"
-msgstr "Variante"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:872
-msgid "labels.version-notes"
-msgstr "Note della versione %s"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:32
-msgid "labels.visibility"
-msgstr "Visibilità"
-
-#: src/app/main/ui/dashboard/team.cljs:825
-msgid "notifications.invitation-deleted"
-msgstr "Invito eliminato con successo"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
-msgid "shortcuts.create-component-variant"
-msgstr "Crea componente / variante"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
-msgid "workspace.colorpicker.color-tokens"
-msgstr "Token colore"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
-msgid "workspace.component.swap.loop-error"
-msgstr "I componenti non possono essere annidati dentro sé stessi."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
-msgid "workspace.component.switch.loop-error-multi"
-msgstr ""
-"Alcune copie non possono essere sostituite. I componenti non possono essere "
-"annidati dentro sé stessi."
-
-#: src/app/main/ui/workspace/libraries.cljs:349
-msgid "workspace.libraries.connected-to"
-msgstr "Connesso a"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.composite-line-height-needs-font-size"
-msgstr ""
-"L'interlinea dipende dalla dimensione del carattere. Aggiungi una dimensione "
-"carattere per ottenere il valore risolto."
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
-msgid "workspace.tokens.edit-token"
-msgstr "Modifica token %s"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:711
-msgid "workspace.tokens.individual-tokens"
-msgstr "Utilizza token individuali"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-token-value-typography"
-msgstr ""
-"Valore non valido: deve fare riferimento a un token tipografico composito."
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1047
-msgid "workspace.tokens.letter-spacing-value-enter-composite"
-msgstr "Aggiungi spaziatura tra lettere o {alias"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1043
-msgid "workspace.tokens.line-height-value-enter"
-msgstr "Inserisci interlinea — moltiplicatore, px, %, o {alias}"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:744
-msgid "workspace.tokens.reference-composite"
-msgstr "Inserisci un alias tipografico del token"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:715
-msgid "workspace.tokens.use-reference"
-msgstr "Utilizza un riferimento"

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -2,15 +2,14 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Edgars Andersons <Edgars+Weblate@gaitenis.id.lv>\n"
-"Language-Team: Latvian <https://hosted.weblate.org/projects/penpot/frontend/"
-"lv/>\n"
+"Language-Team: Latvian "
+"<https://hosted.weblate.org/projects/penpot/frontend/lv/>\n"
 "Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural="
-"(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : "
-"((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 "
+"<= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 "X-Generator: Weblate 5.14-dev\n"
 
 #: src/app/main/ui/auth/register.cljs:215, src/app/main/ui/static.cljs:153, src/app/main/ui/viewer/login.cljs:98
@@ -203,6 +202,16 @@ msgstr "Darba e-pasta adrese"
 #, unused
 msgid "branding-illustrations-marketing-pieces"
 msgstr "... zīmolrades, ilustrācijām, mārketinga materiāliem utt."
+
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
+msgid "color-row.token-color-row.deleted-token"
+msgstr "Šī tekstvienība nepastāv vai ir izdzēsta."
+
+#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
+msgid "color-token.empty-state"
+msgstr ""
+"Nav pieejama neviena krāsu tekstvienība. Jāpārbauda izmantotās "
+"kopas/izskati vai jāpievieno jaunas tekstvienības."
 
 #: src/app/main/ui/comments.cljs:530
 msgid "comments.mentions.not-found"
@@ -746,6 +755,22 @@ msgstr "Augšupielādē datus serverī (%s/%s)"
 #: src/app/main/ui/dashboard/import.cljs:122
 msgid "dashboard.import.progress.upload-media"
 msgstr "Augšupielādē datni: %s"
+
+#: src/app/main/ui/dashboard/team.cljs:765
+msgid "dashboard.invitation-modal.delete"
+msgstr "Tu grasies izdzēst uzaicinājumus:"
+
+#: src/app/main/ui/dashboard/team.cljs:766
+msgid "dashboard.invitation-modal.resend"
+msgstr "Tu grasies atkārtoti nosūtīt uzaicinājumus:"
+
+#: src/app/main/ui/dashboard/team.cljs:756
+msgid "dashboard.invitation-modal.title.delete-invitations"
+msgstr "Izdzēst uzaicinājumus"
+
+#: src/app/main/ui/dashboard/team.cljs:757
+msgid "dashboard.invitation-modal.title.resend-invitations"
+msgstr "Atkārtoti nosūtīt uzaicinājumus"
 
 #: src/app/main/ui/dashboard/team.cljs:122, src/app/main/ui/dashboard/team.cljs:744
 msgid "dashboard.invite-profile"
@@ -4895,6 +4920,9 @@ msgstr "Fonti"
 msgid "workspace.assets.typography.font-size"
 msgstr "Izmērs"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Fonta stils"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Doties uz stilu bibliotēkas datni, lai labotu"
@@ -6243,7 +6271,7 @@ msgstr "Augša"
 msgid "workspace.options.more-colors"
 msgstr "Vairāk krāsu"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Vairāk bibliotēkas krāsu"
 
@@ -7864,29 +7892,3 @@ msgstr "Automātiski saglabātas versijas tiks paturētas %s dienas."
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Jānoklikšķina, lai aizvērtu ceļu"
-
-#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
-msgid "color-row.token-color-row.deleted-token"
-msgstr "Šī tekstvienība nepastāv vai ir izdzēsta."
-
-#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
-msgid "color-token.empty-state"
-msgstr ""
-"Nav pieejama neviena krāsu tekstvienība. Jāpārbauda izmantotās kopas/izskati "
-"vai jāpievieno jaunas tekstvienības."
-
-#: src/app/main/ui/dashboard/team.cljs:765
-msgid "dashboard.invitation-modal.delete"
-msgstr "Tu grasies izdzēst uzaicinājumus:"
-
-#: src/app/main/ui/dashboard/team.cljs:766
-msgid "dashboard.invitation-modal.resend"
-msgstr "Tu grasies atkārtoti nosūtīt uzaicinājumus:"
-
-#: src/app/main/ui/dashboard/team.cljs:756
-msgid "dashboard.invitation-modal.title.delete-invitations"
-msgstr "Izdzēst uzaicinājumus"
-
-#: src/app/main/ui/dashboard/team.cljs:757
-msgid "dashboard.invitation-modal.title.resend-invitations"
-msgstr "Atkārtoti nosūtīt uzaicinājumus"

--- a/frontend/translations/nb_NO.po
+++ b/frontend/translations/nb_NO.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
-"Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/penpot/"
-"frontend/nb_NO/>\n"
+"Language-Team: Norwegian Bokmål "
+"<https://hosted.weblate.org/projects/penpot/frontend/nb_NO/>\n"
 "Language: nb_NO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -596,6 +596,9 @@ msgstr "Skrift"
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:522
 msgid "workspace.assets.typography.font-size"
 msgstr "Størrelse"
+
+msgid "workspace.assets.typography.font-style"
+msgstr "Skriftstil"
 
 #: src/app/main/ui/workspace/main_menu.cljs:361
 msgid "workspace.header.menu.show-rules"

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Stephan Paternotte <stephan@paternottes.net>\n"
-"Language-Team: Dutch <https://hosted.weblate.org/projects/penpot/frontend/nl/"
-">\n"
+"Language-Team: Dutch "
+"<https://hosted.weblate.org/projects/penpot/frontend/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -198,6 +198,16 @@ msgstr "Werk e-mail"
 #, unused
 msgid "branding-illustrations-marketing-pieces"
 msgstr "…branding, illustraties, marketingstukken, etc."
+
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
+msgid "color-row.token-color-row.deleted-token"
+msgstr "Dit token bestaat niet of is verwijderd."
+
+#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
+msgid "color-token.empty-state"
+msgstr ""
+"Geen beschikbare kleurentokens. Controleer actieve sets/thema's of voeg "
+"nieuwe tokens toe."
 
 #: src/app/main/ui/comments.cljs:530
 msgid "comments.mentions.not-found"
@@ -747,6 +757,22 @@ msgstr "Gegevens uploaden naar server (%s/%s)"
 msgid "dashboard.import.progress.upload-media"
 msgstr "Bestand aan het uploaden: %s"
 
+#: src/app/main/ui/dashboard/team.cljs:765
+msgid "dashboard.invitation-modal.delete"
+msgstr "Je gaat de uitnodigingen verwijderen op:"
+
+#: src/app/main/ui/dashboard/team.cljs:766
+msgid "dashboard.invitation-modal.resend"
+msgstr "Je gaat de uitnodigingen opnieuw versturen:"
+
+#: src/app/main/ui/dashboard/team.cljs:756
+msgid "dashboard.invitation-modal.title.delete-invitations"
+msgstr "Uitnodigingen verwijderen"
+
+#: src/app/main/ui/dashboard/team.cljs:757
+msgid "dashboard.invitation-modal.title.resend-invitations"
+msgstr "Uitnodigingen opnieuw versturen"
+
 #: src/app/main/ui/dashboard/team.cljs:122, src/app/main/ui/dashboard/team.cljs:744
 msgid "dashboard.invite-profile"
 msgstr "Nodig mensen uit"
@@ -862,6 +888,14 @@ msgstr "Bestand openen in een nieuw tabblad"
 #: src/app/main/ui/dashboard/files.cljs:119, src/app/main/ui/dashboard/grid.cljs:425, src/app/main/ui/dashboard/projects.cljs:261, src/app/main/ui/dashboard/projects.cljs:262
 msgid "dashboard.options"
 msgstr "Opties"
+
+#: src/app/main/ui/dashboard/team.cljs:949
+msgid "dashboard.order-invitations-by-role"
+msgstr "Sortering op rol"
+
+#: src/app/main/ui/dashboard/team.cljs:958
+msgid "dashboard.order-invitations-by-status"
+msgstr "Sortering op status"
 
 #: src/app/main/ui/settings/password.cljs:94, src/app/main/ui/settings/password.cljs:107
 msgid "dashboard.password-change"
@@ -1885,6 +1919,38 @@ msgstr "Berekend"
 msgid "inspect.tabs.info"
 msgstr "Informatie"
 
+#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
+msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgstr "Kopiëren naar klembord"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:22
+msgid "inspect.tabs.styles.panel.geometry"
+msgstr "Grootte & positie"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
+msgid "inspect.tabs.styles.panel.toggle-style"
+msgstr "Paneel &s wisselen"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:21
+msgid "inspect.tabs.styles.panel.token"
+msgstr "Tokens & thema's"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
+msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgstr "Actieve verzamelingen"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
+msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgstr "Actieve thema's"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:20
+msgid "inspect.tabs.styles.panel.variant"
+msgstr "Variant eigenschappen"
+
+#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
+msgid "inspect.tabs.styles.token.resolved-value"
+msgstr "Opgeloste waarde:"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
 msgid "inspect.tabs.switcher.label"
 msgstr "Laaginfo"
@@ -1896,6 +1962,10 @@ msgstr "Alles als gelezen markeren"
 #: src/app/main/ui/workspace/main_menu.cljs:192
 msgid "label.shortcuts"
 msgstr "Sneltoetsen"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1043
+msgid "labels.about-penpot"
+msgstr "Over Penpot"
 
 #: src/app/main/data/common.cljs:90, src/app/main/ui/dashboard/import.cljs:530
 msgid "labels.accept"
@@ -1952,6 +2022,10 @@ msgstr ""
 msgid "labels.bad-gateway.main-message"
 msgstr "Bad Gateway"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:26
+msgid "labels.blur"
+msgstr "Vervagen"
+
 #: src/app/main/data/common.cljs:129, src/app/main/ui/dashboard/change_owner.cljs:64, src/app/main/ui/dashboard/import.cljs:515, src/app/main/ui/dashboard/team.cljs:780, src/app/main/ui/dashboard/team.cljs:1122, src/app/main/ui/delete_shared.cljs:36, src/app/main/ui/exports/assets.cljs:162, src/app/main/ui/exports/files.cljs:191, src/app/main/ui/settings/access_tokens.cljs:175, src/app/main/ui/viewer/share_link.cljs:205, src/app/main/ui/workspace/sidebar/assets/groups.cljs:159, src/app/main/ui/workspace/tokens/export/modal.cljs:44, src/app/main/ui/workspace/tokens/import/modal.cljs:269, src/app/main/ui/workspace/tokens/management/create/form.cljs:632, src/app/main/ui/workspace/tokens/settings/menu.cljs:104, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:228
 msgid "labels.cancel"
 msgstr "Annuleren"
@@ -1968,6 +2042,10 @@ msgstr "Sluiten"
 msgid "labels.collapse"
 msgstr "Samenvouwen"
 
+#: src/app/main/ui/workspace/colorpicker.cljs:427
+msgid "labels.color"
+msgstr "Kleur"
+
 #: src/app/main/ui/comments.cljs:913
 msgid "labels.comment"
 msgstr "Commentaar"
@@ -1983,6 +2061,10 @@ msgstr "Commentaar"
 #: src/app/main/ui/dashboard/sidebar.cljs:840, src/app/main/ui/workspace/main_menu.cljs:144
 msgid "labels.community"
 msgstr "Gemeenschap"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1030
+msgid "labels.community-contributions"
+msgstr "Gemeenschap & bijdragen"
 
 #: src/app/main/ui/settings/password.cljs:91
 msgid "labels.confirm-password"
@@ -2122,6 +2204,10 @@ msgstr "Feedback verstuurd"
 msgid "labels.figma"
 msgstr "Figma"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:23
+msgid "labels.fill"
+msgstr "Vullen"
+
 #: src/app/main/ui/dashboard/fonts.cljs:430
 msgid "labels.font-family"
 msgstr "Lettertype-familie"
@@ -2168,6 +2254,10 @@ msgstr "Grafisch ontwerp"
 msgid "labels.help-center"
 msgstr "Helpcentrum"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:1019
+msgid "labels.help-learning"
+msgstr "Hulp & studie"
+
 #: src/app/main/ui/dashboard/templates.cljs:91
 msgid "labels.hide"
 msgstr "Verbergen"
@@ -2209,6 +2299,14 @@ msgstr "Uitnodigingen"
 #: src/app/main/ui/settings/options.cljs:53
 msgid "labels.language"
 msgstr "Taal"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:28
+msgid "labels.layout"
+msgstr "Opmaak"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:798
+msgid "labels.learning-center"
+msgstr "Studiecentrum"
 
 #: src/app/main/ui/workspace/main_menu.cljs:168
 msgid "labels.libraries-and-templates"
@@ -2346,6 +2444,14 @@ msgstr "Wachtwoord"
 msgid "labels.pending-invitation"
 msgstr "In behandeling"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:878
+msgid "labels.penpot-changelog"
+msgstr "Penpot wijzigingen"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:804
+msgid "labels.penpot-hub"
+msgstr "Penpot-hub"
+
 #: src/app/main/ui/dashboard/sidebar.cljs:751
 msgid "labels.pinned-projects"
 msgstr "Vastgemaakte projecten"
@@ -2373,6 +2479,10 @@ msgstr "Profiel"
 #: src/app/main/ui/dashboard/sidebar.cljs:718
 msgid "labels.projects"
 msgstr "Projecten"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
+msgid "labels.reference"
+msgstr "Referentie"
 
 #: src/app/main/data/common.cljs:83
 msgid "labels.refresh"
@@ -2423,6 +2533,10 @@ msgstr "nieuwe reactie"
 #: src/app/main/ui/comments.cljs:722
 msgid "labels.reply.thread"
 msgstr "Reageren"
+
+#: src/app/main/ui/dashboard/team.cljs:788
+msgid "labels.resend"
+msgstr "Opnieuw versturen"
 
 #: src/app/main/ui/dashboard/team.cljs:938
 msgid "labels.resend-invitation"
@@ -2480,6 +2594,10 @@ msgstr "Verzamelingen"
 msgid "labels.settings"
 msgstr "Instellingen"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:27
+msgid "labels.shadow"
+msgstr "Schaduw"
+
 #: src/app/main/ui/viewer/header.cljs:204
 msgid "labels.share"
 msgstr "Delen"
@@ -2528,9 +2646,21 @@ msgstr "Starten"
 msgid "labels.status"
 msgstr "Status"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
+msgid "labels.stroke"
+msgstr "Streek"
+
 #: src/app/main/ui/onboarding/questions.cljs:87
 msgid "labels.student-teacher"
 msgstr "Student of docent"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
+msgid "labels.styles"
+msgstr "Stijlen"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:33
+msgid "labels.svg"
+msgstr "SVG"
 
 #: src/app/main/ui/onboarding/questions.cljs:256
 #, unused
@@ -2542,6 +2672,10 @@ msgstr "Teamleider"
 msgid "labels.team-member"
 msgstr "Teamlid"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:25
+msgid "labels.text"
+msgstr "Tekst"
+
 #: src/app/main/ui/workspace/tokens/themes.cljs:36
 msgid "labels.themes"
 msgstr "Thema's"
@@ -2549,6 +2683,10 @@ msgstr "Thema's"
 #: src/app/main/ui/workspace/main_menu.cljs:152
 msgid "labels.tutorials"
 msgstr "Introductie"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
+msgid "labels.typography"
+msgstr "Typografie"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101
 msgid "labels.unknown-error"
@@ -2582,6 +2720,14 @@ msgstr "Eigen lettertypen uploaden"
 msgid "labels.uploading"
 msgstr "Uploaden…"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
+msgid "labels.variant"
+msgstr "Variant"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:872
+msgid "labels.version-notes"
+msgstr "Versie %s opmerkingen"
+
 #: src/app/main/ui/workspace/sidebar/sitemap.cljs:246
 msgid "labels.view-only"
 msgstr "ALLEEN BEKIJKEN"
@@ -2589,6 +2735,10 @@ msgstr "ALLEEN BEKIJKEN"
 #: src/app/main/ui/dashboard/team.cljs:131, src/app/main/ui/dashboard/team.cljs:314, src/app/main/ui/dashboard/team.cljs:567, src/app/main/ui/dashboard/team.cljs:603, src/app/main/ui/onboarding/team_choice.cljs:56
 msgid "labels.viewer"
 msgstr "Kijker"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:32
+msgid "labels.visibility"
+msgstr "Zichtbaarheid"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:441, src/app/main/ui/dashboard/team.cljs:103, src/app/main/ui/dashboard/team.cljs:113, src/app/main/ui/dashboard/team.cljs:1134
 msgid "labels.webhooks"
@@ -3335,6 +3485,10 @@ msgstr ""
 msgid "notifications.by-code.upgrade-version"
 msgstr "Er is een nieuwe versie beschikbaar, vernieuw de pagina"
 
+#: src/app/main/ui/dashboard/team.cljs:825
+msgid "notifications.invitation-deleted"
+msgstr "Uitnodiging met succes verwijderd"
+
 #: src/app/main/ui/dashboard/team.cljs:170, src/app/main/ui/dashboard/team.cljs:867
 msgid "notifications.invitation-email-sent"
 msgstr "Uitnodiging succesvol verstuurd"
@@ -3902,6 +4056,10 @@ msgstr "Link naar klembord kopiëren"
 #, unused
 msgid "shortcuts.copy-props"
 msgstr "Eigenschappen kopiëren"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
+msgid "shortcuts.create-component-variant"
+msgstr "Component/variant aanmaken"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:98
 msgid "shortcuts.create-new-project"
@@ -4634,6 +4792,7 @@ msgid "subscription.settings.sucess.dialog.title"
 msgstr "Je bent %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:413
+#, fuzzy
 msgid "subscription.settings.support-us-since"
 msgstr "Je hebt ons gesteund met dit abonnement sinds: %s"
 
@@ -5009,6 +5168,9 @@ msgstr "Lettertype"
 msgid "workspace.assets.typography.font-size"
 msgstr "Grootte"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Lettertype-stijl"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Ga naar het stijl-bibliotheekbestand om te bewerken"
@@ -5036,6 +5198,20 @@ msgstr "Tekst transformeren"
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:70
 msgid "workspace.assets.ungroup"
 msgstr "Groep opheffen"
+
+#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
+msgid "workspace.colorpicker.color-tokens"
+msgstr "Kleurtokens"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
+msgid "workspace.component.swap.loop-error"
+msgstr "Componenten kunnen niet in zichzelf worden genest."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
+msgid "workspace.component.switch.loop-error-multi"
+msgstr ""
+"Sommige exemplaren konden niet worden verwisseld. Componenten kunnen niet "
+"in zichzelf worden genest."
 
 #: src/app/main/ui/workspace/context_menu.cljs:794
 msgid "workspace.context-menu.grid-cells.area"
@@ -5403,6 +5579,10 @@ msgstr "RGBA"
 #: src/app/main/ui/workspace/colorpicker.cljs:557
 msgid "workspace.libraries.colors.save-color"
 msgstr "Kleurstijl opslaan"
+
+#: src/app/main/ui/workspace/libraries.cljs:349
+msgid "workspace.libraries.connected-to"
+msgstr "Verbonden met"
 
 #: src/app/main/ui/workspace/libraries.cljs:404
 msgid "workspace.libraries.empty.add-some"
@@ -6369,7 +6549,7 @@ msgstr "Bovenkant"
 msgid "workspace.options.more-colors"
 msgstr "Meer kleuren"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Meer bibliotheekkleuren"
 
@@ -7314,6 +7494,12 @@ msgstr "Map kiezen"
 msgid "workspace.tokens.color"
 msgstr "Kleur"
 
+#: src/app/main/data/workspace/tokens/errors.cljs:97
+msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgstr ""
+"Regelafstand is afhankelijk van de lettergrootte. Voeg een lettergrootte "
+"toe om de opgeloste waarde te verkrijgen."
+
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:53
 msgid "workspace.tokens.create-new-theme"
 msgstr "Maak nu je eerste thema aan."
@@ -7353,6 +7539,10 @@ msgstr "Thema bewerken"
 #: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:74
 msgid "workspace.tokens.edit-themes"
 msgstr "Thema's bewerken"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
+msgid "workspace.tokens.edit-token"
+msgstr "%s token bewerken"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
 msgid "workspace.tokens.empty-input"
@@ -7395,6 +7585,10 @@ msgid "workspace.tokens.font-variant-not-found"
 msgstr ""
 "Fout bij instellen van lettertype gewicht/stijl. Deze lettertypestijl "
 "bestaat niet in het huidige lettertype"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1024, src/app/main/ui/workspace/tokens/management/create/form.cljs:1039
+msgid "workspace.tokens.font-weight-value-enter"
+msgstr "Voer een waarde in (300, vet, normaal cursief...) of een {alias}"
 
 #: src/app/main/ui/workspace/tokens/management/context_menu.cljs:228
 msgid "workspace.tokens.gaps"
@@ -7471,6 +7665,10 @@ msgstr ""
 "Deze verzameling is niet ingeschakeld. Verander het thema of activeer deze "
 "verzameling om wijzigingen in de viewport te zien"
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:711
+msgid "workspace.tokens.individual-tokens"
+msgstr "Individuele tokens gebruiken"
+
 #: src/app/main/data/workspace/tokens/errors.cljs:49
 msgid "workspace.tokens.invalid-color"
 msgstr "Ongeldige kleurwaarde: %s"
@@ -7509,6 +7707,10 @@ msgstr ""
 "Ongeldige tokenwaarde: alleen none, underline en strike-through zijn "
 "toegestaan"
 
+#: src/app/main/data/workspace/tokens/errors.cljs:93
+msgid "workspace.tokens.invalid-token-value-typography"
+msgstr "Ongeldige waarde: moet verwijzen naar een samengesteld typografietoken."
+
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
 msgid "workspace.tokens.invalid-value"
 msgstr "Ongeldige tokenwaarde: %s"
@@ -7528,6 +7730,14 @@ msgstr "Thema"
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:200
 msgid "workspace.tokens.label.theme-placeholder"
 msgstr "Een thema toevoegen (bijv. Licht)"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1047
+msgid "workspace.tokens.letter-spacing-value-enter-composite"
+msgstr "Letterafstand of {alias} toevoegen"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1043
+msgid "workspace.tokens.line-height-value-enter"
+msgstr "Voer de regelafstand in — vermenigvuldigingsfactor, px, % of {alias}"
 
 #: src/app/main/ui/workspace/tokens/management/context_menu.cljs:220
 msgid "workspace.tokens.margins"
@@ -7598,6 +7808,7 @@ msgid "workspace.tokens.opacity-range"
 msgstr "De dekking moet tussen 0 en 100% of 0 en 1 zijn (bijv. 50% of 0,5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:120
+#, fuzzy
 msgid "workspace.tokens.original-value"
 msgstr "Oorspronkelijke waarde: %s"
 
@@ -7613,12 +7824,17 @@ msgstr "Radius"
 msgid "workspace.tokens.ref-not-valid"
 msgstr "Referentie is niet geldig of zit niet in een actieve verzameling"
 
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:744
+msgid "workspace.tokens.reference-composite"
+msgstr "Voer een alias voor tokentypografie in"
+
 #: src/app/main/ui/workspace/tokens/style_dictionary.cljs
 #, unused
 msgid "workspace.tokens.reference-error"
 msgstr "Referentie fouten: "
 
 #: src/app/main/data/workspace/tokens/warnings.cljs:15, src/app/main/data/workspace/tokens/warnings.cljs:19, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:56, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:84, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:100, src/app/main/ui/workspace/tokens/management/create/input_tokens_value.cljs:41, src/app/main/ui/workspace/tokens/management/create/input_tokens_value.cljs:46, src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
+#, fuzzy
 msgid "workspace.tokens.resolved-value"
 msgstr "Opgeloste waarde: %s"
 
@@ -7694,6 +7910,7 @@ msgid "workspace.tokens.themes-list"
 msgstr "Lijst met thema's"
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:608, src/app/main/ui/workspace/tokens/management/create/form.cljs:609
+#, fuzzy
 msgid "workspace.tokens.token-description"
 msgstr "Beschrijving"
 
@@ -7748,6 +7965,10 @@ msgstr "Importeren was succesvol. Sommige tokens zijn niet inbegrepen."
 #: src/app/main/data/workspace/tokens/import_export.cljs:49
 msgid "workspace.tokens.unknown-token-type-section"
 msgstr "Typ '%s' wordt niet ondersteund (%s)\n"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:715
+msgid "workspace.tokens.use-reference"
+msgstr "Referentie gebruiken"
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:131
 msgid "workspace.tokens.value-not-valid"
@@ -8096,217 +8317,3 @@ msgstr "Automatisch opgeslagen versies worden %s dagen bewaard."
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Klik om het pad te sluiten"
-
-#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
-msgid "color-row.token-color-row.deleted-token"
-msgstr "Dit token bestaat niet of is verwijderd."
-
-#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
-msgid "color-token.empty-state"
-msgstr ""
-"Geen beschikbare kleurentokens. Controleer actieve sets/thema's of voeg "
-"nieuwe tokens toe."
-
-#: src/app/main/ui/dashboard/team.cljs:765
-msgid "dashboard.invitation-modal.delete"
-msgstr "Je gaat de uitnodigingen verwijderen op:"
-
-#: src/app/main/ui/dashboard/team.cljs:766
-msgid "dashboard.invitation-modal.resend"
-msgstr "Je gaat de uitnodigingen opnieuw versturen:"
-
-#: src/app/main/ui/dashboard/team.cljs:756
-msgid "dashboard.invitation-modal.title.delete-invitations"
-msgstr "Uitnodigingen verwijderen"
-
-#: src/app/main/ui/dashboard/team.cljs:757
-msgid "dashboard.invitation-modal.title.resend-invitations"
-msgstr "Uitnodigingen opnieuw versturen"
-
-#: src/app/main/ui/dashboard/team.cljs:949
-msgid "dashboard.order-invitations-by-role"
-msgstr "Sortering op rol"
-
-#: src/app/main/ui/dashboard/team.cljs:958
-msgid "dashboard.order-invitations-by-status"
-msgstr "Sortering op status"
-
-#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
-msgstr "Kopiëren naar klembord"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
-msgstr "Grootte & positie"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
-msgstr "Paneel &s wisselen"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
-msgstr "Tokens & thema's"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
-msgstr "Actieve verzamelingen"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
-msgstr "Actieve thema's"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
-msgstr "Variant eigenschappen"
-
-#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
-msgstr "Opgeloste waarde:"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1043
-msgid "labels.about-penpot"
-msgstr "Over Penpot"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:26
-msgid "labels.blur"
-msgstr "Vervagen"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:427
-msgid "labels.color"
-msgstr "Kleur"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1030
-msgid "labels.community-contributions"
-msgstr "Gemeenschap & bijdragen"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:23
-msgid "labels.fill"
-msgstr "Vullen"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1019
-msgid "labels.help-learning"
-msgstr "Hulp & studie"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:28
-msgid "labels.layout"
-msgstr "Opmaak"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:798
-msgid "labels.learning-center"
-msgstr "Studiecentrum"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:878
-msgid "labels.penpot-changelog"
-msgstr "Penpot wijzigingen"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:804
-msgid "labels.penpot-hub"
-msgstr "Penpot-hub"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
-msgid "labels.reference"
-msgstr "Referentie"
-
-#: src/app/main/ui/dashboard/team.cljs:788
-msgid "labels.resend"
-msgstr "Opnieuw versturen"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:27
-msgid "labels.shadow"
-msgstr "Schaduw"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
-msgid "labels.stroke"
-msgstr "Streek"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
-msgid "labels.styles"
-msgstr "Stijlen"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:33
-msgid "labels.svg"
-msgstr "SVG"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:25
-msgid "labels.text"
-msgstr "Tekst"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
-msgid "labels.typography"
-msgstr "Typografie"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
-msgid "labels.variant"
-msgstr "Variant"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:872
-msgid "labels.version-notes"
-msgstr "Versie %s opmerkingen"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:32
-msgid "labels.visibility"
-msgstr "Zichtbaarheid"
-
-#: src/app/main/ui/dashboard/team.cljs:825
-msgid "notifications.invitation-deleted"
-msgstr "Uitnodiging met succes verwijderd"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
-msgid "shortcuts.create-component-variant"
-msgstr "Component/variant aanmaken"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
-msgid "workspace.colorpicker.color-tokens"
-msgstr "Kleurtokens"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
-msgid "workspace.component.swap.loop-error"
-msgstr "Componenten kunnen niet in zichzelf worden genest."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
-msgid "workspace.component.switch.loop-error-multi"
-msgstr ""
-"Sommige exemplaren konden niet worden verwisseld. Componenten kunnen niet in "
-"zichzelf worden genest."
-
-#: src/app/main/ui/workspace/libraries.cljs:349
-msgid "workspace.libraries.connected-to"
-msgstr "Verbonden met"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.composite-line-height-needs-font-size"
-msgstr ""
-"Regelafstand is afhankelijk van de lettergrootte. Voeg een lettergrootte toe "
-"om de opgeloste waarde te verkrijgen."
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
-msgid "workspace.tokens.edit-token"
-msgstr "%s token bewerken"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1024, src/app/main/ui/workspace/tokens/management/create/form.cljs:1039
-msgid "workspace.tokens.font-weight-value-enter"
-msgstr "Voer een waarde in (300, vet, normaal cursief...) of een {alias}"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:711
-msgid "workspace.tokens.individual-tokens"
-msgstr "Individuele tokens gebruiken"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-token-value-typography"
-msgstr "Ongeldige waarde: moet verwijzen naar een samengesteld typografietoken."
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1047
-msgid "workspace.tokens.letter-spacing-value-enter-composite"
-msgstr "Letterafstand of {alias} toevoegen"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1043
-msgid "workspace.tokens.line-height-value-enter"
-msgstr "Voer de regelafstand in — vermenigvuldigingsfactor, px, % of {alias}"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:744
-msgid "workspace.tokens.reference-composite"
-msgstr "Voer een alias voor tokentypografie in"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:715
-msgid "workspace.tokens.use-reference"
-msgstr "Referentie gebruiken"

--- a/frontend/translations/pl.po
+++ b/frontend/translations/pl.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Radek Sawicki <radek@sqrc.pl>\n"
-"Language-Team: Polish <https://hosted.weblate.org/projects/penpot/frontend/"
-"pl/>\n"
+"Language-Team: Polish "
+"<https://hosted.weblate.org/projects/penpot/frontend/pl/>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural="
-"(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.14-dev\n"
 
 #: src/app/main/ui/auth/register.cljs:215, src/app/main/ui/static.cljs:153, src/app/main/ui/viewer/login.cljs:98
@@ -3067,6 +3067,9 @@ msgstr "Czcionka"
 msgid "workspace.assets.typography.font-size"
 msgstr "Rozmiar"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Styl czcionki"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Przejdź do pliku biblioteki stylów, żeby edytować"
@@ -3998,7 +4001,7 @@ msgstr "Góra"
 msgid "workspace.options.more-colors"
 msgstr "Więcej kolorów"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Więcej kolorów z biblioteki"
 

--- a/frontend/translations/pt_BR.po
+++ b/frontend/translations/pt_BR.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Hugo Figueira <hugo.figueira7@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
-"penpot/frontend/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) "
+"<https://hosted.weblate.org/projects/penpot/frontend/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3504,6 +3504,9 @@ msgstr "Fonte"
 msgid "workspace.assets.typography.font-size"
 msgstr "Tamanho"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Estilo da fonte"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Ir para biblioteca de estilo para editar"
@@ -4428,7 +4431,7 @@ msgstr "Topo"
 msgid "workspace.options.more-colors"
 msgstr "Mais cores"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Mais cores da biblioteca"
 

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Dário <dariogomes@gmail.com>\n"
-"Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
-"penpot/frontend/pt_PT/>\n"
+"Language-Team: Portuguese (Portugal) "
+"<https://hosted.weblate.org/projects/penpot/frontend/pt_PT/>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4326,6 +4326,9 @@ msgstr "Fonte"
 msgid "workspace.assets.typography.font-size"
 msgstr "Tamanho"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Estilo da Fonte"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Ir para ficheiro da biblioteca de estilos para editar"
@@ -5499,7 +5502,7 @@ msgstr "Topo"
 msgid "workspace.options.more-colors"
 msgstr "Mais cores"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Mais bibliotecas de cor"
 

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: AlexTECPlayz <alextec70@outlook.com>\n"
-"Language-Team: Romanian <https://hosted.weblate.org/projects/penpot/frontend/"
-"ro/>\n"
+"Language-Team: Romanian "
+"<https://hosted.weblate.org/projects/penpot/frontend/ro/>\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : "
-"(n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 "X-Generator: Weblate 5.14-dev\n"
 
 #: src/app/main/ui/auth/register.cljs:215, src/app/main/ui/static.cljs:153, src/app/main/ui/viewer/login.cljs:98
@@ -3606,6 +3606,9 @@ msgstr "Font"
 msgid "workspace.assets.typography.font-size"
 msgstr "Dimensiune"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Stil Font"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Editează fişierul în Colecţia de stiluri"
@@ -4607,7 +4610,7 @@ msgstr "Sus"
 msgid "workspace.options.more-colors"
 msgstr "Mai multe culori"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Mai multe culori de bibliotecă"
 

--- a/frontend/translations/ru.po
+++ b/frontend/translations/ru.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Vint Prox <vintprox@envs.net>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/penpot/frontend/"
-"ru/>\n"
+"Language-Team: Russian "
+"<https://hosted.weblate.org/projects/penpot/frontend/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3964,6 +3964,9 @@ msgstr "Шрифт"
 msgid "workspace.assets.typography.font-size"
 msgstr "Размер"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Шрифт"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Перейти к файлу библиотеки стилей для редактирования"
@@ -5097,7 +5100,7 @@ msgstr "Сверху"
 msgid "workspace.options.more-colors"
 msgstr "Больше цветов"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Больше цветов библиотеки"
 

--- a/frontend/translations/sr.po
+++ b/frontend/translations/sr.po
@@ -2,15 +2,14 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Црнобог <68vuletic@gmail.com>\n"
-"Language-Team: Serbian <https://hosted.weblate.org/projects/penpot/frontend/"
-"sr/>\n"
+"Language-Team: Serbian "
+"<https://hosted.weblate.org/projects/penpot/frontend/sr/>\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural="
-"(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? "
-"1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.14-dev\n"
 
 #: src/app/main/ui/auth/register.cljs:215, src/app/main/ui/static.cljs:153, src/app/main/ui/viewer/login.cljs:98
@@ -3803,6 +3802,9 @@ msgstr "Фонт"
 msgid "workspace.assets.typography.font-size"
 msgstr "Величина"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Стил фонта"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Идите на датотеку библиотеке стилова да бисте је уредили"
@@ -4932,7 +4934,7 @@ msgstr "Врх"
 msgid "workspace.options.more-colors"
 msgstr "Више боја"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Више боја библиотеке"
 

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Henrik Allberg <henrik@thexorb.com>\n"
-"Language-Team: Swedish <https://hosted.weblate.org/projects/penpot/frontend/"
-"sv/>\n"
+"Language-Team: Swedish "
+"<https://hosted.weblate.org/projects/penpot/frontend/sv/>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4269,6 +4269,9 @@ msgstr "Teckensnitt"
 msgid "workspace.assets.typography.font-size"
 msgstr "Storlek"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Teckensnitt"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Gå till stilbibliotek fil för att redigera"
@@ -5480,7 +5483,7 @@ msgstr "Topp"
 msgid "workspace.options.more-colors"
 msgstr "Fler färger"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Fler biblioteksfärger"
 

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Çağlar Yeşilyurt <grch@mm.st>\n"
-"Language-Team: Turkish <https://hosted.weblate.org/projects/penpot/frontend/"
-"tr/>\n"
+"Language-Team: Turkish "
+"<https://hosted.weblate.org/projects/penpot/frontend/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -200,6 +200,20 @@ msgstr "İş e-postası"
 msgid "branding-illustrations-marketing-pieces"
 msgstr "...marka çalışması, çizimler, pazarlama materyalleri, vb."
 
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
+msgid "color-row.token-color-row.deleted-token"
+msgstr "Bu token yok veya silindi."
+
+#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
+msgid "color-token.empty-state"
+msgstr ""
+"Kullanılabilir renk tokeni yok. Etkin kümeleri/temaları gözden geçirin veya "
+"yeni tokenler ekleyin."
+
+#: src/app/main/ui/comments.cljs:530
+msgid "comments.mentions.not-found"
+msgstr "@%s için kişi bulunamadı"
+
 #: src/app/main/ui/workspace/libraries.cljs:333
 msgid "common.publish"
 msgstr "Yayınla"
@@ -393,6 +407,10 @@ msgstr "Tokenin süresi %s tarihinde sona erecek"
 msgid "dashboard.access-tokens.token-will-not-expire"
 msgstr "Tokenin sona erme tarihi yok"
 
+#: src/app/main/ui/dashboard/placeholder.cljs:41
+msgid "dashboard.add-file"
+msgstr "Dosya ekle"
+
 #: src/app/main/ui/dashboard/file_menu.cljs:304, src/app/main/ui/workspace/main_menu.cljs:648
 msgid "dashboard.add-shared"
 msgstr "Paylaşılan Kütüphane olarak ekle"
@@ -408,6 +426,10 @@ msgstr "(kopya)"
 #: src/app/main/ui/dashboard/sidebar.cljs:329
 msgid "dashboard.create-new-team"
 msgstr "Yeni takım oluştur"
+
+#: src/app/main/ui/workspace/main_menu.cljs:659
+msgid "dashboard.create-version-menu"
+msgstr "Bu sürümü sabitle"
 
 #: src/app/main/ui/components/context_menu_a11y.cljs:288, src/app/main/ui/dashboard/sidebar.cljs:549
 msgid "dashboard.default-team-name"
@@ -432,6 +454,74 @@ msgstr "Kopyasını oluştur"
 #: src/app/main/ui/dashboard/file_menu.cljs:242
 msgid "dashboard.duplicate-multi"
 msgstr "%s dosyanın kopyasını oluştur"
+
+#: src/app/main/ui/dashboard/files.cljs:200, src/app/main/ui/dashboard/projects.cljs:285
+msgid "dashboard.empty-placeholder-drafts-subtitle"
+msgstr "Bir proje üyesi taslak oluşturduğunda, bu taslak burada gösterilecektir."
+
+#: src/app/main/ui/dashboard/files.cljs:195, src/app/main/ui/dashboard/projects.cljs:280
+msgid "dashboard.empty-placeholder-drafts-title"
+msgstr "Henüz taslak yok."
+
+#: src/app/main/ui/dashboard/files.cljs:201, src/app/main/ui/dashboard/projects.cljs:286
+msgid "dashboard.empty-placeholder-files-subtitle"
+msgstr "Bir proje üyesi dosya oluşturduğunda, bu dosya burada gösterilecektir."
+
+#: src/app/main/ui/dashboard/files.cljs:196, src/app/main/ui/dashboard/projects.cljs:281
+msgid "dashboard.empty-placeholder-files-title"
+msgstr "Henüz dosya yok."
+
+#: src/app/main/ui/dashboard/placeholder.cljs:118
+#, markdown
+msgid "dashboard.empty-placeholder-libraries"
+msgstr ""
+"Projeye eklenen kütüphaneler burada görünecektir. Dosyalarınızı paylaşmayı "
+"deneyin veya [Kütüphaneler ve "
+"şablonlar](https://penpot.app/libraries-templates) bölümünden ekleyin."
+
+#: src/app/main/ui/dashboard/placeholder.cljs
+#, markdown, unused
+msgid "dashboard.empty-placeholder-libraries-subtitle"
+msgstr ""
+"Projeye eklenen kütüphaneler burada görünecektir. Dosyalarınızı paylaşmayı "
+"deneyin veya [Kütüphaneler ve "
+"şablonlar](https://penpot.app/libraries-templates) bölümünden ekleyin."
+
+#: src/app/main/ui/dashboard/placeholder.cljs:114
+msgid "dashboard.empty-placeholder-libraries-subtitle-viewer-role"
+msgstr "Projeye eklenen kütüphaneler burada görünecektir."
+
+#: src/app/main/ui/dashboard/placeholder.cljs:111
+msgid "dashboard.empty-placeholder-libraries-title"
+msgstr "Henüz kütüphane yok."
+
+#: src/app/main/ui/dashboard/placeholder.cljs:59
+msgid "dashboard.empty-project.add-library"
+msgstr "Kütüphane veya şablon ekle"
+
+#: src/app/main/ui/dashboard/placeholder.cljs:43, src/app/main/ui/dashboard/placeholder.cljs:134
+msgid "dashboard.empty-project.create"
+msgstr "Yeni dosya oluştur"
+
+#: src/app/main/ui/dashboard/placeholder.cljs:61
+msgid "dashboard.empty-project.explore"
+msgstr "Eklemek için keşfedin"
+
+#: src/app/main/ui/dashboard/placeholder.cljs:57
+msgid "dashboard.empty-project.go-to-libraries"
+msgstr "Kütüphaneler ve şablonlara git"
+
+#: src/app/main/ui/dashboard/placeholder.cljs:49, src/app/main/ui/dashboard/placeholder.cljs:51
+msgid "dashboard.empty-project.import"
+msgstr "Dosya içe aktar"
+
+#: src/app/main/ui/dashboard/placeholder.cljs:53
+msgid "dashboard.empty-project.import-penpot"
+msgstr ".penpot dosyasını içe aktar"
+
+#: src/app/main/ui/dashboard/placeholder.cljs:45
+msgid "dashboard.empty-project.start"
+msgstr "Harika şeyler oluşturmaya başlayın"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:252, src/app/main/ui/dashboard/file_menu.cljs:257
 msgid "dashboard.export-binary-multi"
@@ -535,6 +625,16 @@ msgstr "Hepsini kapat"
 msgid "dashboard.fonts.empty-placeholder"
 msgstr "Yüklediğiniz özel yazı tipleri burada görünecektir."
 
+#: src/app/main/ui/dashboard/fonts.cljs:456
+msgid "dashboard.fonts.empty-placeholder-viewer"
+msgstr "Henüz özel yazı tipi yok."
+
+#: src/app/main/ui/dashboard/fonts.cljs:457
+msgid "dashboard.fonts.empty-placeholder-viewer-sub"
+msgstr ""
+"Bir proje üyesi özel bir yazı tipi yüklediğinde, bu yazı tipi burada "
+"gösterilecektir."
+
 #: src/app/main/ui/dashboard/fonts.cljs:206
 msgid "dashboard.fonts.fonts-added"
 msgid_plural "dashboard.fonts.fonts-added"
@@ -590,10 +690,31 @@ msgstr ""
 "Bileşenler v2 ile dosya etkinleştirildi ancak bu takım henüz bunu "
 "desteklemiyor."
 
+#: src/app/main/ui/dashboard.cljs:243
+msgid "dashboard.import.bad-url"
+msgstr "İçe aktarma başarısız oldu. Şablon URL'si yanlış"
+
+#: src/app/main/ui/dashboard.cljs:241
+#, unused
+msgid "dashboard.import.error"
+msgstr "İçe aktarma başarısız oldu. Lütfen tekrar deneyin"
+
 #: src/app/main/ui/dashboard/import.cljs:292
 #, unused
 msgid "dashboard.import.import-error"
 msgstr "Dosya içeri aktarılırken bir sorun oluştu. Dosya içeri aktarılmadı."
+
+#: src/app/main/ui/dashboard/import.cljs:485
+msgid "dashboard.import.import-error.disclaimer"
+msgstr "Tüm dosyalar içe aktarılmadı"
+
+#: src/app/main/ui/dashboard/import.cljs:489
+msgid "dashboard.import.import-error.message1"
+msgstr "Şu dosyalarda hata var:"
+
+#: src/app/main/ui/dashboard/import.cljs:494
+msgid "dashboard.import.import-error.message2"
+msgstr "Hatalı dosyalar karşıya yüklenmeyecektir."
 
 #: src/app/main/ui/dashboard/import.cljs:479
 msgid "dashboard.import.import-message"
@@ -604,6 +725,10 @@ msgstr[1] "%s dosya başarıyla içeri aktarıldı."
 #: src/app/main/ui/dashboard/import.cljs:474
 msgid "dashboard.import.import-warning"
 msgstr "Bazı dosyalar kaldırılmış geçersiz nesneler içeriyordu."
+
+#: src/app/main/ui/dashboard.cljs:244
+msgid "dashboard.import.no-perms"
+msgstr "Bu takıma içe aktarma izniniz yok"
 
 #: src/app/main/ui/dashboard/import.cljs:128
 msgid "dashboard.import.progress.process-colors"
@@ -633,6 +758,22 @@ msgstr "Veriler sunucuya yükleniyor (%s/%s)"
 msgid "dashboard.import.progress.upload-media"
 msgstr "Dosya yükleniyor: %s"
 
+#: src/app/main/ui/dashboard/team.cljs:765
+msgid "dashboard.invitation-modal.delete"
+msgstr "Şu davetleri sileceksiniz:"
+
+#: src/app/main/ui/dashboard/team.cljs:766
+msgid "dashboard.invitation-modal.resend"
+msgstr "Şu davetleri yeniden göndereceksiniz:"
+
+#: src/app/main/ui/dashboard/team.cljs:756
+msgid "dashboard.invitation-modal.title.delete-invitations"
+msgstr "Davetleri sil"
+
+#: src/app/main/ui/dashboard/team.cljs:757
+msgid "dashboard.invitation-modal.title.resend-invitations"
+msgstr "Davetleri yeniden gönder"
+
 #: src/app/main/ui/dashboard/team.cljs:122, src/app/main/ui/dashboard/team.cljs:744
 msgid "dashboard.invite-profile"
 msgstr "İnsanları davet et"
@@ -644,6 +785,12 @@ msgstr "Takımdan ayrıl"
 #: src/app/main/ui/dashboard/templates.cljs:84, src/app/main/ui/dashboard/templates.cljs:169
 msgid "dashboard.libraries-and-templates"
 msgstr "Kütüphaneler ve Şablonlar"
+
+#: src/app/main/ui/dashboard/templates.cljs:267
+msgid "dashboard.libraries-and-templates.description"
+msgstr ""
+"Burada projenize ekleyebileceğiniz bazı kütüphaneler ve şablonlar "
+"bulunmaktadır"
 
 #: src/app/main/ui/dashboard/templates.cljs:170
 msgid "dashboard.libraries-and-templates.explore"
@@ -664,6 +811,10 @@ msgstr "dosyalarınız yükleniyor …"
 #: src/app/main/ui/dashboard/fonts.cljs:447
 msgid "dashboard.loading-fonts"
 msgstr "yazı tipleriniz yükleniyor…"
+
+#: src/app/main/data/comments.cljs:473
+msgid "dashboard.mark-all-as-read.success"
+msgstr "Tüm bildirimleri okundu olarak işaretlendi"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:294, src/app/main/ui/dashboard/project_menu.cljs:101
 msgid "dashboard.move-to"
@@ -701,6 +852,10 @@ msgstr "\"%s\" için sonuç bulunamadı"
 msgid "dashboard.no-projects-placeholder"
 msgstr "Sabitlenmiş projeler burada görünür"
 
+#: src/app/main/ui/dashboard/comments.cljs:91
+msgid "dashboard.notifications"
+msgstr "Bildirimler"
+
 #: src/app/main/ui/auth/verify_token.cljs:34
 msgid "dashboard.notifications.email-changed-successfully"
 msgstr "E-posta adresiniz başarıyla güncellendi"
@@ -709,9 +864,17 @@ msgstr "E-posta adresiniz başarıyla güncellendi"
 msgid "dashboard.notifications.email-verified-successfully"
 msgstr "E-posta adresin başarıyla doğrulandı"
 
+#: src/app/main/data/profile.cljs:273
+msgid "dashboard.notifications.notifications-saved"
+msgstr "Bildirim ayarları güncellendi"
+
 #: src/app/main/ui/settings/password.cljs:36
 msgid "dashboard.notifications.password-saved"
 msgstr "Parola başarıyla kaydedildi!"
+
+#: src/app/main/ui/dashboard/comments.cljs:45
+msgid "dashboard.notifications.view"
+msgstr "Bildirimleri görüntüle"
 
 #: src/app/main/ui/dashboard/team.cljs:1340
 msgid "dashboard.num-of-members"
@@ -725,13 +888,49 @@ msgstr "Dosyayı yeni sekmede aç"
 msgid "dashboard.options"
 msgstr "Seçenekler"
 
+#: src/app/main/ui/dashboard/team.cljs:949
+msgid "dashboard.order-invitations-by-role"
+msgstr "Role göre sırala"
+
+#: src/app/main/ui/dashboard/team.cljs:958
+msgid "dashboard.order-invitations-by-status"
+msgstr "Duruma göre sırala"
+
 #: src/app/main/ui/settings/password.cljs:94, src/app/main/ui/settings/password.cljs:107
 msgid "dashboard.password-change"
 msgstr "Parola değiştir"
 
+#: src/app/main/data/common.cljs:203
+msgid "dashboard.permissions-change.admin"
+msgstr "Artık bu takımda bir yöneticisiniz."
+
+#: src/app/main/data/common.cljs:202
+msgid "dashboard.permissions-change.editor"
+msgstr "Artık bu takımda bir düzenleyicisiniz."
+
+#: src/app/main/data/common.cljs:204
+msgid "dashboard.permissions-change.owner"
+msgstr "Artık bu takımın sahibisiniz."
+
+#: src/app/main/data/common.cljs:201
+msgid "dashboard.permissions-change.viewer"
+msgstr "Artık bu takımda bir görüntüleyicisiniz."
+
 #: src/app/main/ui/dashboard/pin_button.cljs:23, src/app/main/ui/dashboard/project_menu.cljs:96
 msgid "dashboard.pin-unpin"
 msgstr "Sabitle/Sabitleme"
+
+#: src/app/main/ui/dashboard.cljs:207
+msgid "dashboard.plugins.bad-url"
+msgstr "Eklenti URL'si yanlış"
+
+#: src/app/main/ui/dashboard.cljs:205
+msgid "dashboard.plugins.parse-error"
+msgstr "Eklenti bildirim dosyası ayrıştırılamıyor"
+
+#: src/app/main/ui/dashboard.cljs:168
+msgid "dashboard.plugins.try-plugin"
+msgstr "Eklentiyi deneyin: "
 
 #: src/app/main/ui/dashboard/projects.cljs:55
 msgid "dashboard.projects-title"
@@ -745,6 +944,10 @@ msgstr "Hesabınızı kaldırmak mı istiyorsunuz?"
 #, unused
 msgid "dashboard.remove-shared"
 msgstr "Paylaşılan Kütüphane olarak sil"
+
+#: src/app/main/data/common.cljs:236
+msgid "dashboard.removed-from-team"
+msgstr "Artık “%s” takımının bir parçası değilsiniz."
 
 #: src/app/main/ui/settings/profile.cljs:78
 msgid "dashboard.save-settings"
@@ -766,9 +969,85 @@ msgstr "Arayüz dilini seç"
 msgid "dashboard.select-ui-theme"
 msgstr "Tema seç"
 
+#: src/app/main/ui/settings/options.cljs:68
+msgid "dashboard.select-ui-theme.dark"
+msgstr "Penpot Koyu (öntanımlı)"
+
+#: src/app/main/ui/settings/options.cljs:69
+msgid "dashboard.select-ui-theme.light"
+msgstr "Penpot Açık"
+
+#: src/app/main/ui/settings/options.cljs:70
+msgid "dashboard.select-ui-theme.system"
+msgstr "Sistem teması"
+
+#: src/app/main/ui/settings/notifications.cljs:57
+msgid "dashboard.settings.notifications.dashboard-comments.all"
+msgstr "Tüm yorumlar, değinmeler ve yanıtlar"
+
+#: src/app/main/ui/settings/notifications.cljs:59
+msgid "dashboard.settings.notifications.dashboard-comments.none"
+msgstr "Hiçbiri"
+
+#: src/app/main/ui/settings/notifications.cljs:58
+msgid "dashboard.settings.notifications.dashboard-comments.partial"
+msgstr "Yalnızca değinmeler ve yanıtlar"
+
+#: src/app/main/ui/settings/notifications.cljs:54
+msgid "dashboard.settings.notifications.dashboard-comments.title"
+msgstr "Dosya yorumları"
+
+#: src/app/main/ui/settings/notifications.cljs:53
+msgid "dashboard.settings.notifications.dashboard.title"
+msgstr "Denetim Paneli Bildirimleri"
+
+#: src/app/main/ui/settings/notifications.cljs:67
+msgid "dashboard.settings.notifications.email-comments.all"
+msgstr "Tüm yorumlar, değinmeler ve yanıtlar"
+
+#: src/app/main/ui/settings/notifications.cljs:69
+msgid "dashboard.settings.notifications.email-comments.none"
+msgstr "Hiçbiri"
+
+#: src/app/main/ui/settings/notifications.cljs:68
+msgid "dashboard.settings.notifications.email-comments.partial"
+msgstr "Yalnızca değinmeler ve yanıtlar"
+
+#: src/app/main/ui/settings/notifications.cljs:64
+msgid "dashboard.settings.notifications.email-comments.title"
+msgstr "Dosya yorumları"
+
+#: src/app/main/ui/settings/notifications.cljs:76
+msgid "dashboard.settings.notifications.email-invites.all"
+msgstr "Her türlü davet ve istek"
+
+#: src/app/main/ui/settings/notifications.cljs:79
+msgid "dashboard.settings.notifications.email-invites.none"
+msgstr "Hiçbiri"
+
+#: src/app/main/ui/settings/notifications.cljs:73
+msgid "dashboard.settings.notifications.email-invites.title"
+msgstr "Davetler ve istekler"
+
+#: src/app/main/ui/settings/notifications.cljs:63
+msgid "dashboard.settings.notifications.email.title"
+msgstr "E-posta Bildirimleri"
+
+#: src/app/main/ui/settings/notifications.cljs:84
+msgid "dashboard.settings.notifications.submit"
+msgstr "Ayarları güncelle"
+
+#: src/app/main/ui/settings/notifications.cljs:52
+msgid "dashboard.settings.notifications.title"
+msgstr "Bildirimler"
+
 #: src/app/main/ui/dashboard/projects.cljs:304
 msgid "dashboard.show-all-files"
 msgstr "Tüm dosyaları göster"
+
+#: src/app/main/ui/workspace/main_menu.cljs:666
+msgid "dashboard.show-version-history"
+msgstr "Sürüm geçmişi"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:98
 msgid "dashboard.success-delete-file"
@@ -814,6 +1093,10 @@ msgstr "Takım üyeleri"
 msgid "dashboard.team-projects"
 msgstr "Takım projeleri"
 
+#: src/app/main/ui/dashboard/templates.cljs:134
+msgid "dashboard.template.add-to-project"
+msgstr "Projenize ekleyin"
+
 #: src/app/main/ui/settings/options.cljs:63
 msgid "dashboard.theme-change"
 msgstr "Kullanıcı arayüzü teması"
@@ -834,6 +1117,14 @@ msgstr "Kütüphaneyi Yayından Kaldır"
 msgid "dashboard.update-settings"
 msgstr "Ayarları güncelle"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:976
+msgid "dashboard.upgrade-plan.no-limits"
+msgstr "Yaratıcılıkta sınır yok"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:974
+msgid "dashboard.upgrade-plan.penpot-free"
+msgstr "Penpot Ücretsiz"
+
 #: src/app/main/ui/dashboard/team.cljs:1115
 msgid "dashboard.webhooks.active"
 msgstr "Etkin"
@@ -841,6 +1132,12 @@ msgstr "Etkin"
 #: src/app/main/ui/dashboard/team.cljs:1116
 msgid "dashboard.webhooks.active.explain"
 msgstr "Bu kanca tetiklendiğinde olay ayrıntıları iletilecektir"
+
+#: src/app/main/ui/dashboard/team.cljs:1160
+msgid "dashboard.webhooks.cant-edit"
+msgstr ""
+"Yalnızca sizin oluşturduğunuz web kancalarını silebilir veya "
+"değiştirebilirsiniz."
 
 #: src/app/main/ui/dashboard/team.cljs:1106
 msgid "dashboard.webhooks.content-type"
@@ -917,6 +1214,28 @@ msgstr "Tamam"
 msgid "ds.confirm-title"
 msgstr "Emin misin?"
 
+#: src/app/main/ui/ds/controls/numeric_input.cljs:98
+msgid "ds.inputs.numeric-input.no-applicable-tokens"
+msgstr "Etkin kümelerde veya temalarda geçerli token yok."
+
+#: src/app/main/ui/ds/controls/numeric_input.cljs:99
+msgid "ds.inputs.numeric-input.no-matches"
+msgstr "Eşleşme bulunamadı."
+
+#: src/app/main/ui/ds/controls/numeric_input.cljs:641, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:138
+msgid "ds.inputs.numeric-input.open-token-list-dropdown"
+msgstr "Token listesini aç"
+
+#: src/app/main/ui/ds/controls/utilities/token_field.cljs:85, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:133
+msgid "ds.inputs.token-field.detach-token"
+msgstr "Tokeni ayır"
+
+#: src/app/main/ui/ds/controls/utilities/token_field.cljs:40, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:96, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:103
+msgid "ds.inputs.token-field.no-active-token-option"
+msgstr ""
+"Bu token herhangi bir etkin kümede bulunmuyor veya geçersiz bir değere "
+"sahip."
+
 #: src/app/main/data/auth.cljs:314
 msgid "errors.auth-provider-not-allowed"
 msgstr "Kimlik doğrulama sağlayıcısına bu profil için izin verilmiyor"
@@ -941,9 +1260,39 @@ msgstr "%s yazı tipleri yüklenemedi"
 msgid "errors.cannot-upload"
 msgstr "Medya dosyası yüklenemedi."
 
+#: src/app/main/ui/comments.cljs:730, src/app/main/ui/comments.cljs:761, src/app/main/ui/comments.cljs:858
+msgid "errors.character-limit-exceeded"
+msgstr "Karakter sınırı aşıldı"
+
 #: src/app/main/data/workspace/clipboard.cljs:279, src/app/main/data/workspace/clipboard.cljs:497
 msgid "errors.clipboard-not-implemented"
 msgstr "Tarayıcın bu işlemi gerçekleştiremiyor"
+
+#: src/app/main/errors.cljs:231
+msgid "errors.comment-error"
+msgstr "Yorumla ilgili bir hata oluştu"
+
+#: src/app/main/errors.cljs:300
+msgid "errors.deprecated"
+msgstr ""
+"Üzgünüz! Bu, artık kullanılmayan bir Penpot varlık türü kullanan eski bir "
+"dosyadır ve açamazsınız."
+
+#: src/app/main/errors.cljs:303
+msgid "errors.deprecated.contact.after"
+msgstr "böylece size yardımcı olabiliriz."
+
+#: src/app/main/errors.cljs:301
+msgid "errors.deprecated.contact.before"
+msgstr "Penpot artık bu tür varlıkları desteklemese de, bizimle"
+
+#: src/app/main/errors.cljs:302
+msgid "errors.deprecated.contact.text"
+msgstr "iletişime geçebilirsiniz"
+
+#: src/app/main/data/workspace/tokens/library_edit.cljs:274
+msgid "errors.drop-token-set-parent-to-child"
+msgstr "Bir üst kümeyi kendi alt kümesine bırakamazsınız."
 
 #: src/app/main/ui/auth/verify_token.cljs:84, src/app/main/ui/settings/change_email.cljs:29
 msgid "errors.email-already-exists"
@@ -956,6 +1305,10 @@ msgstr "E-posta zaten doğrulandı."
 #: src/app/main/ui/auth/register.cljs:105, src/app/main/ui/settings/password.cljs:27
 msgid "errors.email-as-password"
 msgstr "E-postanızı parola olarak kullanamazsınız"
+
+#: src/app/main/ui/auth/register.cljs:89
+msgid "errors.email-does-not-match-invitation"
+msgstr "E-posta adresi davetiyeyle eşleşmiyor."
 
 #: src/app/main/data/auth.cljs:316, src/app/main/ui/auth/register.cljs:95
 msgid "errors.email-domain-not-allowed"
@@ -988,6 +1341,10 @@ msgstr "En fazla 1 karakter içermelidir."
 msgid "errors.field-min-length"
 msgstr "En az 1 karakter içermelidir."
 
+#: src/app/util/forms.cljs:61
+msgid "errors.field-missing"
+msgstr "Boş alan"
+
 #: src/app/main/ui/settings/team-form.cljs, src/app/main/ui/auth/register.cljs, src/app/main/ui/dashboard/team_form.cljs, src/app/main/ui/onboarding/team_choice.cljs, src/app/main/ui/settings/access_tokens.cljs, src/app/main/ui/settings/feedback.cljs, src/app/main/ui/settings/profile.cljs, src/app/main/ui/workspace/sidebar/assets.cljs
 #, unused
 msgid "errors.field-not-all-whitespace"
@@ -1004,9 +1361,21 @@ msgstr ""
 msgid "errors.generic"
 msgstr "Bir şeyler ters gitti."
 
+#: src/app/main/errors.cljs:193
+msgid "errors.internal-assertion-error"
+msgstr "Dahili Doğrulama Hatası"
+
+#: src/app/main/errors.cljs:209
+msgid "errors.internal-worker-error"
+msgstr "Web çalıştırıcısında bir sorun oluştu."
+
 #: src/app/main/ui/components/color_input.cljs:51
 msgid "errors.invalid-color"
 msgstr "Geçersiz renk"
+
+#: src/app/util/forms.cljs:35, src/app/util/forms.cljs:84
+msgid "errors.invalid-data"
+msgstr "Geçersiz veri"
 
 #: src/app/main/ui/auth/register.cljs, src/app/main/ui/auth/login.cljs, src/app/main/ui/auth/recovery_request.cljs
 #, unused
@@ -1020,6 +1389,11 @@ msgstr "Doğrulama e-postası eşleşmiyor"
 #: src/app/main/ui/auth/recovery.cljs:32
 msgid "errors.invalid-recovery-token"
 msgstr "Kurtarma jetonu geçerli değil."
+
+#: src/app/util/forms.cljs
+#, unused
+msgid "errors.invalid-text"
+msgstr "Geçersiz metin"
 
 #: src/app/main/ui/static.cljs:70
 msgid "errors.invite-invalid"
@@ -1036,6 +1410,10 @@ msgstr "LDAP ile oturum açma devre dışı bırakıldı."
 #: src/app/main/errors.cljs:289, src/app/main/ui/dashboard/team.cljs:191, src/app/main/ui/onboarding/team_choice.cljs:105
 msgid "errors.max-quota-reached"
 msgstr "'%s' sınırına ulaştınız. Destek ile iletişime geçin."
+
+#: src/app/main/ui/dashboard/team.cljs:187, src/app/main/ui/dashboard/team.cljs:849, src/app/main/ui/onboarding/team_choice.cljs:101
+msgid "errors.maximum-invitations-by-request-reached"
+msgstr "Tek bir istekte davet edilebilecek en fazla (%s) e-posta sayısına ulaşıldı"
 
 #: src/app/main/data/workspace/media.cljs:190
 msgid "errors.media-too-large"
@@ -1054,6 +1432,18 @@ msgid "errors.member-is-muted"
 msgstr ""
 "Davet ettiğiniz profilin e-posta adresine ait çok fazla geri dönme raporu "
 "var veya spam olarak bildirilmiş."
+
+#: src/app/main/errors.cljs:263
+msgid "errors.migration-in-progress"
+msgstr "Geçiş devam ediyor"
+
+#: src/app/main/errors.cljs:160
+msgid "errors.only-creator-can-lock"
+msgstr "Yalnızca sürüm oluşturucu onu kilitleyebilir"
+
+#: src/app/main/errors.cljs:168
+msgid "errors.only-creator-can-unlock"
+msgstr "Yalnızca sürüm oluşturucu onun kilidini açabilir"
 
 #: src/app/main/ui/settings/password.cljs
 #, unused
@@ -1083,6 +1473,10 @@ msgstr ""
 msgid "errors.registration-disabled"
 msgstr "Kayıt olma şu anda devre dışı."
 
+#: src/app/main/errors.cljs:222
+msgid "errors.svg-parser.invalid-svg"
+msgstr "SVG geçersiz veya biçimi yanlış"
+
 #: src/app/main/errors.cljs:268
 msgid "errors.team-feature-mismatch"
 msgstr "Uyumsuz '%s' özelliği algılandı"
@@ -1099,6 +1493,23 @@ msgstr "Atamaya çalıştığınız üye mevcut değil."
 msgid "errors.team-leave.owner-cant-leave"
 msgstr "Sahip takımdan ayrılamaz, sahip rolünü yeniden atamanız gerekir."
 
+#: src/app/main/data/workspace/tokens/library_edit.cljs:150, src/app/main/data/workspace/tokens/library_edit.cljs:180
+msgid "errors.token-set-already-exists"
+msgstr "Aynı ada sahip bir küme zaten var"
+
+#: src/app/main/data/tokens.cljs:
+#, unused
+msgid "errors.token-set-doesnt-exists"
+msgstr "Bilinmeyen bir küme çoğaltılamıyor"
+
+#: src/app/main/data/workspace/tokens/library_edit.cljs:273
+msgid "errors.token-set-exists-on-drop"
+msgstr "Bırakma işlemi tamamlanamıyor, aynı ada sahip bir küme zaten bu yolda var."
+
+#: src/app/main/data/workspace/tokens/library_edit.cljs:77, src/app/main/data/workspace/tokens/library_edit.cljs:95
+msgid "errors.token-theme-already-exists"
+msgstr "Aynı ada sahip tema seçeneği var"
+
 #: src/app/main/data/media.cljs:73
 msgid "errors.unexpected-error"
 msgstr "Beklenmedik bir hata oluştu."
@@ -1110,6 +1521,14 @@ msgstr "Bilinmeyen jeton"
 #, unused
 msgid "errors.validation"
 msgstr "Doğrulama Hatası"
+
+#: src/app/main/errors.cljs:176
+msgid "errors.version-already-locked"
+msgstr "Bu sürüm zaten kilitli"
+
+#: src/app/main/errors.cljs:152
+msgid "errors.version-locked"
+msgstr "Bu sürüm kilitlidir ve başkaları tarafından silinemez"
 
 #: src/app/main/errors.cljs:285
 msgid "errors.version-not-supported"
@@ -1206,6 +1625,10 @@ msgstr "Bulanıklık"
 #: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:125
 msgid "inspect.attributes.blur.value"
 msgstr "Değer"
+
+#: src/app/main/ui/components/color_input.cljs:31
+msgid "inspect.attributes.color"
+msgstr "Renk"
 
 #: src/app/main/ui/inspect/attributes/common.cljs:91, src/app/main/ui/inspect/right_sidebar.cljs:97
 msgid "inspect.attributes.color.hex"
@@ -1351,6 +1774,10 @@ msgstr "Satır Yüksekliği"
 msgid "inspect.attributes.typography.text-decoration"
 msgstr "Metin Süsleme"
 
+#, unused
+msgid "inspect.attributes.typography.text-decoration.line-through"
+msgstr "Üstü çizili"
+
 #: src/app/main/ui/inspect/attributes/text.cljs:136
 msgid "inspect.attributes.typography.text-decoration.none"
 msgstr "Hiçbiri"
@@ -1384,6 +1811,14 @@ msgstr "Ayarlanmadı"
 msgid "inspect.attributes.typography.text-transform.uppercase"
 msgstr "Büyük Harf"
 
+#: src/app/main/ui/inspect/attributes/variant.cljs:44
+msgid "inspect.attributes.variant"
+msgstr "Çeşit özellikleri"
+
+#: src/app/main/ui/inspect/attributes/variant.cljs:44
+msgid "inspect.attributes.variants"
+msgstr "Çeşitlerin özellikleri"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:232
 msgid "inspect.empty.help"
 msgstr ""
@@ -1399,6 +1834,14 @@ msgid "inspect.empty.select"
 msgstr ""
 "Özelliklerini ve kodunu incelemek için bir şekil, çalışma yüzeyi veya grup "
 "seçin"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:67
+msgid "inspect.subtitle.copy"
+msgstr "Kopyala"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:63
+msgid "inspect.subtitle.main"
+msgstr "Ana bileşen"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:111, src/app/main/ui/inspect/right_sidebar.cljs:116
 msgid "inspect.tabs.code"
@@ -1452,13 +1895,61 @@ msgstr "SVG"
 msgid "inspect.tabs.code.selected.text"
 msgstr "Metin"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:109
+msgid "inspect.tabs.computed"
+msgstr "Hesaplanan"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:114
 msgid "inspect.tabs.info"
 msgstr "Bilgi"
 
+#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
+msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgstr "Panoya kopyala"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:22
+msgid "inspect.tabs.styles.panel.geometry"
+msgstr "Boyut ve Konum"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
+msgid "inspect.tabs.styles.panel.toggle-style"
+msgstr "%s panelini aç/kapat"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:21
+msgid "inspect.tabs.styles.panel.token"
+msgstr "Token Kümeleri ve Temalar"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
+msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgstr "Etkin kümeler"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
+msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgstr "Etkin temalar"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:20
+msgid "inspect.tabs.styles.panel.variant"
+msgstr "Çeşit özellikleri"
+
+#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
+msgid "inspect.tabs.styles.token.resolved-value"
+msgstr "Çözülen değer:"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:165
+msgid "inspect.tabs.switcher.label"
+msgstr "Katman bilgisi"
+
+#: src/app/main/ui/dashboard/comments.cljs:96
+msgid "label.mark-all-as-read"
+msgstr "Tümünü okundu olarak işaretle"
+
 #: src/app/main/ui/workspace/main_menu.cljs:192
 msgid "label.shortcuts"
 msgstr "Kısayollar"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1043
+msgid "labels.about-penpot"
+msgstr "Penpot hakkında"
 
 #: src/app/main/data/common.cljs:90, src/app/main/ui/dashboard/import.cljs:530
 msgid "labels.accept"
@@ -1472,9 +1963,17 @@ msgstr "Erişim tokenleri"
 msgid "labels.active"
 msgstr "Etkin"
 
+#: src/app/main/ui/workspace/libraries.cljs:177
+msgid "labels.add"
+msgstr "Ekle"
+
 #: src/app/main/ui/dashboard/fonts.cljs:186
 msgid "labels.add-custom-font"
 msgstr "Özel yazı tipi ekle"
+
+#: src/app/main/ui/workspace/libraries.cljs:177
+msgid "labels.adding"
+msgstr "Ekleniyor..."
 
 #: src/app/main/ui/dashboard/team.cljs:134, src/app/main/ui/dashboard/team.cljs:320, src/app/main/ui/dashboard/team.cljs:565, src/app/main/ui/dashboard/team.cljs:595, src/app/main/ui/onboarding/team_choice.cljs:58
 msgid "labels.admin"
@@ -1507,6 +2006,10 @@ msgstr ""
 msgid "labels.bad-gateway.main-message"
 msgstr "Hatalı Ağ Geçidi"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:26
+msgid "labels.blur"
+msgstr "Bulanıklık"
+
 #: src/app/main/data/common.cljs:129, src/app/main/ui/dashboard/change_owner.cljs:64, src/app/main/ui/dashboard/import.cljs:515, src/app/main/ui/dashboard/team.cljs:780, src/app/main/ui/dashboard/team.cljs:1122, src/app/main/ui/delete_shared.cljs:36, src/app/main/ui/exports/assets.cljs:162, src/app/main/ui/exports/files.cljs:191, src/app/main/ui/settings/access_tokens.cljs:175, src/app/main/ui/viewer/share_link.cljs:205, src/app/main/ui/workspace/sidebar/assets/groups.cljs:159, src/app/main/ui/workspace/tokens/export/modal.cljs:44, src/app/main/ui/workspace/tokens/import/modal.cljs:269, src/app/main/ui/workspace/tokens/management/create/form.cljs:632, src/app/main/ui/workspace/tokens/settings/menu.cljs:104, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:228
 msgid "labels.cancel"
 msgstr "İptal"
@@ -1519,6 +2022,22 @@ msgstr "Canva"
 msgid "labels.close"
 msgstr "Kapat"
 
+#: src/app/main/ui/workspace/tokens/sets/lists.cljs:181
+msgid "labels.collapse"
+msgstr "Daralt"
+
+#: src/app/main/ui/workspace/colorpicker.cljs:427
+msgid "labels.color"
+msgstr "Renk"
+
+#: src/app/main/ui/comments.cljs:913
+msgid "labels.comment"
+msgstr "Yorum"
+
+#: src/app/main/ui/comments.cljs:917
+msgid "labels.comment.mark-as-solved"
+msgstr "Çözüldü olarak işaretle"
+
 #: src/app/main/ui/viewer/comments.cljs:71, src/app/main/ui/workspace/comments.cljs:127
 msgid "labels.comments"
 msgstr "Yorumlar"
@@ -1526,6 +2045,10 @@ msgstr "Yorumlar"
 #: src/app/main/ui/dashboard/sidebar.cljs:840, src/app/main/ui/workspace/main_menu.cljs:144
 msgid "labels.community"
 msgstr "Topluluk"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:1030
+msgid "labels.community-contributions"
+msgstr "Topluluk ve Katkılar"
 
 #: src/app/main/ui/settings/password.cljs:91
 msgid "labels.confirm-password"
@@ -1542,6 +2065,14 @@ msgstr "İle devam et"
 #: src/app/main/ui/viewer/login.cljs:69
 msgid "labels.continue-with-penpot"
 msgstr "Penpot hesabıyla devam edebilirsiniz"
+
+#: src/app/main/ui/components/copy_button.cljs:41
+msgid "labels.copy"
+msgstr "Kopyala"
+
+#: src/app/main/ui/inspect/attributes/common.cljs:99
+msgid "labels.copy-color"
+msgstr "Rengi kopyala"
 
 #: src/app/main/ui/dashboard/team.cljs:650
 msgid "labels.copy-invitation-link"
@@ -1608,6 +2139,10 @@ msgstr "At"
 msgid "labels.drafts"
 msgstr "Taslak"
 
+#: src/app/main/ui/workspace/tokens/sets/context_menu.cljs:65
+msgid "labels.duplicate"
+msgstr "Çoğalt"
+
 #: src/app/main/ui/comments.cljs:1005, src/app/main/ui/dashboard/fonts.cljs:264, src/app/main/ui/dashboard/team.cljs:1156, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:220, src/app/main/ui/workspace/tokens/themes.cljs:51
 msgid "labels.edit"
 msgstr "Düzenle"
@@ -1619,6 +2154,14 @@ msgstr "Dosya düzenle"
 #: src/app/main/ui/dashboard/team.cljs:132, src/app/main/ui/dashboard/team.cljs:317, src/app/main/ui/dashboard/team.cljs:566, src/app/main/ui/dashboard/team.cljs:599, src/app/main/ui/onboarding/team_choice.cljs:57
 msgid "labels.editor"
 msgstr "Düzenleyici"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:301
+msgid "labels.empty"
+msgstr "Boş"
+
+#: src/app/main/ui/dashboard/import.cljs:297
+msgid "labels.error"
+msgstr "Hata"
 
 #: src/app/main/ui/onboarding/questions.cljs:404
 #, unused
@@ -1644,6 +2187,10 @@ msgstr "Geri bildirim gönderildi"
 #: src/app/main/ui/onboarding/questions.cljs:156
 msgid "labels.figma"
 msgstr "Figma"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:23
+msgid "labels.fill"
+msgstr "Doldur"
 
 #: src/app/main/ui/dashboard/fonts.cljs:430
 msgid "labels.font-family"
@@ -1691,9 +2238,21 @@ msgstr "Grafik tasarımı"
 msgid "labels.help-center"
 msgstr "Yardım Merkezi"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:1019
+msgid "labels.help-learning"
+msgstr "Yardım ve Öğrenme"
+
+#: src/app/main/ui/dashboard/templates.cljs:91
+msgid "labels.hide"
+msgstr "Gizle"
+
 #: src/app/main/ui/viewer/comments.cljs:104, src/app/main/ui/workspace/comments.cljs:74
 msgid "labels.hide-resolved-comments"
 msgstr "Çözülen yorumları gizle"
+
+#: src/app/main/ui/workspace/tokens/sidebar.cljs:130
+msgid "labels.import"
+msgstr "İçe aktar"
 
 #: src/app/main/ui/dashboard/team.cljs:1224
 msgid "labels.inactive"
@@ -1725,6 +2284,14 @@ msgstr "Davetler"
 msgid "labels.language"
 msgstr "Dil"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:28
+msgid "labels.layout"
+msgstr "Yerleşim düzeni"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:798
+msgid "labels.learning-center"
+msgstr "Öğrenme Merkezi"
+
 #: src/app/main/ui/workspace/main_menu.cljs:168
 msgid "labels.libraries-and-templates"
 msgstr "Kütüphaneler ve Şablonlar"
@@ -1732,6 +2299,10 @@ msgstr "Kütüphaneler ve Şablonlar"
 #: src/app/main/ui/auth/verify_token.cljs:100, src/app/main/ui/dashboard/grid.cljs:115, src/app/main/ui/dashboard/grid.cljs:134, src/app/main/ui/dashboard/import.cljs:258, src/app/main/ui/dashboard/placeholder.cljs:140, src/app/main/ui/ds/product/loader.cljs:85, src/app/main/ui/exports/files.cljs:62, src/app/main/ui/viewer.cljs:643, src/app/main/ui/workspace/sidebar/assets/file_library.cljs:249, src/app/main/ui/workspace.cljs:128, src/app/main/ui.cljs:68, src/app/main/ui.cljs:106, src/app/main/ui.cljs:125
 msgid "labels.loading"
 msgstr "Yükleniyor…"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:209
+msgid "labels.lock"
+msgstr "Kilitle"
 
 #: src/app/main/ui/viewer/header.cljs:208
 msgid "labels.log-or-sign"
@@ -1757,6 +2328,14 @@ msgstr "Üye"
 msgid "labels.members"
 msgstr "Üyeler"
 
+#: src/app/main/ui/comments.cljs:581
+msgid "labels.mention"
+msgstr "Değinme"
+
+#: src/app/main/ui/ds/controls/numeric_input.cljs:619
+msgid "labels.mixed-values"
+msgstr "Karışık"
+
 #: src/app/main/ui/settings/password.cljs:84
 msgid "labels.new-password"
 msgstr "Yeni parola"
@@ -1773,6 +2352,10 @@ msgstr "Hepsini bitirdiniz! Yeni yorum bildirimleri burada görünecektir."
 msgid "labels.no-invitations"
 msgstr "Bekleyen davetiye yok."
 
+#: src/app/main/ui/dashboard/team.cljs:739
+msgid "labels.no-invitations-gather-people"
+msgstr "Arkadaşlarınızı toplayın ve birlikte harika şeyler oluşturun."
+
 #: src/app/main/ui/static.cljs
 #, unused
 msgid "labels.not-found.desc-message"
@@ -1781,6 +2364,10 @@ msgstr "Bu sayfa mevcut olmayabilir veya erişim izniniz olmayabilir."
 #: src/app/main/ui/static.cljs:281
 msgid "labels.not-found.main-message"
 msgstr "Oops!"
+
+#: src/app/main/ui/settings/sidebar.cljs:103
+msgid "labels.notifications"
+msgstr "Bildirimler"
 
 #: src/app/main/ui/dashboard/projects.cljs:238, src/app/main/ui/dashboard/team.cljs:1354
 msgid "labels.num-of-files"
@@ -1813,6 +2400,10 @@ msgstr "Eski parola"
 msgid "labels.only-yours"
 msgstr "Sadece seninkiler"
 
+#: src/app/main/ui/comments.cljs:923, src/app/main/ui/comments.cljs:988, src/app/main/ui/workspace/sidebar/options/menus/text.cljs:310, src/app/main/ui/workspace/sidebar/options/menus/text.cljs:339
+msgid "labels.options"
+msgstr "Seçenekler"
+
 #, unused
 msgid "labels.or"
 msgstr "veya"
@@ -1837,6 +2428,22 @@ msgstr "Parola"
 msgid "labels.pending-invitation"
 msgstr "Bekliyor"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:878
+msgid "labels.penpot-changelog"
+msgstr "Penpot Değişiklik Günlüğü"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:804
+msgid "labels.penpot-hub"
+msgstr "Penpot merkezi"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:751
+msgid "labels.pinned-projects"
+msgstr "Sabitlenen Projeler"
+
+#: src/app/main/ui/comments.cljs:679
+msgid "labels.post"
+msgstr "Gönder"
+
 #: src/app/main/ui/onboarding/questions.cljs:50, src/app/main/ui/viewer.cljs:105
 msgid "labels.previous"
 msgstr "Önceki"
@@ -1856,6 +2463,14 @@ msgstr "Profil"
 #: src/app/main/ui/dashboard/sidebar.cljs:718
 msgid "labels.projects"
 msgstr "Projeler"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
+msgid "labels.reference"
+msgstr "Referans"
+
+#: src/app/main/data/common.cljs:83
+msgid "labels.refresh"
+msgstr "Yenile"
 
 #: src/app/main/ui/settings/sidebar.cljs:129, src/app/main/ui/workspace/main_menu.cljs:160
 msgid "labels.release-notes"
@@ -1883,9 +2498,37 @@ msgstr "Yeniden adlandır"
 msgid "labels.rename-team"
 msgstr "Takımı yeniden adlandır"
 
+#: src/app/main/ui/comments.cljs:642
+msgid "labels.replies"
+msgstr "yanıt"
+
+#: src/app/main/ui/comments.cljs:647
+msgid "labels.replies.new"
+msgstr "yeni yanıt"
+
+#: src/app/main/ui/comments.cljs:641
+msgid "labels.reply"
+msgstr "yanıt"
+
+#: src/app/main/ui/comments.cljs:646
+msgid "labels.reply.new"
+msgstr "yeni yanıt"
+
+#: src/app/main/ui/comments.cljs:722
+msgid "labels.reply.thread"
+msgstr "Yanıtla"
+
+#: src/app/main/ui/dashboard/team.cljs:788
+msgid "labels.resend"
+msgstr "Yeniden gönder"
+
 #: src/app/main/ui/dashboard/team.cljs:938
 msgid "labels.resend-invitation"
 msgstr "Daveti yeniden gönder"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:86, src/app/main/ui/workspace/sidebar/versions.cljs:196
+msgid "labels.restore"
+msgstr "Geri yükle"
 
 #: src/app/main/ui/static.cljs:294, src/app/main/ui/static.cljs:303, src/app/main/ui/static.cljs:377
 msgid "labels.retry"
@@ -1927,9 +2570,17 @@ msgstr "Sistemlerimizin programlı bakımını yapıyoruz."
 msgid "labels.service-unavailable.main-message"
 msgstr "Hizmet Kullanılamıyor"
 
+#: src/app/main/ui/workspace/tokens/sidebar.cljs:75
+msgid "labels.sets"
+msgstr "Kümeler"
+
 #: src/app/main/ui/dashboard/sidebar.cljs:446, src/app/main/ui/dashboard/team.cljs:101, src/app/main/ui/dashboard/team.cljs:115, src/app/main/ui/settings/options.cljs:87, src/app/main/ui/settings/sidebar.cljs:109
 msgid "labels.settings"
 msgstr "Ayarlar"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:27
+msgid "labels.shadow"
+msgstr "Gölge"
 
 #: src/app/main/ui/viewer/header.cljs:204
 msgid "labels.share"
@@ -1943,6 +2594,10 @@ msgstr "Prototipi paylaş"
 msgid "labels.shared-libraries"
 msgstr "Paylaşılan Kütüphaneler"
 
+#: src/app/main/ui/dashboard/templates.cljs:87
+msgid "labels.show"
+msgstr "Göster"
+
 #: src/app/main/ui/viewer/comments.cljs:83, src/app/main/ui/workspace/comments.cljs:56, src/app/main/ui/workspace/comments.cljs:138
 msgid "labels.show-all-comments"
 msgstr "Tüm yorumları göster"
@@ -1950,6 +2605,10 @@ msgstr "Tüm yorumları göster"
 #: src/app/main/ui/viewer/comments.cljs:116
 msgid "labels.show-comments-list"
 msgstr "Yorum listesini göster"
+
+#: src/app/main/ui/workspace/comments.cljs:68, src/app/main/ui/workspace/comments.cljs:140
+msgid "labels.show-mentions"
+msgstr "Yalnızca değinmelerinizi göster"
 
 #: src/app/main/ui/viewer/comments.cljs:92, src/app/main/ui/workspace/comments.cljs:62, src/app/main/ui/workspace/comments.cljs:139
 msgid "labels.show-your-comments"
@@ -1959,6 +2618,10 @@ msgstr "Yalnızca kendi yorumlarımı göster"
 msgid "labels.sketch"
 msgstr "Sketch"
 
+#: src/app/main/ui/dashboard/sidebar.cljs:730
+msgid "labels.sources"
+msgstr "Kaynaklar"
+
 #: src/app/main/ui/onboarding/questions.cljs:55
 msgid "labels.start"
 msgstr "Başla"
@@ -1967,9 +2630,21 @@ msgstr "Başla"
 msgid "labels.status"
 msgstr "Durum"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
+msgid "labels.stroke"
+msgstr "Çerçeve"
+
 #: src/app/main/ui/onboarding/questions.cljs:87
 msgid "labels.student-teacher"
 msgstr "Öğrenci veya öğretmen"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
+msgid "labels.styles"
+msgstr "Biçimler"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:33
+msgid "labels.svg"
+msgstr "SVG"
 
 #: src/app/main/ui/onboarding/questions.cljs:256
 #, unused
@@ -1981,9 +2656,29 @@ msgstr "Takım Lideri"
 msgid "labels.team-member"
 msgstr "Takım üyesi"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:25
+msgid "labels.text"
+msgstr "Metin"
+
+#: src/app/main/ui/workspace/tokens/themes.cljs:36
+msgid "labels.themes"
+msgstr "Temalar"
+
 #: src/app/main/ui/workspace/main_menu.cljs:152
 msgid "labels.tutorials"
 msgstr "Öğreticiler"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
+msgid "labels.typography"
+msgstr "Tipografi"
+
+#: src/app/main/data/workspace/tokens/errors.cljs:101
+msgid "labels.unknown-error"
+msgstr "Bilinmeyen hata"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:203
+msgid "labels.unlock"
+msgstr "Kilidi aç"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:267
 msgid "labels.unpublish-multi-files"
@@ -2009,6 +2704,14 @@ msgstr "Özel yazı tipi yükle"
 msgid "labels.uploading"
 msgstr "Yükleniyor…"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
+msgid "labels.variant"
+msgstr "Çeşit"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:872
+msgid "labels.version-notes"
+msgstr "Sürüm %s notları"
+
 #: src/app/main/ui/workspace/sidebar/sitemap.cljs:246
 msgid "labels.view-only"
 msgstr "YALNIZCA GÖRÜNTÜLE"
@@ -2016,6 +2719,10 @@ msgstr "YALNIZCA GÖRÜNTÜLE"
 #: src/app/main/ui/dashboard/team.cljs:131, src/app/main/ui/dashboard/team.cljs:314, src/app/main/ui/dashboard/team.cljs:567, src/app/main/ui/dashboard/team.cljs:603, src/app/main/ui/onboarding/team_choice.cljs:56
 msgid "labels.viewer"
 msgstr "Görüntüleyici"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:32
+msgid "labels.visibility"
+msgstr "Görünürlük"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:441, src/app/main/ui/dashboard/team.cljs:103, src/app/main/ui/dashboard/team.cljs:113, src/app/main/ui/dashboard/team.cljs:1134
 msgid "labels.webhooks"
@@ -2037,6 +2744,90 @@ msgstr "Hesabınız"
 #, unused
 msgid "labels.youtube"
 msgstr "YouTube"
+
+#: src/app/main/ui/ds/product/loader.cljs:21
+msgid "loader.tips.01.message"
+msgstr "Tasarımlarınızı tüm projelerde tutarlı ve güncellemesi kolay tutun."
+
+#: src/app/main/ui/ds/product/loader.cljs:20
+msgid "loader.tips.01.title"
+msgstr "Yeniden Kullanılabilir Bileşenler"
+
+#: src/app/main/ui/ds/product/loader.cljs:23
+msgid "loader.tips.02.message"
+msgstr "Takımınızla canlı olarak çalışın, geri bildirimleri anında paylaşın."
+
+#: src/app/main/ui/ds/product/loader.cljs:22
+msgid "loader.tips.02.title"
+msgstr "Gerçek Zamanlı İş Birliği"
+
+#: src/app/main/ui/ds/product/loader.cljs:25
+msgid "loader.tips.03.message"
+msgstr "Tanıdık CSS benzeri düzen denetimleriyle esnek bir şekilde tasarım yapın."
+
+#: src/app/main/ui/ds/product/loader.cljs:24
+msgid "loader.tips.03.title"
+msgstr "CSS Benzeri Düzenler"
+
+#: src/app/main/ui/ds/product/loader.cljs:27
+msgid "loader.tips.04.message"
+msgstr "Tasarımlarınızdan doğrudan CSS ve SVG kodları alın."
+
+#: src/app/main/ui/ds/product/loader.cljs:26
+msgid "loader.tips.04.title"
+msgstr "Kod Olarak Dışa Aktarın"
+
+#: src/app/main/ui/ds/product/loader.cljs:29
+msgid "loader.tips.05.message"
+msgstr "Tutarlılığı korumak için varlıkları ve biçimleri paylaşın."
+
+#: src/app/main/ui/ds/product/loader.cljs:28
+msgid "loader.tips.05.title"
+msgstr "Kütüphaneler Tasarlayın"
+
+#: src/app/main/ui/ds/product/loader.cljs:31
+msgid "loader.tips.06.message"
+msgstr "Animasyonlar ve geçişlerle fikirlerinizi hayata geçirin."
+
+#: src/app/main/ui/ds/product/loader.cljs:30
+msgid "loader.tips.06.title"
+msgstr "Etkileşimli Prototipler"
+
+#: src/app/main/ui/ds/product/loader.cljs:33
+msgid "loader.tips.07.message"
+msgstr "Penpot, sorunsuz geliştirme için SVG ve CSS kullanır."
+
+#: src/app/main/ui/ds/product/loader.cljs:32
+msgid "loader.tips.07.title"
+msgstr "Web Standartları Biçimleri"
+
+#: src/app/main/ui/ds/product/loader.cljs:35
+msgid "loader.tips.08.message"
+msgstr ""
+"Otomatik Düzenleme için Shift + A gibi kullanışlı kısayollarla iş akışınızı "
+"hızlandırın."
+
+#: src/app/main/ui/ds/product/loader.cljs:34
+msgid "loader.tips.08.title"
+msgstr "Klavye Kısayolları"
+
+#: src/app/main/ui/ds/product/loader.cljs:37
+msgid "loader.tips.09.message"
+msgstr "Tarzınıza uygun temayı seçin."
+
+#: src/app/main/ui/ds/product/loader.cljs:36
+msgid "loader.tips.09.title"
+msgstr "Koyu ve Açık Mod"
+
+#: src/app/main/ui/ds/product/loader.cljs:39
+msgid "loader.tips.10.message"
+msgstr ""
+"Ek işlevsellik için topluluk tarafından geliştirilen eklentilerle Penpot'u "
+"genişletin."
+
+#: src/app/main/ui/ds/product/loader.cljs:38
+msgid "loader.tips.10.title"
+msgstr "Eklenti Desteği"
 
 #: src/app/main/ui/workspace/colorpicker.cljs:486, src/app/main/ui/workspace/colorpicker.cljs:487, src/app/main/ui/workspace/colorpicker.cljs:489
 msgid "media.choose-image"
@@ -2377,6 +3168,12 @@ msgstr ""
 "Bazı e-posta adresleri mevcut takım üyelerine aittir. Davetleri "
 "gönderilmeyecektir."
 
+#: src/app/main/ui/dashboard/team.cljs:222
+msgid "modals.invite-team-member.text"
+msgstr ""
+"Üyeleri takıma davet ederek bu dosyaya ve tüm takım dosyalarına "
+"erişmelerini sağlayabilirsiniz."
+
 #: src/app/main/ui/dashboard/team.cljs:218
 msgid "modals.invite-team-member.title"
 msgstr "Üyeleri takıma davet et"
@@ -2657,6 +3454,10 @@ msgstr "Bakım arası: 5 dakika içinde kısa bir bakım için kapalı olacağı
 #: src/app/main/data/common.cljs:82
 msgid "notifications.by-code.upgrade-version"
 msgstr "Yeni bir sürüm mevcut, lütfen sayfayı yenileyin"
+
+#: src/app/main/ui/dashboard/team.cljs:825
+msgid "notifications.invitation-deleted"
+msgstr "Davet başarıyla silindi"
 
 #: src/app/main/ui/dashboard/team.cljs:170, src/app/main/ui/dashboard/team.cljs:867
 msgid "notifications.invitation-email-sent"
@@ -3037,6 +3838,10 @@ msgstr "Çıkar"
 msgid "settings.multiple"
 msgstr "Karışık"
 
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:423
+msgid "settings.remove-color"
+msgstr "Rengi kaldır"
+
 #: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:428
 msgid "settings.select-this-color"
 msgstr "Bu biçimi kullanan ögeleri seç"
@@ -3210,6 +4015,19 @@ msgstr "Geri almayı temizle"
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:95
 msgid "shortcuts.copy"
 msgstr "Kopyala"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:96
+msgid "shortcuts.copy-link"
+msgstr "Bağlantıyı kopyala"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:106
+#, unused
+msgid "shortcuts.copy-props"
+msgstr "Özellikleri kopyala"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
+msgid "shortcuts.create-component-variant"
+msgstr "Bileşen / çeşit oluştur"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:98
 msgid "shortcuts.create-new-project"
@@ -3479,6 +4297,16 @@ msgstr " veya "
 msgid "shortcuts.paste"
 msgstr "Yapıştır"
 
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:111
+#, unused
+msgid "shortcuts.paste-props"
+msgstr "Özellikleri yapıştır"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:604
+#, unused
+msgid "shortcuts.plugins"
+msgstr "Eklenti yöneticisi"
+
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:163
 msgid "shortcuts.prev-frame"
 msgstr "Önceki çalışma yüzeyi"
@@ -3486,6 +4314,10 @@ msgstr "Önceki çalışma yüzeyi"
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:164
 msgid "shortcuts.redo"
 msgstr "Yeniden yap"
+
+#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:165
+msgid "shortcuts.rename"
+msgstr "Yeniden adlandır"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:166
 msgid "shortcuts.reset-zoom"
@@ -3663,6 +4495,320 @@ msgstr "Görüntüyü büyült"
 msgid "shortcuts.zoom-selected"
 msgstr "Seçilene yakınlaştır"
 
+#: src/app/main/ui/dashboard/subscription.cljs:89, src/app/main/ui/dashboard/subscription.cljs:131
+msgid "subscription.dashboard.power-up.enterprise-plan"
+msgstr "Kurumsal plan"
+
+#: src/app/main/ui/dashboard/subscription.cljs:85
+msgid "subscription.dashboard.power-up.enterprise-trial.top-title"
+msgstr "Kurumsal plan (deneme)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:64
+#, markdown
+msgid "subscription.dashboard.power-up.professional.bottom-text"
+msgstr ""
+"Sınırsız plan ile takımlarınız için ek depolama alanı, dosya kurtarma ve "
+"daha fazlasını elde edin. [Güçlenin!|target:self](%s)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:63
+msgid "subscription.dashboard.power-up.professional.top-title"
+msgstr "Profesyonel plan"
+
+#: src/app/main/ui/dashboard/subscription.cljs:64, src/app/main/ui/settings/subscription.cljs:107, src/app/main/ui/settings/subscription.cljs:131
+#, unused
+msgid "subscription.dashboard.power-up.subscribe"
+msgstr "Abone ol"
+
+#: src/app/main/ui/dashboard/subscription.cljs:72
+#, markdown
+msgid "subscription.dashboard.power-up.trial.bottom-description"
+msgstr ""
+"Deneme sürenizi beğendiniz mi? Tam erişimi sonsuza kadar açın. [Abone "
+"olun|target:self](%s)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:71
+msgid "subscription.dashboard.power-up.trial.top-title"
+msgstr "Sınırsız plan (deneme)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:77, src/app/main/ui/dashboard/subscription.cljs:130
+msgid "subscription.dashboard.power-up.unlimited-plan"
+msgstr "Sınırsız plan"
+
+#: src/app/main/ui/dashboard/subscription.cljs:78
+#, markdown
+msgid "subscription.dashboard.power-up.unlimited.bottom-text"
+msgstr ""
+"Sabit bir fiyatla tüm takımlarınız için sınırsız depolama alanı, kapsamlı "
+"dosya kurtarma ve sınırsız düzenleyici elde edin. [Kurumsal plana göz "
+"atın.|target:self](%s)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:70
+#, unused
+msgid "subscription.dashboard.power-up.unlimited.cta"
+msgstr "Göz atın"
+
+#: src/app/main/ui/dashboard/subscription.cljs:68
+#, unused
+msgid "subscription.dashboard.power-up.unlimited.top-description"
+msgstr ""
+"Ek düzenleyiciler, depolama ve otomatik kaydedilen sürüm, dosya yedekleme "
+"ve daha fazlası."
+
+#: src/app/main/ui/dashboard/subscription.cljs:62, src/app/main/ui/dashboard/subscription.cljs:70, src/app/main/ui/dashboard/subscription.cljs:76, src/app/main/ui/dashboard/subscription.cljs:84, src/app/main/ui/dashboard/subscription.cljs:88
+msgid "subscription.dashboard.power-up.your-subscription"
+msgstr "Aboneliğiniz:"
+
+#: src/app/main/ui/dashboard/subscription.cljs:168
+msgid "subscription.dashboard.professional-dashboard-cta-title"
+msgstr ""
+"Sahip olduğunuz takımlarda %s düzenleyiciniz varken, profesyonel planınız "
+"8'e kadar düzenleyiciyi kapsamaktadır."
+
+#: src/app/main/ui/dashboard/subscription.cljs:176
+#, markdown
+msgid "subscription.dashboard.professional-dashboard-cta-upgrade-owner"
+msgstr ""
+"Daha fazla düzenleyici, depolama alanı ve dosya kurtarma özelliğinin "
+"kilidini açmak için şimdi Sınırsız veya Kurumsal sürümüne yükseltin. [Şimdi "
+"abone olun.|target:self](%s)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:111
+msgid "subscription.dashboard.team-plan"
+msgstr "Takım planı"
+
+#: src/app/main/ui/dashboard/subscription.cljs:171
+msgid "subscription.dashboard.unlimited-dashboard-cta-title"
+msgstr ""
+"Takımınız büyümeye devam ediyor! Sınırsız planınız %s düzenleyiciye kadar "
+"kapsıyor, ancak şu anda %s düzenleyiciniz var."
+
+#: src/app/main/ui/dashboard/subscription.cljs:179
+#, markdown
+msgid "subscription.dashboard.unlimited-dashboard-cta-upgrade-owner"
+msgstr ""
+"Lütfen düzenleyici sayınızla eşleşecek şekilde şimdi yükseltin. [Şimdi "
+"abone olun.|target:self](%s)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:156
+msgid "subscription.dashboard.unlimited-members-extra-editors-cta-text"
+msgstr ""
+"Yalnızca sahip olduğunuz takımlardaki yeni düzenleyiciler gelecekteki "
+"faturalandırmaya dahil edilir. 25'ten fazla düzenleyici için aylık 175$ "
+"sabit ücret uygulanmaya devam eder."
+
+#: src/app/main/ui/dashboard/subscription.cljs:152
+msgid "subscription.dashboard.unlimited-members-extra-editors-cta-title"
+msgstr "Sınırsız plandayken kişileri davet etme"
+
+#: src/app/main/ui/dashboard/sidebar.cljs:978
+msgid "subscription.dashboard.upgrade-plan.power-up"
+msgstr "Güçlenin"
+
+#: src/app/main/ui/settings/sidebar.cljs:116, src/app/main/ui/settings/subscription.cljs:318, src/app/main/ui/settings/subscription.cljs:351
+msgid "subscription.labels"
+msgstr "Abonelik"
+
+#: src/app/main/ui/settings/subscription.cljs:373, src/app/main/ui/settings/subscription.cljs:397
+msgid "subscription.settings.add-payment-to-continue"
+msgstr "Deneme süreniz bittikten sonra devam etmek için bir ödeme yöntemi ekleyin"
+
+#: src/app/main/ui/settings/subscription.cljs:367, src/app/main/ui/settings/subscription.cljs:439
+msgid "subscription.settings.benefits.all-professional-benefits"
+msgstr "Tüm Profesyonel plan faydaları ve:"
+
+#: src/app/main/ui/settings/subscription.cljs:379, src/app/main/ui/settings/subscription.cljs:391, src/app/main/ui/settings/subscription.cljs:401, src/app/main/ui/settings/subscription.cljs:453
+msgid "subscription.settings.benefits.all-unlimited-benefits"
+msgstr "Tüm Sınırsız plan faydaları ve:"
+
+#: src/app/main/ui/settings/subscription.cljs:39
+msgid "subscription.settings.editors"
+msgstr "(x %s düzenleyici)"
+
+#: src/app/main/ui/dashboard/subscription.cljs:119, src/app/main/ui/settings/subscription.cljs:72, src/app/main/ui/settings/subscription.cljs:346, src/app/main/ui/settings/subscription.cljs:399, src/app/main/ui/settings/subscription.cljs:449
+msgid "subscription.settings.enterprise"
+msgstr "Kurumsal"
+
+#: src/app/main/ui/settings/subscription.cljs:68, src/app/main/ui/settings/subscription.cljs:345, src/app/main/ui/settings/subscription.cljs:389
+msgid "subscription.settings.enterprise-trial"
+msgstr "Kurumsal (deneme)"
+
+#: src/app/main/ui/settings/subscription.cljs:393, src/app/main/ui/settings/subscription.cljs:403, src/app/main/ui/settings/subscription.cljs:455
+msgid "subscription.settings.enterprise.autosave"
+msgstr "90 günlük sürümleri otomatik kaydetme ve dosya kurtarma"
+
+#: src/app/main/ui/settings/subscription.cljs:394, src/app/main/ui/settings/subscription.cljs:404, src/app/main/ui/settings/subscription.cljs:456
+msgid "subscription.settings.enterprise.capped-bill"
+msgstr "Sabit aylık fatura"
+
+#: src/app/main/ui/settings/subscription.cljs:392, src/app/main/ui/settings/subscription.cljs:402, src/app/main/ui/settings/subscription.cljs:454
+msgid "subscription.settings.enterprise.unlimited-storage-benefit"
+msgstr "Sınırsız depolama alanı"
+
+#: src/app/main/ui/dashboard/subscription.cljs:124, src/app/main/ui/settings/subscription.cljs:371, src/app/main/ui/settings/subscription.cljs:383, src/app/main/ui/settings/subscription.cljs:395, src/app/main/ui/settings/subscription.cljs:405
+msgid "subscription.settings.manage-your-subscription"
+msgstr "Aboneliğinizi yönetin"
+
+#: src/app/main/ui/settings/subscription.cljs:131
+msgid "subscription.settings.management.dialog.currently-editors-title"
+msgid_plural "subscription.settings.management.dialog.currently-editors-title"
+msgstr[0] "Şu anda, takımlarınızda düzenleme yapabilen %s kişi bulunuyor."
+msgstr[1] "Şu anda, takımlarınızda düzenleme yapabilen %s kişi bulunuyor."
+
+#: src/app/main/ui/settings/subscription.cljs:149
+msgid "subscription.settings.management.dialog.downgrade"
+msgstr ""
+"Dikkat: Daha düşük bir plana geçmek, daha az depolama alanı, daha kısa "
+"yedeklemeler ve daha kısa sürüm geçmişi anlamına gelir."
+
+#: src/app/main/ui/settings/subscription.cljs:133
+msgid "subscription.settings.management.dialog.editors"
+msgstr "Düzenleyiciler"
+
+#: src/app/main/ui/settings/subscription.cljs:138
+msgid "subscription.settings.management.dialog.editors-explanation"
+msgstr ""
+"(Sahipler, Yöneticiler ve Düzenleyiciler. Görüntüleyiciler, Düzenleyici "
+"olarak sayılmaz)"
+
+#: src/app/main/ui/settings/subscription.cljs:181
+msgid "subscription.settings.management.dialog.input-error"
+msgstr ""
+"Şu anda sahip olduğunuzdan daha az sayıda düzenleyici ayarlayamazsınız. "
+"Takım ayarlarında, dosyaları düzenlemeyen kişilerin rolünü "
+"(düzenleyici/yönetici yerine görüntüleyici) değiştirin."
+
+#: src/app/main/ui/settings/subscription.cljs:177
+msgid "subscription.settings.management.dialog.payment-explanation"
+msgstr "Deneme süresinden sonra ücretlendirilir. Şu anda kredi kartı gerekmez."
+
+#: src/app/main/ui/settings/subscription.cljs:170, src/app/main/ui/settings/subscription.cljs:174
+#, markdown
+msgid "subscription.settings.management.dialog.price-month"
+msgstr "**%s$**/ay"
+
+#: src/app/main/ui/settings/subscription.cljs:126
+msgid "subscription.settings.management.dialog.title"
+msgstr "Takımlarınıza %s uygulayın"
+
+#: src/app/main/ui/settings/subscription.cljs:184
+msgid "subscription.settings.management.dialog.unlimited-capped-warning"
+msgstr ""
+"İpucu: Davetlerin öncesinde hazırlıklı olmak için şimdi koltuk sayınızı "
+"artırabilirsiniz. Takımlar genelinde 25'ten fazla düzenleyiciye aylık 175$ "
+"sabit ücretten sahip olacaksınız."
+
+#: src/app/main/ui/settings/subscription.cljs:418
+msgid "subscription.settings.member-since"
+msgstr "Penpot üyelik tarihi: %s"
+
+#: src/app/main/ui/settings/subscription.cljs:431, src/app/main/ui/settings/subscription.cljs:445, src/app/main/ui/settings/subscription.cljs:459
+msgid "subscription.settings.more-information"
+msgstr "Daha fazla bilgi"
+
+#: src/app/main/ui/settings/subscription.cljs:421
+msgid "subscription.settings.other-plans"
+msgstr "Diğer penpot planları"
+
+#: src/app/main/ui/settings/subscription.cljs:425, src/app/main/ui/settings/subscription.cljs:438
+msgid "subscription.settings.price-editor-month"
+msgstr "aylık düzenleyici"
+
+#: src/app/main/ui/dashboard/subscription.cljs:114, src/app/main/ui/settings/subscription.cljs:70, src/app/main/ui/settings/subscription.cljs:358, src/app/main/ui/settings/subscription.cljs:423
+msgid "subscription.settings.professional"
+msgstr "Profesyonel"
+
+#: src/app/main/ui/settings/subscription.cljs:360, src/app/main/ui/settings/subscription.cljs:427
+msgid "subscription.settings.professional.autosave-benefit"
+msgstr "7 günlük sürümleri otomatik kaydetme ve dosya kurtarma"
+
+#: src/app/main/ui/settings/subscription.cljs:359, src/app/main/ui/settings/subscription.cljs:426
+msgid "subscription.settings.professional.storage-benefit"
+msgstr "10GB depolama alanı"
+
+#: src/app/main/ui/settings/subscription.cljs:361, src/app/main/ui/settings/subscription.cljs:428
+msgid "subscription.settings.professional.teams-editors-benefit"
+msgstr "Sınırsız sayıda takım. Sahip olduğunuz takımlarda en fazla 8 düzenleyici."
+
+#: src/app/main/ui/settings/subscription.cljs:355
+msgid "subscription.settings.section-plan"
+msgstr "Aboneliğiniz"
+
+#: src/app/main/ui/settings/subscription.cljs:195, src/app/main/ui/settings/subscription.cljs:210
+msgid "subscription.settings.start-trial"
+msgstr "Ücretsiz denemeyi başlat"
+
+#: src/app/main/ui/settings/subscription.cljs:429, src/app/main/ui/settings/subscription.cljs:443, src/app/main/ui/settings/subscription.cljs:457
+msgid "subscription.settings.subscribe"
+msgstr "Abone ol"
+
+#: src/app/main/ui/settings/subscription.cljs:239
+msgid "subscription.settings.success.dialog.description"
+msgstr ""
+"Aboneliğinizi, hesap ayrıntılarınızdaki 'Abonelik' sayfasından istediğiniz "
+"zaman düzenleyebilirsiniz."
+
+#: src/app/main/ui/settings/subscription.cljs:238
+msgid "subscription.settings.success.dialog.thanks"
+msgstr "Penpot %s planını seçtiğiniz için teşekkür ederiz!"
+
+#: src/app/main/ui/settings/subscription.cljs:240
+msgid "subscription.settings.sucess.dialog.footer"
+msgstr "Planınızın tadını çıkarın!"
+
+#: src/app/main/ui/settings/subscription.cljs:236
+msgid "subscription.settings.sucess.dialog.title"
+msgstr "%s oldunuz!"
+
+#: src/app/main/ui/settings/subscription.cljs:413
+#, fuzzy
+msgid "subscription.settings.support-us-since"
+msgstr "Bu planla bizi şu zamandan beri destekliyorsunuz: %s"
+
+#: src/app/main/ui/settings/subscription.cljs:443, src/app/main/ui/settings/subscription.cljs:457
+msgid "subscription.settings.try-it-free"
+msgstr "14 gün boyunca ücretsiz deneyin"
+
+#: src/app/main/ui/dashboard/subscription.cljs:117, src/app/main/ui/settings/subscription.cljs:71, src/app/main/ui/settings/subscription.cljs:343, src/app/main/ui/settings/subscription.cljs:377, src/app/main/ui/settings/subscription.cljs:435
+msgid "subscription.settings.unlimited"
+msgstr "Sınırsız"
+
+#: src/app/main/ui/dashboard/subscription.cljs:116, src/app/main/ui/settings/subscription.cljs:67, src/app/main/ui/settings/subscription.cljs:342, src/app/main/ui/settings/subscription.cljs:365
+msgid "subscription.settings.unlimited-trial"
+msgstr "Sınırsız (deneme)"
+
+#: src/app/main/ui/settings/subscription.cljs:369, src/app/main/ui/settings/subscription.cljs:381, src/app/main/ui/settings/subscription.cljs:441
+msgid "subscription.settings.unlimited.autosave-benefit"
+msgstr "30 günlük sürümleri otomatik kaydetme ve dosya kurtarma"
+
+#: src/app/main/ui/settings/subscription.cljs:370, src/app/main/ui/settings/subscription.cljs:382, src/app/main/ui/settings/subscription.cljs:442
+msgid "subscription.settings.unlimited.bill"
+msgstr "Aylık fatura üst sınırı 175$"
+
+#: src/app/main/ui/settings/subscription.cljs:368, src/app/main/ui/settings/subscription.cljs:380, src/app/main/ui/settings/subscription.cljs:440
+msgid "subscription.settings.unlimited.storage-benefit"
+msgstr "25GB depolama alanı"
+
+#: src/app/main/ui/dashboard/subscription.cljs:147, src/app/main/ui/workspace/main_menu.cljs:961
+msgid "subscription.workspace.header.menu.option.power-up"
+msgstr "Planınızı güçlendirin"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:56
+#, markdown
+msgid "subscription.workspace.versions.warning.enterprise.subtext-owner"
+msgstr "Bu sınırı artırmak isterseniz, bize [%s](mailto) adresinden yazabilirsiniz"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:58
+#, markdown
+msgid "subscription.workspace.versions.warning.subtext-member"
+msgstr ""
+"Bu sınırı artırmak isterseniz, takım sahibi ile iletişime geçin: "
+"[%s](mailto)"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:57
+#, markdown
+msgid "subscription.workspace.versions.warning.subtext-owner"
+msgstr "Bu sınırı artırmak isterseniz, [planınızı yükseltin|target:self](%s)"
+
 #: src/app/main/ui/dashboard/files.cljs:180
 msgid "title.dashboard.files"
 msgstr "%s - Penpot"
@@ -3698,6 +4844,10 @@ msgstr "Profil - Erişim tokenleri"
 #: src/app/main/ui/settings/feedback.cljs:107
 msgid "title.settings.feedback"
 msgstr "Geri bildirimde bulun - Penpot"
+
+#: src/app/main/ui/settings/notifications.cljs:45
+msgid "title.settings.notifications"
+msgstr "Bildirimler - Penpot"
 
 #: src/app/main/ui/settings/options.cljs:83
 msgid "title.settings.options"
@@ -3831,6 +4981,10 @@ msgstr "Dikeyde dağıt (%s)"
 msgid "workspace.align.vtop"
 msgstr "Üste hizala (%s)"
 
+#: src/app/main/ui/workspace/sidebar/assets.cljs:172
+msgid "workspace.assets.add-library"
+msgstr "Kütüphane ekle"
+
 #: src/app/main/ui/workspace/sidebar/assets.cljs
 #, unused
 msgid "workspace.assets.assets"
@@ -3844,9 +4998,25 @@ msgstr "Tüm varlıklar"
 msgid "workspace.assets.colors"
 msgstr "Renkler"
 
+#: src/app/main/ui/workspace/sidebar/assets/colors.cljs:497
+msgid "workspace.assets.colors.add-color"
+msgstr "Renk ekle"
+
+#: src/app/main/ui/workspace/sidebar/assets/groups.cljs:81
+msgid "workspace.assets.component-group-options"
+msgstr "Bileşen grubu seçenekleri"
+
 #: src/app/main/ui/dashboard/grid.cljs:144, src/app/main/ui/dashboard/grid.cljs:159, src/app/main/ui/workspace/sidebar/assets/components.cljs:560, src/app/main/ui/workspace/sidebar/assets.cljs:155
 msgid "workspace.assets.components"
 msgstr "Bileşenler"
+
+#: src/app/main/ui/workspace/sidebar/assets/components.cljs:581
+msgid "workspace.assets.components.add-component"
+msgstr "Bileşen ekle"
+
+#: src/app/main/ui/workspace/sidebar/assets/components.cljs:178, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:547
+msgid "workspace.assets.components.num-variants"
+msgstr "%s Çeşit"
 
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:141
 msgid "workspace.assets.create-group"
@@ -3901,6 +5071,10 @@ msgstr "Liste görünümü"
 msgid "workspace.assets.local-library"
 msgstr "yerel kütüphane"
 
+#: src/app/main/ui/workspace/sidebar/assets.cljs:177
+msgid "workspace.assets.manage-library"
+msgstr "Kütüphaneyi yönet"
+
 #: src/app/main/ui/workspace/sidebar/assets/file_library.cljs:307
 msgid "workspace.assets.not-found"
 msgstr "Varlık bulunmadı"
@@ -3947,6 +5121,10 @@ msgstr "Sırala"
 msgid "workspace.assets.typography"
 msgstr "Tipografiler"
 
+#: src/app/main/ui/workspace/sidebar/assets/typographies.cljs:405
+msgid "workspace.assets.typography.add-typography"
+msgstr "Tipografi ekle"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 #, unused
 msgid "workspace.assets.typography.font-id"
@@ -3955,6 +5133,9 @@ msgstr "Yazı tipi"
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:522
 msgid "workspace.assets.typography.font-size"
 msgstr "Boyut"
+
+msgid "workspace.assets.typography.font-style"
+msgstr "Yazı Tipi Biçimi"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
@@ -3983,6 +5164,18 @@ msgstr "Metin Dönüşümü"
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:70
 msgid "workspace.assets.ungroup"
 msgstr "Grubu dağıt"
+
+#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
+msgid "workspace.colorpicker.color-tokens"
+msgstr "Tokenleri renklendir"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
+msgid "workspace.component.swap.loop-error"
+msgstr "Bileşenler kendi içlerinde iç içe geçemez."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
+msgid "workspace.component.switch.loop-error-multi"
+msgstr "Bazı kopyalar değiştirilemedi. Bileşenler kendi içlerinde iç içe geçemez."
 
 #: src/app/main/ui/workspace/context_menu.cljs:794
 msgid "workspace.context-menu.grid-cells.area"
@@ -4146,6 +5339,11 @@ msgstr "Dosya"
 msgid "workspace.header.menu.option.help-info"
 msgstr "Yardım ve bilgi"
 
+#: src/app/main/ui/workspace/main_menu.cljs:916
+#, unused
+msgid "workspace.header.menu.option.power-up"
+msgstr "Planınızı güçlendirin"
+
 #: src/app/main/ui/workspace/main_menu.cljs:922
 msgid "workspace.header.menu.option.preferences"
 msgstr "Tercihler"
@@ -4194,6 +5392,10 @@ msgstr "Koyu temaya geç"
 msgid "workspace.header.menu.toggle-light-theme"
 msgstr "Açık temaya geç"
 
+#: src/app/main/ui/workspace/main_menu.cljs:315
+msgid "workspace.header.menu.toggle-system-theme"
+msgstr "Sistem temasına geç"
+
 #: src/app/main/ui/workspace/main_menu.cljs:492
 msgid "workspace.header.menu.undo"
 msgstr "Geri al"
@@ -4213,6 +5415,10 @@ msgstr "Kaydedildi"
 #: src/app/main/ui/workspace/left_header.cljs:123, src/app/main/ui/workspace/left_header.cljs:124
 msgid "workspace.header.saving"
 msgstr "Kaydediliyor"
+
+#: src/app/main/ui/workspace/right_header.cljs:240
+msgid "workspace.header.share"
+msgstr "Paylaş"
 
 #: src/app/main/ui/workspace/right_header.cljs:48, src/app/main/ui/workspace/right_header.cljs:53
 #, unused
@@ -4255,9 +5461,33 @@ msgstr "Izgarayı düzenle"
 msgid "workspace.layout_grid.editor.options.exit"
 msgstr "Çıkış"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:430, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:436
+msgid "workspace.layout_grid.editor.padding.bottom"
+msgstr "Alt dolgu"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:490, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:491
 msgid "workspace.layout_grid.editor.padding.expand"
 msgstr "4 taraflı dolgu seçeneklerini göster"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:355, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:362
+msgid "workspace.layout_grid.editor.padding.horizontal"
+msgstr "Yatay dolgu"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:445, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:451
+msgid "workspace.layout_grid.editor.padding.left"
+msgstr "Sol dolgu"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:415, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:421
+msgid "workspace.layout_grid.editor.padding.right"
+msgstr "Sağ dolgu"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:400, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:406
+msgid "workspace.layout_grid.editor.padding.top"
+msgstr "Üst dolgu"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:341, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:347
+msgid "workspace.layout_grid.editor.padding.vertical"
+msgstr "Dikey dolgu"
 
 #: src/app/main/ui/workspace/viewport/grid_layout_editor.cljs:60
 msgid "workspace.layout_grid.editor.title"
@@ -4314,6 +5544,22 @@ msgstr "RGBA"
 msgid "workspace.libraries.colors.save-color"
 msgstr "Renk biçimini kaydet"
 
+#: src/app/main/ui/workspace/libraries.cljs:349
+msgid "workspace.libraries.connected-to"
+msgstr "Bağlandı"
+
+#: src/app/main/ui/workspace/libraries.cljs:404
+msgid "workspace.libraries.empty.add-some"
+msgstr "Veya denemek için bunlardan bazılarını ekleyin:"
+
+#: src/app/main/ui/workspace/libraries.cljs:398
+msgid "workspace.libraries.empty.no-libraries"
+msgstr "Takımınızda Paylaşılan Kütüphaneler bulunmuyor, burada bulunan"
+
+#: src/app/main/ui/workspace/libraries.cljs:402
+msgid "workspace.libraries.empty.some-templates"
+msgstr "şablonlara bakabilirsiniz"
+
 #: src/app/main/ui/workspace/libraries.cljs:322
 msgid "workspace.libraries.file-library"
 msgstr "Dosya kütüphanesi"
@@ -4338,6 +5584,11 @@ msgstr "KÜTÜPHANE GÜNCELLEMELERİ"
 #: src/app/main/ui/workspace/libraries.cljs:393
 msgid "workspace.libraries.loading"
 msgstr "Yükleniyor…"
+
+#: src/app/main/ui/workspace/libraries.cljs:387
+#, unused
+msgid "workspace.libraries.more-templates"
+msgstr "Bakabilirsiniz "
 
 #: src/app/main/ui/workspace/libraries.cljs:498
 msgid "workspace.libraries.no-libraries-need-sync"
@@ -4383,9 +5634,21 @@ msgstr "tüm değişiklikleri gör"
 msgid "workspace.libraries.updates"
 msgstr "GÜNCELLEMELER"
 
+#: src/app/main/ui/ds/notifications/shared/notification_pill.cljs:67, src/app/main/ui/ds/notifications/shared/notification_pill.cljs:72
+msgid "workspace.notification-pill.detail"
+msgstr "Ayrıntılar"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:746
 msgid "workspace.options.add-interaction"
 msgstr "Etkileşimler eklemek için + düğmesine tıklayın."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:97
+msgid "workspace.options.blur-options.add-blur"
+msgstr "Bulanıklık ekle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:118
+msgid "workspace.options.blur-options.remove-blur"
+msgstr "Bulanıklığı kaldır"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:93, src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:111
 msgid "workspace.options.blur-options.title"
@@ -4398,6 +5661,10 @@ msgstr "Grup bulanıklığı"
 #: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:91
 msgid "workspace.options.blur-options.title.multiple"
 msgstr "Seçim bulanıklığı"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:114
+msgid "workspace.options.blur-options.toggle-blur"
+msgstr "Bulanıklığı değiştir"
 
 #: src/app/main/ui/workspace/sidebar/options/page.cljs:42, src/app/main/ui/workspace/sidebar/options/page.cljs:50
 msgid "workspace.options.canvas-background"
@@ -4438,6 +5705,121 @@ msgstr "Bileşeni değiştir"
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:765
 msgid "workspace.options.component.swap.empty"
 msgstr "Bu kütüphanede henüz varlık yok"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:993
+msgid "workspace.options.component.unlinked"
+msgstr "Ayrıldı"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:512
+msgid "workspace.options.component.variant.duplicated.copy.locate"
+msgstr "Çakışan çeşitleri bul"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:509
+msgid "workspace.options.component.variant.duplicated.copy.title"
+msgstr ""
+"Bu bileşenin çakışan çeşitleri var. Her çeşidin kendine özgü özellik "
+"değerleri olduğundan emin olun."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1281
+msgid "workspace.options.component.variant.duplicated.group.locate"
+msgstr "Yinelenen çeşitleri bul"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1278
+msgid "workspace.options.component.variant.duplicated.group.title"
+msgstr "Bazı çeşitler aynı özelliklere ve değerlere sahip"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:268
+msgid "workspace.options.component.variant.duplicated.single.all"
+msgstr ""
+"Bu çeşitler aynı özelliklere ve değerlere sahiptir. Değerleri, "
+"çağrılabilecekleri şekilde ayarlayın."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:265
+msgid "workspace.options.component.variant.duplicated.single.one"
+msgstr ""
+"Bu çeşit, başka bir çeşitle aynı özelliklere ve değerlere sahiptir. "
+"Değerleri, çağrılabilecekleri şekilde ayarlayın."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:271
+msgid "workspace.options.component.variant.duplicated.single.some"
+msgstr ""
+"Bu çeşitlerden bazıları aynı özelliklere ve değerlere sahiptir. Değerleri, "
+"geri çağrılabilecekleri şekilde ayarlayın."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:499
+msgid "workspace.options.component.variant.malformed.copy"
+msgstr ""
+"Bu bileşenin geçersiz ada sahip çeşitleri var. Her çeşidin doğru yapıyı "
+"takip ettiğinden emin olun."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1271
+msgid "workspace.options.component.variant.malformed.group.locate"
+msgstr "Geçersiz çeşitleri bul"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1268
+msgid "workspace.options.component.variant.malformed.group.title"
+msgstr "Bazı çeşitlerin adları geçersiz"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:502
+msgid "workspace.options.component.variant.malformed.locate"
+msgstr "Geçersiz çeşitleri bul"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:252
+msgid "workspace.options.component.variant.malformed.single.all"
+msgstr "Bu çeşitlerin adları geçersiz."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:249
+msgid "workspace.options.component.variant.malformed.single.one"
+msgstr "Bu çeşidin adı geçersiz."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:255
+msgid "workspace.options.component.variant.malformed.single.some"
+msgstr "Bu çeşitlerden bazılarının adları geçersiz."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:391
+msgid "workspace.options.component.variant.malformed.structure.example"
+msgstr "[özellik]=[değer], [özellik]=[değer]"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:389
+msgid "workspace.options.component.variant.malformed.structure.title"
+msgstr "Şu yapıyı kullanmayı deneyin:"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:54
+msgid "workspace.options.component.variants-help-modal.intro"
+msgstr ""
+"Çeşitler arasında geçiş yaparken değişiklikleri korumak için Penpot şu "
+"katmanları birbirine bağlar:"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:91
+msgid "workspace.options.component.variants-help-modal.outro"
+msgstr ""
+"Bunlardan herhangi birini değiştirmek (örneğin, bir katmanı yeniden "
+"adlandırmak veya gruplamak) bağlantıyı keser, ancak değişikliği geri almak "
+"bağlantıyı yeniden kurar."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:67
+msgid "workspace.options.component.variants-help-modal.rule1"
+msgstr "Aynı ada sahip."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:76
+msgid "workspace.options.component.variants-help-modal.rule2"
+msgstr "Aynı türden."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:77
+msgid "workspace.options.component.variants-help-modal.rule2.detail"
+msgstr "Dikdörtgen, elips, yollar ve boole işlemleri aynı tür olarak kabul edilir."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:87
+msgid "workspace.options.component.variants-help-modal.rule3"
+msgstr "Aynı hiyerarşi düzeyine sahip."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:88
+msgid "workspace.options.component.variants-help-modal.rule3.detail"
+msgstr "Gruplar, çalışma yüzeyleri ve yerleşim düzenleri eş değer kabul edilir."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:955, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1191, src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:47
+msgid "workspace.options.component.variants-help-modal.title"
+msgstr "Çeşitler nasıl bağlantılı kalır"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs:163
 msgid "workspace.options.constraints"
@@ -4498,6 +5880,14 @@ msgid_plural "workspace.options.export-object"
 msgstr[0] "1 ögeyi dışa aktar"
 msgstr[1] "%s ögeyi dışa aktar"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:214
+msgid "workspace.options.export.add-export"
+msgstr "Dışa aktarım ekle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:226, src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:261
+msgid "workspace.options.export.remove-export"
+msgstr "Dışa aktarımı kaldır"
+
 #: src/app/main/ui/inspect/exports.cljs:179, src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:255
 msgid "workspace.options.export.suffix"
 msgstr "Son ek"
@@ -4522,6 +5912,18 @@ msgstr "Dışa aktarma beklenmedik şekilde yavaş"
 msgid "workspace.options.fill"
 msgstr "Doldur"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/fill.cljs:234
+msgid "workspace.options.fill.add-fill"
+msgstr "Doldurma ekle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/fill.cljs:248
+msgid "workspace.options.fill.remove-fill"
+msgstr "Doldurmayı kaldır"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:474
+msgid "workspace.options.fit-content"
+msgstr "Çalışma yüzeyini içeriğe sığacak şekilde yeniden boyutlandır"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:183
 msgid "workspace.options.flows.add-flow-start"
 msgstr "Akış başlangıcı ekle"
@@ -4538,6 +5940,10 @@ msgstr "Akış başlangıcı"
 #: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:165
 msgid "workspace.options.flows.flow-starts"
 msgstr "Akış başlar"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:155
+msgid "workspace.options.flows.remove-flow"
+msgstr "Akışı kaldır"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:32
 msgid "workspace.options.grid.auto"
@@ -4640,9 +6046,21 @@ msgstr "Grubu doldur"
 msgid "workspace.options.group-stroke"
 msgstr "Grubu çiz"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:326
+msgid "workspace.options.guides.add-guide"
+msgstr "Kılavuz ekle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:188
+msgid "workspace.options.guides.remove-guide"
+msgstr "Kılavuzu kaldır"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:323
 msgid "workspace.options.guides.title"
 msgstr "Kılavuzlar"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:184
+msgid "workspace.options.guides.toggle-guide"
+msgstr "Kılavuzu değiştir"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:501, src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:520
 msgid "workspace.options.height"
@@ -4870,6 +6288,15 @@ msgstr "Basarken"
 msgid "workspace.options.interactions"
 msgstr "Etkileşimler"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:736
+msgid "workspace.options.interactions.add-interaction"
+msgstr "Etkileşim ekle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
+#, unused
+msgid "workspace.options.interactions.remove-interaction"
+msgstr "Etkileşimi kaldır"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:169
 msgid "workspace.options.layer-options.blend-mode.color"
 msgstr "Renk"
@@ -4948,6 +6375,10 @@ msgstr "Katman grubu"
 #, unused
 msgid "workspace.options.layer-options.title.multiple"
 msgstr "Seçili katmanlar"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:207, src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:213
+msgid "workspace.options.layer-options.toggle-layer"
+msgstr "Katman görünürlüğünü değiştir"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
 #, unused
@@ -5084,7 +6515,7 @@ msgstr "Üst"
 msgid "workspace.options.more-colors"
 msgstr "Daha fazla renk"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Daha fazla kütüphane rengi"
 
@@ -5121,6 +6552,14 @@ msgstr "Sol üst"
 msgid "workspace.options.radius-top-right"
 msgstr "Sağ üst"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/border_radius.cljs:152
+msgid "workspace.options.radius.hide-all-corners"
+msgstr "Bağımsız yarıçapı daralt"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/border_radius.cljs:153
+msgid "workspace.options.radius.show-single-corners"
+msgstr "Bağımsız yarıçapı göster"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:190
 msgid "workspace.options.recent-fonts"
 msgstr "Son kullanılanlar"
@@ -5155,6 +6594,10 @@ msgstr "Seçimi doldur"
 msgid "workspace.options.selection-stroke"
 msgstr "Seçimi çiz"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:341
+msgid "workspace.options.shadow-options.add-shadow"
+msgstr "Gölge ekle"
+
 #: src/app/main/ui/inspect/attributes/shadow.cljs:47, src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:203, src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:205
 msgid "workspace.options.shadow-options.blur"
 msgstr "Bulanıklık"
@@ -5179,6 +6622,10 @@ msgstr "X"
 msgid "workspace.options.shadow-options.offsety"
 msgstr "Y"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:183, src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:354
+msgid "workspace.options.shadow-options.remove-shadow"
+msgstr "Gölgeyi kaldır"
+
 #: src/app/main/ui/inspect/attributes/shadow.cljs:48, src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:214, src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:216
 msgid "workspace.options.shadow-options.spread"
 msgstr "Yayılma"
@@ -5195,6 +6642,10 @@ msgstr "Gölge grubu"
 msgid "workspace.options.shadow-options.title.multiple"
 msgstr "Gölge seçimi"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:179
+msgid "workspace.options.shadow-options.toggle-shadow"
+msgstr "Gölgeyi değiştir"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/fill.cljs:285
 msgid "workspace.options.show-fill-on-export"
 msgstr "Dışa aktarmalarda göster"
@@ -5210,6 +6661,14 @@ msgstr "Boyut"
 #: src/app/main/ui/workspace/sidebar/options/drawing/frame.cljs:70, src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:434
 msgid "workspace.options.size-presets"
 msgstr "Boyut ön ayarları"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:534
+msgid "workspace.options.size.lock"
+msgstr "Oranı kilitle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:534
+msgid "workspace.options.size.unlock"
+msgstr "Oranın kilidini kaldır"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:44
 #, unused
@@ -5281,6 +6740,10 @@ msgstr "Çerçeve rengi"
 msgid "workspace.options.stroke-width"
 msgstr "Çerçeve genişliği"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:189
+msgid "workspace.options.stroke.add-stroke"
+msgstr "Çerçeve rengi ekle"
+
 #: src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs:97
 msgid "workspace.options.stroke.center"
 msgstr "Merkez"
@@ -5304,6 +6767,10 @@ msgstr "Karışık"
 #: src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs:99
 msgid "workspace.options.stroke.outer"
 msgstr "Dışında"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:202
+msgid "workspace.options.stroke.remove-stroke"
+msgstr "Çerçeveyi kaldır"
 
 #: src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs:136
 msgid "workspace.options.stroke.solid"
@@ -5474,6 +6941,14 @@ msgstr "Keşfet [daha fazla eklenti](%s)"
 msgid "workspace.plugins.empty-plugins"
 msgstr "Henüz eklenti kurulmadı"
 
+#: src/app/main/ui/workspace/plugins.cljs:192
+msgid "workspace.plugins.error.manifest"
+msgstr "Eklenti bildirimi yanlış."
+
+#: src/app/main/data/plugins.cljs:89, src/app/main/ui/workspace/main_menu.cljs:783, src/app/main/ui/workspace/plugins.cljs:83
+msgid "workspace.plugins.error.need-editor"
+msgstr "Bu eklentiyi kullanmak için düzenleyici olmanız gerekir"
+
 #: src/app/main/ui/workspace/plugins.cljs:188
 msgid "workspace.plugins.error.url"
 msgstr "Eklenti yok veya URL doğru değil."
@@ -5493,6 +6968,32 @@ msgstr "Eklenti yöneticisi"
 #: src/app/main/ui/workspace/main_menu.cljs:934
 msgid "workspace.plugins.menu.title"
 msgstr "Eklentiler"
+
+#: src/app/main/ui/workspace/plugins.cljs:375
+msgid "workspace.plugins.permissions-update.title"
+msgstr "BU EKLENTİYİ GÜNCELLE"
+
+#: src/app/main/ui/workspace/plugins.cljs:379
+msgid "workspace.plugins.permissions-update.warning"
+msgstr ""
+"Eklenti, son açtığınızdan beri değiştirildi. Artık şuraya da erişmek "
+"istiyor:"
+
+#: src/app/main/ui/workspace/plugins.cljs:279
+msgid "workspace.plugins.permissions.allow-download"
+msgstr "Dosya indirmesi başlat."
+
+#: src/app/main/ui/workspace/plugins.cljs:286
+msgid "workspace.plugins.permissions.allow-localstorage"
+msgstr "Tarayıcıda veri depola."
+
+#: src/app/main/ui/workspace/plugins.cljs:272
+msgid "workspace.plugins.permissions.comment-read"
+msgstr "Yorumlarınızı ve yanıtlarınızı oku."
+
+#: src/app/main/ui/workspace/plugins.cljs:266
+msgid "workspace.plugins.permissions.comment-write"
+msgstr "Yorumlarınızı oku, değiştir ve sizin adınıza yanıtla."
 
 #: src/app/main/ui/workspace/plugins.cljs:239
 msgid "workspace.plugins.permissions.content-read"
@@ -5526,6 +7027,10 @@ msgstr "Geçerli kullanıcının profil bilgilerini oku."
 msgid "workspace.plugins.plugin-list-link"
 msgstr "Eklenti Listesi"
 
+#: src/app/main/ui/workspace/plugins.cljs:87
+msgid "workspace.plugins.remove-plugin"
+msgstr "Eklentiyi kaldır"
+
 #: src/app/main/ui/workspace/plugins.cljs:179
 msgid "workspace.plugins.search-placeholder"
 msgstr "Bir eklenti URL'si yazın"
@@ -5538,6 +7043,25 @@ msgstr "Eklenti doğru şekilde yüklendi."
 msgid "workspace.plugins.title"
 msgstr "Eklentiler"
 
+#: src/app/main/ui/workspace/plugins.cljs:439
+msgid "workspace.plugins.try-out.cancel"
+msgstr "ŞİMDİ DEĞİL"
+
+#: src/app/main/ui/workspace/plugins.cljs:432
+msgid "workspace.plugins.try-out.message"
+msgstr ""
+"Bir göz atmak ister misiniz? Geçerli takımınız için yeni bir taslakta "
+"açılacaktır. (İstemiyorsanız, onu herhangi bir dosyanın kurulu "
+"eklentilerinde her zaman bulabilirsiniz.)"
+
+#: src/app/main/ui/workspace/plugins.cljs:428
+msgid "workspace.plugins.try-out.title"
+msgstr "'%s' EKLENTİSİ KULLANICINIZ İÇİN KURULDU!"
+
+#: src/app/main/ui/workspace/plugins.cljs:445
+msgid "workspace.plugins.try-out.try"
+msgstr "EKLENTİYİ DENE"
+
 #: src/app/main/ui/workspace/context_menu.cljs:557
 msgid "workspace.shape.menu.add-flex"
 msgstr "Esnek düzen ekle"
@@ -5545,6 +7069,18 @@ msgstr "Esnek düzen ekle"
 #: src/app/main/ui/workspace/context_menu.cljs:561
 msgid "workspace.shape.menu.add-grid"
 msgstr "Izgara düzeni ekle"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1016, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1040
+msgid "workspace.shape.menu.add-layout"
+msgstr "Yerleşim düzeni ekle"
+
+#: src/app/main/ui/workspace/context_menu.cljs:610, src/app/main/ui/workspace/sidebar/assets/common.cljs:514, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:961, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1113, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1195
+msgid "workspace.shape.menu.add-variant"
+msgstr "Çeşit oluştur"
+
+#: src/app/main/ui/workspace/sidebar/assets/common.cljs:518, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1010, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1115, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1233
+msgid "workspace.shape.menu.add-variant-property"
+msgstr "Yeni özellik ekle"
 
 #: src/app/main/ui/workspace/context_menu.cljs:281
 msgid "workspace.shape.menu.back"
@@ -5554,9 +7090,45 @@ msgstr "En arkaya gönder"
 msgid "workspace.shape.menu.backward"
 msgstr "Arkaya gönder"
 
+#: src/app/main/ui/workspace/context_menu.cljs:617, src/app/main/ui/workspace/sidebar/assets/components.cljs:634, src/app/main/ui/workspace/sidebar/assets/groups.cljs:75, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1041
+msgid "workspace.shape.menu.combine-as-variants"
+msgstr "Çeşit olarak birleştir"
+
+#: src/app/main/ui/workspace/sidebar/assets/components.cljs:636
+msgid "workspace.shape.menu.combine-as-variants-error"
+msgstr "Bileşenler aynı sayfada olmalıdır"
+
 #: src/app/main/ui/workspace/context_menu.cljs:199
 msgid "workspace.shape.menu.copy"
 msgstr "Kopyala"
+
+#: src/app/main/ui/workspace/context_menu.cljs:217
+msgid "workspace.shape.menu.copy-css"
+msgstr "CSS olarak kopyala"
+
+#: src/app/main/ui/workspace/context_menu.cljs:219
+msgid "workspace.shape.menu.copy-css-nested"
+msgstr "CSS olarak kopyala (iç içe katmanlar)"
+
+#: src/app/main/ui/workspace/context_menu.cljs:202
+msgid "workspace.shape.menu.copy-link"
+msgstr "Bağlantıyı kopyala"
+
+#: src/app/main/ui/workspace/context_menu.cljs:215
+msgid "workspace.shape.menu.copy-paste-as"
+msgstr "Farklı kopyala/yapıştır ..."
+
+#: src/app/main/ui/workspace/context_menu.cljs:229
+msgid "workspace.shape.menu.copy-props"
+msgstr "Özellikleri kopyala"
+
+#: src/app/main/ui/workspace/context_menu.cljs:221
+msgid "workspace.shape.menu.copy-svg"
+msgstr "SVG olarak kopyala"
+
+#: src/app/main/ui/workspace/context_menu.cljs:226
+msgid "workspace.shape.menu.copy-text"
+msgstr "Metin olarak kopyala"
 
 #: src/app/main/ui/workspace/sidebar/assets/common.cljs:490
 msgid "workspace.shape.menu.create-annotation"
@@ -5667,6 +7239,10 @@ msgstr "Maskele"
 msgid "workspace.shape.menu.paste"
 msgstr "Yapıştır"
 
+#: src/app/main/ui/workspace/context_menu.cljs:233
+msgid "workspace.shape.menu.paste-props"
+msgstr "Özellikleri yapıştır"
+
 #: src/app/main/ui/workspace/context_menu.cljs:441
 msgid "workspace.shape.menu.path"
 msgstr "Yol"
@@ -5679,6 +7255,22 @@ msgstr "Düzen esnekliğini kaldır"
 msgid "workspace.shape.menu.remove-grid"
 msgstr "Izgara düzenini kaldır"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1034
+msgid "workspace.shape.menu.remove-layout"
+msgstr "Yerleşim düzenini kaldır"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1257
+msgid "workspace.shape.menu.remove-variant-property"
+msgstr "Özelliği kaldır"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1256
+msgid "workspace.shape.menu.remove-variant-property.last-property"
+msgstr "Çeşidin en az bir özelliği olmalıdır"
+
+#: src/app/main/ui/workspace/context_menu.cljs:328
+msgid "workspace.shape.menu.rename"
+msgstr "Yeniden adlandır"
+
 #: src/app/main/ui/workspace/sidebar/assets/common.cljs:499
 msgid "workspace.shape.menu.reset-overrides"
 msgstr "Geçersiz kılmaları sıfırla"
@@ -5686,6 +7278,10 @@ msgstr "Geçersiz kılmaları sıfırla"
 #: src/app/main/ui/workspace/sidebar/assets/common.cljs:505
 msgid "workspace.shape.menu.restore-main"
 msgstr "Ana bileşeni geri yükle"
+
+#: src/app/main/ui/workspace/sidebar/assets/common.cljs:504
+msgid "workspace.shape.menu.restore-variant"
+msgstr "Çeşidi geri yükle"
 
 #: src/app/main/ui/workspace/context_menu.cljs:262
 msgid "workspace.shape.menu.select-layer"
@@ -5797,9 +7393,154 @@ msgstr "İçe Aktarılan SVG Öznitelikleri"
 msgid "workspace.sidebar.sitemap"
 msgstr "Sayfalar"
 
+#: src/app/main/ui/workspace/sidebar/sitemap.cljs:249
+msgid "workspace.sidebar.sitemap.add-page"
+msgstr "Sayfa ekle"
+
 #: src/app/main/ui/workspace/left_header.cljs:96
 msgid "workspace.sitemap"
 msgstr "Site haritası"
+
+#: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:86
+msgid "workspace.tokens.active-themes"
+msgstr "%s etkin tema"
+
+#: src/app/main/ui/workspace/tokens/sidebar.cljs
+#, unused
+msgid "workspace.tokens.add set"
+msgstr "Küme ekle"
+
+#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:62, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:165, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:328
+msgid "workspace.tokens.add-new-theme"
+msgstr "Yeni tema ekle"
+
+#: src/app/main/ui/workspace/tokens/sets/context_menu.cljs:62
+msgid "workspace.tokens.add-set-to-group"
+msgstr "Bu gruba küme ekle"
+
+#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:197, src/app/main/ui/workspace/tokens/management/group.cljs:115
+msgid "workspace.tokens.add-token"
+msgstr "Token ekle: %s"
+
+#: src/app/main/ui/workspace/tokens/management/token_pill.cljs:136
+msgid "workspace.tokens.applied-to"
+msgstr "Uygulanan"
+
+#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:316
+msgid "workspace.tokens.axis"
+msgstr "Eksen"
+
+#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:337
+msgid "workspace.tokens.back-to-themes"
+msgstr "Tema listesine geri dön"
+
+#: src/app/main/ui/workspace/tokens/settings/menu.cljs:89
+msgid "workspace.tokens.base-font-size"
+msgstr "Temel yazı tipi boyutu"
+
+#: src/app/main/ui/workspace/tokens/settings/menu.cljs:43
+msgid "workspace.tokens.base-font-size.error"
+msgstr "Temel yazı tipi boyutu piksel cinsinden veya birimsiz bir değer olmalıdır."
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:127
+#, unused
+msgid "workspace.tokens.choose-file"
+msgstr "Dosya seç"
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:132
+#, unused
+msgid "workspace.tokens.choose-folder"
+msgstr "Klasör seç"
+
+#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:286
+msgid "workspace.tokens.color"
+msgstr "Renk"
+
+#: src/app/main/data/workspace/tokens/errors.cljs:97
+msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgstr ""
+"Satır yüksekliği yazı tipi boyutuna bağlıdır. Çözülen değeri elde etmek "
+"için bir yazı tipi boyutu ekleyin."
+
+#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:53
+msgid "workspace.tokens.create-new-theme"
+msgstr "Şimdi ilk temanızı oluşturun."
+
+#: src/app/main/ui/workspace/tokens/sets/lists.cljs:96, src/app/main/ui/workspace/tokens/themes.cljs:44
+msgid "workspace.tokens.create-one"
+msgstr "Bir tane oluşturun."
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:552
+msgid "workspace.tokens.create-token"
+msgstr "Yeni %s tokeni oluştur"
+
+#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:338
+msgid "workspace.tokens.delete"
+msgstr "Tokeni sil"
+
+#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:154
+msgid "workspace.tokens.delete-theme-title"
+msgstr "Temayı sil"
+
+#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:335
+msgid "workspace.tokens.duplicate"
+msgstr "Tokeni çoğalt"
+
+#: src/app/main/data/workspace/tokens/library_edit.cljs:197, src/app/main/data/workspace/tokens/library_edit.cljs:415
+msgid "workspace.tokens.duplicate-suffix"
+msgstr "kopyala"
+
+#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:322
+msgid "workspace.tokens.edit"
+msgstr "Tokeni düzenle"
+
+#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:327
+msgid "workspace.tokens.edit-theme-title"
+msgstr "Temayı düzenle"
+
+#: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:74
+msgid "workspace.tokens.edit-themes"
+msgstr "Temaları düzenle"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
+msgid "workspace.tokens.edit-token"
+msgstr "%s tokenini düzenle"
+
+#: src/app/main/data/workspace/tokens/errors.cljs:41
+msgid "workspace.tokens.empty-input"
+msgstr "Token değeri boş olamaz"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:558
+msgid "workspace.tokens.enter-token-name"
+msgstr "%s token adını gir"
+
+#: src/app/main/data/workspace/tokens/errors.cljs:15
+msgid "workspace.tokens.error-parse"
+msgstr "İçe Aktarma Hatası: JSON ayrıştırılamadı."
+
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:49
+msgid "workspace.tokens.export"
+msgstr "Dışa aktar"
+
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:125
+msgid "workspace.tokens.export-tokens"
+msgstr "Tokenleri dışa aktar"
+
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:118
+msgid "workspace.tokens.export.multiple-files"
+msgstr "Birden fazla dosya"
+
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:38
+msgid "workspace.tokens.export.no-tokens-themes-sets"
+msgstr "Dışa aktarılacak token, tema veya küme yok."
+
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:35
+msgid "workspace.tokens.export.preview"
+msgstr "Ön izleme:"
+
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:116
+msgid "workspace.tokens.export.single-file"
+msgstr "Tek dosya"
 
 #: src/app/main/ui/workspace/sidebar.cljs:139, src/app/main/ui/workspace/sidebar.cljs:146
 msgid "workspace.toolbar.assets"
@@ -6093,1747 +7834,3 @@ msgstr "Yolu kapatmak için tıklayın"
 
 #~ msgid "workspace.options.layout-item.title.min-w"
 #~ msgstr "Asgari genişlik"
-
-#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:98, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:105
-msgid "color-row.token-color-row.deleted-token"
-msgstr "Bu token yok veya silindi."
-
-#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:35
-msgid "color-token.empty-state"
-msgstr ""
-"Kullanılabilir renk tokeni yok. Etkin kümeleri/temaları gözden geçirin veya "
-"yeni tokenler ekleyin."
-
-#: src/app/main/ui/comments.cljs:530
-msgid "comments.mentions.not-found"
-msgstr "@%s için kişi bulunamadı"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:41
-msgid "dashboard.add-file"
-msgstr "Dosya ekle"
-
-#: src/app/main/ui/workspace/main_menu.cljs:659
-msgid "dashboard.create-version-menu"
-msgstr "Bu sürümü sabitle"
-
-#: src/app/main/ui/dashboard/files.cljs:200, src/app/main/ui/dashboard/projects.cljs:285
-msgid "dashboard.empty-placeholder-drafts-subtitle"
-msgstr ""
-"Bir proje üyesi taslak oluşturduğunda, bu taslak burada gösterilecektir."
-
-#: src/app/main/ui/dashboard/files.cljs:195, src/app/main/ui/dashboard/projects.cljs:280
-msgid "dashboard.empty-placeholder-drafts-title"
-msgstr "Henüz taslak yok."
-
-#: src/app/main/ui/dashboard/files.cljs:201, src/app/main/ui/dashboard/projects.cljs:286
-msgid "dashboard.empty-placeholder-files-subtitle"
-msgstr "Bir proje üyesi dosya oluşturduğunda, bu dosya burada gösterilecektir."
-
-#: src/app/main/ui/dashboard/files.cljs:196, src/app/main/ui/dashboard/projects.cljs:281
-msgid "dashboard.empty-placeholder-files-title"
-msgstr "Henüz dosya yok."
-
-#: src/app/main/ui/dashboard/placeholder.cljs:118
-#, markdown
-msgid "dashboard.empty-placeholder-libraries"
-msgstr ""
-"Projeye eklenen kütüphaneler burada görünecektir. Dosyalarınızı paylaşmayı "
-"deneyin veya [Kütüphaneler ve şablonlar]"
-"(https://penpot.app/libraries-templates) bölümünden ekleyin."
-
-#: src/app/main/ui/dashboard/placeholder.cljs
-#, markdown, unused
-msgid "dashboard.empty-placeholder-libraries-subtitle"
-msgstr ""
-"Projeye eklenen kütüphaneler burada görünecektir. Dosyalarınızı paylaşmayı "
-"deneyin veya [Kütüphaneler ve şablonlar]"
-"(https://penpot.app/libraries-templates) bölümünden ekleyin."
-
-#: src/app/main/ui/dashboard/placeholder.cljs:114
-msgid "dashboard.empty-placeholder-libraries-subtitle-viewer-role"
-msgstr "Projeye eklenen kütüphaneler burada görünecektir."
-
-#: src/app/main/ui/dashboard/placeholder.cljs:111
-msgid "dashboard.empty-placeholder-libraries-title"
-msgstr "Henüz kütüphane yok."
-
-#: src/app/main/ui/dashboard/placeholder.cljs:59
-msgid "dashboard.empty-project.add-library"
-msgstr "Kütüphane veya şablon ekle"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:43, src/app/main/ui/dashboard/placeholder.cljs:134
-msgid "dashboard.empty-project.create"
-msgstr "Yeni dosya oluştur"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:61
-msgid "dashboard.empty-project.explore"
-msgstr "Eklemek için keşfedin"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:57
-msgid "dashboard.empty-project.go-to-libraries"
-msgstr "Kütüphaneler ve şablonlara git"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:49, src/app/main/ui/dashboard/placeholder.cljs:51
-msgid "dashboard.empty-project.import"
-msgstr "Dosya içe aktar"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:53
-msgid "dashboard.empty-project.import-penpot"
-msgstr ".penpot dosyasını içe aktar"
-
-#: src/app/main/ui/dashboard/placeholder.cljs:45
-msgid "dashboard.empty-project.start"
-msgstr "Harika şeyler oluşturmaya başlayın"
-
-#: src/app/main/ui/dashboard/fonts.cljs:456
-msgid "dashboard.fonts.empty-placeholder-viewer"
-msgstr "Henüz özel yazı tipi yok."
-
-#: src/app/main/ui/dashboard/fonts.cljs:457
-msgid "dashboard.fonts.empty-placeholder-viewer-sub"
-msgstr ""
-"Bir proje üyesi özel bir yazı tipi yüklediğinde, bu yazı tipi burada "
-"gösterilecektir."
-
-#: src/app/main/ui/dashboard.cljs:243
-msgid "dashboard.import.bad-url"
-msgstr "İçe aktarma başarısız oldu. Şablon URL'si yanlış"
-
-#: src/app/main/ui/dashboard.cljs:241
-#, unused
-msgid "dashboard.import.error"
-msgstr "İçe aktarma başarısız oldu. Lütfen tekrar deneyin"
-
-#: src/app/main/ui/dashboard/import.cljs:485
-msgid "dashboard.import.import-error.disclaimer"
-msgstr "Tüm dosyalar içe aktarılmadı"
-
-#: src/app/main/ui/dashboard/import.cljs:489
-msgid "dashboard.import.import-error.message1"
-msgstr "Şu dosyalarda hata var:"
-
-#: src/app/main/ui/dashboard/import.cljs:494
-msgid "dashboard.import.import-error.message2"
-msgstr "Hatalı dosyalar karşıya yüklenmeyecektir."
-
-#: src/app/main/ui/dashboard.cljs:244
-msgid "dashboard.import.no-perms"
-msgstr "Bu takıma içe aktarma izniniz yok"
-
-#: src/app/main/ui/dashboard/team.cljs:765
-msgid "dashboard.invitation-modal.delete"
-msgstr "Şu davetleri sileceksiniz:"
-
-#: src/app/main/ui/dashboard/team.cljs:766
-msgid "dashboard.invitation-modal.resend"
-msgstr "Şu davetleri yeniden göndereceksiniz:"
-
-#: src/app/main/ui/dashboard/team.cljs:756
-msgid "dashboard.invitation-modal.title.delete-invitations"
-msgstr "Davetleri sil"
-
-#: src/app/main/ui/dashboard/team.cljs:757
-msgid "dashboard.invitation-modal.title.resend-invitations"
-msgstr "Davetleri yeniden gönder"
-
-#: src/app/main/ui/dashboard/templates.cljs:267
-msgid "dashboard.libraries-and-templates.description"
-msgstr ""
-"Burada projenize ekleyebileceğiniz bazı kütüphaneler ve şablonlar "
-"bulunmaktadır"
-
-#: src/app/main/data/comments.cljs:473
-msgid "dashboard.mark-all-as-read.success"
-msgstr "Tüm bildirimleri okundu olarak işaretlendi"
-
-#: src/app/main/ui/dashboard/comments.cljs:91
-msgid "dashboard.notifications"
-msgstr "Bildirimler"
-
-#: src/app/main/data/profile.cljs:273
-msgid "dashboard.notifications.notifications-saved"
-msgstr "Bildirim ayarları güncellendi"
-
-#: src/app/main/ui/dashboard/comments.cljs:45
-msgid "dashboard.notifications.view"
-msgstr "Bildirimleri görüntüle"
-
-#: src/app/main/ui/dashboard/team.cljs:949
-msgid "dashboard.order-invitations-by-role"
-msgstr "Role göre sırala"
-
-#: src/app/main/ui/dashboard/team.cljs:958
-msgid "dashboard.order-invitations-by-status"
-msgstr "Duruma göre sırala"
-
-#: src/app/main/data/common.cljs:203
-msgid "dashboard.permissions-change.admin"
-msgstr "Artık bu takımda bir yöneticisiniz."
-
-#: src/app/main/data/common.cljs:202
-msgid "dashboard.permissions-change.editor"
-msgstr "Artık bu takımda bir düzenleyicisiniz."
-
-#: src/app/main/data/common.cljs:204
-msgid "dashboard.permissions-change.owner"
-msgstr "Artık bu takımın sahibisiniz."
-
-#: src/app/main/data/common.cljs:201
-msgid "dashboard.permissions-change.viewer"
-msgstr "Artık bu takımda bir görüntüleyicisiniz."
-
-#: src/app/main/ui/dashboard.cljs:207
-msgid "dashboard.plugins.bad-url"
-msgstr "Eklenti URL'si yanlış"
-
-#: src/app/main/ui/dashboard.cljs:205
-msgid "dashboard.plugins.parse-error"
-msgstr "Eklenti bildirim dosyası ayrıştırılamıyor"
-
-#: src/app/main/ui/dashboard.cljs:168
-msgid "dashboard.plugins.try-plugin"
-msgstr "Eklentiyi deneyin: "
-
-#: src/app/main/data/common.cljs:236
-msgid "dashboard.removed-from-team"
-msgstr "Artık “%s” takımının bir parçası değilsiniz."
-
-#: src/app/main/ui/settings/options.cljs:68
-msgid "dashboard.select-ui-theme.dark"
-msgstr "Penpot Koyu (öntanımlı)"
-
-#: src/app/main/ui/settings/options.cljs:69
-msgid "dashboard.select-ui-theme.light"
-msgstr "Penpot Açık"
-
-#: src/app/main/ui/settings/options.cljs:70
-msgid "dashboard.select-ui-theme.system"
-msgstr "Sistem teması"
-
-#: src/app/main/ui/settings/notifications.cljs:57
-msgid "dashboard.settings.notifications.dashboard-comments.all"
-msgstr "Tüm yorumlar, değinmeler ve yanıtlar"
-
-#: src/app/main/ui/settings/notifications.cljs:59
-msgid "dashboard.settings.notifications.dashboard-comments.none"
-msgstr "Hiçbiri"
-
-#: src/app/main/ui/settings/notifications.cljs:58
-msgid "dashboard.settings.notifications.dashboard-comments.partial"
-msgstr "Yalnızca değinmeler ve yanıtlar"
-
-#: src/app/main/ui/settings/notifications.cljs:54
-msgid "dashboard.settings.notifications.dashboard-comments.title"
-msgstr "Dosya yorumları"
-
-#: src/app/main/ui/settings/notifications.cljs:53
-msgid "dashboard.settings.notifications.dashboard.title"
-msgstr "Denetim Paneli Bildirimleri"
-
-#: src/app/main/ui/settings/notifications.cljs:67
-msgid "dashboard.settings.notifications.email-comments.all"
-msgstr "Tüm yorumlar, değinmeler ve yanıtlar"
-
-#: src/app/main/ui/settings/notifications.cljs:69
-msgid "dashboard.settings.notifications.email-comments.none"
-msgstr "Hiçbiri"
-
-#: src/app/main/ui/settings/notifications.cljs:68
-msgid "dashboard.settings.notifications.email-comments.partial"
-msgstr "Yalnızca değinmeler ve yanıtlar"
-
-#: src/app/main/ui/settings/notifications.cljs:64
-msgid "dashboard.settings.notifications.email-comments.title"
-msgstr "Dosya yorumları"
-
-#: src/app/main/ui/settings/notifications.cljs:76
-msgid "dashboard.settings.notifications.email-invites.all"
-msgstr "Her türlü davet ve istek"
-
-#: src/app/main/ui/settings/notifications.cljs:79
-msgid "dashboard.settings.notifications.email-invites.none"
-msgstr "Hiçbiri"
-
-#: src/app/main/ui/settings/notifications.cljs:73
-msgid "dashboard.settings.notifications.email-invites.title"
-msgstr "Davetler ve istekler"
-
-#: src/app/main/ui/settings/notifications.cljs:63
-msgid "dashboard.settings.notifications.email.title"
-msgstr "E-posta Bildirimleri"
-
-#: src/app/main/ui/settings/notifications.cljs:84
-msgid "dashboard.settings.notifications.submit"
-msgstr "Ayarları güncelle"
-
-#: src/app/main/ui/settings/notifications.cljs:52
-msgid "dashboard.settings.notifications.title"
-msgstr "Bildirimler"
-
-#: src/app/main/ui/workspace/main_menu.cljs:666
-msgid "dashboard.show-version-history"
-msgstr "Sürüm geçmişi"
-
-#: src/app/main/ui/dashboard/templates.cljs:134
-msgid "dashboard.template.add-to-project"
-msgstr "Projenize ekleyin"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:976
-msgid "dashboard.upgrade-plan.no-limits"
-msgstr "Yaratıcılıkta sınır yok"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:974
-msgid "dashboard.upgrade-plan.penpot-free"
-msgstr "Penpot Ücretsiz"
-
-#: src/app/main/ui/dashboard/team.cljs:1160
-msgid "dashboard.webhooks.cant-edit"
-msgstr ""
-"Yalnızca sizin oluşturduğunuz web kancalarını silebilir veya "
-"değiştirebilirsiniz."
-
-#: src/app/main/ui/ds/controls/numeric_input.cljs:98
-msgid "ds.inputs.numeric-input.no-applicable-tokens"
-msgstr "Etkin kümelerde veya temalarda geçerli token yok."
-
-#: src/app/main/ui/ds/controls/numeric_input.cljs:99
-msgid "ds.inputs.numeric-input.no-matches"
-msgstr "Eşleşme bulunamadı."
-
-#: src/app/main/ui/ds/controls/numeric_input.cljs:641, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:138
-msgid "ds.inputs.numeric-input.open-token-list-dropdown"
-msgstr "Token listesini aç"
-
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:85, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:133
-msgid "ds.inputs.token-field.detach-token"
-msgstr "Tokeni ayır"
-
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:40, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:96, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:103
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr ""
-"Bu token herhangi bir etkin kümede bulunmuyor veya geçersiz bir değere sahip."
-
-#: src/app/main/ui/comments.cljs:730, src/app/main/ui/comments.cljs:761, src/app/main/ui/comments.cljs:858
-msgid "errors.character-limit-exceeded"
-msgstr "Karakter sınırı aşıldı"
-
-#: src/app/main/errors.cljs:231
-msgid "errors.comment-error"
-msgstr "Yorumla ilgili bir hata oluştu"
-
-#: src/app/main/errors.cljs:300
-msgid "errors.deprecated"
-msgstr ""
-"Üzgünüz! Bu, artık kullanılmayan bir Penpot varlık türü kullanan eski bir "
-"dosyadır ve açamazsınız."
-
-#: src/app/main/errors.cljs:303
-msgid "errors.deprecated.contact.after"
-msgstr "böylece size yardımcı olabiliriz."
-
-#: src/app/main/errors.cljs:301
-msgid "errors.deprecated.contact.before"
-msgstr "Penpot artık bu tür varlıkları desteklemese de, bizimle"
-
-#: src/app/main/errors.cljs:302
-msgid "errors.deprecated.contact.text"
-msgstr "iletişime geçebilirsiniz"
-
-#: src/app/main/data/workspace/tokens/library_edit.cljs:274
-msgid "errors.drop-token-set-parent-to-child"
-msgstr "Bir üst kümeyi kendi alt kümesine bırakamazsınız."
-
-#: src/app/main/ui/auth/register.cljs:89
-msgid "errors.email-does-not-match-invitation"
-msgstr "E-posta adresi davetiyeyle eşleşmiyor."
-
-#: src/app/util/forms.cljs:61
-msgid "errors.field-missing"
-msgstr "Boş alan"
-
-#: src/app/main/errors.cljs:193
-msgid "errors.internal-assertion-error"
-msgstr "Dahili Doğrulama Hatası"
-
-#: src/app/main/errors.cljs:209
-msgid "errors.internal-worker-error"
-msgstr "Web çalıştırıcısında bir sorun oluştu."
-
-#: src/app/util/forms.cljs:35, src/app/util/forms.cljs:84
-msgid "errors.invalid-data"
-msgstr "Geçersiz veri"
-
-#: src/app/util/forms.cljs
-#, unused
-msgid "errors.invalid-text"
-msgstr "Geçersiz metin"
-
-#: src/app/main/ui/dashboard/team.cljs:187, src/app/main/ui/dashboard/team.cljs:849, src/app/main/ui/onboarding/team_choice.cljs:101
-msgid "errors.maximum-invitations-by-request-reached"
-msgstr ""
-"Tek bir istekte davet edilebilecek en fazla (%s) e-posta sayısına ulaşıldı"
-
-#: src/app/main/errors.cljs:263
-msgid "errors.migration-in-progress"
-msgstr "Geçiş devam ediyor"
-
-#: src/app/main/errors.cljs:160
-msgid "errors.only-creator-can-lock"
-msgstr "Yalnızca sürüm oluşturucu onu kilitleyebilir"
-
-#: src/app/main/errors.cljs:168
-msgid "errors.only-creator-can-unlock"
-msgstr "Yalnızca sürüm oluşturucu onun kilidini açabilir"
-
-#: src/app/main/errors.cljs:222
-msgid "errors.svg-parser.invalid-svg"
-msgstr "SVG geçersiz veya biçimi yanlış"
-
-#: src/app/main/data/workspace/tokens/library_edit.cljs:150, src/app/main/data/workspace/tokens/library_edit.cljs:180
-msgid "errors.token-set-already-exists"
-msgstr "Aynı ada sahip bir küme zaten var"
-
-#: src/app/main/data/tokens.cljs:
-#, unused
-msgid "errors.token-set-doesnt-exists"
-msgstr "Bilinmeyen bir küme çoğaltılamıyor"
-
-#: src/app/main/data/workspace/tokens/library_edit.cljs:273
-msgid "errors.token-set-exists-on-drop"
-msgstr ""
-"Bırakma işlemi tamamlanamıyor, aynı ada sahip bir küme zaten bu yolda var."
-
-#: src/app/main/data/workspace/tokens/library_edit.cljs:77, src/app/main/data/workspace/tokens/library_edit.cljs:95
-msgid "errors.token-theme-already-exists"
-msgstr "Aynı ada sahip tema seçeneği var"
-
-#: src/app/main/errors.cljs:176
-msgid "errors.version-already-locked"
-msgstr "Bu sürüm zaten kilitli"
-
-#: src/app/main/errors.cljs:152
-msgid "errors.version-locked"
-msgstr "Bu sürüm kilitlidir ve başkaları tarafından silinemez"
-
-#: src/app/main/ui/components/color_input.cljs:31
-msgid "inspect.attributes.color"
-msgstr "Renk"
-
-#, unused
-msgid "inspect.attributes.typography.text-decoration.line-through"
-msgstr "Üstü çizili"
-
-#: src/app/main/ui/inspect/attributes/variant.cljs:44
-msgid "inspect.attributes.variant"
-msgstr "Çeşit özellikleri"
-
-#: src/app/main/ui/inspect/attributes/variant.cljs:44
-msgid "inspect.attributes.variants"
-msgstr "Çeşitlerin özellikleri"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:67
-msgid "inspect.subtitle.copy"
-msgstr "Kopyala"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:63
-msgid "inspect.subtitle.main"
-msgstr "Ana bileşen"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:109
-msgid "inspect.tabs.computed"
-msgstr "Hesaplanan"
-
-#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
-msgstr "Panoya kopyala"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
-msgstr "Boyut ve Konum"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
-msgstr "%s panelini aç/kapat"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
-msgstr "Token Kümeleri ve Temalar"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
-msgstr "Etkin kümeler"
-
-#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
-msgstr "Etkin temalar"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
-msgstr "Çeşit özellikleri"
-
-#: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
-msgstr "Çözülen değer:"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
-msgstr "Katman bilgisi"
-
-#: src/app/main/ui/dashboard/comments.cljs:96
-msgid "label.mark-all-as-read"
-msgstr "Tümünü okundu olarak işaretle"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1043
-msgid "labels.about-penpot"
-msgstr "Penpot hakkında"
-
-#: src/app/main/ui/workspace/libraries.cljs:177
-msgid "labels.add"
-msgstr "Ekle"
-
-#: src/app/main/ui/workspace/libraries.cljs:177
-msgid "labels.adding"
-msgstr "Ekleniyor..."
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:26
-msgid "labels.blur"
-msgstr "Bulanıklık"
-
-#: src/app/main/ui/workspace/tokens/sets/lists.cljs:181
-msgid "labels.collapse"
-msgstr "Daralt"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:427
-msgid "labels.color"
-msgstr "Renk"
-
-#: src/app/main/ui/comments.cljs:913
-msgid "labels.comment"
-msgstr "Yorum"
-
-#: src/app/main/ui/comments.cljs:917
-msgid "labels.comment.mark-as-solved"
-msgstr "Çözüldü olarak işaretle"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1030
-msgid "labels.community-contributions"
-msgstr "Topluluk ve Katkılar"
-
-#: src/app/main/ui/components/copy_button.cljs:41
-msgid "labels.copy"
-msgstr "Kopyala"
-
-#: src/app/main/ui/inspect/attributes/common.cljs:99
-msgid "labels.copy-color"
-msgstr "Rengi kopyala"
-
-#: src/app/main/ui/workspace/tokens/sets/context_menu.cljs:65
-msgid "labels.duplicate"
-msgstr "Çoğalt"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:301
-msgid "labels.empty"
-msgstr "Boş"
-
-#: src/app/main/ui/dashboard/import.cljs:297
-msgid "labels.error"
-msgstr "Hata"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:23
-msgid "labels.fill"
-msgstr "Doldur"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:1019
-msgid "labels.help-learning"
-msgstr "Yardım ve Öğrenme"
-
-#: src/app/main/ui/dashboard/templates.cljs:91
-msgid "labels.hide"
-msgstr "Gizle"
-
-#: src/app/main/ui/workspace/tokens/sidebar.cljs:130
-msgid "labels.import"
-msgstr "İçe aktar"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:28
-msgid "labels.layout"
-msgstr "Yerleşim düzeni"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:798
-msgid "labels.learning-center"
-msgstr "Öğrenme Merkezi"
-
-#: src/app/main/ui/workspace/sidebar/versions.cljs:209
-msgid "labels.lock"
-msgstr "Kilitle"
-
-#: src/app/main/ui/comments.cljs:581
-msgid "labels.mention"
-msgstr "Değinme"
-
-#: src/app/main/ui/ds/controls/numeric_input.cljs:619
-msgid "labels.mixed-values"
-msgstr "Karışık"
-
-#: src/app/main/ui/dashboard/team.cljs:739
-msgid "labels.no-invitations-gather-people"
-msgstr "Arkadaşlarınızı toplayın ve birlikte harika şeyler oluşturun."
-
-#: src/app/main/ui/settings/sidebar.cljs:103
-msgid "labels.notifications"
-msgstr "Bildirimler"
-
-#: src/app/main/ui/comments.cljs:923, src/app/main/ui/comments.cljs:988, src/app/main/ui/workspace/sidebar/options/menus/text.cljs:310, src/app/main/ui/workspace/sidebar/options/menus/text.cljs:339
-msgid "labels.options"
-msgstr "Seçenekler"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:878
-msgid "labels.penpot-changelog"
-msgstr "Penpot Değişiklik Günlüğü"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:804
-msgid "labels.penpot-hub"
-msgstr "Penpot merkezi"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:751
-msgid "labels.pinned-projects"
-msgstr "Sabitlenen Projeler"
-
-#: src/app/main/ui/comments.cljs:679
-msgid "labels.post"
-msgstr "Gönder"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:644
-msgid "labels.reference"
-msgstr "Referans"
-
-#: src/app/main/data/common.cljs:83
-msgid "labels.refresh"
-msgstr "Yenile"
-
-#: src/app/main/ui/comments.cljs:642
-msgid "labels.replies"
-msgstr "yanıt"
-
-#: src/app/main/ui/comments.cljs:647
-msgid "labels.replies.new"
-msgstr "yeni yanıt"
-
-#: src/app/main/ui/comments.cljs:641
-msgid "labels.reply"
-msgstr "yanıt"
-
-#: src/app/main/ui/comments.cljs:646
-msgid "labels.reply.new"
-msgstr "yeni yanıt"
-
-#: src/app/main/ui/comments.cljs:722
-msgid "labels.reply.thread"
-msgstr "Yanıtla"
-
-#: src/app/main/ui/dashboard/team.cljs:788
-msgid "labels.resend"
-msgstr "Yeniden gönder"
-
-#: src/app/main/ui/workspace/sidebar/versions.cljs:86, src/app/main/ui/workspace/sidebar/versions.cljs:196
-msgid "labels.restore"
-msgstr "Geri yükle"
-
-#: src/app/main/ui/workspace/tokens/sidebar.cljs:75
-msgid "labels.sets"
-msgstr "Kümeler"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:27
-msgid "labels.shadow"
-msgstr "Gölge"
-
-#: src/app/main/ui/dashboard/templates.cljs:87
-msgid "labels.show"
-msgstr "Göster"
-
-#: src/app/main/ui/workspace/comments.cljs:68, src/app/main/ui/workspace/comments.cljs:140
-msgid "labels.show-mentions"
-msgstr "Yalnızca değinmelerinizi göster"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:730
-msgid "labels.sources"
-msgstr "Kaynaklar"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:24, src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:46
-msgid "labels.stroke"
-msgstr "Çerçeve"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:107, src/app/main/ui/inspect/styles.cljs:107
-msgid "labels.styles"
-msgstr "Biçimler"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:33
-msgid "labels.svg"
-msgstr "SVG"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:25
-msgid "labels.text"
-msgstr "Metin"
-
-#: src/app/main/ui/workspace/tokens/themes.cljs:36
-msgid "labels.themes"
-msgstr "Temalar"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:1148
-msgid "labels.typography"
-msgstr "Tipografi"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:101
-msgid "labels.unknown-error"
-msgstr "Bilinmeyen hata"
-
-#: src/app/main/ui/workspace/sidebar/versions.cljs:203
-msgid "labels.unlock"
-msgstr "Kilidi aç"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:65, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:949, src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
-msgid "labels.variant"
-msgstr "Çeşit"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:872
-msgid "labels.version-notes"
-msgstr "Sürüm %s notları"
-
-#: src/app/main/ui/inspect/styles/style_box.cljs:32
-msgid "labels.visibility"
-msgstr "Görünürlük"
-
-#: src/app/main/ui/ds/product/loader.cljs:21
-msgid "loader.tips.01.message"
-msgstr "Tasarımlarınızı tüm projelerde tutarlı ve güncellemesi kolay tutun."
-
-#: src/app/main/ui/ds/product/loader.cljs:20
-msgid "loader.tips.01.title"
-msgstr "Yeniden Kullanılabilir Bileşenler"
-
-#: src/app/main/ui/ds/product/loader.cljs:23
-msgid "loader.tips.02.message"
-msgstr "Takımınızla canlı olarak çalışın, geri bildirimleri anında paylaşın."
-
-#: src/app/main/ui/ds/product/loader.cljs:22
-msgid "loader.tips.02.title"
-msgstr "Gerçek Zamanlı İş Birliği"
-
-#: src/app/main/ui/ds/product/loader.cljs:25
-msgid "loader.tips.03.message"
-msgstr ""
-"Tanıdık CSS benzeri düzen denetimleriyle esnek bir şekilde tasarım yapın."
-
-#: src/app/main/ui/ds/product/loader.cljs:24
-msgid "loader.tips.03.title"
-msgstr "CSS Benzeri Düzenler"
-
-#: src/app/main/ui/ds/product/loader.cljs:27
-msgid "loader.tips.04.message"
-msgstr "Tasarımlarınızdan doğrudan CSS ve SVG kodları alın."
-
-#: src/app/main/ui/ds/product/loader.cljs:26
-msgid "loader.tips.04.title"
-msgstr "Kod Olarak Dışa Aktarın"
-
-#: src/app/main/ui/ds/product/loader.cljs:29
-msgid "loader.tips.05.message"
-msgstr "Tutarlılığı korumak için varlıkları ve biçimleri paylaşın."
-
-#: src/app/main/ui/ds/product/loader.cljs:28
-msgid "loader.tips.05.title"
-msgstr "Kütüphaneler Tasarlayın"
-
-#: src/app/main/ui/ds/product/loader.cljs:31
-msgid "loader.tips.06.message"
-msgstr "Animasyonlar ve geçişlerle fikirlerinizi hayata geçirin."
-
-#: src/app/main/ui/ds/product/loader.cljs:30
-msgid "loader.tips.06.title"
-msgstr "Etkileşimli Prototipler"
-
-#: src/app/main/ui/ds/product/loader.cljs:33
-msgid "loader.tips.07.message"
-msgstr "Penpot, sorunsuz geliştirme için SVG ve CSS kullanır."
-
-#: src/app/main/ui/ds/product/loader.cljs:32
-msgid "loader.tips.07.title"
-msgstr "Web Standartları Biçimleri"
-
-#: src/app/main/ui/ds/product/loader.cljs:35
-msgid "loader.tips.08.message"
-msgstr ""
-"Otomatik Düzenleme için Shift + A gibi kullanışlı kısayollarla iş akışınızı "
-"hızlandırın."
-
-#: src/app/main/ui/ds/product/loader.cljs:34
-msgid "loader.tips.08.title"
-msgstr "Klavye Kısayolları"
-
-#: src/app/main/ui/ds/product/loader.cljs:37
-msgid "loader.tips.09.message"
-msgstr "Tarzınıza uygun temayı seçin."
-
-#: src/app/main/ui/ds/product/loader.cljs:36
-msgid "loader.tips.09.title"
-msgstr "Koyu ve Açık Mod"
-
-#: src/app/main/ui/ds/product/loader.cljs:39
-msgid "loader.tips.10.message"
-msgstr ""
-"Ek işlevsellik için topluluk tarafından geliştirilen eklentilerle Penpot'u "
-"genişletin."
-
-#: src/app/main/ui/ds/product/loader.cljs:38
-msgid "loader.tips.10.title"
-msgstr "Eklenti Desteği"
-
-#: src/app/main/ui/dashboard/team.cljs:222
-msgid "modals.invite-team-member.text"
-msgstr ""
-"Üyeleri takıma davet ederek bu dosyaya ve tüm takım dosyalarına erişmelerini "
-"sağlayabilirsiniz."
-
-#: src/app/main/ui/dashboard/team.cljs:825
-msgid "notifications.invitation-deleted"
-msgstr "Davet başarıyla silindi"
-
-#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:423
-msgid "settings.remove-color"
-msgstr "Rengi kaldır"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:96
-msgid "shortcuts.copy-link"
-msgstr "Bağlantıyı kopyala"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:106
-#, unused
-msgid "shortcuts.copy-props"
-msgstr "Özellikleri kopyala"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:97
-msgid "shortcuts.create-component-variant"
-msgstr "Bileşen / çeşit oluştur"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:111
-#, unused
-msgid "shortcuts.paste-props"
-msgstr "Özellikleri yapıştır"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:604
-#, unused
-msgid "shortcuts.plugins"
-msgstr "Eklenti yöneticisi"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:165
-msgid "shortcuts.rename"
-msgstr "Yeniden adlandır"
-
-#: src/app/main/ui/dashboard/subscription.cljs:89, src/app/main/ui/dashboard/subscription.cljs:131
-msgid "subscription.dashboard.power-up.enterprise-plan"
-msgstr "Kurumsal plan"
-
-#: src/app/main/ui/dashboard/subscription.cljs:85
-msgid "subscription.dashboard.power-up.enterprise-trial.top-title"
-msgstr "Kurumsal plan (deneme)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:64
-#, markdown
-msgid "subscription.dashboard.power-up.professional.bottom-text"
-msgstr ""
-"Sınırsız plan ile takımlarınız için ek depolama alanı, dosya kurtarma ve "
-"daha fazlasını elde edin. [Güçlenin!|target:self](%s)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:63
-msgid "subscription.dashboard.power-up.professional.top-title"
-msgstr "Profesyonel plan"
-
-#: src/app/main/ui/dashboard/subscription.cljs:64, src/app/main/ui/settings/subscription.cljs:107, src/app/main/ui/settings/subscription.cljs:131
-#, unused
-msgid "subscription.dashboard.power-up.subscribe"
-msgstr "Abone ol"
-
-#: src/app/main/ui/dashboard/subscription.cljs:72
-#, markdown
-msgid "subscription.dashboard.power-up.trial.bottom-description"
-msgstr ""
-"Deneme sürenizi beğendiniz mi? Tam erişimi sonsuza kadar açın. "
-"[Abone olun|target:self](%s)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:71
-msgid "subscription.dashboard.power-up.trial.top-title"
-msgstr "Sınırsız plan (deneme)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:77, src/app/main/ui/dashboard/subscription.cljs:130
-msgid "subscription.dashboard.power-up.unlimited-plan"
-msgstr "Sınırsız plan"
-
-#: src/app/main/ui/dashboard/subscription.cljs:78
-#, markdown
-msgid "subscription.dashboard.power-up.unlimited.bottom-text"
-msgstr ""
-"Sabit bir fiyatla tüm takımlarınız için sınırsız depolama alanı, kapsamlı "
-"dosya kurtarma ve sınırsız düzenleyici elde edin. "
-"[Kurumsal plana göz atın.|target:self](%s)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:70
-#, unused
-msgid "subscription.dashboard.power-up.unlimited.cta"
-msgstr "Göz atın"
-
-#: src/app/main/ui/dashboard/subscription.cljs:68
-#, unused
-msgid "subscription.dashboard.power-up.unlimited.top-description"
-msgstr ""
-"Ek düzenleyiciler, depolama ve otomatik kaydedilen sürüm, dosya yedekleme ve "
-"daha fazlası."
-
-#: src/app/main/ui/dashboard/subscription.cljs:62, src/app/main/ui/dashboard/subscription.cljs:70, src/app/main/ui/dashboard/subscription.cljs:76, src/app/main/ui/dashboard/subscription.cljs:84, src/app/main/ui/dashboard/subscription.cljs:88
-msgid "subscription.dashboard.power-up.your-subscription"
-msgstr "Aboneliğiniz:"
-
-#: src/app/main/ui/dashboard/subscription.cljs:168
-msgid "subscription.dashboard.professional-dashboard-cta-title"
-msgstr ""
-"Sahip olduğunuz takımlarda %s düzenleyiciniz varken, profesyonel planınız "
-"8'e kadar düzenleyiciyi kapsamaktadır."
-
-#: src/app/main/ui/dashboard/subscription.cljs:176
-#, markdown
-msgid "subscription.dashboard.professional-dashboard-cta-upgrade-owner"
-msgstr ""
-"Daha fazla düzenleyici, depolama alanı ve dosya kurtarma özelliğinin "
-"kilidini açmak için şimdi Sınırsız veya Kurumsal sürümüne yükseltin. "
-"[Şimdi abone olun.|target:self](%s)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:111
-msgid "subscription.dashboard.team-plan"
-msgstr "Takım planı"
-
-#: src/app/main/ui/dashboard/subscription.cljs:171
-msgid "subscription.dashboard.unlimited-dashboard-cta-title"
-msgstr ""
-"Takımınız büyümeye devam ediyor! Sınırsız planınız %s düzenleyiciye kadar "
-"kapsıyor, ancak şu anda %s düzenleyiciniz var."
-
-#: src/app/main/ui/dashboard/subscription.cljs:179
-#, markdown
-msgid "subscription.dashboard.unlimited-dashboard-cta-upgrade-owner"
-msgstr ""
-"Lütfen düzenleyici sayınızla eşleşecek şekilde şimdi yükseltin. "
-"[Şimdi abone olun.|target:self](%s)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:156
-msgid "subscription.dashboard.unlimited-members-extra-editors-cta-text"
-msgstr ""
-"Yalnızca sahip olduğunuz takımlardaki yeni düzenleyiciler gelecekteki "
-"faturalandırmaya dahil edilir. 25'ten fazla düzenleyici için aylık 175$ "
-"sabit ücret uygulanmaya devam eder."
-
-#: src/app/main/ui/dashboard/subscription.cljs:152
-msgid "subscription.dashboard.unlimited-members-extra-editors-cta-title"
-msgstr "Sınırsız plandayken kişileri davet etme"
-
-#: src/app/main/ui/dashboard/sidebar.cljs:978
-msgid "subscription.dashboard.upgrade-plan.power-up"
-msgstr "Güçlenin"
-
-#: src/app/main/ui/settings/sidebar.cljs:116, src/app/main/ui/settings/subscription.cljs:318, src/app/main/ui/settings/subscription.cljs:351
-msgid "subscription.labels"
-msgstr "Abonelik"
-
-#: src/app/main/ui/settings/subscription.cljs:373, src/app/main/ui/settings/subscription.cljs:397
-msgid "subscription.settings.add-payment-to-continue"
-msgstr ""
-"Deneme süreniz bittikten sonra devam etmek için bir ödeme yöntemi ekleyin"
-
-#: src/app/main/ui/settings/subscription.cljs:367, src/app/main/ui/settings/subscription.cljs:439
-msgid "subscription.settings.benefits.all-professional-benefits"
-msgstr "Tüm Profesyonel plan faydaları ve:"
-
-#: src/app/main/ui/settings/subscription.cljs:379, src/app/main/ui/settings/subscription.cljs:391, src/app/main/ui/settings/subscription.cljs:401, src/app/main/ui/settings/subscription.cljs:453
-msgid "subscription.settings.benefits.all-unlimited-benefits"
-msgstr "Tüm Sınırsız plan faydaları ve:"
-
-#: src/app/main/ui/settings/subscription.cljs:39
-msgid "subscription.settings.editors"
-msgstr "(x %s düzenleyici)"
-
-#: src/app/main/ui/dashboard/subscription.cljs:119, src/app/main/ui/settings/subscription.cljs:72, src/app/main/ui/settings/subscription.cljs:346, src/app/main/ui/settings/subscription.cljs:399, src/app/main/ui/settings/subscription.cljs:449
-msgid "subscription.settings.enterprise"
-msgstr "Kurumsal"
-
-#: src/app/main/ui/settings/subscription.cljs:68, src/app/main/ui/settings/subscription.cljs:345, src/app/main/ui/settings/subscription.cljs:389
-msgid "subscription.settings.enterprise-trial"
-msgstr "Kurumsal (deneme)"
-
-#: src/app/main/ui/settings/subscription.cljs:393, src/app/main/ui/settings/subscription.cljs:403, src/app/main/ui/settings/subscription.cljs:455
-msgid "subscription.settings.enterprise.autosave"
-msgstr "90 günlük sürümleri otomatik kaydetme ve dosya kurtarma"
-
-#: src/app/main/ui/settings/subscription.cljs:394, src/app/main/ui/settings/subscription.cljs:404, src/app/main/ui/settings/subscription.cljs:456
-msgid "subscription.settings.enterprise.capped-bill"
-msgstr "Sabit aylık fatura"
-
-#: src/app/main/ui/settings/subscription.cljs:392, src/app/main/ui/settings/subscription.cljs:402, src/app/main/ui/settings/subscription.cljs:454
-msgid "subscription.settings.enterprise.unlimited-storage-benefit"
-msgstr "Sınırsız depolama alanı"
-
-#: src/app/main/ui/dashboard/subscription.cljs:124, src/app/main/ui/settings/subscription.cljs:371, src/app/main/ui/settings/subscription.cljs:383, src/app/main/ui/settings/subscription.cljs:395, src/app/main/ui/settings/subscription.cljs:405
-msgid "subscription.settings.manage-your-subscription"
-msgstr "Aboneliğinizi yönetin"
-
-#: src/app/main/ui/settings/subscription.cljs:131
-msgid "subscription.settings.management.dialog.currently-editors-title"
-msgid_plural "subscription.settings.management.dialog.currently-editors-title"
-msgstr[0] "Şu anda, takımlarınızda düzenleme yapabilen %s kişi bulunuyor."
-msgstr[1] "Şu anda, takımlarınızda düzenleme yapabilen %s kişi bulunuyor."
-
-#: src/app/main/ui/settings/subscription.cljs:149
-msgid "subscription.settings.management.dialog.downgrade"
-msgstr ""
-"Dikkat: Daha düşük bir plana geçmek, daha az depolama alanı, daha kısa "
-"yedeklemeler ve daha kısa sürüm geçmişi anlamına gelir."
-
-#: src/app/main/ui/settings/subscription.cljs:133
-msgid "subscription.settings.management.dialog.editors"
-msgstr "Düzenleyiciler"
-
-#: src/app/main/ui/settings/subscription.cljs:138
-msgid "subscription.settings.management.dialog.editors-explanation"
-msgstr ""
-"(Sahipler, Yöneticiler ve Düzenleyiciler. Görüntüleyiciler, Düzenleyici "
-"olarak sayılmaz)"
-
-#: src/app/main/ui/settings/subscription.cljs:181
-msgid "subscription.settings.management.dialog.input-error"
-msgstr ""
-"Şu anda sahip olduğunuzdan daha az sayıda düzenleyici ayarlayamazsınız. "
-"Takım ayarlarında, dosyaları düzenlemeyen kişilerin rolünü "
-"(düzenleyici/yönetici yerine görüntüleyici) değiştirin."
-
-#: src/app/main/ui/settings/subscription.cljs:177
-msgid "subscription.settings.management.dialog.payment-explanation"
-msgstr "Deneme süresinden sonra ücretlendirilir. Şu anda kredi kartı gerekmez."
-
-#: src/app/main/ui/settings/subscription.cljs:170, src/app/main/ui/settings/subscription.cljs:174
-#, markdown
-msgid "subscription.settings.management.dialog.price-month"
-msgstr "**%s$**/ay"
-
-#: src/app/main/ui/settings/subscription.cljs:126
-msgid "subscription.settings.management.dialog.title"
-msgstr "Takımlarınıza %s uygulayın"
-
-#: src/app/main/ui/settings/subscription.cljs:184
-msgid "subscription.settings.management.dialog.unlimited-capped-warning"
-msgstr ""
-"İpucu: Davetlerin öncesinde hazırlıklı olmak için şimdi koltuk sayınızı "
-"artırabilirsiniz. Takımlar genelinde 25'ten fazla düzenleyiciye aylık 175$ "
-"sabit ücretten sahip olacaksınız."
-
-#: src/app/main/ui/settings/subscription.cljs:418
-msgid "subscription.settings.member-since"
-msgstr "Penpot üyelik tarihi: %s"
-
-#: src/app/main/ui/settings/subscription.cljs:431, src/app/main/ui/settings/subscription.cljs:445, src/app/main/ui/settings/subscription.cljs:459
-msgid "subscription.settings.more-information"
-msgstr "Daha fazla bilgi"
-
-#: src/app/main/ui/settings/subscription.cljs:421
-msgid "subscription.settings.other-plans"
-msgstr "Diğer penpot planları"
-
-#: src/app/main/ui/settings/subscription.cljs:425, src/app/main/ui/settings/subscription.cljs:438
-msgid "subscription.settings.price-editor-month"
-msgstr "aylık düzenleyici"
-
-#: src/app/main/ui/dashboard/subscription.cljs:114, src/app/main/ui/settings/subscription.cljs:70, src/app/main/ui/settings/subscription.cljs:358, src/app/main/ui/settings/subscription.cljs:423
-msgid "subscription.settings.professional"
-msgstr "Profesyonel"
-
-#: src/app/main/ui/settings/subscription.cljs:360, src/app/main/ui/settings/subscription.cljs:427
-msgid "subscription.settings.professional.autosave-benefit"
-msgstr "7 günlük sürümleri otomatik kaydetme ve dosya kurtarma"
-
-#: src/app/main/ui/settings/subscription.cljs:359, src/app/main/ui/settings/subscription.cljs:426
-msgid "subscription.settings.professional.storage-benefit"
-msgstr "10GB depolama alanı"
-
-#: src/app/main/ui/settings/subscription.cljs:361, src/app/main/ui/settings/subscription.cljs:428
-msgid "subscription.settings.professional.teams-editors-benefit"
-msgstr ""
-"Sınırsız sayıda takım. Sahip olduğunuz takımlarda en fazla 8 düzenleyici."
-
-#: src/app/main/ui/settings/subscription.cljs:355
-msgid "subscription.settings.section-plan"
-msgstr "Aboneliğiniz"
-
-#: src/app/main/ui/settings/subscription.cljs:195, src/app/main/ui/settings/subscription.cljs:210
-msgid "subscription.settings.start-trial"
-msgstr "Ücretsiz denemeyi başlat"
-
-#: src/app/main/ui/settings/subscription.cljs:429, src/app/main/ui/settings/subscription.cljs:443, src/app/main/ui/settings/subscription.cljs:457
-msgid "subscription.settings.subscribe"
-msgstr "Abone ol"
-
-#: src/app/main/ui/settings/subscription.cljs:239
-msgid "subscription.settings.success.dialog.description"
-msgstr ""
-"Aboneliğinizi, hesap ayrıntılarınızdaki 'Abonelik' sayfasından istediğiniz "
-"zaman düzenleyebilirsiniz."
-
-#: src/app/main/ui/settings/subscription.cljs:238
-msgid "subscription.settings.success.dialog.thanks"
-msgstr "Penpot %s planını seçtiğiniz için teşekkür ederiz!"
-
-#: src/app/main/ui/settings/subscription.cljs:240
-msgid "subscription.settings.sucess.dialog.footer"
-msgstr "Planınızın tadını çıkarın!"
-
-#: src/app/main/ui/settings/subscription.cljs:236
-msgid "subscription.settings.sucess.dialog.title"
-msgstr "%s oldunuz!"
-
-#: src/app/main/ui/settings/subscription.cljs:413
-msgid "subscription.settings.support-us-since"
-msgstr "Bu planla bizi şu zamandan beri destekliyorsunuz: %s"
-
-#: src/app/main/ui/settings/subscription.cljs:443, src/app/main/ui/settings/subscription.cljs:457
-msgid "subscription.settings.try-it-free"
-msgstr "14 gün boyunca ücretsiz deneyin"
-
-#: src/app/main/ui/dashboard/subscription.cljs:117, src/app/main/ui/settings/subscription.cljs:71, src/app/main/ui/settings/subscription.cljs:343, src/app/main/ui/settings/subscription.cljs:377, src/app/main/ui/settings/subscription.cljs:435
-msgid "subscription.settings.unlimited"
-msgstr "Sınırsız"
-
-#: src/app/main/ui/dashboard/subscription.cljs:116, src/app/main/ui/settings/subscription.cljs:67, src/app/main/ui/settings/subscription.cljs:342, src/app/main/ui/settings/subscription.cljs:365
-msgid "subscription.settings.unlimited-trial"
-msgstr "Sınırsız (deneme)"
-
-#: src/app/main/ui/settings/subscription.cljs:369, src/app/main/ui/settings/subscription.cljs:381, src/app/main/ui/settings/subscription.cljs:441
-msgid "subscription.settings.unlimited.autosave-benefit"
-msgstr "30 günlük sürümleri otomatik kaydetme ve dosya kurtarma"
-
-#: src/app/main/ui/settings/subscription.cljs:370, src/app/main/ui/settings/subscription.cljs:382, src/app/main/ui/settings/subscription.cljs:442
-msgid "subscription.settings.unlimited.bill"
-msgstr "Aylık fatura üst sınırı 175$"
-
-#: src/app/main/ui/settings/subscription.cljs:368, src/app/main/ui/settings/subscription.cljs:380, src/app/main/ui/settings/subscription.cljs:440
-msgid "subscription.settings.unlimited.storage-benefit"
-msgstr "25GB depolama alanı"
-
-#: src/app/main/ui/dashboard/subscription.cljs:147, src/app/main/ui/workspace/main_menu.cljs:961
-msgid "subscription.workspace.header.menu.option.power-up"
-msgstr "Planınızı güçlendirin"
-
-#: src/app/main/ui/workspace/sidebar/versions.cljs:56
-#, markdown
-msgid "subscription.workspace.versions.warning.enterprise.subtext-owner"
-msgstr ""
-"Bu sınırı artırmak isterseniz, bize [%s](mailto) adresinden yazabilirsiniz"
-
-#: src/app/main/ui/workspace/sidebar/versions.cljs:58
-#, markdown
-msgid "subscription.workspace.versions.warning.subtext-member"
-msgstr ""
-"Bu sınırı artırmak isterseniz, takım sahibi ile iletişime geçin: [%s](mailto)"
-
-#: src/app/main/ui/workspace/sidebar/versions.cljs:57
-#, markdown
-msgid "subscription.workspace.versions.warning.subtext-owner"
-msgstr "Bu sınırı artırmak isterseniz, [planınızı yükseltin|target:self](%s)"
-
-#: src/app/main/ui/settings/notifications.cljs:45
-msgid "title.settings.notifications"
-msgstr "Bildirimler - Penpot"
-
-#: src/app/main/ui/workspace/sidebar/assets.cljs:172
-msgid "workspace.assets.add-library"
-msgstr "Kütüphane ekle"
-
-#: src/app/main/ui/workspace/sidebar/assets/colors.cljs:497
-msgid "workspace.assets.colors.add-color"
-msgstr "Renk ekle"
-
-#: src/app/main/ui/workspace/sidebar/assets/groups.cljs:81
-msgid "workspace.assets.component-group-options"
-msgstr "Bileşen grubu seçenekleri"
-
-#: src/app/main/ui/workspace/sidebar/assets/components.cljs:581
-msgid "workspace.assets.components.add-component"
-msgstr "Bileşen ekle"
-
-#: src/app/main/ui/workspace/sidebar/assets/components.cljs:178, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:547
-msgid "workspace.assets.components.num-variants"
-msgstr "%s Çeşit"
-
-#: src/app/main/ui/workspace/sidebar/assets.cljs:177
-msgid "workspace.assets.manage-library"
-msgstr "Kütüphaneyi yönet"
-
-#: src/app/main/ui/workspace/sidebar/assets/typographies.cljs:405
-msgid "workspace.assets.typography.add-typography"
-msgstr "Tipografi ekle"
-
-#: src/app/main/ui/workspace/colorpicker.cljs:431, src/app/main/ui/workspace/colorpicker.cljs:443
-msgid "workspace.colorpicker.color-tokens"
-msgstr "Tokenleri renklendir"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:464
-msgid "workspace.component.swap.loop-error"
-msgstr "Bileşenler kendi içlerinde iç içe geçemez."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:463
-msgid "workspace.component.switch.loop-error-multi"
-msgstr ""
-"Bazı kopyalar değiştirilemedi. Bileşenler kendi içlerinde iç içe geçemez."
-
-#: src/app/main/ui/workspace/main_menu.cljs:916
-#, unused
-msgid "workspace.header.menu.option.power-up"
-msgstr "Planınızı güçlendirin"
-
-#: src/app/main/ui/workspace/main_menu.cljs:315
-msgid "workspace.header.menu.toggle-system-theme"
-msgstr "Sistem temasına geç"
-
-#: src/app/main/ui/workspace/right_header.cljs:240
-msgid "workspace.header.share"
-msgstr "Paylaş"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:430, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:436
-msgid "workspace.layout_grid.editor.padding.bottom"
-msgstr "Alt dolgu"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:355, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:362
-msgid "workspace.layout_grid.editor.padding.horizontal"
-msgstr "Yatay dolgu"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:445, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:451
-msgid "workspace.layout_grid.editor.padding.left"
-msgstr "Sol dolgu"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:415, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:421
-msgid "workspace.layout_grid.editor.padding.right"
-msgstr "Sağ dolgu"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:400, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:406
-msgid "workspace.layout_grid.editor.padding.top"
-msgstr "Üst dolgu"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:341, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:347
-msgid "workspace.layout_grid.editor.padding.vertical"
-msgstr "Dikey dolgu"
-
-#: src/app/main/ui/workspace/libraries.cljs:349
-msgid "workspace.libraries.connected-to"
-msgstr "Bağlandı"
-
-#: src/app/main/ui/workspace/libraries.cljs:404
-msgid "workspace.libraries.empty.add-some"
-msgstr "Veya denemek için bunlardan bazılarını ekleyin:"
-
-#: src/app/main/ui/workspace/libraries.cljs:398
-msgid "workspace.libraries.empty.no-libraries"
-msgstr "Takımınızda Paylaşılan Kütüphaneler bulunmuyor, burada bulunan"
-
-#: src/app/main/ui/workspace/libraries.cljs:402
-msgid "workspace.libraries.empty.some-templates"
-msgstr "şablonlara bakabilirsiniz"
-
-#: src/app/main/ui/workspace/libraries.cljs:387
-#, unused
-msgid "workspace.libraries.more-templates"
-msgstr "Bakabilirsiniz "
-
-#: src/app/main/ui/ds/notifications/shared/notification_pill.cljs:67, src/app/main/ui/ds/notifications/shared/notification_pill.cljs:72
-msgid "workspace.notification-pill.detail"
-msgstr "Ayrıntılar"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:97
-msgid "workspace.options.blur-options.add-blur"
-msgstr "Bulanıklık ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:118
-msgid "workspace.options.blur-options.remove-blur"
-msgstr "Bulanıklığı kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:114
-msgid "workspace.options.blur-options.toggle-blur"
-msgstr "Bulanıklığı değiştir"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:993
-msgid "workspace.options.component.unlinked"
-msgstr "Ayrıldı"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:512
-msgid "workspace.options.component.variant.duplicated.copy.locate"
-msgstr "Çakışan çeşitleri bul"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:509
-msgid "workspace.options.component.variant.duplicated.copy.title"
-msgstr ""
-"Bu bileşenin çakışan çeşitleri var. Her çeşidin kendine özgü özellik "
-"değerleri olduğundan emin olun."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1281
-msgid "workspace.options.component.variant.duplicated.group.locate"
-msgstr "Yinelenen çeşitleri bul"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1278
-msgid "workspace.options.component.variant.duplicated.group.title"
-msgstr "Bazı çeşitler aynı özelliklere ve değerlere sahip"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:268
-msgid "workspace.options.component.variant.duplicated.single.all"
-msgstr ""
-"Bu çeşitler aynı özelliklere ve değerlere sahiptir. Değerleri, "
-"çağrılabilecekleri şekilde ayarlayın."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:265
-msgid "workspace.options.component.variant.duplicated.single.one"
-msgstr ""
-"Bu çeşit, başka bir çeşitle aynı özelliklere ve değerlere sahiptir. "
-"Değerleri, çağrılabilecekleri şekilde ayarlayın."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:271
-msgid "workspace.options.component.variant.duplicated.single.some"
-msgstr ""
-"Bu çeşitlerden bazıları aynı özelliklere ve değerlere sahiptir. Değerleri, "
-"geri çağrılabilecekleri şekilde ayarlayın."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:499
-msgid "workspace.options.component.variant.malformed.copy"
-msgstr ""
-"Bu bileşenin geçersiz ada sahip çeşitleri var. Her çeşidin doğru yapıyı "
-"takip ettiğinden emin olun."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1271
-msgid "workspace.options.component.variant.malformed.group.locate"
-msgstr "Geçersiz çeşitleri bul"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1268
-msgid "workspace.options.component.variant.malformed.group.title"
-msgstr "Bazı çeşitlerin adları geçersiz"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:502
-msgid "workspace.options.component.variant.malformed.locate"
-msgstr "Geçersiz çeşitleri bul"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:252
-msgid "workspace.options.component.variant.malformed.single.all"
-msgstr "Bu çeşitlerin adları geçersiz."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:249
-msgid "workspace.options.component.variant.malformed.single.one"
-msgstr "Bu çeşidin adı geçersiz."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:255
-msgid "workspace.options.component.variant.malformed.single.some"
-msgstr "Bu çeşitlerden bazılarının adları geçersiz."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:391
-msgid "workspace.options.component.variant.malformed.structure.example"
-msgstr "[özellik]=[değer], [özellik]=[değer]"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:389
-msgid "workspace.options.component.variant.malformed.structure.title"
-msgstr "Şu yapıyı kullanmayı deneyin:"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:54
-msgid "workspace.options.component.variants-help-modal.intro"
-msgstr ""
-"Çeşitler arasında geçiş yaparken değişiklikleri korumak için Penpot şu "
-"katmanları birbirine bağlar:"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:91
-msgid "workspace.options.component.variants-help-modal.outro"
-msgstr ""
-"Bunlardan herhangi birini değiştirmek "
-"(örneğin, bir katmanı yeniden adlandırmak veya gruplamak) bağlantıyı keser, "
-"ancak değişikliği geri almak bağlantıyı yeniden kurar."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:67
-msgid "workspace.options.component.variants-help-modal.rule1"
-msgstr "Aynı ada sahip."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:76
-msgid "workspace.options.component.variants-help-modal.rule2"
-msgstr "Aynı türden."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:77
-msgid "workspace.options.component.variants-help-modal.rule2.detail"
-msgstr ""
-"Dikdörtgen, elips, yollar ve boole işlemleri aynı tür olarak kabul edilir."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:87
-msgid "workspace.options.component.variants-help-modal.rule3"
-msgstr "Aynı hiyerarşi düzeyine sahip."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:88
-msgid "workspace.options.component.variants-help-modal.rule3.detail"
-msgstr "Gruplar, çalışma yüzeyleri ve yerleşim düzenleri eş değer kabul edilir."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:955, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1191, src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs:47
-msgid "workspace.options.component.variants-help-modal.title"
-msgstr "Çeşitler nasıl bağlantılı kalır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:214
-msgid "workspace.options.export.add-export"
-msgstr "Dışa aktarım ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:226, src/app/main/ui/workspace/sidebar/options/menus/exports.cljs:261
-msgid "workspace.options.export.remove-export"
-msgstr "Dışa aktarımı kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/fill.cljs:234
-msgid "workspace.options.fill.add-fill"
-msgstr "Doldurma ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/fill.cljs:248
-msgid "workspace.options.fill.remove-fill"
-msgstr "Doldurmayı kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:474
-msgid "workspace.options.fit-content"
-msgstr "Çalışma yüzeyini içeriğe sığacak şekilde yeniden boyutlandır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:155
-msgid "workspace.options.flows.remove-flow"
-msgstr "Akışı kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:326
-msgid "workspace.options.guides.add-guide"
-msgstr "Kılavuz ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:188
-msgid "workspace.options.guides.remove-guide"
-msgstr "Kılavuzu kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:184
-msgid "workspace.options.guides.toggle-guide"
-msgstr "Kılavuzu değiştir"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:736
-msgid "workspace.options.interactions.add-interaction"
-msgstr "Etkileşim ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
-#, unused
-msgid "workspace.options.interactions.remove-interaction"
-msgstr "Etkileşimi kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:207, src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:213
-msgid "workspace.options.layer-options.toggle-layer"
-msgstr "Katman görünürlüğünü değiştir"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/border_radius.cljs:152
-msgid "workspace.options.radius.hide-all-corners"
-msgstr "Bağımsız yarıçapı daralt"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/border_radius.cljs:153
-msgid "workspace.options.radius.show-single-corners"
-msgstr "Bağımsız yarıçapı göster"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:341
-msgid "workspace.options.shadow-options.add-shadow"
-msgstr "Gölge ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:183, src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:354
-msgid "workspace.options.shadow-options.remove-shadow"
-msgstr "Gölgeyi kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs:179
-msgid "workspace.options.shadow-options.toggle-shadow"
-msgstr "Gölgeyi değiştir"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:534
-msgid "workspace.options.size.lock"
-msgstr "Oranı kilitle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/measures.cljs:534
-msgid "workspace.options.size.unlock"
-msgstr "Oranın kilidini kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:189
-msgid "workspace.options.stroke.add-stroke"
-msgstr "Çerçeve rengi ekle"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs:202
-msgid "workspace.options.stroke.remove-stroke"
-msgstr "Çerçeveyi kaldır"
-
-#: src/app/main/ui/workspace/plugins.cljs:192
-msgid "workspace.plugins.error.manifest"
-msgstr "Eklenti bildirimi yanlış."
-
-#: src/app/main/data/plugins.cljs:89, src/app/main/ui/workspace/main_menu.cljs:783, src/app/main/ui/workspace/plugins.cljs:83
-msgid "workspace.plugins.error.need-editor"
-msgstr "Bu eklentiyi kullanmak için düzenleyici olmanız gerekir"
-
-#: src/app/main/ui/workspace/plugins.cljs:375
-msgid "workspace.plugins.permissions-update.title"
-msgstr "BU EKLENTİYİ GÜNCELLE"
-
-#: src/app/main/ui/workspace/plugins.cljs:379
-msgid "workspace.plugins.permissions-update.warning"
-msgstr ""
-"Eklenti, son açtığınızdan beri değiştirildi. Artık şuraya da erişmek istiyor:"
-
-#: src/app/main/ui/workspace/plugins.cljs:279
-msgid "workspace.plugins.permissions.allow-download"
-msgstr "Dosya indirmesi başlat."
-
-#: src/app/main/ui/workspace/plugins.cljs:286
-msgid "workspace.plugins.permissions.allow-localstorage"
-msgstr "Tarayıcıda veri depola."
-
-#: src/app/main/ui/workspace/plugins.cljs:272
-msgid "workspace.plugins.permissions.comment-read"
-msgstr "Yorumlarınızı ve yanıtlarınızı oku."
-
-#: src/app/main/ui/workspace/plugins.cljs:266
-msgid "workspace.plugins.permissions.comment-write"
-msgstr "Yorumlarınızı oku, değiştir ve sizin adınıza yanıtla."
-
-#: src/app/main/ui/workspace/plugins.cljs:87
-msgid "workspace.plugins.remove-plugin"
-msgstr "Eklentiyi kaldır"
-
-#: src/app/main/ui/workspace/plugins.cljs:439
-msgid "workspace.plugins.try-out.cancel"
-msgstr "ŞİMDİ DEĞİL"
-
-#: src/app/main/ui/workspace/plugins.cljs:432
-msgid "workspace.plugins.try-out.message"
-msgstr ""
-"Bir göz atmak ister misiniz? Geçerli takımınız için yeni bir taslakta "
-"açılacaktır. (İstemiyorsanız, onu herhangi bir dosyanın kurulu "
-"eklentilerinde her zaman bulabilirsiniz.)"
-
-#: src/app/main/ui/workspace/plugins.cljs:428
-msgid "workspace.plugins.try-out.title"
-msgstr "'%s' EKLENTİSİ KULLANICINIZ İÇİN KURULDU!"
-
-#: src/app/main/ui/workspace/plugins.cljs:445
-msgid "workspace.plugins.try-out.try"
-msgstr "EKLENTİYİ DENE"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1016, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1040
-msgid "workspace.shape.menu.add-layout"
-msgstr "Yerleşim düzeni ekle"
-
-#: src/app/main/ui/workspace/context_menu.cljs:610, src/app/main/ui/workspace/sidebar/assets/common.cljs:514, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:961, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1113, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1195
-msgid "workspace.shape.menu.add-variant"
-msgstr "Çeşit oluştur"
-
-#: src/app/main/ui/workspace/sidebar/assets/common.cljs:518, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1010, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1115, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1233
-msgid "workspace.shape.menu.add-variant-property"
-msgstr "Yeni özellik ekle"
-
-#: src/app/main/ui/workspace/context_menu.cljs:617, src/app/main/ui/workspace/sidebar/assets/components.cljs:634, src/app/main/ui/workspace/sidebar/assets/groups.cljs:75, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1041
-msgid "workspace.shape.menu.combine-as-variants"
-msgstr "Çeşit olarak birleştir"
-
-#: src/app/main/ui/workspace/sidebar/assets/components.cljs:636
-msgid "workspace.shape.menu.combine-as-variants-error"
-msgstr "Bileşenler aynı sayfada olmalıdır"
-
-#: src/app/main/ui/workspace/context_menu.cljs:217
-msgid "workspace.shape.menu.copy-css"
-msgstr "CSS olarak kopyala"
-
-#: src/app/main/ui/workspace/context_menu.cljs:219
-msgid "workspace.shape.menu.copy-css-nested"
-msgstr "CSS olarak kopyala (iç içe katmanlar)"
-
-#: src/app/main/ui/workspace/context_menu.cljs:202
-msgid "workspace.shape.menu.copy-link"
-msgstr "Bağlantıyı kopyala"
-
-#: src/app/main/ui/workspace/context_menu.cljs:215
-msgid "workspace.shape.menu.copy-paste-as"
-msgstr "Farklı kopyala/yapıştır ..."
-
-#: src/app/main/ui/workspace/context_menu.cljs:229
-msgid "workspace.shape.menu.copy-props"
-msgstr "Özellikleri kopyala"
-
-#: src/app/main/ui/workspace/context_menu.cljs:221
-msgid "workspace.shape.menu.copy-svg"
-msgstr "SVG olarak kopyala"
-
-#: src/app/main/ui/workspace/context_menu.cljs:226
-msgid "workspace.shape.menu.copy-text"
-msgstr "Metin olarak kopyala"
-
-#: src/app/main/ui/workspace/context_menu.cljs:233
-msgid "workspace.shape.menu.paste-props"
-msgstr "Özellikleri yapıştır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1034
-msgid "workspace.shape.menu.remove-layout"
-msgstr "Yerleşim düzenini kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1257
-msgid "workspace.shape.menu.remove-variant-property"
-msgstr "Özelliği kaldır"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:1256
-msgid "workspace.shape.menu.remove-variant-property.last-property"
-msgstr "Çeşidin en az bir özelliği olmalıdır"
-
-#: src/app/main/ui/workspace/context_menu.cljs:328
-msgid "workspace.shape.menu.rename"
-msgstr "Yeniden adlandır"
-
-#: src/app/main/ui/workspace/sidebar/assets/common.cljs:504
-msgid "workspace.shape.menu.restore-variant"
-msgstr "Çeşidi geri yükle"
-
-#: src/app/main/ui/workspace/sidebar/sitemap.cljs:249
-msgid "workspace.sidebar.sitemap.add-page"
-msgstr "Sayfa ekle"
-
-#: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:86
-msgid "workspace.tokens.active-themes"
-msgstr "%s etkin tema"
-
-#: src/app/main/ui/workspace/tokens/sidebar.cljs
-#, unused
-msgid "workspace.tokens.add set"
-msgstr "Küme ekle"
-
-#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:62, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:165, src/app/main/ui/workspace/tokens/themes/create_modal.cljs:328
-msgid "workspace.tokens.add-new-theme"
-msgstr "Yeni tema ekle"
-
-#: src/app/main/ui/workspace/tokens/sets/context_menu.cljs:62
-msgid "workspace.tokens.add-set-to-group"
-msgstr "Bu gruba küme ekle"
-
-#: src/app/main/ui/workspace/colorpicker/color_tokens.cljs:197, src/app/main/ui/workspace/tokens/management/group.cljs:115
-msgid "workspace.tokens.add-token"
-msgstr "Token ekle: %s"
-
-#: src/app/main/ui/workspace/tokens/management/token_pill.cljs:136
-msgid "workspace.tokens.applied-to"
-msgstr "Uygulanan"
-
-#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:316
-msgid "workspace.tokens.axis"
-msgstr "Eksen"
-
-#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:337
-msgid "workspace.tokens.back-to-themes"
-msgstr "Tema listesine geri dön"
-
-#: src/app/main/ui/workspace/tokens/settings/menu.cljs:89
-msgid "workspace.tokens.base-font-size"
-msgstr "Temel yazı tipi boyutu"
-
-#: src/app/main/ui/workspace/tokens/settings/menu.cljs:43
-msgid "workspace.tokens.base-font-size.error"
-msgstr ""
-"Temel yazı tipi boyutu piksel cinsinden veya birimsiz bir değer olmalıdır."
-
-#: src/app/main/ui/workspace/tokens/modals/import.cljs:127
-#, unused
-msgid "workspace.tokens.choose-file"
-msgstr "Dosya seç"
-
-#: src/app/main/ui/workspace/tokens/modals/import.cljs:132
-#, unused
-msgid "workspace.tokens.choose-folder"
-msgstr "Klasör seç"
-
-#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:286
-msgid "workspace.tokens.color"
-msgstr "Renk"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.composite-line-height-needs-font-size"
-msgstr ""
-"Satır yüksekliği yazı tipi boyutuna bağlıdır. Çözülen değeri elde etmek için "
-"bir yazı tipi boyutu ekleyin."
-
-#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:53
-msgid "workspace.tokens.create-new-theme"
-msgstr "Şimdi ilk temanızı oluşturun."
-
-#: src/app/main/ui/workspace/tokens/sets/lists.cljs:96, src/app/main/ui/workspace/tokens/themes.cljs:44
-msgid "workspace.tokens.create-one"
-msgstr "Bir tane oluşturun."
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:552
-msgid "workspace.tokens.create-token"
-msgstr "Yeni %s tokeni oluştur"
-
-#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:338
-msgid "workspace.tokens.delete"
-msgstr "Tokeni sil"
-
-#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:154
-msgid "workspace.tokens.delete-theme-title"
-msgstr "Temayı sil"
-
-#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:335
-msgid "workspace.tokens.duplicate"
-msgstr "Tokeni çoğalt"
-
-#: src/app/main/data/workspace/tokens/library_edit.cljs:197, src/app/main/data/workspace/tokens/library_edit.cljs:415
-msgid "workspace.tokens.duplicate-suffix"
-msgstr "kopyala"
-
-#: src/app/main/ui/workspace/tokens/management/context_menu.cljs:322
-msgid "workspace.tokens.edit"
-msgstr "Tokeni düzenle"
-
-#: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:327
-msgid "workspace.tokens.edit-theme-title"
-msgstr "Temayı düzenle"
-
-#: src/app/main/ui/workspace/tokens/themes/theme_selector.cljs:74
-msgid "workspace.tokens.edit-themes"
-msgstr "Temaları düzenle"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:551
-msgid "workspace.tokens.edit-token"
-msgstr "%s tokenini düzenle"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
-msgstr "Token değeri boş olamaz"
-
-#: src/app/main/ui/workspace/tokens/management/create/form.cljs:558
-msgid "workspace.tokens.enter-token-name"
-msgstr "%s token adını gir"
-
-#: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
-msgstr "İçe Aktarma Hatası: JSON ayrıştırılamadı."
-
-#: src/app/main/ui/workspace/tokens/export/modal.cljs:49
-msgid "workspace.tokens.export"
-msgstr "Dışa aktar"
-
-#: src/app/main/ui/workspace/tokens/export/modal.cljs:125
-msgid "workspace.tokens.export-tokens"
-msgstr "Tokenleri dışa aktar"
-
-#: src/app/main/ui/workspace/tokens/export/modal.cljs:118
-msgid "workspace.tokens.export.multiple-files"
-msgstr "Birden fazla dosya"
-
-#: src/app/main/ui/workspace/tokens/export/modal.cljs:38
-msgid "workspace.tokens.export.no-tokens-themes-sets"
-msgstr "Dışa aktarılacak token, tema veya küme yok."
-
-#: src/app/main/ui/workspace/tokens/export/modal.cljs:35
-msgid "workspace.tokens.export.preview"
-msgstr "Ön izleme:"
-
-#: src/app/main/ui/workspace/tokens/export/modal.cljs:116
-msgid "workspace.tokens.export.single-file"
-msgstr "Tek dosya"

--- a/frontend/translations/ukr_UA.po
+++ b/frontend/translations/ukr_UA.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Denys Kisil <ossenjoyer@proton.me>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/penpot/"
-"frontend/ukr_UA/>\n"
+"Language-Team: Ukrainian "
+"<https://hosted.weblate.org/projects/penpot/frontend/ukr_UA/>\n"
 "Language: ukr_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4852,6 +4852,9 @@ msgstr "Шрифт"
 msgid "workspace.assets.typography.font-size"
 msgstr "Розмір"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Стиль шрифта"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Перейти до файлу бібліотеки стилів для редагування"
@@ -6166,7 +6169,7 @@ msgstr "Згори"
 msgid "workspace.options.more-colors"
 msgstr "Більше кольорів"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Більше кольорів бібліотеки"
 

--- a/frontend/translations/yo.po
+++ b/frontend/translations/yo.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Alejandro Alonso <alejandro.alonso@kaleidos.net>\n"
-"Language-Team: Yoruba <https://hosted.weblate.org/projects/penpot/frontend/"
-"yo/>\n"
+"Language-Team: Yoruba "
+"<https://hosted.weblate.org/projects/penpot/frontend/yo/>\n"
 "Language: yo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3179,6 +3179,9 @@ msgstr "Fonti"
 msgid "workspace.assets.typography.font-size"
 msgstr "Iwon"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "Àrà Fọ́ǹtì"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:530
 msgid "workspace.assets.typography.letter-spacing"
 msgstr "Aaye leta"
@@ -4112,7 +4115,7 @@ msgstr "Òkè"
 msgid "workspace.options.more-colors"
 msgstr "Àwọn àwọ̀ púpọ̀ sí i"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "Àwọn yàrá àwọ̀ púpọ̀ sí I"
 

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
-"projects/penpot/frontend/zh_Hans/>\n"
+"Language-Team: Chinese (Simplified Han script) "
+"<https://hosted.weblate.org/projects/penpot/frontend/zh_Hans/>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4711,6 +4711,9 @@ msgstr "字体"
 msgid "workspace.assets.typography.font-size"
 msgstr "尺寸"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "文字风格"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "前往样式库文件进行编辑"
@@ -6014,7 +6017,7 @@ msgstr "顶部"
 msgid "workspace.options.more-colors"
 msgstr "更多颜色"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "更多共享库颜色"
 

--- a/frontend/translations/zh_Hant.po
+++ b/frontend/translations/zh_Hant.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-10-13 09:26+0000\n"
 "Last-Translator: william chen <william.fromtw@gmail.com>\n"
-"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
-"projects/penpot/frontend/zh_Hant/>\n"
+"Language-Team: Chinese (Traditional Han script) "
+"<https://hosted.weblate.org/projects/penpot/frontend/zh_Hant/>\n"
 "Language: zh_Hant\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4105,6 +4105,9 @@ msgstr "字型"
 msgid "workspace.assets.typography.font-size"
 msgstr "尺寸"
 
+msgid "workspace.assets.typography.font-style"
+msgstr "字體樣式"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "前往樣式圖庫檔案進行編輯"
@@ -5319,7 +5322,7 @@ msgstr "上"
 msgid "workspace.options.more-colors"
 msgstr "更多顏色"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:161
+#: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:140
 msgid "workspace.options.more-lib-colors"
 msgstr "更多圖層顏色"
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11963

### Summary

"Font Style" text was already present in most translations, but instead of re-using an existing text (Font Style or Style), we're adding a new one to be used in this specific component: `workspace.assets.typography.font-style`

### Steps to reproduce 

Check the label for remote libraries imported is used correctly

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
