### PR TITLE
:whale: Set default values for maxmemory and maxmemory-policy in Valkey

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -247,6 +247,11 @@ services:
     networks:
       - penpot
 
+    environment:
+      # You can increase the max memory size if you have sufficient resources,
+      # although this should not be necessary.
+      - VALKEY_EXTRA_FLAGS=--maxmemory 128mb --maxmemory-policy volatile-lfu
+
   ## A mailcatch service, used as temporal SMTP server. You can access via HTTP to the
   ## port 1080 for read all emails the penpot platform has sent. Should be only used as a
   ## temporal solution while no real SMTP provider is configured.


### PR DESCRIPTION
<div align="center">

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3hzbWc0ODk0eXZwc29pOWo3M2FheTFpMWlsNjZhYjZ6aGliajNiNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tGOvTAUiumv2o/giphy.gif)

</div>

Sets default values for `maxmemory` and `maxmemory-policy` in Valkey that should be enough for most on-premise instances