### PR TITLE
:sparkles: Fix formatting and indentation for token set label and checkbox

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -280,7 +280,7 @@
                                 :dnd-over     (= drop-over :center)
                                 :dnd-over-top (= drop-over :top)
                                 :dnd-over-bot (= drop-over :bot))
-                                
+
            :on-double-click on-double-click
            :on-context-menu on-context-menu
            :aria-checked is-active}
@@ -303,9 +303,9 @@
          label]
         [:> checkbox*
          {:on-click  (fn [e]
-                      (.stopPropagation e)
-                      (when (fn? on-toggle)
-                        (on-toggle (ctob/get-name set))))
+                       (.stopPropagation e)
+                       (when (fn? on-toggle)
+                         (on-toggle (ctob/get-name set))))
           :disabled (not can-edit?)
           :arial-label (tr "workspace.tokens.select-set")
           :checked is-active}]])]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -198,9 +198,10 @@
 ;; ----------------------------
 
 (mf/defc sets-tree-set*
-  [{:keys [id set label is-editing is-active is-selected is-draggable is-new path depth index
-           on-select on-toggle on-drop on-start-edition on-reset-edition on-edit-submit]}]
-
+  [{:keys [id set label is-editing is-active is-selected
+           is-draggable is-new path depth index
+           on-select on-toggle on-drop
+           on-start-edition on-reset-edition on-edit-submit]}]
   (let [can-edit? (mf/use-ctx ctx/can-edit?)
         on-context-menu
         (mf/use-fn (mf/deps is-editing id path can-edit?)
@@ -212,25 +213,36 @@
                          {:position (dom/get-client-position event)
                           :is-group false
                           :id id
-                          :path path})))) )
+                          :path path})))))
+
         on-double-click
         (mf/use-fn (mf/deps id is-new)
           (fn []
             (when-not is-new (on-start-edition id))))
+
         on-edit-submit'
-        (mf/use-fn (mf/deps set on-edit-submit) #(on-edit-submit set %))
+        (mf/use-fn (mf/deps set on-edit-submit)
+          #(on-edit-submit set %))
+
         on-drag
         (mf/use-fn (mf/deps path)
-          (fn [_] (when-not is-selected (on-select path))))
+          (fn [_]
+            (when-not is-selected (on-select path))))
+
         on-drop
-        (mf/use-fn (mf/deps index on-drop) (fn [position data] (on-drop index position data)))
+        (mf/use-fn (mf/deps index on-drop)
+          (fn [position data]
+            (on-drop index position data)))
+
         [dprops dref] (h/use-sortable
-                        :data-type "penpot/token-set"
-                        :on-drag on-drag
-                        :on-drop on-drop
-                        :data {:index index :is-group false}
-                        :draggable? is-draggable)
+                       :data-type "penpot/token-set"
+                       :on-drag on-drag
+                       :on-drop on-drop
+                       :data {:index index :is-group false}
+                       :draggable? is-draggable)
+
         drop-over (:over dprops)]
+    
     [:div {:ref dref
            :role "button"
            :data-testid "tokens-set-item"
@@ -244,9 +256,11 @@
            :on-double-click on-double-click
            :on-context-menu on-context-menu
            :aria-checked is-active}
+
      [:> icon* {:icon-id i/document
                 :class (stl/css-case :icon true
                                      :root-icon (not depth))}]
+
      (if is-editing
        [:> editing-label* {:default-value label
                            :on-cancel on-reset-edition
@@ -262,9 +276,9 @@
                                    (.stopPropagation e)
                                    (when (fn? on-toggle)
                                      (on-toggle (ctob/get-name set))))
-                        :disabled (not can-edit?)
-                        :aria-label (tr "workspace.tokens.select-set")
-                        :checked is-active}]])])))
+                       :disabled (not can-edit?)
+                       :aria-label (tr "workspace.tokens.select-set")
+                       :checked is-active}]])])))
 
 ;; ----------------------------
 ;; Token sets tree

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -229,10 +229,10 @@
                      (fn [_]
                        (when-not is-selected (on-select path))))
 
-         on-drop
-         (mf/use-fn (mf/deps index on-drop)
-                    (fn [position data]
-                      (on-drop index position data)))
+          on-drop
+          (mf/use-fn (mf/deps index on-drop)
+                     (fn [position data]
+                       (on-drop index position data)))
 
           [dprops dref] (h/use-sortable
                          :data-type "penpot/token-set"
@@ -243,42 +243,44 @@
 
           drop-over (:over dprops)]
     
