### PR TITLE
:sparkles: Add cause stack trace logging on ui error boundary

### DIFF
--- a/frontend/src/app/main/ui/error_boundary.cljs
+++ b/frontend/src/app/main/ui/error_boundary.cljs
@@ -34,6 +34,7 @@
           ;; very small amount of time, so we debounce for 100ms for
           ;; avoid duplicate and redundant reports
           (gfn/debounce (fn [error info]
+                          (js/console.log "Cause stack: \n" (.-stack error))
                           (js/console.error
                            "Component trace: \n"
                            (unchecked-get info "componentStack")


### PR DESCRIPTION
### Summary

A simple improvement on ui error error printing. This PR prints also the cause stack trace and not only the component stack trace.

No specific user tests are needed.