### PR TITLE
:bug: Make internal DOM of text editor v2 break words as the render engine does

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
@@ -37,7 +37,6 @@
   [data-itype="inline"] {
     line-break: auto;
     line-height: inherit;
-    overflow-wrap: initial;
     caret-color: var(--text-editor-caret-color);
   }
 
@@ -45,15 +44,6 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-  }
-}
-
-// Grow type
-.grow-type-fixed,
-.grow-type-auto-height {
-  [data-itype="inline"],
-  [data-itype="paragraph"] {
-    white-space: break-spaces;
   }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12329

### Summary

<img width="271" height="169" alt="Screenshot 2025-10-16 at 2 39 18 PM" src="https://github.com/user-attachments/assets/5d511eb8-479a-465f-a3a7-f656b9878ab6" />

### Steps to reproduce 

Create a text shape with a long-ish text that does not fit the shape's selrect. The text should render by breaking the word (as usual) but if you select it to make the editor's inner DOM visible, you should be able to see that the internal DOM text breaks the line in the same way.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
