### PR TITLE
:bug: Fix scrollbar in the inspect tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,7 @@
 - Fix auto-width changes to fixed when switching variants [Taiga #12172](https://tree.taiga.io/project/penpot/issue/12172)
 - Fix component number has no singular translation string [Taiga #12106](https://tree.taiga.io/project/penpot/issue/12106)
 - Fix adding/removing identical text fills [Taiga #12287](https://tree.taiga.io/project/penpot/issue/12287)
+- Fix scroll on the inspect tab [Taiga #12293](https://tree.taiga.io/project/penpot/issue/12293)
 
 
 ## 2.10.1

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -146,9 +146,12 @@
 .viewer-tab-switcher {
   --tabs-nav-padding-inline-start: 0;
   --tabs-nav-padding-inline-end: var(--sp-m);
-  --max-inspect-tab-height: calc(100vh - 12rem);
 
+  /* same height as .element-options in workspace/sidebar/options.scss */
+  /* which is one of the parents of this component */
+  --max-inspect-tab-height: var(--sidebar-element-options-height);
   max-block-size: var(--max-inspect-tab-height);
+
   overflow: auto;
 }
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options.scss
@@ -30,7 +30,10 @@
   flex-direction: column;
   gap: deprecated.$s-8;
   width: 100%;
-  height: calc(100vh - $sz-88);
+  /* FIXME: This is hacky and prone to break, we should tackle the whole layout
+            of the sidebar differently */
+  --sidebar-element-options-height: calc(100vh - $sz-88);
+  height: var(--sidebar-element-options-height);
   padding-top: deprecated.$s-8;
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12293

### Summary

This fixes a scrollbar that was always present in the inspect tab.
<img width="320" height="498" alt="Screenshot 2025-10-15 at 3 22 14 PM" src="https://github.com/user-attachments/assets/deefd447-b2b9-49f5-b595-cb6dfc27956c" />

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
