### PR TITLE
:bug: Remove duplicated tokens on stroke panel

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -45,13 +45,17 @@
         token (get resolved-tokens applied-tokens-in-shape)]
     token))
 
-;; Current token implementation on fills only supports one token per shape and has to be the first fill
+;; Current token implementation on strokes only supports one token per shape and has to be the first stroke
 ;; This must be improved in the future
+(defn- is-first-element?
+  [idx]
+  (= 0 idx))
+
 (defn- has-color-token?
-  "Returns true if the resolved token matches the color and is the first fill (idx = 0)."
+  "Returns true if the resolved token matches the color and is the first stroke (idx = 0)."
   [resolved-token stroke-type idx]
   (and (= (:resolved-value resolved-token) (:color stroke-type))
-       (= 0 idx)))
+       (is-first-element? idx)))
 
 (mf/defc stroke-panel*
   [{:keys [shapes objects resolved-tokens color-space]}]
@@ -60,12 +64,11 @@
      [:div {:key (:id shape) :class "stroke-shape"}
       (for [[idx stroke] (map-indexed vector (:strokes shape))]
         (for [property properties]
-          (let [property property
-                value (css/get-css-value objects stroke property)
+          (let [value (css/get-css-value objects stroke property)
                 stroke-type (stroke->color stroke)
                 property-name (cmm/get-css-rule-humanized property)
                 property-value (css/get-css-property objects stroke property)
-                resolved-token (get-resolved-token property shape resolved-tokens)
+                resolved-token (when (is-first-element? idx) (get-resolved-token property shape resolved-tokens))
                 has-color-token (has-color-token? resolved-token stroke-type idx)]
             (if (= property :border-color)
               [:> color-properties-row* {:key (str idx property)


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/12056

### Summary

When there are more than one border and one of them has a stroke-width token applied, this token is displayed in all the strokes. It should be displayed only in the stroke that has this token applied

<img width="286" height="282" alt="image" src="https://github.com/user-attachments/assets/97736056-4393-44aa-adf7-4411b21866cd" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
