### PR TITLE
:tada: Add shadow panel to inspect styles tab

### DIFF
--- a/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
@@ -52,9 +52,9 @@
          (str (:spread shadow) "px")]]]]
 
      [:& cmm/color-row {:color (:color shadow)
-                    :format @color-format
-                    :copy-data (copy-color-data (:color shadow) color-format*)
-                    :on-change-format on-change-format}]]))
+                        :format @color-format
+                        :copy-data (copy-color-data (:color shadow) color-format*)
+                        :on-change-format on-change-format}]]))
 
 (mf/defc shadow-panel [{:keys [shapes]}]
   (let [shapes (->> shapes (filter has-shadow?))]

--- a/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
@@ -7,11 +7,10 @@
 (ns app.main.ui.inspect.attributes.shadow
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.main.ui.components.copy-button :refer [copy-button*]]
    [app.main.ui.components.title-bar :refer [inspect-title-bar*]]
-   [app.main.ui.inspect.attributes.common :refer [color-row]]
+   [app.main.ui.inspect.attributes.common :as cmm]
    [app.util.code-gen.style-css :as css]
    [app.util.code-gen.style-css-formats :refer [format-color-value]]
    [app.util.i18n :refer [tr]]
@@ -31,13 +30,14 @@
 (mf/defc shadow-block [{:keys [shadow]}]
   (let [color-format (mf/use-state :hex)
         color-format* (deref color-format)
+        label (cmm/get-css-rule-humanized (:style shadow))
         on-change-format
         (mf/use-fn
          (fn [format]
            (reset! color-format format)))]
     [:div {:class (stl/css :attributes-shadow-block)}
      [:div {:class (stl/css :shadow-row)}
-      [:div {:class (stl/css :global/attr-label)} (->> shadow :style d/name (str "workspace.options.shadow-options.") (tr))]
+      [:div {:class (stl/css :global/attr-label)} label]
       [:div {:class (stl/css :global/attr-value)}
        [:> copy-button* {:data  (shadow-copy-data shadow)
                          :class (stl/css :color-row-copy-btn)}
@@ -51,7 +51,7 @@
          (str (:blur shadow) "px") " "
          (str (:spread shadow) "px")]]]]
 
-     [:& color-row {:color (:color shadow)
+     [:& cmm/color-row {:color (:color shadow)
                     :format @color-format
                     :copy-data (copy-color-data (:color shadow) color-format*)
                     :on-change-format on-change-format}]]))

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -20,6 +20,7 @@
    [app.main.ui.inspect.styles.panels.geometry :refer [geometry-panel*]]
    [app.main.ui.inspect.styles.panels.layout :refer [layout-panel*]]
    [app.main.ui.inspect.styles.panels.layout-element :refer [layout-element-panel*]]
+   [app.main.ui.inspect.styles.panels.shadow :refer [shadow-panel*]]
    [app.main.ui.inspect.styles.panels.stroke :refer [stroke-panel*]]
    [app.main.ui.inspect.styles.panels.svg :refer [svg-panel*]]
    [app.main.ui.inspect.styles.panels.text :refer [text-panel*]]
@@ -74,6 +75,9 @@
 
 (defn- has-text? [shape]
   (:content shape))
+
+(defn- has-shadow? [shape]
+  (:shadow shape))
 
 (defn- get-shape-type
   [shapes first-shape first-component]
@@ -199,6 +203,7 @@
               [:> style-box* {:panel :blur}
                [:> blur-panel* {:shapes shapes
                                 :objects objects}]]))
+          ;; TEXT PANEL
           :text
           (let [shapes (filter has-text? shapes)]
             (when (seq shapes)
@@ -207,6 +212,13 @@
                                 :color-space color-space
                                 :objects objects
                                 :resolved-tokens resolved-active-tokens}]]))
+          ;; SHADOW PANEL
+          :shadow
+          (let [shapes (filter has-shadow? shapes)]
+            (when (seq shapes)
+              [:> style-box* {:panel :shadow}
+               [:> shadow-panel* {:shapes shapes
+                                  :color-space color-space}]]))
           ;; DEFAULT WIP
           [:> style-box* {:panel panel}
            [:div color-space]])])]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
@@ -1,0 +1,36 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.main.ui.inspect.styles.panels.shadow
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [app.common.data :as d]
+   [app.common.data.macros :as dm]
+   [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
+   [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
+   [app.util.code-gen.style-css :as css]
+   [app.util.i18n :refer [tr]]
+   [rumext.v2 :as mf]))
+
+(mf/defc shadow-panel*
+  [{:keys [shapes color-space]}]
+  [:div {:class (stl/css :shadow-panel)}
+   (for [shape shapes]
+     (for [shadow (:shadow shape)]
+       [:div {:key (dm/str (:id shape) (:type shadow)) :class "shadow-shape"}
+        [:> color-properties-row* {:term "Color"
+                                   :color (:color shadow)
+                                   :format color-space
+                                   :copiable true}]
+        (let [property :shadow
+              value (dm/str (:offset-x shadow) "px" " " (:offset-y shadow) "px" " " (:blur shadow) "px" " " (:spread shadow) "px")
+              property-name (->> shadow :style d/name (str "workspace.options.shadow-options.") (tr))
+              property-value (css/shadow->css shadow)]
+          [:> properties-row* {:key (dm/str "shadow-property-" property)
+                               :term property-name
+                               :detail (dm/str value)
+                               :property property-value
+                               :copiable true}])]))])