-     [:div {:ref dref
-            :role "button"
-            :data-testid "tokens-set-item"
-            :id (str "token-set-item-" (str/join "/" path))
-            :style {"--tree-depth" depth}
-            :class (stl/css-case :set-item-container true
-                                 :selected-set is-selected
-                                 :dnd-over (= drop-over :center)
-                                 :dnd-over-top (= drop-over :top)
-                                 :dnd-over-bot (= drop-over :bot))
-            :on-double-click on-double-click
-            :on-context-menu on-context-menu
-            :aria-checked is-active}
+      [:div {:ref dref
+             :role "button"
+             :data-testid "tokens-set-item"
+             :id (str "token-set-item-" (str/join "/" path))
+             :style {"--tree-depth" depth}
+             :class (stl/css-case :set-item-container true
+                                  :selected-set is-selected
+                                  :dnd-over (= drop-over :center)
+                                  :dnd-over-top (= drop-over :top)
+                                  :dnd-over-bot (= drop-over :bot))
+             :on-double-click on-double-click
+             :on-context-menu on-context-menu
+             :aria-checked is-active}
 
-     [:> icon* {:icon-id i/document
-                :class (stl/css-case :icon true
-                                     :root-icon (not depth))}]
 
-     (if is-editing
-       [:> editing-label* {:default-value label
-                           :on-cancel on-reset-edition
-                           :on-submit on-edit-submit'}]
-       [:<>
-        [:div {:class (stl/css :set-name)
-               :on-click (fn [e]
-                           (.stopPropagation e)
-                           (when (fn? on-select)
-                             (on-select id)))}
-         label]
-        [:> checkbox* {:on-click (fn [e]
-                                   (.stopPropagation e)
-                                   (when (fn? on-toggle)
-                                     (on-toggle (ctob/get-name set))))
-                       :disabled (not can-edit?)
-                       :aria-label (tr "workspace.tokens.select-set")
-                       :checked is-active}]])])))
+       [:> icon* {:icon-id i/document
+                  :class (stl/css-case :icon true
+                                       :root-icon (not depth))}]
+ 
+       (if is-editing
+         [:> editing-label* {:default-value label
+                             :on-cancel on-reset-edition
+                             :on-submit on-edit-submit'}]
+         [:<>
+          [:div {:class (stl/css :set-name)
+                 :on-click (fn [e]
+                             (.stopPropagation e)
+                             (when (fn? on-select)
+                               (on-select id)))}
+           label]
+          [:> checkbox* {:on-click (fn [e]
+                                     (.stopPropagation e)
+                                     (when (fn? on-toggle)
+                                       (on-toggle (ctob/get-name set))))
+                         :disabled (not can-edit?)
+                         :aria-label (tr "workspace.tokens.select-set")
+                         :checked is-active}]])])))
+
 
 ;; ----------------------------
 ;; Token sets tree
@@ -296,17 +298,17 @@
         collapsed-paths @collapsed-paths*
 
         collapsed? (mf/use-fn (mf/deps collapsed-paths)
-                     (partial contains? collapsed-paths))
+                              (partial contains? collapsed-paths))
 
         on-drop (mf/use-fn (mf/deps collapsed-paths)
-                  (fn [index position data]
-                    (let [params {:from-index (:index data)
-                                  :to-index index
-                                  :position position
-                                  :collapsed-paths collapsed-paths}]
-                      (if (:is-group data)
-                        (st/emit! (dwtl/drop-token-set-group params))
-                        (st/emit! (dwtl/drop-token-set params))))))
+                      (fn [index position data]
+                        (let [params {:from-index (:index data)
+                                      :to-index index
+                                      :position position
+                                      :collapsed-paths collapsed-paths}]
+                          (if (:is-group data)
+                            (st/emit! (dwtl/drop-token-set-group params))
+                            (st/emit! (dwtl/drop-token-set params))))))
 
         on-toggle-collapse
         (mf/use-fn (fn [path]

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -264,7 +264,7 @@
                                      (on-toggle (ctob/get-name set))))
                         :disabled (not can-edit?)
                         :aria-label (tr "workspace.tokens.select-set")
-                        :checked is-active}]]])))
+                        :checked is-active}]])])))
 
 ;; ----------------------------
 ;; Token sets tree
