### PR TITLE
:bug: Fix on copy instance inside a components chain touched are missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fix pan cursor not disabling viewport guides [Github #6985](https://github.com/penpot/penpot/issues/6985)
 - Fix viewport resize on locked shapes [Taiga #11974](https://tree.taiga.io/project/penpot/issue/11974)
 - Fix nested variant in a component doesn't keep inherited overrides [Taiga #12299](https://tree.taiga.io/project/penpot/issue/12299)
+- Fix on copy instance inside a components chain touched are missing [Taiga #12371](https://tree.taiga.io/project/penpot/issue/12371)
 
 ## 2.11.0 (Unreleased)
 

--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -59,6 +59,31 @@
    [potok.v2.core :as ptk]
    [promesa.core :as p]))
 
+
+(defn- get-ref-chain-until-target-ref
+  "Returns a vector with the shape ref chain until target-ref, including itself"
+  [container libraries shape target-ref]
+  (loop [chain [shape]
+         current shape]
+    (if (= current target-ref)
+      chain
+      (if-let [ref (ctf/find-ref-shape nil container libraries current :with-context? true)]
+        (recur (conj chain ref) ref)
+        chain))))
+
+(defn- get-touched-from-ref-chain-until-target-ref
+  "Returns a set with the :touched of all the items on the shape
+   ref chain until target-ref, including itself"
+  [container libraries shape target-ref]
+  (let [chain (when target-ref (get-ref-chain-until-target-ref container libraries shape target-ref))
+        more-touched (->> chain
+                          (map :touched)
+                          (remove nil?)
+                          (apply set/union)
+                          (remove ctc/swap-slot?)
+                          set)]
+    (set/union (or (:touched shape) #{}) more-touched)))
+
 (defn copy-selected
   []
   (letfn [(sort-selected [state data]
@@ -164,10 +189,13 @@
               objects))
 
           (advance-shape [file libraries page level-delta objects shape]
-            (let [new-shape-ref (ctf/advance-shape-ref file page libraries shape level-delta {:include-deleted? true})]
+            (let [new-shape-ref (ctf/advance-shape-ref file page libraries shape level-delta {:include-deleted? true})
+                  container     (ctn/make-container page :page)
+                  new-touched   (get-touched-from-ref-chain-until-target-ref container libraries shape new-shape-ref)]
               (cond-> objects
                 (and (some? new-shape-ref) (not= new-shape-ref (:shape-ref shape)))
-                (assoc-in [(:id shape) :shape-ref] new-shape-ref))))
+                (-> (assoc-in [(:id shape) :shape-ref] new-shape-ref)
+                    (assoc-in [(:id shape) :touched] new-touched)))))
 
           (on-copy-error [error]
             (js/console.error "clipboard blocked:" error)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12371

### Summary

When you copy a an instance that is part of a chain of components, its “touched” is keept. But if it is part of a chain, the touched must be recalculated with the touched of the chain

### Steps to reproduce 

1. Create a gray rect, and make it a component (R1) 
2. Create a board, and make it a component (B1) 
3. Add a copy of R1 inside B1 (CR1) 
4. Change the color of CR1 to blue. This mark CR1 as touched 
5. Make a copy of B1 (CB1). In CB1, there is a copy of R1, (CR1-in-CB1). That is not touched 
6. Copy CR1-in-CB1 and paste it on root (CR1-in-root). That is not touched 
7. Change the color of R1 to orange. 

WHAT HAPPENS 
CR1-in-root change color from blue to orange

WHAT SHOULD HAPPEN 
CR1-in-root keeps its color

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
