### PR TITLE
:wrench: Improve text tiles intersection on changes

### DIFF
--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -200,17 +200,16 @@ fn draw_text(
     shape: &Shape,
     paragraph_builder_groups: &mut [Vec<ParagraphBuilder>],
 ) {
-    // Width
-    let paragraph_width = if let crate::shapes::Type::Text(text_content) = &shape.shape_type {
-        text_content.width()
+    let container_height = if let crate::shapes::Type::Text(text_content) = &shape.shape_type {
+        text_content.size.height
     } else {
-        shape.width()
+        shape.selrect().height()
     };
 
-    // Height
-    let container_height = shape.selrect().height();
+    let paragraph_width = shape.selrect().width();
     let total_content_height =
         calculate_all_paragraphs_height(paragraph_builder_groups, paragraph_width);
+
     let mut global_offset_y = match shape.vertical_align() {
         VerticalAlign::Center => (container_height - total_content_height) / 2.0,
         VerticalAlign::Bottom => container_height - total_content_height,

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -266,6 +266,7 @@ impl Shape {
         self.invalidate_extrect();
         self.selrect.set_ltrb(left, top, right, bottom);
         if let Type::Text(ref mut text) = self.shape_type {
+            text.update_layout(self.selrect);
             text.set_xywh(left, top, right - left, bottom - top);
         }
     }
@@ -832,7 +833,8 @@ impl Shape {
                 shape.bounds().to_rect()
             }
             Type::Text(text_content) => {
-                let text_bounds = text_content.get_bounds(&shape);
+                // FIXME: we need to recalculate the text bounds here because the shape's selrect
+                let text_bounds = text_content.calculate_bounds(&shape);
                 text_bounds.to_rect()
             }
             _ => shape.bounds().to_rect(),

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -337,6 +337,7 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
 #[no_mangle]
 pub extern "C" fn update_shape_text_layout() {
     with_current_shape_mut!(state, |shape: &mut Shape| {
+        shape.invalidate_extrect();
         if let Type::Text(text_content) = &mut shape.shape_type {
             text_content.update_layout(shape.selrect);
         }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12292

### Summary

This PR fixes extrect (bounding box) calculation when a text is resized, moved, or rotated. We need to review in which cases we can reduce paragraph calculations, as I've introduced another call to re-calculate the height on changes.

### Steps to reproduce 

[screen-recorder-mon-oct-20-2025-17-38-39.webm](https://github.com/user-attachments/assets/d171a24d-1ffc-4347-8f3a-2bb6b1c0a718)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.