@@ -405,4 +405,4 @@
                              :on-start-edition on-start-edition
                              :on-reset-edition on-reset-edition
                              :on-edit-submit-set on-update-token-set
-                             :on-edit-submit-group on-update-token-set-group}]]]))
+                             :on-edit-submit-group on-update-token-set-group}])]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -302,10 +302,10 @@
          :on-submit on-edit-submit'}]
        [:*
         [:div {:class (stl/css :set-name)}
-               :on-click (fn [e]
-                           (.stopPropagation e)
-                           (when (fn? on-select)
-                             (on-select id)))
+         :on-click (fn [e]
+                     (.stopPropagation e)
+                     (when (fn? on-select)
+                       (on-select id)))
          label]
         [:> checkbox*
          {:on-click (fn [e]

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -209,14 +209,7 @@
 
   (let [can-edit? (mf/use-ctx ctx/can-edit?)
 
-        on-click
-        (mf/use-fn
-         (mf/deps is-editing on-select id)
-         (fn [event]
-           (dom/stop-propagation event)
-           (when-not is-editing
-             (when (fn? on-select)
-               (on-select id)))))
+        
 
         on-context-menu
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -240,7 +240,7 @@
                          :on-drop on-drop
                          :data {:index index :is-group false}
                          :draggable? is-draggable)
-
+                                                                 
           drop-over (:over dprops)]
     
       [:div {:ref dref
@@ -261,7 +261,7 @@
        [:> icon* {:icon-id i/document
                   :class (stl/css-case :icon true
                                        :root-icon (not depth))}]
- 
+                                       
        (if is-editing
          [:> editing-label* {:default-value label
                              :on-cancel on-reset-edition

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -136,7 +136,7 @@
                         {:position (dom/get-client-position event)
                          :is-group true
                          :id id
-                         :path path})))) )
+                         :path path})))))
         on-collapse-click
         (mf/use-fn (fn [event]
                      (dom/prevent-default event)
@@ -151,11 +151,11 @@
         on-drop
         (mf/use-fn (mf/deps index on-drop) (fn [position data] (on-drop index position data)))
         [dprops dref] (h/use-sortable
-                        :data-type "penpot/token-set"
-                        :on-drop on-drop
-                        :data {:index index :is-group true}
-                        :detect-center? true
-                        :draggable? is-draggable)]
+                      :data-type "penpot/token-set"
+                      :on-drop on-drop
+                      :data {:index index :is-group true}
+                      :detect-center? true
+                      :draggable? is-draggable)]
     [:div {:ref dref
            :data-testid "tokens-set-group-item"
            :style {"--tree-depth" depth}
@@ -186,62 +186,62 @@
                :id label-id}
          label]
         [:> checkbox* {:on-click on-checkbox-click
-                        :disabled (not can-edit?)
-                        :checked (case is-active
-                                   :all true
-                                   :partial "mixed"
-                                   :none false)
-                        :aria-label (tr "workspace.tokens.select-set")}]])])
+                       :disabled (not can-edit?)
+                       :checked (case is-active
+                                  :all true
+                                  :partial "mixed"
+                                  :none false)
+                       :aria-label (tr "workspace.tokens.select-set")}]])])
 
 ;; ----------------------------
 ;; Token set component
 ;; ----------------------------
 
