### PR TITLE
:bug: Fix property input remains editable after keeping default property name

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -28,11 +28,7 @@
               (pcb/update-component
                changes (:id component)
                (fn [component]
-                 (d/update-in-when component [:variant-properties pos]
-                                   (fn [property]
-                                     (-> property
-                                         (assoc :name new-name)
-                                         (with-meta nil)))))
+                 (d/update-in-when component [:variant-properties pos] #(assoc % :name new-name)))
                {:apply-changes-local-library? true}))
             changes
             related-components)))

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -105,10 +105,8 @@
     ptk/UpdateEvent
     (update [_ state]
       (let [file-id (:current-file-id state)
-            page-id (:current-page-id state)
             data    (dsh/lookup-file-data state)
-            objects (-> (dsh/get-page data page-id)
-                        (get :objects))
+            objects (dsh/lookup-page-objects state)
 
             related-components    (cfv/find-variant-components data objects variant-id)]
 


### PR DESCRIPTION
### Related Ticket

Taiga [#12282](https://tree.taiga.io/project/penpot/issue/12282)

### Summary

When a variant property is added and its name is not modified, the input remains focused even after interaction with other elements.

This is because the `generate-update-property-name` function, which is responsible for this, is not executed when the name is not modified, in order to avoid adding an unnecessary change to the history and calling the backend.

The solution is to manage this with an `UpdateEvent`, which always runs.

### Steps to reproduce 

Check that the property name input loses its focus when clicking outside, regardless of whether the name has been modified.