--- a/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
@@ -7,12 +7,11 @@
 (ns app.main.ui.inspect.styles.panels.shadow
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
-   [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
 (mf/defc shadow-panel*
@@ -21,13 +20,13 @@
    (for [shape shapes]
      (for [shadow (:shadow shape)]
        [:div {:key (dm/str (:id shape) (:type shadow)) :class "shadow-shape"}
-        [:> color-properties-row* {:term "Color"
+        [:> color-properties-row* {:term "Shadow Color"
                                    :color (:color shadow)
                                    :format color-space
                                    :copiable true}]
         (let [property :shadow
               value (dm/str (:offset-x shadow) "px" " " (:offset-y shadow) "px" " " (:blur shadow) "px" " " (:spread shadow) "px")
-              property-name (->> shadow :style d/name (str "workspace.options.shadow-options.") (tr))
+              property-name (cmm/get-css-rule-humanized (:style shadow))
               property-value (css/shadow->css shadow)]
           [:> properties-row* {:key (dm/str "shadow-property-" property)
                                :term property-name

--- a/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
@@ -24,12 +24,10 @@
                                    :color (:color shadow)
                                    :format color-space
                                    :copiable true}]
-        (let [property :shadow
-              value (dm/str (:offset-x shadow) "px" " " (:offset-y shadow) "px" " " (:blur shadow) "px" " " (:spread shadow) "px")
+        (let [value (dm/str (:offset-x shadow) "px" " " (:offset-y shadow) "px" " " (:blur shadow) "px" " " (:spread shadow) "px")
               property-name (cmm/get-css-rule-humanized (:style shadow))
               property-value (css/shadow->css shadow)]
-          [:> properties-row* {:key (dm/str "shadow-property-" property)
-                               :term property-name
+          [:> properties-row* {:term property-name
                                :detail (dm/str value)
                                :property property-value
                                :copiable true}])]))])

--- a/frontend/src/app/main/ui/inspect/styles/property_detail_copiable.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/property_detail_copiable.cljs
@@ -8,8 +8,8 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.main.refs :as refs]
-   [app.main.ui.components.color-bullet :as bc]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
+   [app.main.ui.ds.utilities.swatch :refer [swatch*]]
    [app.main.ui.inspect.common.colors :as isc]
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
@@ -29,8 +29,8 @@
                                  :property-detail-copiable-color (some? color))
             :on-click on-click}
    (when color
-     [:> bc/color-bullet {:color color
-                          :mini true}])
+     [:> swatch* {:background color
+                  :size "small"}])
    (if token
      [:span {:class (stl/css :property-detail-text :property-detail-text-token)}
       (:name token)]

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -50,7 +50,7 @@
                                     (fmt/format-number)) "%"))
 
         formatted-color-value (mf/use-memo
-                               (mf/deps color)
+                               (mf/deps color format color-opacity )
                                #(cond
                                   (some? (:color color)) (case format
                                                            "hex" (dm/str color-value " " color-opacity)

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -50,7 +50,7 @@
                                     (fmt/format-number)) "%"))
 
         formatted-color-value (mf/use-memo
-                               (mf/deps color format color-opacity )
+                               (mf/deps color format color-opacity)
                                #(cond
                                   (some? (:color color)) (case format
                                                            "hex" (dm/str color-value " " color-opacity)

--- a/frontend/src/app/util/code_gen/style_css.cljs
+++ b/frontend/src/app/util/code_gen/style_css.cljs
@@ -332,4 +332,4 @@ body {
 
 (defn shadow->css
   [shadow]
-  (dm/str "box-shadow: " (format-shadow->css shadow {})))
+  (dm/str "box-shadow: " (format-shadow->css shadow {}) ";"))


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/12058

### Summary
This PR adds the `shadow panel` to the `styles` tab.

### Steps to reproduce 

- Create a shape. E.g a rectangle
- Add a shadow (drop-shadow), edit as you prefer.
- Ensure that shadow is being displayed at the `styles tab` including color
- Add a new shadow (inner-shadow) to the same shape. Edit as you prefer
- Ensure that both shadows are being displayed at the `styles tab` including both colors

<img width="349" height="294" alt="image" src="https://github.com/user-attachments/assets/af0f4438-b5aa-4911-ad32-04787284d666" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