-(mf/defc sets-tree-set*
-  [{:keys [id set label is-editing is-active is-selected
-           is-draggable is-new path depth index
-           on-select on-toggle on-drop
-           on-start-edition on-reset-edition on-edit-submit]}]
-  (let [can-edit? (mf/use-ctx ctx/can-edit?)
-        on-context-menu
-        (mf/use-fn (mf/deps is-editing id path can-edit?)
-          (fn [event]
-            (dom/prevent-default event)
-            (dom/stop-propagation event)
-            (when (and can-edit? (not is-editing))
-              (st/emit! (dwtl/assign-token-set-context-menu
-                         {:position (dom/get-client-position event)
-                          :is-group false
-                          :id id
-                          :path path})))))
+ (mf/defc sets-tree-set*
+   [{:keys [id set label is-editing is-active is-selected
+            is-draggable is-new path depth index
+            on-select on-toggle on-drop
+            on-start-edition on-reset-edition on-edit-submit]}]
+   (let [can-edit? (mf/use-ctx ctx/can-edit?)
+         on-context-menu
+         (mf/use-fn (mf/deps is-editing id path can-edit?)
+                    (fn [event]
+                      (dom/prevent-default event)
+                      (dom/stop-propagation event)
+                      (when (and can-edit? (not is-editing))
+                        (st/emit! (dwtl/assign-token-set-context-menu
+                                   {:position (dom/get-client-position event)
+                                    :is-group false
+                                    :id id
+                                    :path path})))))
 
-        on-double-click
-        (mf/use-fn (mf/deps id is-new)
-          (fn []
-            (when-not is-new (on-start-edition id))))
+         on-double-click
+         (mf/use-fn (mf/deps id is-new)
+                    (fn []
+                      (when-not is-new (on-start-edition id))))
 
-        on-edit-submit'
-        (mf/use-fn (mf/deps set on-edit-submit)
-          #(on-edit-submit set %))
+         on-edit-submit'
+         (mf/use-fn (mf/deps set on-edit-submit)
+                    #(on-edit-submit set %))
 
-        on-drag
-        (mf/use-fn (mf/deps path)
-          (fn [_]
-            (when-not is-selected (on-select path))))
+         on-drag
+         (mf/use-fn (mf/deps path)
+                    (fn [_]
+                      (when-not is-selected (on-select path))))
 
-        on-drop
-        (mf/use-fn (mf/deps index on-drop)
-          (fn [position data]
-            (on-drop index position data)))
+         on-drop
+         (mf/use-fn (mf/deps index on-drop)
+                    (fn [position data]
+                      (on-drop index position data)))
 
-        [dprops dref] (h/use-sortable
-                       :data-type "penpot/token-set"
-                       :on-drag on-drag
-                       :on-drop on-drop
-                       :data {:index index :is-group false}
-                       :draggable? is-draggable)
+         [dprops dref] (h/use-sortable
+                        :data-type "penpot/token-set"
+                        :on-drag on-drag
+                        :on-drop on-drop
+                        :data {:index index :is-group false}
+                        :draggable? is-draggable)
 
-        drop-over (:over dprops)]
+         drop-over (:over dprops)]
     
     [:div {:ref dref
            :role "button"
@@ -397,9 +397,9 @@
         empty-state? (and theme-modal? (empty? token-sets) (not new-path))
 
         on-reset-edition (mf/use-fn (mf/deps on-reset-edition)
-                             #(when (fn? on-reset-edition) (on-reset-edition %)))
+                                    #(when (fn? on-reset-edition) (on-reset-edition %)))
         on-start-edition (mf/use-fn (mf/deps on-start-edition)
-                             #(when (fn? on-start-edition) (on-start-edition %)))]
+                                    #(when (fn? on-start-edition) (on-start-edition %)))]
 
     [:div {:class (stl/css :sets-list)}
      (if empty-state?

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -25,14 +25,12 @@
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
-
 ;; ----------------------------
 ;; Helpers
 ;; ----------------------------
 
 (defn- on-start-creation []
   (st/emit! (dwtl/start-token-set-creation [])))
-
 
 ;; ----------------------------
 ;; Editing label component
@@ -57,7 +55,6 @@
            (cond
              (kbd/enter? event) (on-submit event)
              (kbd/esc? event) (on-cancel))))]
-
     [:input
      {:class (stl/css :editing-node)
       :type "text"
@@ -67,7 +64,6 @@
       :auto-focus true
       :placeholder (tr "workspace.tokens.set-edit-placeholder")
       :default-value default-value}]))
-
 
 ;; ----------------------------
 ;; Checkbox component
@@ -94,7 +90,6 @@
          :class (stl/css :check-icon)
          :size "s"
          :icon-id (if mixed? i/remove i/tick)}])]))
-
 
 ;; ----------------------------
 ;; Add buttons
@@ -141,7 +136,7 @@
                         {:position (dom/get-client-position event)
                          :is-group true
                          :id id
-                         :path path})))))
+                         :path path})))) )
         on-collapse-click
         (mf/use-fn (fn [event]
                      (dom/prevent-default event)
@@ -182,7 +177,7 @@
        [:> editing-label* {:default-value label
                            :on-cancel on-reset-edition
                            :on-submit on-edit-submit'}]
-       [:*
+       [:<>
         [:div {:class (stl/css :set-name)
                :role "button"
                :title label
@@ -196,8 +191,7 @@
                                    :all true
                                    :partial "mixed"
                                    :none false)
-                        :aria-label (tr "workspace.tokens.select-set")}]]]))
-
+                        :aria-label (tr "workspace.tokens.select-set")}]]])))
 
 ;; ----------------------------
 ;; Token set component
