### PR TITLE
:bug: Fix texts offset-y calculation when there are multiple lines and stroke paints

### DIFF
--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -220,7 +220,6 @@ fn draw_text(
     canvas.save_layer(&layer_rec);
     for paragraph_builder_group in paragraph_builder_groups {
         let mut group_offset_y = global_offset_y;
-        let group_len = paragraph_builder_group.len();
 
         for (paragraph_index, paragraph_builder) in paragraph_builder_group.iter_mut().enumerate() {
             let mut paragraph = paragraph_builder.build();
@@ -230,25 +229,18 @@ fn draw_text(
             // a reminder in the future to keep digging why the ideographic_baseline
             // works so well and not the paragraph_height. I think we should test
             // this more.
-            let ideographic_baseline = paragraph.ideographic_baseline();
-            let xy = (shape.selrect().x(), shape.selrect().y() + group_offset_y);
+            if paragraph_index == 0 {
+                group_offset_y += paragraph.ideographic_baseline();
+            }
+            let xy = (shape.selrect().x(), shape.selrect().y() + global_offset_y);
             paragraph.paint(canvas, xy);
 
             for line_metrics in paragraph.get_line_metrics().iter() {
                 render_text_decoration(canvas, &paragraph, paragraph_builder, line_metrics, xy);
             }
-
-            #[allow(clippy::collapsible_else_if)]
-            if group_len == 1 {
-                group_offset_y += ideographic_baseline;
-            } else {
-                if paragraph_index == 0 {
-                    group_offset_y += ideographic_baseline;
-                }
-            }
         }
 
-        global_offset_y = group_offset_y;
+        global_offset_y += group_offset_y;
     }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12386

### Summary

We've introduced a regression related with text strokes. This PR fixes that issue by making sure that when there are multiple paragraphs for a text (the case of the strokes, which have different paints) the offset-y is calculated correctly

### Steps to reproduce 

- Create a text with multiple lines and breaking lines
- Try different strokes
- Check it works as expected

<img width="981" height="668" alt="Screenshot 2025-10-21 at 16-15-35 New File 10 - Penpot" src="https://github.com/user-attachments/assets/acc087ff-69ba-4373-85cf-53fb44e4f8ce" />
<img width="1207" height="931" alt="Screenshot 2025-10-21 at 16-13-25 New File 10 - Penpot" src="https://github.com/user-attachments/assets/5558b777-7f56-4a27-98bd-7e15ebe59d72" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.


