### PR TITLE
:bug: Fix nested variant in a component doesn't keep inherited overrides (2)

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1992,6 +1992,9 @@
                ;; If the values are already equal, don't copy them
                (= (get previous-shape attr) (get current-shape attr))
 
+               ;; If the value is the same as the origin, don't copy it
+               (= (get previous-shape attr) (get origin-ref-shape attr))
+
                ;; If both variants (origin and destiny) don't have the same value
                ;; for that attribute, don't copy it.
                ;; Exceptions: :points :selrect and :content can be different
@@ -2007,10 +2010,7 @@
                 (not= (get origin-ref-shape attr) (get current-shape attr)))
 
                ;; The :content attr cant't be copied to elements of different type
-               (and (= attr :content) (not= (:type previous-shape) (:type current-shape)))
-
-               ;; If the attr is not touched, don't copy it
-               (not (touched attr-group)))
+               (and (= attr :content) (not= (:type previous-shape) (:type current-shape))))
 
               ;; On texts, both text (the actual letters)
               ;; and attrs (bold, font, etc) are in the same attr :content.

--- a/common/src/app/common/logic/variants.cljc
+++ b/common/src/app/common/logic/variants.cljc
@@ -11,8 +11,7 @@
    [app.common.types.container :as ctn]
    [app.common.types.file :as ctf]
    [app.common.types.variant :as ctv]
