### PR TITLE
:wrench: Update text extrect on resize (WIP)

### DIFF
--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -1,5 +1,5 @@
 use crate::{
-    math::{Bounds, Matrix, Rect},
+    math::{Matrix, Rect},
     render::{default_font, DEFAULT_EMOJI_FONT},
 };
 
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use super::FontFamily;
 use crate::math::Point;
-use crate::shapes::{self, merge_fills, Shape};
+use crate::shapes::{self, merge_fills};
 use crate::utils::{get_fallback_fonts, get_font_collection};
 use crate::Uuid;
 
@@ -218,7 +218,11 @@ impl TextContent {
     }
 
     pub fn width(&self) -> f32 {
-        self.size.width
+        if self.grow_type() == GrowType::AutoWidth {
+            self.size.width
+        } else {
+            self.bounds.width()
+        }
     }
 
     pub fn grow_type(&self) -> GrowType {
@@ -227,36 +231,6 @@ impl TextContent {
 
     pub fn set_grow_type(&mut self, grow_type: GrowType) {
         self.grow_type = grow_type;
-    }
-
-    pub fn get_bounds(&self, shape: &Shape) -> Bounds {
-        let (x, y, transform, center) = (
-            shape.selrect.x(),
-            shape.selrect.y(),
-            &shape.transform,
-            &shape.center(),
-        );
-        let (width, height) = (self.size.width, self.size.height);
-        let text_rect = Rect::from_xywh(x, y, width, height);
-
-        let mut bounds = Bounds::new(
-            Point::new(text_rect.x(), text_rect.y()),
-            Point::new(text_rect.x() + text_rect.width(), text_rect.y()),
-            Point::new(
-                text_rect.x() + text_rect.width(),
-                text_rect.y() + text_rect.height(),
-            ),
-            Point::new(text_rect.x(), text_rect.y() + text_rect.height()),
-        );
-
-        if !transform.is_identity() {
-            let mut matrix = *transform;
-            matrix.post_translate(*center);
-            matrix.pre_translate(-*center);
-            bounds.transform_mut(&matrix);
-        }
-
-        bounds
     }
 
     pub fn transform(&mut self, transform: &Matrix) {

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -1,7 +1,6 @@
-use crate::{
-    math::{Matrix, Rect},
-    render::{default_font, DEFAULT_EMOJI_FONT},
-};
+use crate::render::{default_font, DEFAULT_EMOJI_FONT};
+
+use crate::math::{Matrix, Point, Rect};
 
 use core::f32;
 use macros::ToJs;
@@ -15,7 +14,6 @@ use skia_safe::{
 use std::collections::HashSet;
 
 use super::FontFamily;
-use crate::math::Point;
 use crate::shapes::{self, merge_fills};
 use crate::utils::{get_fallback_fonts, get_font_collection};
 use crate::Uuid;
@@ -397,8 +395,21 @@ impl TextContent {
         self.size.copy_finite_size(result.2);
     }
 
+    pub fn get_height(&self, width: f32) -> f32 {
+        let mut paragraph_builders = self.paragraph_builder_group_from_text(None);
+        let paragraphs =
+            self.build_paragraphs_from_paragraph_builders(&mut paragraph_builders, width);
+        paragraphs
+            .iter()
+            .flatten()
+            .fold(0.0, |auto_height, paragraph| {
+                auto_height + paragraph.height()
+            })
+    }
+
     pub fn update_layout(&mut self, selrect: Rect) -> TextContentSize {
-        self.size.set_size(selrect.width(), selrect.height());
+        let height = self.get_height(selrect.width());
+        self.size.set_size(selrect.width(), height);
 
         match self.grow_type() {
             GrowType::AutoHeight => {

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -317,7 +317,9 @@ pub extern "C" fn set_shape_grow_type(grow_type: u8) {
 #[no_mangle]
 pub extern "C" fn get_text_dimensions() -> *mut u8 {
     let mut ptr = std::ptr::null_mut();
+    println!("@@@ get_text_dimensions called");
     with_current_shape_mut!(state, |shape: &mut Shape| {
+        shape.invalidate_extrect();
         if let Type::Text(content) = &mut shape.shape_type {
             let text_content_size = content.update_layout(shape.selrect);
 
@@ -337,6 +339,7 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
 #[no_mangle]
 pub extern "C" fn update_shape_text_layout() {
     with_current_shape_mut!(state, |shape: &mut Shape| {
+        shape.invalidate_extrect();
         if let Type::Text(text_content) = &mut shape.shape_type {
             text_content.update_layout(shape.selrect);
         }

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -317,10 +317,9 @@ pub extern "C" fn set_shape_grow_type(grow_type: u8) {
 #[no_mangle]
 pub extern "C" fn get_text_dimensions() -> *mut u8 {
     let mut ptr = std::ptr::null_mut();
-    println!("@@@ get_text_dimensions called");
     with_current_shape_mut!(state, |shape: &mut Shape| {
-        shape.invalidate_extrect();
         if let Type::Text(content) = &mut shape.shape_type {
+            // FIXME: can we use content.size here?
             let text_content_size = content.update_layout(shape.selrect);
 
             let mut bytes = vec![0; 12];


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12292

### Summary

This is a follow-up of this PR https://github.com/penpot/penpot/pull/7490, if fixes extrect calculation on text resize. There's still a corner case when there are rotations, as it does not get the text dimensions properly **while dragging**, we'll investigate that separately

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
