### PR TITLE
:sparkles: Display resolved value for composite typography tokens

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
@@ -8,6 +8,8 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data :as d]
+   [app.main.data.workspace.tokens.format :refer [category-dictionary
+                                                  format-token-value]]
    [app.main.ui.ds.tooltip :refer [tooltip*]]
    [app.main.ui.inspect.styles.property-detail-copiable :refer [property-detail-copiable*]]
    [app.util.i18n :refer [tr]]
@@ -35,6 +37,7 @@
         copiable-value (if (some? token)
                          (:name token)
                          property)
+
         copy-attr
         (mf/use-fn
          (mf/deps copied)
@@ -52,7 +55,11 @@
                         :content #(mf/html
                                    [:div {:class (stl/css :tooltip-token)}
                                     [:div {:class (stl/css :tooltip-token-title)} (tr "inspect.tabs.styles.token.resolved-value")]
-                                    [:div {:class (stl/css :tooltip-token-value)} (if (= :typography (:type token)) (:name token) (:resolved-value token))]])}
+                                    [:div {:class (stl/css :tooltip-token-value)} (if (= :typography (:type token))
+                                                                                    [:ul {:class (stl/css :tooltip-token-resolved-values)}
+                                                                                     (for [[property value] (:resolved-value token)]
+                                                                                       [:li (str (category-dictionary property) ": " (format-token-value value))])]
+                                                                                    (:resolved-value token))]])}
            [:> property-detail-copiable* {:token token
                                           :copied copied
                                           :on-click copy-attr} detail]]

--- a/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
@@ -58,7 +58,7 @@
                                     [:div {:class (stl/css :tooltip-token-value)} (if (= :typography (:type token))
                                                                                     [:ul {:class (stl/css :tooltip-token-resolved-values)}
                                                                                      (for [[property value] (:resolved-value token)]
-                                                                                       [:li (str (category-dictionary property) ": " (format-token-value value))])]
+                                                                                       [:li {:key property} (str (category-dictionary property) ": " (format-token-value value))])]
                                                                                     (:resolved-value token))]])}
            [:> property-detail-copiable* {:token token
                                           :copied copied

--- a/frontend/src/app/main/ui/inspect/styles/rows/properties_row.scss
+++ b/frontend/src/app/main/ui/inspect/styles/rows/properties_row.scss
@@ -53,6 +53,12 @@
   color: var(--title-value);
 }
 
+.tooltip-token-resolved-values {
+  padding: var(--sp-xs) 0 var(--sp-xs) var(--sp-m);
+  margin: 0;
+  list-style-type: disc;
+}
+
 .tooltip-token-wrapper {
   inline-size: 100%;
 }


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/12281

### Summary

This PR displays the resolved value of a composite typography token in the `inspect` tab.

### Steps to reproduce 


> [!WARNING]
> Requires the `enable-inspect-styles` flag activated 

- Create a composite token
- Open the inspect `styles` tab
- Hover typography property to display the tooltip
- Ensure that the resolved value is displayed
- 
<img width="320" height="244" alt="Screenshot from 2025-10-17 14-05-27" src="https://github.com/user-attachments/assets/82bea437-5660-437f-b69b-94436a44b83f" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
