### PR TITLE
:bug: Fix underline not matching spacing/thickness

### DIFF
--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -289,12 +289,21 @@ fn calculate_decoration_metrics(
             .abs()
             .max(font_metrics.x_height.abs());
         let min_thickness = (font_size * 0.06).max(1.0);
-        let thickness = font_metrics
-            .underline_thickness()
-            .unwrap_or(1.0)
+
+        // Magic numbers for line thickness partially based on Chromium
+        // (see https://source.chromium.org/chromium/chromium/src/+/main:ui/gfx/render_text.cc
+        let raw_font_size = style_metric.text_style.font_size();
+        let thickness_factor = raw_font_size.powf(0.4) * 6.0 / 18.0;
+
+        let thickness = (font_metrics.underline_thickness().unwrap_or(1.0) * thickness_factor)
             .max(min_thickness);
+
         if style_metric.text_style.decoration().ty == TextDecoration::UNDERLINE {
-            let y = line_baseline + font_metrics.underline_position().unwrap_or(thickness);
+            // Same gap from baseline to underline as in Chromium
+            // (see https://source.chromium.org/chromium/chromium/src/+/main:ui/gfx/render_text.cc
+            let gap_scaling = raw_font_size * 1.0 / 9.0;
+            let y = line_baseline + gap_scaling;
+
             max_underline_thickness = max_underline_thickness.max(thickness);
             underline_y = Some(y);
         }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12362

### Summary

This makes the underline thickness and spacing no match more closely the old renderer / CSS.

<img width="1775" height="492" alt="Screenshot 2025-10-20 at 5 37 57 PM" src="https://github.com/user-attachments/assets/0432a53a-8425-4c9d-883b-706b69bfacb7" />

### Steps to reproduce 

Create a text and add an underline.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
