### PR TITLE
:bug: Fix incorrect behavior of Alt + Drag for variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,7 @@
 - Fix internal Error when selecting a set by name in the token theme editor [Taiga #12310](https://tree.taiga.io/project/penpot/issue/12310)
 - Fix drag & drop functionality is swapping instead or reordering [Taiga #12254](https://tree.taiga.io/project/penpot/issue/12254)
 - Fix variants not syncronizing tokens on switch [Taiga #12290](https://tree.taiga.io/project/penpot/issue/12290)
+- Fix incorrect behavior of Alt + Drag for variants [Taiga #12309](https://tree.taiga.io/project/penpot/issue/12309)
 
 ## 2.10.1
 

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -463,7 +463,7 @@
                 library-data    (dsh/lookup-file-data state file-id)
 
                 changes         (-> (pcb/empty-changes it)
-                                    (cll/generate-duplicate-changes objects page ids delta libraries library-data file-id)
+                                    (cll/generate-duplicate-changes objects page ids delta libraries library-data file-id {:alt-duplication? alt-duplication?})
                                     (cll/generate-duplicate-changes-update-indices objects ids))
 
                 tags            (or (:tags changes) #{})


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12309

### Summary

Duplicating a variant with alt+drag should create a copy of the variant

### Steps to reproduce 

Pre-conditions: 
User is logged in 
Open any file.

Steps: 
Create a rectangle. 
Create a component. 
Create a variant of this component. 
Select first variant, hold Alt, and drag it outside the board.

Actual result: 
The element is duplicated inside the variants group instead of creating a separate copy outside the board.

Expected Result: 
Holding Alt and dragging a variant outside the board should create a detached copy of the component outside the variants group.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