-   [app.common.uuid :as uuid]
-   [clojure.set :as set]))
+   [app.common.uuid :as uuid]))
 
 (defn generate-add-new-variant
   [changes shape variant-id new-component-id new-shape-id prop-num]
@@ -131,34 +130,13 @@
 
         ref-shape-container   (when ref-shape (:container (meta ref-shape)))
         ref-shape-parents-set (when ref-shape
-                                (->> (cfh/get-parents (:objects ref-shape-container) (:id ref-shape))
+                                (->> (cfh/get-parents-with-self (:objects ref-shape-container) (:id ref-shape))
                                      (into #{} d/xf:map-id)))]
 
     (if (or (nil? ref-shape) (contains? ref-shape-parents-set parent-id))
       ref-shape
       (find-shape-ref-child-of ref-shape-container libraries ref-shape parent-id))))
 
-(defn- get-ref-chain
-  "Returns a vector with the shape ref chain including itself"
-  [container libraries shape]
-  (loop [chain [shape]
-         current shape]
-    (if-let [ref (ctf/find-ref-shape nil container libraries current :with-context? true)]
-      (recur (conj chain ref) ref)
-      chain)))
-
-(defn- add-touched-from-ref-chain
-  "Adds to the :touched attr of a shape the content of
-   the :touched of all its chain of ref shapes"
-  [container libraries shape]
-  (let [chain (get-ref-chain container libraries shape)
-        more-touched (->> chain
-                          (map :touched)
-                          (remove nil?)
-                          (apply set/union)
-                          (remove ctk/swap-slot?)
-                          set)]
-    (update shape :touched #(set/union (or % #{}) more-touched))))
 
 (defn generate-keep-touched
   "This is used as part of the switch process, when you switch from
@@ -179,9 +157,6 @@
         ;; they will be moved without change when
         ;; managing their swapped ancestor
         orig-touched       (->> original-shapes
-                                ;; Add to each shape also the touched of its ref chain
-                                (map #(add-touched-from-ref-chain container libraries %))
-                                (filter (comp seq :touched))
                                 (remove
                                  #(child-of-swapped? %
                                                      page-objects
@@ -198,15 +173,15 @@
 
         ;; The original-shape is in a copy. For the relation rules, we need the referenced
         ;; shape on the main component
-        orig-ref-shape     (ctf/find-remote-shape container libraries original-shape {:with-context? true})
-        orig-ref-objects   (:objects (:container (meta orig-ref-shape)))
+        orig-base-ref-shape (ctf/find-remote-shape container libraries original-shape {:with-context? true})
+        orig-ref-objects   (:objects (:container (meta orig-base-ref-shape)))
 
         ;; Adds a :shape-path attribute to the children of the orig-ref-shape,
         ;; that contains the type of its ancestors and its name
         o-ref-shapes-wp    (add-unique-path
-                            (reverse (cfh/get-children-with-self orig-ref-objects (:id orig-ref-shape)))
+                            (reverse (cfh/get-children-with-self orig-ref-objects (:id orig-base-ref-shape)))
                             orig-ref-objects
-                            (:id orig-ref-shape))
+                            (:id orig-base-ref-shape))
 
         ;; Creates a map to quickly find a child of the orig-ref-shape by its shape-path
         o-ref-shapes-p-map  (into {} (map (juxt :id :shape-path)) o-ref-shapes-wp)
@@ -221,7 +196,7 @@
                  ;; orig-child-touched is in a copy. Get the referenced shape on the main component
                  ;; If there is a swap slot, we will get the referenced shape in another way
                  orig-ref-shape (when-not swap-slot
-                                  (find-shape-ref-child-of container libraries orig-child-touched (:id orig-ref-shape)))
+                                  (find-shape-ref-child-of container libraries orig-child-touched (:id orig-base-ref-shape)))
 
                  orig-ref-id    (if swap-slot
                                   ;; If there is a swap slot, find the referenced shape id
@@ -231,6 +206,7 @@
 
                  ;; Get the shape path of the referenced main
                  shape-path     (get o-ref-shapes-p-map orig-ref-id)
+
                  ;; Get its related shape in the children of new-shape: the one that
                  ;; has the same shape-path
                  related-shape-in-new  (get new-shapes-map shape-path)

--- a/common/src/app/common/test_helpers/variants.cljc
+++ b/common/src/app/common/test_helpers/variants.cljc
@@ -14,13 +14,14 @@
 
 (defn add-variant
   [file variant-label component1-label root1-label component2-label root2-label
-   & {:keys []}]
+   & {:keys [variant1-params variant2-params]
+      :or   {variant1-params {} variant2-params {}}}]
   (let [file (ths/add-sample-shape file variant-label :type :frame :is-variant-container true)
         variant-id (thi/id variant-label)]
 
     (-> file
-        (ths/add-sample-shape root2-label :type :frame :parent-label variant-label :variant-id variant-id :variant-name "Value2")
-        (ths/add-sample-shape root1-label :type :frame :parent-label variant-label :variant-id variant-id :variant-name "Value1")
+        (ths/add-sample-shape root2-label (assoc variant2-params :type :frame :parent-label variant-label :variant-id variant-id :variant-name "Value2"))
+        (ths/add-sample-shape root1-label (assoc variant1-params :type :frame :parent-label variant-label :variant-id variant-id :variant-name "Value1"))
         (thc/make-component component1-label root1-label)
         (thc/update-component component1-label {:variant-id variant-id :variant-properties [{:name "Property 1" :value "Value1"}]})
         (thc/make-component component2-label root2-label)
@@ -42,7 +43,8 @@
 
 (defn add-variant-with-child
   [file variant-label component1-label root1-label component2-label root2-label child1-label child2-label
-   & {:keys [child1-params child2-params]}]
+   & {:keys [child1-params child2-params]
+      :or   {child1-params {} child2-params {}}}]
   (let [file (ths/add-sample-shape file variant-label :type :frame :is-variant-container true)
         variant-id (thi/id variant-label)]
     (-> file

--- a/common/test/common_tests/logic/variants_switch_test.cljc
+++ b/common/test/common_tests/logic/variants_switch_test.cljc
@@ -18,6 +18,29 @@
 
 (t/use-fixtures :each thi/test-fixture)
 
+
+(t/deftest test-basic-switch
+  (let [;; ==== Setup
+        file      (-> (thf/sample-file :file1)
+                      (thv/add-variant
+                       :v01 :c01 :m01 :c02 :m02
+                       {:variant1-params {:width 5}
+                        :variant2-params  {:width 15}})
+
+                      (thc/instantiate-component :c01
+                                                 :copy01))
+        copy01 (ths/get-shape file :copy01)
+
+        ;; ==== Action
+        file'     (tho/swap-component file copy01 :c02 {:new-shape-label :copy02 :keep-touched? true})
+
+        copy01'   (ths/get-shape file' :copy02)]
+    (thf/dump-file file :keys [:width])
+    ;; The copy had width 5 before the switch
+    (t/is (= (:width copy01) 5))
+    ;; The rect has width 15 after the switch
+    (t/is (= (:width copy01') 15))))
+
 (t/deftest test-simple-switch
   (let [;; ==== Setup
         file      (-> (thf/sample-file :file1)
@@ -44,6 +67,43 @@
     (t/is (= (:width rect01) 5))
     ;; The rect has width 15 after the switch
     (t/is (= (:width rect02') 15))))
+
+
+
+(t/deftest test-basic-switch-override
+  (let [;; ==== Setup
+        file      (-> (thf/sample-file :file1)
+                      (thv/add-variant
+                       :v01 :c01 :m01 :c02 :m02
+                       {:variant1-params {:width 5}
+                        :variant2-params  {:width 5}})
+
+                      (thc/instantiate-component :c01
+                                                 :copy01))
+        copy01 (ths/get-shape file :copy01)
+
+        ;; Change width of copy
+        page   (thf/current-page file)
+        changes (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                            #{(:id copy01)}
+                                            (fn [shape]
+                                              (assoc shape :width 25))
+                                            (:objects page)
+                                            {})
+
+        file   (thf/apply-changes file changes)
+        copy01 (ths/get-shape file :copy01)
+
+        ;; ==== Action
+        file'     (tho/swap-component file copy01 :c02 {:new-shape-label :copy02 :keep-touched? true})
+
+        copy01'   (ths/get-shape file' :copy02)]
+    (thf/dump-file file :keys [:width])
+    ;; The copy had width 25 before the switch
+    (t/is (= (:width copy01) 25))
+    ;; The override is keept: The copy still has width 25 after the switch
+    (t/is (= (:width copy01') 25))))
+
 
 (t/deftest test-switch-with-override
   (let [;; ==== Setup


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12299

### Summary

Inside a component called C1, you have a copy of a variant and override a value on that copy. 
Then, you create a copy of C1 itself and switch the variant on the copy to another one. 
As a result, the override you applied is lost.

### Steps to reproduce 

1. Create a component with a gray rect inside
2. Transform it into a variant
3. Create an empty frame, and make it a component called C1
4. Add a copy of the variant into C1
5. On the copy of the variant in C1, set the rect to blue
6. Make a copy of C1
7. Copy the variant inside the copy of C1, and paste it on root. Let's call this variant-in-root
9. Switch variant-in-root to the other one

As a result, the rect in variant-in-root becomes gray again


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