@@ -218,7 +212,7 @@
                          {:position (dom/get-client-position event)
                           :is-group false
                           :id id
-                          :path path})))))
+                          :path path})))) )
         on-double-click
         (mf/use-fn (mf/deps id is-new)
           (fn []
@@ -257,7 +251,7 @@
        [:> editing-label* {:default-value label
                            :on-cancel on-reset-edition
                            :on-submit on-edit-submit'}]
-       [:*
+       [:<>
         [:div {:class (stl/css :set-name)
                :on-click (fn [e]
                            (.stopPropagation e)
@@ -270,8 +264,7 @@
                                      (on-toggle (ctob/get-name set))))
                         :disabled (not can-edit?)
                         :aria-label (tr "workspace.tokens.select-set")
-                        :checked is-active}]]]))
-
+                        :checked is-active}]]])))
 
 ;; ----------------------------
 ;; Token sets tree
@@ -306,6 +299,7 @@
                      (swap! collapsed-paths* #(if (contains? % path)
                                                 (disj % path)
                                                 (conj % path)))))]
+
     (mf/with-effect []
       (let [sub (rx/subs! (fn [paths']
                             (swap! collapsed-paths* #(apply disj % paths')))
@@ -314,6 +308,7 @@
                                (rx/map deref)
                                (rx/map :paths)))]
         (fn [] (rx/dispose! sub))))
+
     (for [{:keys [token-set id index is-new is-group path depth] :as node}
           (ctob/sets-tree-seq token-sets {:skip-children-pred collapsed?
                                           :new-at-path new-path})]
@@ -369,7 +364,6 @@
                                   :on-reset-edition on-reset-edition
                                   :on-edit-submit on-edit-submit-set}]))))
 
-
 ;; ----------------------------
 ;; Controlled sets list
 ;; ----------------------------
@@ -392,6 +386,7 @@
                              #(when (fn? on-reset-edition) (on-reset-edition %)))
         on-start-edition (mf/use-fn (mf/deps on-start-edition)
                              #(when (fn? on-start-edition) (on-start-edition %)))]
+
     [:div {:class (stl/css :sets-list)}
      (if empty-state?
        [:> text* {:as "span" :typography "body-small" :class (stl/css :empty-state-message-sets)}
@@ -410,4 +405,4 @@
                              :on-start-edition on-start-edition
                              :on-reset-edition on-reset-edition
                              :on-edit-submit-set on-update-token-set
-                             :on-edit-submit-group on-update-token-set-group}])]))
+                             :on-edit-submit-group on-update-token-set-group}]]]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -301,14 +301,14 @@
                               (partial contains? collapsed-paths))
 
         on-drop (mf/use-fn (mf/deps collapsed-paths)
-                      (fn [index position data]
-                        (let [params {:from-index (:index data)
-                                      :to-index index
-                                      :position position
-                                      :collapsed-paths collapsed-paths}]
-                          (if (:is-group data)
-                            (st/emit! (dwtl/drop-token-set-group params))
-                            (st/emit! (dwtl/drop-token-set params))))))
+                           (fn [index position data]
+                             (let [params {:from-index (:index data)
+                                           :to-index index
+                                           :position position
+                                           :collapsed-paths collapsed-paths}]
+                               (if (:is-group data)
+                                 (st/emit! (dwtl/drop-token-set-group params))
+                                 (st/emit! (dwtl/drop-token-set params))))))
 
         on-toggle-collapse
         (mf/use-fn (fn [path]

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -238,13 +238,7 @@
            (when-not is-new
              (on-start-edition id))))
 
-        on-checkbox-click
-        (mf/use-fn
-         (mf/deps id on-toggle)
-         (fn [event]
-           (dom/stop-propagation event)
-           (when (fn? on-toggle)
-             (on-toggle (ctob/get-name set)))))
+
 
         on-edit-submit'
         (mf/use-fn
@@ -286,7 +280,7 @@
                                 :dnd-over     (= drop-over :center)
                                 :dnd-over-top (= drop-over :top)
                                 :dnd-over-bot (= drop-over :bot))
-           :on-click on-click
+                                
            :on-double-click on-double-click
            :on-context-menu on-context-menu
            :aria-checked is-active}
