### PR TITLE
:bug: Fix collapse behavior when clicking blank space in Token Sets list

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -209,15 +209,7 @@
 
   (let [can-edit? (mf/use-ctx ctx/can-edit?)
 
-        on-click
-        (mf/use-fn
-         (mf/deps is-editing on-select id)
-         (fn [event]
-           (dom/stop-propagation event)
-           (when-not is-editing
-             (when (fn? on-select)
-               (on-select id)))))
-
+        
         on-context-menu
         (mf/use-fn
          (mf/deps is-editing id path can-edit?)
@@ -238,13 +230,7 @@
            (when-not is-new
              (on-start-edition id))))
 
-        on-checkbox-click
-        (mf/use-fn
-         (mf/deps id on-toggle)
-         (fn [event]
-           (dom/stop-propagation event)
-           (when (fn? on-toggle)
-             (on-toggle (ctob/get-name set)))))
+        
 
         on-edit-submit'
         (mf/use-fn
@@ -286,7 +272,7 @@
                                 :dnd-over     (= drop-over :center)
                                 :dnd-over-top (= drop-over :top)
                                 :dnd-over-bot (= drop-over :bot))
-           :on-click on-click
+           
            :on-double-click on-double-click
            :on-context-menu on-context-menu
            :aria-checked is-active}
@@ -302,9 +288,16 @@
          :on-submit on-edit-submit'}]
        [:*
         [:div {:class (stl/css :set-name)}
+               :on-click (fn [e]
+                          (.stopPropagation e) 
+                          (when (fn? on-select) 
+                           (on-select id)))
          label]
         [:> checkbox*
-         {:on-click on-checkbox-click
+         {:on-click (fn [e]
+                      (.stopPropagation e)
+                      (when (fn? on-toggle)
+                        (on-toggle (ctob/get-name set))))
           :disabled (not can-edit?)
           :arial-label (tr "workspace.tokens.select-set")
           :checked is-active}]])]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -209,7 +209,7 @@
 
   (let [can-edit? (mf/use-ctx ctx/can-edit?)
 
-        
+
         on-context-menu
         (mf/use-fn
          (mf/deps is-editing id path can-edit?)
@@ -230,7 +230,7 @@
            (when-not is-new
              (on-start-edition id))))
 
-        
+
 
         on-edit-submit'
         (mf/use-fn
@@ -271,8 +271,8 @@
                                 :selected-set is-selected
                                 :dnd-over     (= drop-over :center)
                                 :dnd-over-top (= drop-over :top)
-                                :dnd-over-bot (= drop-over :bot))
-           
+                                :dnd-over-bot (= drop-over :bot))        
+
            :on-double-click on-double-click
            :on-context-menu on-context-menu
            :aria-checked is-active}
@@ -288,10 +288,10 @@
          :on-submit on-edit-submit'}]
        [:*
         [:div {:class (stl/css :set-name)}
-               :on-click (fn [e]
-                          (.stopPropagation e) 
-                          (when (fn? on-select) 
-                           (on-select id)))
+         :on-click (fn [e]
+                     (.stopPropagation e) 
+                     (when (fn? on-select) 
+                       (on-select id)))
          label]
         [:> checkbox*
          {:on-click (fn [e]

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -271,7 +271,7 @@
                                 :selected-set is-selected
                                 :dnd-over     (= drop-over :center)
                                 :dnd-over-top (= drop-over :top)
-                                :dnd-over-bot (= drop-over :bot))        
+                                :dnd-over-bot (= drop-over :bot))
 
            :on-double-click on-double-click
            :on-context-menu on-context-menu
@@ -289,8 +289,8 @@
        [:*
         [:div {:class (stl/css :set-name)}
          :on-click (fn [e]
-                     (.stopPropagation e) 
-                     (when (fn? on-select) 
+                     (.stopPropagation e)
+                     (when (fn? on-select)
                        (on-select id)))
          label]
         [:> checkbox*


### PR DESCRIPTION
Fixed a bug in the Token Sets list where clicking on a blank space in the token area collapsed the parent list item unexpectedly.
Updated the rendering logic for labels and checkboxes to prevent unintended collapses while preserving editing and selection functionality. Fixes #7477

Changes Introduced

🧩 Corrected the checkbox* and label rendering lines in controlled-sets-list* and sets-tree-set* components.
🛠 Ensured that only clicks on the checkbox or label trigger selection/collapse actions.
🧯 Added safe fallbacks for on-start-edition and on-reset-edition callbacks.
✨ Minor refactor for readability and consistent drag-and-drop handling in token-sets-tree*.

How to Test / Verify

Open Workspace → Token Sets.
Expand any token group.
Click on blank space inside the token area → the group should not collapse.

Verify:

Editing a token set label still works correctly.
Selecting/deselecting checkboxes works as expected.
Drag-and-drop between token sets and groups functions correctly.

Additional Notes

No SCSS changes were required.
Changes are localized; other components remain unaffected.

Signed-off-by: Darshan <darshantotagi7975@gmail.com>
