### PR TITLE
:bug: Fix error when selecting set in theme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@
 - Fix adding/removing identical text fills [Taiga #12287](https://tree.taiga.io/project/penpot/issue/12287)
 - Fix scroll on the inspect tab [Taiga #12293](https://tree.taiga.io/project/penpot/issue/12293)
 - Fix lock proportion tooltip [Taiga #12326](https://tree.taiga.io/project/penpot/issue/12326)
+- Fix internal Error when selecting a set by name in the token theme editor [Taiga #12310](https://tree.taiga.io/project/penpot/issue/12310)
 
 
 ## 2.10.1

--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -864,6 +864,12 @@ test.describe("Tokens: Themes modal", () => {
       }
     }
 
+    const firstButton = await tokenThemeUpdateCreateModal
+      .getByTestId('tokens-set-item')
+      .first();
+    
+    await firstButton.click();
+
     await tokenThemeUpdateCreateModal
       .getByRole("button", {
         name: "Save theme",

--- a/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
@@ -319,7 +319,8 @@
         (mf/use-fn
          (mf/deps on-toggle-token-set)
          (fn [set-id]
-           (on-toggle-token-set set-id)))]
+           (let [set (ctob/get-set lib set-id)]
+             (on-toggle-token-set (ctob/get-name set)))))]
 
     [:div {:class (stl/css :themes-modal-wrapper)}
      [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :themes-modal-title)}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12310

### Summary

Internal error when clicking the set name in the theme edit form.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->