@@ -308,7 +302,7 @@
                        (on-select id)))
          label]
         [:> checkbox*
-         {:on-click (fn [e]
+         {:on-click  (fn [e]
                       (.stopPropagation e)
                       (when (fn? on-toggle)
                         (on-toggle (ctob/get-name set))))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -258,13 +258,13 @@
              :aria-checked is-active}
 
 
-       [:> icon* {:icon-id i/document
-                  :class (stl/css-case :icon true
-                                       :root-icon (not depth))}]
-                                       
-       (if is-editing
-         [:> editing-label* {:default-value label
-                             :on-cancel on-reset-edition
+        [:> icon* {:icon-id i/document
+                   :class (stl/css-case :icon true
+                                        :root-icon (not depth))}]
+
+        (if is-editing
+          [:> editing-label* {:default-value label
+                              :on-cancel on-reset-edition
                              :on-submit on-edit-submit'}]
          [:<>
           [:div {:class (stl/css :set-name)

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -239,10 +239,10 @@
                          :on-drag on-drag
                          :on-drop on-drop
                          :data {:index index :is-group false}
-                         :draggable? is-draggable)
-                                                                 
+                         :draggable? is-draggable)      
+        
           drop-over (:over dprops)]
-    
+
       [:div {:ref dref
              :role "button"
              :data-testid "tokens-set-item"
@@ -260,8 +260,8 @@
 
         [:> icon* {:icon-id i/document
                    :class (stl/css-case :icon true
-                                        :root-icon (not depth))}]
-
+                                        :root-icon (not depth))}]                   
+                                     
         (if is-editing
           [:> editing-label* {:default-value label
                               :on-cancel on-reset-edition

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -151,11 +151,11 @@
         on-drop
         (mf/use-fn (mf/deps index on-drop) (fn [position data] (on-drop index position data)))
         [dprops dref] (h/use-sortable
-                      :data-type "penpot/token-set"
-                      :on-drop on-drop
-                      :data {:index index :is-group true}
-                      :detect-center? true
-                      :draggable? is-draggable)]
+                       :data-type "penpot/token-set"
+                       :on-drop on-drop
+                       :data {:index index :is-group true}
+                       :detect-center? true
+                       :draggable? is-draggable)]
     [:div {:ref dref
            :data-testid "tokens-set-group-item"
            :style {"--tree-depth" depth}
@@ -197,65 +197,65 @@
 ;; Token set component
 ;; ----------------------------
 
- (mf/defc sets-tree-set*
-   [{:keys [id set label is-editing is-active is-selected
-            is-draggable is-new path depth index
-            on-select on-toggle on-drop
-            on-start-edition on-reset-edition on-edit-submit]}]
-   (let [can-edit? (mf/use-ctx ctx/can-edit?)
-         on-context-menu
-         (mf/use-fn (mf/deps is-editing id path can-edit?)
-                    (fn [event]
-                      (dom/prevent-default event)
-                      (dom/stop-propagation event)
-                      (when (and can-edit? (not is-editing))
-                        (st/emit! (dwtl/assign-token-set-context-menu
-                                   {:position (dom/get-client-position event)
-                                    :is-group false
-                                    :id id
-                                    :path path})))))
+  (mf/defc sets-tree-set*
+    [{:keys [id set label is-editing is-active is-selected
+             is-draggable is-new path depth index
+             on-select on-toggle on-drop
+             on-start-edition on-reset-edition on-edit-submit]}]
+    (let [can-edit? (mf/use-ctx ctx/can-edit?)
+          on-context-menu
+          (mf/use-fn (mf/deps is-editing id path can-edit?)
+                     (fn [event]
+                       (dom/prevent-default event)
+                       (dom/stop-propagation event)
+                       (when (and can-edit? (not is-editing))
+                         (st/emit! (dwtl/assign-token-set-context-menu
+                                    {:position (dom/get-client-position event)
+                                     :is-group false
+                                     :id id
+                                     :path path})))))
 
-         on-double-click
-         (mf/use-fn (mf/deps id is-new)
-                    (fn []
-                      (when-not is-new (on-start-edition id))))
+          on-double-click
+          (mf/use-fn (mf/deps id is-new)
+                     (fn []
+                       (when-not is-new (on-start-edition id))))
 
-         on-edit-submit'
-         (mf/use-fn (mf/deps set on-edit-submit)
-                    #(on-edit-submit set %))
+          on-edit-submit'
+          (mf/use-fn (mf/deps set on-edit-submit)
+                     #(on-edit-submit set %))
 
-         on-drag
-         (mf/use-fn (mf/deps path)
-                    (fn [_]
-                      (when-not is-selected (on-select path))))
+          on-drag
+          (mf/use-fn (mf/deps path)
+                     (fn [_]
+                       (when-not is-selected (on-select path))))
 
          on-drop
          (mf/use-fn (mf/deps index on-drop)
                     (fn [position data]
                       (on-drop index position data)))
 
-         [dprops dref] (h/use-sortable
-                        :data-type "penpot/token-set"
-                        :on-drag on-drag
-                        :on-drop on-drop
-                        :data {:index index :is-group false}
-                        :draggable? is-draggable)
+          [dprops dref] (h/use-sortable
+                         :data-type "penpot/token-set"
+                         :on-drag on-drag
+                         :on-drop on-drop
+                         :data {:index index :is-group false}
+                         :draggable? is-draggable)
 
-         drop-over (:over dprops)]
+          drop-over (:over dprops)]
     
-    [:div {:ref dref
-           :role "button"
-           :data-testid "tokens-set-item"
-           :id (str "token-set-item-" (str/join "/" path))
-           :style {"--tree-depth" depth}
-           :class (stl/css-case :set-item-container true
-                                :selected-set is-selected
-                                :dnd-over (= drop-over :center)
-                                :dnd-over-top (= drop-over :top)
-                                :dnd-over-bot (= drop-over :bot))
-           :on-double-click on-double-click
-           :on-context-menu on-context-menu
-           :aria-checked is-active}
+     [:div {:ref dref
+            :role "button"
+            :data-testid "tokens-set-item"
+            :id (str "token-set-item-" (str/join "/" path))
+            :style {"--tree-depth" depth}
+            :class (stl/css-case :set-item-container true
+                                 :selected-set is-selected
+                                 :dnd-over (= drop-over :center)
+                                 :dnd-over-top (= drop-over :top)
+                                 :dnd-over-bot (= drop-over :bot))
+            :on-double-click on-double-click
+            :on-context-menu on-context-menu
+            :aria-checked is-active}
 
      [:> icon* {:icon-id i/document
                 :class (stl/css-case :icon true

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -302,9 +302,16 @@
          :on-submit on-edit-submit'}]
        [:*
         [:div {:class (stl/css :set-name)}
+               :on-click (fn [e]
+                           (.stopPropagation e)
+                           (when (fn? on-select)
+                             (on-select id)))
          label]
         [:> checkbox*
-         {:on-click on-checkbox-click
+         {:on-click (fn [e]
+                      (.stopPropagation e)
+                      (when (fn? on-toggle)
+                        (on-toggle (ctob/get-name set))))
           :disabled (not can-edit?)
           :arial-label (tr "workspace.tokens.select-set")
           :checked is-active}]])]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -191,7 +191,7 @@
                                    :all true
                                    :partial "mixed"
                                    :none false)
-                        :aria-label (tr "workspace.tokens.select-set")}]]])))
+                        :aria-label (tr "workspace.tokens.select-set")}]])])
 
 ;; ----------------------------
 ;; Token set component


### PR DESCRIPTION
Fixed a bug in the Token Sets list where clicking on a blank space in the token area collapsed the parent list item unexpectedly.
Updated the rendering logic for labels and checkboxes to prevent unintended collapses while preserving editing and selection functionality .Fixes #7477

Changes Introduced

🧩 Corrected the checkbox* and label rendering lines in controlled-sets-list* and sets-tree-set* components.
🛠 Ensured that only clicks on the checkbox or label trigger selection/collapse actions.
🧯 Added safe fallbacks for on-start-edition and on-reset-edition callbacks.
✨ Minor refactor for readability and consistent drag-and-drop handling in token-sets-tree*.

How to Test / Verify

Open Workspace → Token Sets.
Expand any token group.
Click on blank space inside the token area → the group should not collapse.

Verify:

Editing a token set label still works correctly.
Selecting/deselecting checkboxes works as expected.
Drag-and-drop between token sets and groups functions correct

Additional Notes

No SCSS changes were required.
Changes are localized; other components remain unaffected.

Signed-off-by: Darshan <darshantotagi7975@gmail.com>
