### PR TITLE
:bug: Remove color validation for non-color tokens in strokes

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -47,7 +47,7 @@
 
 ;; Current token implementation on fills only supports one token per shape and has to be the first fill
 ;; This must be improved in the future
-(defn- has-token?
+(defn- has-color-token?
   "Returns true if the resolved token matches the color and is the first fill (idx = 0)."
   [resolved-token stroke-type idx]
   (and (= (:resolved-value resolved-token) (:color stroke-type))
@@ -66,17 +66,17 @@
                 property-name (cmm/get-css-rule-humanized property)
                 property-value (css/get-css-property objects stroke property)
                 resolved-token (get-resolved-token property shape resolved-tokens)
-                has-token (has-token? resolved-token stroke-type idx)]
+                has-color-token (has-color-token? resolved-token stroke-type idx)]
             (if (= property :border-color)
               [:> color-properties-row* {:key (str idx property)
                                          :term property-name
                                          :color stroke-type
-                                         :token (when has-token resolved-token)
+                                         :token (when has-color-token resolved-token)
                                          :format color-space
                                          :copiable true}]
               [:> properties-row* {:key  (str idx property)
                                    :term (d/name property-name)
                                    :detail (dm/str value)
-                                   :token (when has-token resolved-token)
+                                   :token resolved-token
                                    :property property-value
                                    :copiable true}]))))])])


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/12056

### Summary
Stroke width tokens are not displayed in border width: 

### Steps to reproduce 

- create a rectangle
- add a border
- apply a stroke width token to the border
- go to info tab, 

Ensure the stroke width token is not displayed as a hardcoded value

Current wrong behaviour
<img width="474" height="123" alt="image" src="https://github.com/user-attachments/assets/793c7def-c566-4f98-a6e0-1346cd283b58" />
<img width="505" height="168" alt="image" src="https://github.com/user-attachments/assets/5010bc29-110b-4d97-8301-905bf7c0f9d3" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
