### PR TITLE
:tada: Add copy shortands button to panels

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -112,18 +112,18 @@
                                     (or (:opacity shape)
                                         (:blend-mode shape)
                                         (:visibility shape))))))
-        shorthands* (mf/use-state {:fill nil
-                                   :stroke nil
-                                   :text nil
-                                   :shadow nil
-                                   :blur nil
-                                   :layout nil
-                                   :layout-element nil
-                                   :geometry nil
-                                   :svg nil
-                                   :visibility nil
-                                   :variant nil
-                                   :grid-element nil})
+        shorthands* (mf/use-state #(do {:fill nil
+                                        :stroke nil
+                                        :text nil
+                                        :shadow nil
+                                        :blur nil
+                                        :layout nil
+                                        :layout-element nil
+                                        :geometry nil
+                                        :svg nil
+                                        :visibility nil
+                                        :variant nil
+                                        :grid-element nil}))
         shorthands (deref shorthands*)
         set-shorthands
         ;; This fn must receive an object `shorthand` with :panel and :property (the shorthand string) keys

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -30,7 +30,8 @@
    [app.main.ui.inspect.styles.style-box :refer [style-box*]]
    [app.util.code-gen.style-css :as css]
    [app.util.i18n :refer [tr]]
-   [rumext.v2 :as mf]))
+   [rumext.v2 :as mf]
+   [cljs.pprint :as pp]))
 
 (def layout-element-properties
   [:margin-block-start
@@ -111,7 +112,26 @@
                                     (not (or (= shape-type :text) (= shape-type :group)))
                                     (or (:opacity shape)
                                         (:blend-mode shape)
-                                        (:visibility shape))))))]
+                                        (:visibility shape))))))
+        shorthands* (mf/use-state {:fill nil
+                                   :stroke nil
+                                   :text nil
+                                   :shadow nil
+                                   :blur nil
+                                   :layout nil
+                                   :layout-element nil
+                                   :geometry nil
+                                   :svg nil
+                                   :visibility nil
+                                   :variant nil
+                                   :grid-element nil})
+        shorthands (deref shorthands*)
+        set-shorthands
+        ;; This fn must receive an object `shorthand` with :panel and :property (the shorthand string) keys
+        (mf/use-fn
+         (mf/deps shorthands*)
+         (fn [shorthand]
+           (swap! shorthands* assoc (:panel shorthand) (:property shorthand))))]
     [:ol {:class (stl/css :styles-tab) :aria-label (tr "labels.styles")}
      ;;  TOKENS PANEL
      (when (or active-themes active-sets)
@@ -166,10 +186,12 @@
           :fill
           (let [shapes (filter has-fill? shapes)]
             (when (seq shapes)
-              [:> style-box* {:panel :fill}
+              [:> style-box* {:panel :fill
+                              :shorthand (:fill shorthands)}
                [:> fill-panel* {:color-space color-space
                                 :shapes shapes
-                                :resolved-tokens resolved-active-tokens}]]))
+                                :resolved-tokens resolved-active-tokens
+                                :on-fill-shorthand set-shorthands}]]))
 
           ;; STROKE PANEL
           :stroke

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -182,11 +182,13 @@
                             (if only-grid?
                               :grid-element
                               :layout-element))]
-                [:> style-box* {:panel panel}
+                [:> style-box* {:panel panel
+                                :shorthand (:layout-element shorthands)}
                  [:> layout-element-panel* {:shapes shapes
                                             :objects objects
                                             :resolved-tokens resolved-active-tokens
-                                            :layout-element-properties layout-element-properties}]])))
+                                            :layout-element-properties layout-element-properties
+                                            :on-layout-element-shorthand set-shorthands}]])))
           ;; FILL PANEL
           :fill
           (let [shapes (filter has-fill? shapes)]

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -249,9 +249,11 @@
           :shadow
           (let [shapes (filter has-shadow? shapes)]
             (when (seq shapes)
-              [:> style-box* {:panel :shadow}
+              [:> style-box* {:panel :shadow
+                              :shorthand (:shadow shorthands)}
                [:> shadow-panel* {:shapes shapes
-                                  :color-space color-space}]]))
+                                  :color-space color-space
+                                  :on-shadow-shorthand set-shorthands}]]))
 
           ;; DEFAULT WIP
           [:> style-box* {:panel panel}

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -150,10 +150,12 @@
                                 :data data}]]
         ;;  GEOMETRY PANEL
           :geometry
-          [:> style-box* {:panel :geometry}
+          [:> style-box* {:panel :geometry
+                          :shorthand (:geometry shorthands)}
            [:> geometry-panel* {:shapes shapes
                                 :objects objects
-                                :resolved-tokens resolved-active-tokens}]]
+                                :resolved-tokens resolved-active-tokens
+                                :on-geometry-shorthand set-shorthands}]]
          ;;  LAYOUT PANEL
           :layout
           (let [layout-shapes (->> shapes (filter ctl/any-layout?))]

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -30,7 +30,8 @@
    [app.main.ui.inspect.styles.style-box :refer [style-box*]]
    [app.util.code-gen.style-css :as css]
    [app.util.i18n :refer [tr]]
-   [rumext.v2 :as mf]))
+   [rumext.v2 :as mf]
+   [cljs.pprint :as pp]))
 
 (def layout-element-properties
   [:margin-block-start
@@ -125,7 +126,7 @@
                                    :variant nil
                                    :grid-element nil})
         shorthands (deref shorthands*)
-        _ (.log js/console shorthands)
+        _ (pp/pprint shorthands)
         set-shorthands
         ;; This fn must receive an object `shorthand` with :panel and :property (the shorthand string) keys
         (mf/use-fn
@@ -160,10 +161,12 @@
           :layout
           (let [layout-shapes (->> shapes (filter ctl/any-layout?))]
             (when (seq layout-shapes)
-              [:> style-box* {:panel :layout}
+              [:> style-box* {:panel :layout
+                              :shorthand (:layout shorthands)}
                [:> layout-panel* {:shapes layout-shapes
                                   :objects objects
-                                  :resolved-tokens resolved-active-tokens}]]))
+                                  :resolved-tokens resolved-active-tokens
+                                  :on-layout-shorthand set-shorthands}]]))
          ;;  LAYOUT ELEMENT PANEL
           :layout-element
           (let [shapes (->> shapes (filter #(ctl/any-layout-immediate-child? objects %)))

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -30,8 +30,7 @@
    [app.main.ui.inspect.styles.style-box :refer [style-box*]]
    [app.util.code-gen.style-css :as css]
    [app.util.i18n :refer [tr]]
-   [rumext.v2 :as mf]
-   [cljs.pprint :as pp]))
+   [rumext.v2 :as mf]))
 
 (def layout-element-properties
   [:margin-block-start
@@ -126,7 +125,6 @@
                                    :variant nil
                                    :grid-element nil})
         shorthands (deref shorthands*)
-        _ (pp/pprint shorthands)
         set-shorthands
         ;; This fn must receive an object `shorthand` with :panel and :property (the shorthand string) keys
         (mf/use-fn

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -77,7 +77,7 @@
   (:content shape))
 
 (defn- has-shadow? [shape]
-  (:shadow shape))
+  (seq (:shadow shape)))
 
 (defn- get-shape-type
   [shapes first-shape first-component]

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -126,6 +126,7 @@
                                    :variant nil
                                    :grid-element nil})
         shorthands (deref shorthands*)
+        _ (pp/pprint shorthands)
         set-shorthands
         ;; This fn must receive an object `shorthand` with :panel and :property (the shorthand string) keys
         (mf/use-fn
@@ -197,11 +198,13 @@
           :stroke
           (let [shapes (filter has-stroke? shapes)]
             (when (seq shapes)
-              [:> style-box* {:panel :stroke}
+              [:> style-box* {:panel :stroke
+                              :shorthand (:stroke shorthands)}
                [:> stroke-panel* {:color-space color-space
                                   :shapes shapes
                                   :objects objects
-                                  :resolved-tokens resolved-active-tokens}]]))
+                                  :resolved-tokens resolved-active-tokens
+                                  :on-stroke-shorthand set-shorthands}]]))
 
           ;; VISIBILITY PANEL
           :visibility

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -30,8 +30,7 @@
    [app.main.ui.inspect.styles.style-box :refer [style-box*]]
    [app.util.code-gen.style-css :as css]
    [app.util.i18n :refer [tr]]
-   [rumext.v2 :as mf]
-   [cljs.pprint :as pp]))
+   [rumext.v2 :as mf]))
 
 (def layout-element-properties
   [:margin-block-start
@@ -126,7 +125,7 @@
                                    :variant nil
                                    :grid-element nil})
         shorthands (deref shorthands*)
-        _ (pp/pprint shorthands)
+        _ (.log js/console shorthands)
         set-shorthands
         ;; This fn must receive an object `shorthand` with :panel and :property (the shorthand string) keys
         (mf/use-fn
@@ -232,11 +231,13 @@
           :text
           (let [shapes (filter has-text? shapes)]
             (when (seq shapes)
-              [:> style-box* {:panel :text}
+              [:> style-box* {:panel :text
+                              :shorthand (:text shorthands)}
                [:> text-panel* {:shapes shapes
                                 :color-space color-space
-                                :objects objects
-                                :resolved-tokens resolved-active-tokens}]]))
+                                :resolved-tokens resolved-active-tokens
+                                :on-font-shorthand set-shorthands}]]))
+
           ;; SHADOW PANEL
           :shadow
           (let [shapes (filter has-shadow? shapes)]
@@ -244,6 +245,7 @@
               [:> style-box* {:panel :shadow}
                [:> shadow-panel* {:shapes shapes
                                   :color-space color-space}]]))
+
           ;; DEFAULT WIP
           [:> style-box* {:panel panel}
            [:div color-space]])])]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/blur.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/blur.cljs
@@ -17,7 +17,7 @@
   [{:keys [shapes objects]}]
   [:div {:class (stl/css :blur-panel)}
    (for [shape shapes]
-     [:div {:key (:id shape) :class "blur-shape"}
+     [:div {:key (:id shape) :class (stl/css :blur-shape)}
       (let [property :filter
             value (css/get-css-value objects shape property)
             property-name (cmm/get-css-rule-humanized property)

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -7,9 +7,13 @@
 (ns app.main.ui.inspect.styles.panels.fill
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data.macros :as dm]
    [app.common.types.fills :as types.fills]
+   [app.config :as cfg]
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
+   [app.util.color :as uc]
+   [cljs.pprint :as pp]
    [rumext.v2 :as mf]))
 
 (defn- get-applied-tokens-in-shape
@@ -33,27 +37,54 @@
        (= 0 idx)))
 
 (mf/defc fill-panel*
-  [{:keys [shapes resolved-tokens color-space]}]
+  [{:keys [shapes resolved-tokens color-space on-fill-shorthand]}]
   [:div {:class (stl/css :fill-panel)}
    (for [shape shapes]
      [:div {:key (:id shape) :class "fill-shape"}
-      (for [[idx fill] (map-indexed vector (:fills shape))]
-        (let [property :background
-              color-type (types.fills/fill->color fill) ;; can be :color, :gradient or :image
-              property-name (cmm/get-css-rule-humanized property)
-              resolved-token (get-resolved-token shape resolved-tokens)
-              has-token (has-token? resolved-token color-type idx)]
+      (let [shorthand
+            ;; A background-image shorthand for all fills in the shape
+            (reduce
+             (fn [acc fill]
+               (let [color-type (types.fills/fill->color fill)
+                     color-value (:color color-type)
+                     color-gradient (:gradient color-type)
+                     gradient-data  {:type color-type
+                                     :stops (:stops color-gradient)}
+                     color-image (:image color-type)
+                     image-url (cfg/resolve-file-media color-image)
+                     value (cond
+                             (:color color-type) (dm/str color-value)
+                             color-gradient (uc/gradient->css gradient-data)
+                             color-image (str "url(\"" image-url "\")")
+                             :else "")]
+                 (if (empty? acc)
+                   value
+                   (str acc ", " value))))
+             ""
+             (:fills shape))
+            shorthand (str "background-image: " shorthand ";")]
+        (mf/use-effect
+         (fn []
+           (when on-fill-shorthand
+             (on-fill-shorthand {:panel :fill
+                                 :property shorthand}))))
+        (for [[idx fill] (map-indexed vector (:fills shape))]
+          (let [property :background
+                color-type (types.fills/fill->color fill) ;; can be :color, :gradient or :image
+                property-name (cmm/get-css-rule-humanized property)
+                resolved-token (get-resolved-token shape resolved-tokens)
+                has-token (has-token? resolved-token color-type idx)]
 
-          (if (:color color-type)
-            [:> color-properties-row* {:key idx
-                                       :term property-name
-                                       :color color-type
-                                       :token (when has-token resolved-token)
-                                       :format color-space
-                                       :copiable true}]
-            (if (or (:gradient color-type) (:image color-type))
+            (if (:color color-type)
               [:> color-properties-row* {:key idx
                                          :term property-name
                                          :color color-type
+                                         :token (when has-token resolved-token)
+                                         :format color-space
                                          :copiable true}]
-              [:span "background-image"]))))])])
+              (if (or (:gradient color-type) (:image color-type))
+                [:> color-properties-row* {:key idx
+                                           :term property-name
+                                           :color color-type
+                                           :copiable true}]
+                [:span "background-image"])))))])])

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -53,7 +53,7 @@
                    :else "")
            full-value (str prefix value ";")]
        (if (empty? acc)
-         acc
+         full-value
          (str acc " " full-value))))
    ""
    (:fills shape)))

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -13,7 +13,6 @@
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.util.color :as uc]
-   [cljs.pprint :as pp]
    [rumext.v2 :as mf]))
 
 (defn- get-applied-tokens-in-shape

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -43,26 +43,28 @@
      [:div {:key (:id shape) :class "fill-shape"}
       (let [shorthand
             ;; A background-image shorthand for all fills in the shape
-            (reduce
-             (fn [acc fill]
-               (let [color-type (types.fills/fill->color fill)
-                     color-value (:color color-type)
-                     color-gradient (:gradient color-type)
-                     gradient-data  {:type color-type
-                                     :stops (:stops color-gradient)}
-                     color-image (:image color-type)
-                     image-url (cfg/resolve-file-media color-image)
-                     value (cond
-                             (:color color-type) (dm/str color-value)
-                             color-gradient (uc/gradient->css gradient-data)
-                             color-image (str "url(\"" image-url "\")")
-                             :else "")]
-                 (if (empty? acc)
-                   value
-                   (str acc ", " value))))
-             ""
-             (:fills shape))
-            shorthand (str "background-image: " shorthand ";")]
+            (when (= (count shapes) 1)
+              (reduce
+               (fn [acc fill]
+                 (let [color-type (types.fills/fill->color fill)
+                       color-value (:color color-type)
+                       color-gradient (:gradient color-type)
+                       gradient-data  {:type color-type
+                                       :stops (:stops color-gradient)}
+                       color-image (:image color-type)
+                       image-url (cfg/resolve-file-media color-image)
+                       value (cond
+                               (:color color-type) (dm/str color-value)
+                               color-gradient (uc/gradient->css gradient-data)
+                               color-image (str "url(\"" image-url "\")")
+                               :else "")]
+                   (if (empty? acc)
+                     value
+                     (str acc ", " value))))
+               ""
+               (:fills shape)))
+            shorthand (when shorthand
+                        (str "background-image: " shorthand ";"))]
         (mf/use-effect
          (fn []
            (when on-fill-shorthand

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -13,7 +13,8 @@
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.util.color :as uc]
-   [rumext.v2 :as mf]))
+   [rumext.v2 :as mf]
+   [cljs.pprint :as pp]))
 
 (defn- get-applied-tokens-in-shape
   [shape-tokens property]
@@ -45,25 +46,27 @@
             (when (= (count shapes) 1)
               (reduce
                (fn [acc fill]
-                 (let [color-type (types.fills/fill->color fill)
+                 (let [_ (pp/pprint "acc")
+                       _ (pp/pprint acc)
+                       color-type (types.fills/fill->color fill)
                        color-value (:color color-type)
                        color-gradient (:gradient color-type)
                        gradient-data  {:type color-type
                                        :stops (:stops color-gradient)}
                        color-image (:image color-type)
                        image-url (cfg/resolve-file-media color-image)
+                       prefix (if color-value "background-color: " "background-image: ")
                        value (cond
                                (:color color-type) (dm/str color-value)
                                color-gradient (uc/gradient->css gradient-data)
                                color-image (str "url(\"" image-url "\")")
-                               :else "")]
+                               :else "")
+                       full-value (str prefix value ";")]
                    (if (empty? acc)
-                     value
-                     (str acc ", " value))))
+                     full-value
+                     (str acc " " full-value))))
                ""
-               (:fills shape)))
-            shorthand (when shorthand
-                        (str "background-image: " shorthand ";"))]
+               (:fills shape)))]
         (mf/use-effect
          (fn []
            (when on-fill-shorthand

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -45,16 +45,15 @@
            gradient-data  {:type color-type
                            :stops (:stops color-gradient)}
            color-image (:image color-type)
-           image-url (cfg/resolve-file-media color-image)
            prefix (if color-value "background-color: " "background-image: ")
            value (cond
                    (:color color-type) (dm/str color-value)
                    color-gradient (uc/gradient->css gradient-data)
-                   color-image (str "url(\"" image-url "\")")
+                   color-image (str "url(\"" (cfg/resolve-file-media color-image) "\")")
                    :else "")
            full-value (str prefix value ";")]
        (if (empty? acc)
-         full-value
+         acc
          (str acc " " full-value))))
    ""
    (:fills shape)))
@@ -85,9 +84,7 @@
                                          :token (when has-token resolved-token)
                                          :format color-space
                                          :copiable true}]
-              (if (or (:gradient color-type) (:image color-type))
-                [:> color-properties-row* {:key idx
-                                           :term property-name
-                                           :color color-type
-                                           :copiable true}]
-                [:span "background-image"]))))])]))
+              [:> color-properties-row* {:key idx
+                                         :term property-name
+                                         :color color-type
+                                         :copiable true}])))])]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -60,7 +60,7 @@
 
 (mf/defc fill-panel*
   [{:keys [shapes resolved-tokens color-space on-fill-shorthand]}]
-  (let [shorthand* (mf/use-state (generate-fill-shorthand (first shapes)))
+  (let [shorthand* (mf/use-state #(generate-fill-shorthand (first shapes)))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-fill-shorthand shapes)
@@ -70,7 +70,7 @@
                            :property shorthand})))
     [:div {:class (stl/css :fill-panel)}
      (for [shape shapes]
-       [:div {:key (:id shape) :class "fill-shape"}
+       [:div {:key (:id shape) :class (stl/css :fill-shape)}
         (for [[idx fill] (map-indexed vector (:fills shape))]
           (let [property :background
                 color-type (types.fills/fill->color fill) ;; can be :color, :gradient or :image

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -13,7 +13,6 @@
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.util.color :as uc]
-   [me.flowthing.pp :as pp]
    [rumext.v2 :as mf]))
 
 (defn- get-applied-tokens-in-shape
@@ -65,7 +64,9 @@
   (let [shorthand* (mf/use-state (generate-fill-shorthand (first shapes)))
         shorthand (deref shorthand*)]
     (mf/use-effect
+     (mf/deps shorthand on-fill-shorthand shapes)
      (fn []
+       (reset! shorthand* (generate-fill-shorthand (first shapes)))
        (on-fill-shorthand {:panel :fill
                            :property shorthand})))
     [:div {:class (stl/css :fill-panel)}

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -13,8 +13,7 @@
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.util.color :as uc]
-   [rumext.v2 :as mf]
-   [cljs.pprint :as pp]))
+   [rumext.v2 :as mf]))
 
 (defn- get-applied-tokens-in-shape
   [shape-tokens property]
@@ -46,9 +45,7 @@
             (when (= (count shapes) 1)
               (reduce
                (fn [acc fill]
-                 (let [_ (pp/pprint "acc")
-                       _ (pp/pprint acc)
-                       color-type (types.fills/fill->color fill)
+                 (let [color-type (types.fills/fill->color fill)
                        color-value (:color color-type)
                        color-gradient (:gradient color-type)
                        gradient-data  {:type color-type

--- a/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
@@ -31,6 +31,10 @@
    :border-end-start-radius :r3
    :border-end-end-radius :r4})
 
+(defn- has-border-radius?
+  [shape]
+  (some #(and (contains? shape %) (not= 0 (get shape %))) [:r1 :r2 :r3 :r4]))
+
 (defn- get-applied-tokens-in-shape
   [shape-tokens property]
   (let [border-prop (get shape-prop->border-radius-prop property)]
@@ -50,27 +54,21 @@
   [:div {:class (stl/css :geometry-panel)}
    (for [shape shapes]
      [:div {:key (:id shape) :class "geometry-shape"}
-      (let [has-border-radius? (some #(and (contains? shape %) (not= 0 (get shape %))) [:r1 :r2 :r3 :r4])
-            shorthand (when (and (= (count shapes) 1) has-border-radius?)
-                        (dm/str "border-radius: "
-                                (:r1 shape) "px "
-                                (:r2 shape) "px "
-                                (:r3 shape) "px "
-                                (:r4 shape) "px;"))
-            ]
+      (let [shorthand (when (and (= (count shapes) 1) (has-border-radius? shape))
+                        (css/get-css-property objects shape :border-radius))]
         (mf/use-effect
          (fn []
            (when on-geometry-shorthand
              (on-geometry-shorthand {:panel :geometry
                                      :property shorthand}))))
-       (for [property properties]
-        (when-let [value (css/get-css-value objects shape property)]
-          (let [property-name (cmm/get-css-rule-humanized property)
-                resolved-token (get-resolved-token property shape resolved-tokens)
-                property-value (if (not resolved-token) (css/get-css-property objects shape property) "")]
-            [:> properties-row* {:key (dm/str "geometry-property-" property)
-                                 :term property-name
-                                 :detail value
-                                 :token resolved-token
-                                 :property property-value
-                                 :copiable true}]))))])])
+        (for [property properties]
+          (when-let [value (css/get-css-value objects shape property)]
+            (let [property-name (cmm/get-css-rule-humanized property)
+                  resolved-token (get-resolved-token property shape resolved-tokens)
+                  property-value (if (not resolved-token) (css/get-css-property objects shape property) "")]
+              [:> properties-row* {:key (dm/str "geometry-property-" property)
+                                   :term property-name
+                                   :detail value
+                                   :token resolved-token
+                                   :property property-value
+                                   :copiable true}]))))])])

--- a/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
@@ -31,8 +31,13 @@
    :border-end-end-radius :r4})
 
 (defn- has-border-radius?
+  "Returns true if the shape has any non-zero border radius values."
   [shape]
-  (some #(and (contains? shape %) (not= 0 (get shape %))) [:r1 :r2 :r3 :r4]))
+  (let [radius-keys [:r1 :r2 :r3 :r4]]
+    (some (fn [key]
+            (and (contains? shape key)
+                 (not= 0 (get shape key))))
+          radius-keys)))
 
 (defn- get-applied-tokens-in-shape
   [shape-tokens property]

--- a/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
@@ -11,8 +11,7 @@
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
-   [rumext.v2 :as mf]
-   [cljs.pprint :as pp]))
+   [rumext.v2 :as mf]))
 
 (def ^:private properties
   [:width

--- a/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
@@ -58,10 +58,11 @@
   (let [shorthand* (mf/use-state (generate-geometry-shorthand shapes objects))
         shorthand (deref shorthand*)]
     (mf/use-effect
+     (mf/deps shorthand on-geometry-shorthand shapes objects)
      (fn []
-       (when on-geometry-shorthand
-         (on-geometry-shorthand {:panel :geometry
-                                 :property shorthand}))))
+       (reset! shorthand* (generate-geometry-shorthand shapes objects))
+       (on-geometry-shorthand {:panel :geometry
+                               :property shorthand})))
     [:div {:class (stl/css :geometry-panel)}
      (for [shape shapes]
        [:div {:key (:id shape) :class "geometry-shape"}

--- a/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
@@ -48,18 +48,24 @@
         token (get resolved-tokens applied-tokens-in-shape)]
     token))
 
+(defn- generate-geometry-shorthand
+  [shapes objects]
+  (when (and (= (count shapes) 1) (has-border-radius? (first shapes)))
+    (css/get-css-property objects (first shapes) :border-radius)))
+
 (mf/defc geometry-panel*
   [{:keys [shapes objects resolved-tokens on-geometry-shorthand]}]
-  [:div {:class (stl/css :geometry-panel)}
-   (for [shape shapes]
-     [:div {:key (:id shape) :class "geometry-shape"}
-      (let [shorthand (when (and (= (count shapes) 1) (has-border-radius? shape))
-                        (css/get-css-property objects shape :border-radius))]
-        (mf/use-effect
-         (fn []
-           (when on-geometry-shorthand
-             (on-geometry-shorthand {:panel :geometry
-                                     :property shorthand}))))
+  (let [shorthand* (mf/use-state (generate-geometry-shorthand shapes objects))
+        shorthand (deref shorthand*)]
+    (mf/use-effect
+     (fn []
+       (when on-geometry-shorthand
+         (on-geometry-shorthand {:panel :geometry
+                                 :property shorthand}))))
+    [:div {:class (stl/css :geometry-panel)}
+     (for [shape shapes]
+       [:div {:key (:id shape) :class "geometry-shape"}
+
         (for [property properties]
           (when-let [value (css/get-css-value objects shape property)]
             (let [property-name (cmm/get-css-rule-humanized property)
@@ -70,4 +76,4 @@
                                    :detail value
                                    :token resolved-token
                                    :property property-value
-                                   :copiable true}]))))])])
+                                   :copiable true}])))])]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/geometry.cljs
@@ -60,7 +60,7 @@
 
 (mf/defc geometry-panel*
   [{:keys [shapes objects resolved-tokens on-geometry-shorthand]}]
-  (let [shorthand* (mf/use-state (generate-geometry-shorthand shapes objects))
+  (let [shorthand* (mf/use-state #(generate-geometry-shorthand shapes objects))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-geometry-shorthand shapes objects)
@@ -70,7 +70,7 @@
                                :property shorthand})))
     [:div {:class (stl/css :geometry-panel)}
      (for [shape shapes]
-       [:div {:key (:id shape) :class "geometry-shape"}
+       [:div {:key (:id shape) :class (stl/css :geometry-shape)}
 
         (for [property properties]
           (when-let [value (css/get-css-value objects shape property)]

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
@@ -13,7 +13,8 @@
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
-   [rumext.v2 :as mf]))
+   [rumext.v2 :as mf]
+   [promesa.core :as p]))
 
 (def ^:private properties
   [:display
@@ -61,8 +62,16 @@
   [{:keys [shapes objects resolved-tokens on-layout-shorthand]}]
   [:div {:class (stl/css :variants-panel)}
    (for [shape shapes]
-     (let [shorthand (when (and (= (count shapes) 1) (has-padding? shape))
-                       (css/get-css-property objects shape :padding))]
+     (let [shorthand-padding (when (and (= (count shapes) 1) (has-padding? shape))
+                               (css/get-css-property objects shape :padding))
+           shorthand-grid (when (and (= (count shapes) 1)
+                                     (= :grid (:layout shape)))
+                            (str "grid: "
+                                 (css/get-css-value objects shape :grid-template-rows)
+                                 " / "
+                                 (css/get-css-value objects shape :grid-template-columns)
+                                 ";"))
+           shorthand (str shorthand-padding " " shorthand-grid)]
        (mf/use-effect
         (fn []
           (when on-layout-shorthand

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
@@ -39,7 +39,12 @@
 
 (defn- has-padding?
   [shape]
-  (some #(and (contains? (:layout-padding shape) %) (not= 0 (get (:layout-padding shape) %))) [:p1 :p2 :p3 :p4]))
+  (let [padding (:layout-padding shape)
+        padding-keys [:p1 :p2 :p3 :p4]]
+    (some (fn [key]
+            (and (contains? padding key)
+                 (not= 0 (get padding key))))
+          padding-keys)))
 
 (defn- get-applied-tokens-in-shape
   [shape-tokens property]

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
@@ -78,7 +78,7 @@
 
 (mf/defc layout-panel*
   [{:keys [shapes objects resolved-tokens on-layout-shorthand]}]
-  (let [shorthand* (mf/use-state (generate-layout-shorthand shapes objects))
+  (let [shorthand* (mf/use-state #(generate-layout-shorthand shapes objects))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-layout-shorthand shapes objects)
@@ -88,7 +88,7 @@
                              :property shorthand})))
     [:div {:class (stl/css :variants-panel)}
      (for [shape shapes]
-       [:div {:key (:id shape) :class "layout-shape"}
+       [:div {:key (:id shape) :class (stl/css :layout-shape)}
         (for [property properties]
           (when-let [value (css/get-css-value objects shape property)]
             (let [property-name (cmm/get-css-rule-humanized property)

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
@@ -81,12 +81,13 @@
   (let [shorthand* (mf/use-state (generate-layout-shorthand shapes objects))
         shorthand (deref shorthand*)]
     (mf/use-effect
+     (mf/deps shorthand on-layout-shorthand shapes objects)
      (fn []
-       (when on-layout-shorthand
-         (on-layout-shorthand {:panel :layout
-                               :property shorthand}))))
-  [:div {:class (stl/css :variants-panel)}
-   (for [shape shapes]
+       (reset! shorthand* (generate-layout-shorthand shapes objects))
+       (on-layout-shorthand {:panel :layout
+                             :property shorthand})))
+    [:div {:class (stl/css :variants-panel)}
+     (for [shape shapes]
        [:div {:key (:id shape) :class "layout-shape"}
         (for [property properties]
           (when-let [value (css/get-css-value objects shape property)]

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout.cljs
@@ -63,22 +63,17 @@
 (defn- generate-layout-shorthand
   [shapes objects]
   (let [shape (first shapes)
-        shorthand-padding (mf/use-memo
-                           [shapes shape objects]
-                           (fn []
-                             (when (and (= (count shapes) 1) (has-padding? shape))
-                               (css/get-css-property objects shape :padding))))
-        shorthand-grid (mf/use-memo
-                        [shapes shape objects]
-                        (fn []
-                          (when (and (= (count shapes) 1)
-                                     (= :grid (:layout shape)))
-                            (str "grid: "
-                                 (css/get-css-value objects shape :grid-template-rows)
-                                 " / "
-                                 (css/get-css-value objects shape :grid-template-columns)
-                                 ";"))))
-        shorthand (str shorthand-padding " " shorthand-grid)]
+        shorthand-padding (when (and (= (count shapes) 1) (has-padding? shape))
+                            (css/get-css-property objects shape :padding))
+        shorthand-grid (when (and (= (count shapes) 1)
+                                  (= :grid (:layout shape)))
+                         (str "grid: "
+                              (css/get-css-value objects shape :grid-template-rows)
+                              " / "
+                              (css/get-css-value objects shape :grid-template-columns)
+                              ";"))
+        shorthand (when (or shorthand-padding shorthand-grid)
+                    (str shorthand-grid " " shorthand-padding))]
     shorthand))
 
 (mf/defc layout-panel*

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
@@ -27,7 +27,12 @@
 
 (defn- has-margin?
   [shape]
-  (some #(and (contains? (:layout-item-margin shape) %) (not= 0 (get (:layout-item-margin shape) %))) [:m1 :m2 :m3 :m4]))
+  (let [margin (:layout-item-margin shape)
+        margin-keys [:m1 :m2 :m3 :m4]]
+    (some (fn [key]
+            (and (contains? margin key)
+                 (not= 0 (get margin key))))
+          margin-keys)))
 
 (defn- get-applied-margins-in-shape
   [shape-tokens property]
@@ -52,12 +57,13 @@
                          (if-let [flex-value (css/get-css-value objects shape :flex)]
                            flex-value
                            0))
+        shorthand-basis 0 ;; Default-value. Currently not supported in the UI
         shorthand-shrink (when (and (= (count shapes) 1)
                                     (ctl/flex-layout-immediate-child? objects shape))
                            (if-let [flex-shrink-value (css/get-css-value objects shape :flex-shrink)]
                              flex-shrink-value
                              0))
-        shorthand-flex (dm/str "flex: " shorthand-grow " 0 " shorthand-shrink ";")
+        shorthand-flex (dm/str "flex: " shorthand-grow " " shorthand-basis " " shorthand-shrink ";")
         shorthand (dm/str  shorthand-margin " " shorthand-flex)]
     shorthand))
 

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
@@ -70,7 +70,7 @@
 (mf/defc layout-element-panel*
   [{:keys [shapes objects resolved-tokens layout-element-properties on-layout-element-shorthand]}]
   (let [shapes (->> shapes (filter #(ctl/any-layout-immediate-child? objects %)))
-        shorthand* (mf/use-state (generate-layout-element-shorthand shapes objects))
+        shorthand* (mf/use-state #(generate-layout-element-shorthand shapes objects))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-layout-element-shorthand shapes objects)
@@ -80,7 +80,7 @@
                                      :property shorthand})))
     [:div {:class (stl/css :layout-element-panel)}
      (for [shape shapes]
-       [:div {:key (:id shape) :class "layout-element-shape"}
+       [:div {:key (:id shape) :class (stl/css :layout-element-shape)}
         (for [property layout-element-properties]
           (when-let [value (css/get-css-value objects shape property)]
             (let [property-name (cmm/get-css-rule-humanized property)

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
@@ -42,39 +42,46 @@
           token (get resolved-tokens applied-tokens-in-shape)]
       token)))
 
+(defn- generate-layout-element-shorthand
+  [shapes objects]
+  (let [shape (first shapes)
+        shorthand-margin (when (and (= (count shapes) 1) (has-margin? shape))
+                           (css/get-css-property objects shape :margin))
+        shorthand-grow (when (and (= (count shapes) 1)
+                                  (ctl/flex-layout-immediate-child? objects shape))
+                         (if-let [flex-value (css/get-css-value objects shape :flex)]
+                           flex-value
+                           0))
+        shorthand-shrink (when (and (= (count shapes) 1)
+                                    (ctl/flex-layout-immediate-child? objects shape))
+                           (if-let [flex-shrink-value (css/get-css-value objects shape :flex-shrink)]
+                             flex-shrink-value
+                             0))
+        shorthand-flex (dm/str "flex: " shorthand-grow " 0 " shorthand-shrink ";")
+        shorthand (dm/str  shorthand-margin " " shorthand-flex)]
+    shorthand))
+
 (mf/defc layout-element-panel*
   [{:keys [shapes objects resolved-tokens layout-element-properties on-layout-element-shorthand]}]
-  (let [shapes (->> shapes (filter #(ctl/any-layout-immediate-child? objects %)))]
+  (let [shapes (->> shapes (filter #(ctl/any-layout-immediate-child? objects %)))
+        shorthand* (mf/use-state (generate-layout-element-shorthand shapes objects))
+        shorthand (deref shorthand*)]
+    (mf/use-effect
+     (fn []
+       (when on-layout-element-shorthand
+         (on-layout-element-shorthand {:panel :layout-element
+                                       :property shorthand}))))
     [:div {:class (stl/css :layout-element-panel)}
      (for [shape shapes]
-       (let [shorthand-margin (when (and (= (count shapes) 1) (has-margin? shape))
-                                (css/get-css-property objects shape :margin))
-             shorthand-grow (when (and (= (count shapes) 1)
-                                       (ctl/flex-layout-immediate-child? objects shape))
-                              (if-let [flex-value (css/get-css-value objects shape :flex)]
-                                flex-value
-                                0))
-             shorthand-shrink (when (and (= (count shapes) 1)
-                                         (ctl/flex-layout-immediate-child? objects shape))
-                                (if-let [flex-shrink-value (css/get-css-value objects shape :flex-shrink)]
-                                  flex-shrink-value
-                                  0))
-             shorthand-flex (dm/str "flex: " shorthand-grow " 0 " shorthand-shrink ";")
-             shorthand (dm/str  shorthand-margin " " shorthand-flex)]
-         (mf/use-effect
-          (fn []
-            (when on-layout-element-shorthand
-              (on-layout-element-shorthand {:panel :layout-element
-                                            :property shorthand}))))
-         [:div {:key (:id shape) :class "layout-element-shape"}
-          (for [property layout-element-properties]
-            (when-let [value (css/get-css-value objects shape property)]
-              (let [property-name (cmm/get-css-rule-humanized property)
-                    resolved-token (get-resolved-tokens property shape resolved-tokens)
-                    property-value (if (not resolved-token) (css/get-css-property objects shape property) "")]
-                [:> properties-row* {:key (dm/str "layout-element-property-" property)
-                                     :term property-name
-                                     :detail (str value)
-                                     :token resolved-token
-                                     :property property-value
-                                     :copiable true}])))]))]))
+       [:div {:key (:id shape) :class "layout-element-shape"}
+        (for [property layout-element-properties]
+          (when-let [value (css/get-css-value objects shape property)]
+            (let [property-name (cmm/get-css-rule-humanized property)
+                  resolved-token (get-resolved-tokens property shape resolved-tokens)
+                  property-value (if (not resolved-token) (css/get-css-property objects shape property) "")]
+              [:> properties-row* {:key (dm/str "layout-element-property-" property)
+                                   :term property-name
+                                   :detail (str value)
+                                   :token resolved-token
+                                   :property property-value
+                                   :copiable true}])))])]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/layout_element.cljs
@@ -67,10 +67,11 @@
         shorthand* (mf/use-state (generate-layout-element-shorthand shapes objects))
         shorthand (deref shorthand*)]
     (mf/use-effect
+     (mf/deps shorthand on-layout-element-shorthand shapes objects)
      (fn []
-       (when on-layout-element-shorthand
-         (on-layout-element-shorthand {:panel :layout-element
-                                       :property shorthand}))))
+       (reset! shorthand* (generate-layout-element-shorthand shapes objects))
+       (on-layout-element-shorthand {:panel :layout-element
+                                     :property shorthand})))
     [:div {:class (stl/css :layout-element-panel)}
      (for [shape shapes]
        [:div {:key (:id shape) :class "layout-element-shape"}

--- a/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
@@ -41,8 +41,8 @@
                              :property shorthand})))
     [:div {:class (stl/css :shadow-panel)}
      (for [shape shapes]
-       (for [shadow (:shadow shape)]
-         [:div {:key (dm/str (:id shape) (:type shadow)) :class "shadow-shape"}
+       (for [[idx shadow] (map-indexed vector (:shadow shape))]
+         [:div {:key (dm/str idx) :class "shadow-shape"}
           [:> color-properties-row* {:term "Shadow Color"
                                      :color (:color shadow)
                                      :format color-space

--- a/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
@@ -31,7 +31,7 @@
 
 (mf/defc shadow-panel*
   [{:keys [shapes color-space on-shadow-shorthand]}]
-  (let [shorthand* (mf/use-state (generate-shadow-shorthand shapes))
+  (let [shorthand* (mf/use-state #(generate-shadow-shorthand shapes))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-shadow-shorthand shapes)
@@ -42,7 +42,7 @@
     [:div {:class (stl/css :shadow-panel)}
      (for [shape shapes]
        (for [[idx shadow] (map-indexed vector (:shadow shape))]
-         [:div {:key (dm/str idx) :class "shadow-shape"}
+         [:div {:key (dm/str idx) :class (stl/css :shadow-shape)}
           [:> color-properties-row* {:term "Shadow Color"
                                      :color (:color shadow)
                                      :format color-space

--- a/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/shadow.cljs
@@ -12,22 +12,42 @@
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
+   [app.util.code-gen.style-css-formats :as scf]
    [rumext.v2 :as mf]))
 
+(defn- generate-shadow-shorthand
+  [shapes]
+  (when (= (count shapes) 1)
+    (reduce
+     (fn [acc shadow]
+       (let [value (scf/format-shadow->css shadow {})]
+         (if (empty? acc)
+           value
+           (dm/str acc ", " value))))
+     ""
+     (:shadow (first shapes)))))
+
 (mf/defc shadow-panel*
-  [{:keys [shapes color-space]}]
-  [:div {:class (stl/css :shadow-panel)}
-   (for [shape shapes]
-     (for [shadow (:shadow shape)]
-       [:div {:key (dm/str (:id shape) (:type shadow)) :class "shadow-shape"}
-        [:> color-properties-row* {:term "Shadow Color"
-                                   :color (:color shadow)
-                                   :format color-space
-                                   :copiable true}]
-        (let [value (dm/str (:offset-x shadow) "px" " " (:offset-y shadow) "px" " " (:blur shadow) "px" " " (:spread shadow) "px")
-              property-name (cmm/get-css-rule-humanized (:style shadow))
-              property-value (css/shadow->css shadow)]
-          [:> properties-row* {:term property-name
-                               :detail (dm/str value)
-                               :property property-value
-                               :copiable true}])]))])
+  [{:keys [shapes color-space on-shadow-shorthand]}]
+  ( let [shorthand* (mf/use-state (generate-shadow-shorthand shapes))
+        shorthand (deref shorthand*)]
+    (mf/use-effect
+     (fn []
+       (when on-shadow-shorthand
+         (on-shadow-shorthand {:panel :shadow
+                               :property shorthand}))))
+   [:div {:class (stl/css :shadow-panel)}
+    (for [shape shapes]
+      (for [shadow (:shadow shape)]
+        [:div {:key (dm/str (:id shape) (:type shadow)) :class "shadow-shape"}
+         [:> color-properties-row* {:term "Shadow Color"
+                                    :color (:color shadow)
+                                    :format color-space
+                                    :copiable true}]
+         (let [value (dm/str (:offset-x shadow) "px" " " (:offset-y shadow) "px" " " (:blur shadow) "px" " " (:spread shadow) "px")
+               property-name (cmm/get-css-rule-humanized (:style shadow))
+               property-value (css/shadow->css shadow)]
+           [:> properties-row* {:term property-name
+                                :detail (dm/str value)
+                                :property property-value
+                                :copiable true}])]))]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -79,7 +79,7 @@
 
 (mf/defc stroke-panel*
   [{:keys [shapes objects resolved-tokens color-space on-stroke-shorthand]}]
-  (let [shorthand* (mf/use-state (generate-stroke-shorthand shapes))
+  (let [shorthand* (mf/use-state #(generate-stroke-shorthand shapes))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-stroke-shorthand shapes)
@@ -89,7 +89,7 @@
                              :property shorthand})))
     [:div {:class (stl/css :stroke-panel)}
      (for [shape shapes]
-       [:div {:key (:id shape) :class "stroke-shape"}
+       [:div {:key (:id shape) :class (stl/css :stroke-shape)}
         (for [[idx stroke] (map-indexed vector (:strokes shape))]
           (for [property properties]
             (let [value (css/get-css-value objects stroke property)

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -9,24 +9,17 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.types.color :as ctc]
    [app.config :as cfg]
    [app.main.ui.inspect.attributes.common :as cmm]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
    [app.util.color :as uc]
-   [rumext.v2 :as mf]
-   [cljs.pprint :as pp]))
+   [cljs.pprint :as pp]
+   [rumext.v2 :as mf]))
 
 (def ^:private properties [:border-color :border-style :border-width])
-
-(defn- stroke->color [shape]
-  {:color (:stroke-color shape)
-   :opacity (:stroke-opacity shape)
-   :gradient (:stroke-color-gradient shape)
-   :id (:stroke-color-ref-id shape)
-   :file-id (:stroke-color-ref-file shape)
-   :image (:stroke-image shape)})
 
 (def ^:private shape-prop->stroke-prop
   {:border-style :stroke-style
@@ -70,7 +63,7 @@
             (when (= (count shapes) 1)
               (reduce
                (fn [acc stroke]
-                 (let [stroke-type (stroke->color stroke)
+                 (let [stroke-type (ctc/stroke->color stroke)
                        stroke-width (:stroke-width stroke)
                        stroke-style (:stroke-style stroke)
                        color-value (:color stroke-type)
@@ -97,7 +90,7 @@
         (for [[idx stroke] (map-indexed vector (:strokes shape))]
           (for [property properties]
             (let [value (css/get-css-value objects stroke property)
-                  stroke-type (stroke->color stroke)
+                  stroke-type (ctc/stroke->color stroke)
                   property-name (cmm/get-css-rule-humanized property)
                   property-value (css/get-css-property objects stroke property)
                   resolved-token (when (is-first-element? idx) (get-resolved-token property shape resolved-tokens))

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -66,11 +66,10 @@
                gradient-data  {:type (get-in stroke-type [:gradient :type])
                                :stops (get-in stroke-type [:gradient :stops])}
                color-image (:image stroke-type)
-               image-url (cfg/resolve-file-media color-image)
                value (cond
                        color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " color-value ";")
                        color-gradient (dm/str "border-image: " (uc/gradient->css gradient-data) " 100 / " stroke-width "px;")
-                       color-image (dm/str "border-image: url(" image-url ") 100 / " stroke-width "px;")
+                       color-image (dm/str "border-image: url(" (cfg/resolve-file-media color-image) ") 100 / " stroke-width "px;")
                        :else "")]
            (if (empty? acc)
              value

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -67,27 +67,28 @@
      [:div {:key (:id shape) :class "stroke-shape"}
       (let [shorthand
             ;; Since CSS does not have a shorthand for multiple borders, we create a shorthand for each stroke in the shape
-            (reduce
-             (fn [acc stroke]
-               (let [stroke-type (stroke->color stroke)
-                     stroke-width (:stroke-width stroke)
-                     stroke-style (:stroke-style stroke)
-                     color-value (:color stroke-type)
-                     color-gradient (:gradient stroke-type)
-                     gradient-data  {:type (get-in stroke-type [:gradient :type])
-                                     :stops (get-in stroke-type [:gradient :stops])}
-                     color-image (:image stroke-type)
-                     image-url (cfg/resolve-file-media color-image)
-                     value (cond
-                             color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " color-value ";")
-                             color-gradient (dm/str "border-image: " (uc/gradient->css gradient-data) " 100 / " stroke-width "px;")
-                             color-image (dm/str "border-image: url(" image-url ") 100 / " stroke-width "px;")
-                             :else "")]
-                 (if (empty? acc)
-                   value
-                   (str acc " " value))))
-             ""
-             (:strokes shape))]
+            (when (= (count shapes) 1)
+              (reduce
+               (fn [acc stroke]
+                 (let [stroke-type (stroke->color stroke)
+                       stroke-width (:stroke-width stroke)
+                       stroke-style (:stroke-style stroke)
+                       color-value (:color stroke-type)
+                       color-gradient (:gradient stroke-type)
+                       gradient-data  {:type (get-in stroke-type [:gradient :type])
+                                       :stops (get-in stroke-type [:gradient :stops])}
+                       color-image (:image stroke-type)
+                       image-url (cfg/resolve-file-media color-image)
+                       value (cond
+                               color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " color-value ";")
+                               color-gradient (dm/str "border-image: " (uc/gradient->css gradient-data) " 100 / " stroke-width "px;")
+                               color-image (dm/str "border-image: url(" image-url ") 100 / " stroke-width "px;")
+                               :else "")]
+                   (if (empty? acc)
+                     value
+                     (str acc " " value))))
+               ""
+               (:strokes shape)))]
         (mf/use-effect
          (fn []
            (when on-stroke-shorthand

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -16,7 +16,6 @@
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
    [app.util.color :as uc]
-   [cljs.pprint :as pp]
    [rumext.v2 :as mf]))
 
 (def ^:private properties [:border-color :border-style :border-width])

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -52,40 +52,44 @@
   (and (= (:resolved-value resolved-token) (:color stroke-type))
        (is-first-element? idx)))
 
+(defn- generate-stroke-shorthand
+  [shapes]
+  (when (= (count shapes) 1)
+    (let [shape (first shapes)]
+      (reduce
+       (fn [acc stroke]
+         (let [stroke-type (ctc/stroke->color stroke)
+               stroke-width (:stroke-width stroke)
+               stroke-style (:stroke-style stroke)
+               color-value (:color stroke-type)
+               color-gradient (:gradient stroke-type)
+               gradient-data  {:type (get-in stroke-type [:gradient :type])
+                               :stops (get-in stroke-type [:gradient :stops])}
+               color-image (:image stroke-type)
+               image-url (cfg/resolve-file-media color-image)
+               value (cond
+                       color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " color-value ";")
+                       color-gradient (dm/str "border-image: " (uc/gradient->css gradient-data) " 100 / " stroke-width "px;")
+                       color-image (dm/str "border-image: url(" image-url ") 100 / " stroke-width "px;")
+                       :else "")]
+           (if (empty? acc)
+             value
+             (str acc " " value))))
+       ""
+       (:strokes shape)))))
+
 (mf/defc stroke-panel*
   [{:keys [shapes objects resolved-tokens color-space on-stroke-shorthand]}]
-  [:div {:class (stl/css :stroke-panel)}
-   (for [shape shapes]
-     [:div {:key (:id shape) :class "stroke-shape"}
-      (let [shorthand
-            ;; Since CSS does not have a shorthand for multiple borders, we create a shorthand for each stroke in the shape
-            (when (= (count shapes) 1)
-              (reduce
-               (fn [acc stroke]
-                 (let [stroke-type (ctc/stroke->color stroke)
-                       stroke-width (:stroke-width stroke)
-                       stroke-style (:stroke-style stroke)
-                       color-value (:color stroke-type)
-                       color-gradient (:gradient stroke-type)
-                       gradient-data  {:type (get-in stroke-type [:gradient :type])
-                                       :stops (get-in stroke-type [:gradient :stops])}
-                       color-image (:image stroke-type)
-                       image-url (cfg/resolve-file-media color-image)
-                       value (cond
-                               color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " color-value ";")
-                               color-gradient (dm/str "border-image: " (uc/gradient->css gradient-data) " 100 / " stroke-width "px;")
-                               color-image (dm/str "border-image: url(" image-url ") 100 / " stroke-width "px;")
-                               :else "")]
-                   (if (empty? acc)
-                     value
-                     (str acc " " value))))
-               ""
-               (:strokes shape)))]
-        (mf/use-effect
-         (fn []
-           (when on-stroke-shorthand
-             (on-stroke-shorthand {:panel :stroke
-                                   :property shorthand}))))
+  (let [shorthand* (mf/use-state (generate-stroke-shorthand shapes))
+        shorthand (deref shorthand*)]
+    (mf/use-effect
+     (fn []
+       (when on-stroke-shorthand
+         (on-stroke-shorthand {:panel :stroke
+                               :property shorthand}))))
+    [:div {:class (stl/css :stroke-panel)}
+     (for [shape shapes]
+       [:div {:key (:id shape) :class "stroke-shape"}
         (for [[idx stroke] (map-indexed vector (:strokes shape))]
           (for [property properties]
             (let [value (css/get-css-value objects stroke property)
@@ -106,4 +110,4 @@
                                      :detail (dm/str value)
                                      :token resolved-token
                                      :property property-value
-                                     :copiable true}])))))])])
+                                     :copiable true}]))))])]))

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -83,10 +83,11 @@
   (let [shorthand* (mf/use-state (generate-stroke-shorthand shapes))
         shorthand (deref shorthand*)]
     (mf/use-effect
+     (mf/deps shorthand on-stroke-shorthand shapes)
      (fn []
-       (when on-stroke-shorthand
-         (on-stroke-shorthand {:panel :stroke
-                               :property shorthand}))))
+       (reset! shorthand* (generate-stroke-shorthand shapes))
+       (on-stroke-shorthand {:panel :stroke
+                             :property shorthand})))
     [:div {:class (stl/css :stroke-panel)}
      (for [shape shapes]
        [:div {:key (:id shape) :class "stroke-shape"}

--- a/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
@@ -7,6 +7,7 @@
 (ns app.main.ui.inspect.styles.panels.text
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data.macros :as dm]
    [app.common.types.fills :as types.fills]
    [app.common.types.text :as txt]
    [app.main.fonts :as fonts]
@@ -18,6 +19,7 @@
    [app.util.timers :as tm]
    [app.util.webapi :as wapi]
    [cuerdas.core :as str]
+   [me.flowthing.pp :as pp]
    [rumext.v2 :as mf]))
 
 (defn- get-applied-tokens-in-shape
@@ -59,11 +61,29 @@
                                :copiable true}]))
 
 (mf/defc text-panel*
-  [{:keys [shapes _ resolved-tokens color-space]}]
+  [{:keys [shapes resolved-tokens color-space on-font-shorthand]}]
   [:div {:class (stl/css :text-panel)}
    (for [shape shapes]
      (let [style-text-blocks (get-style-text shape)
-           composite-typography-token (get-resolved-token :typography shape resolved-tokens)]
+           composite-typography-token (get-resolved-token :typography shape resolved-tokens)
+           shorthand
+
+           (when (= (count shapes) 1)
+             (reduce
+              (fn [acc [style _]]
+                (let [font-style (:font-style style)
+                      font-family (dm/str (:font-family style))
+                      font-size (:font-size style)
+                      font-weight (:font-weight style)
+                      line-height (:line-height style)
+                      text-transform (:text-transform style)]
+                  (dm/str acc "font:" font-style " " text-transform " " font-weight " " font-size "/" line-height " "  \"  font-family  \" ";")))
+              ""
+              style-text-blocks))]
+       (mf/use-effect
+        (fn []
+          (on-font-shorthand {:panel :text
+                              :property shorthand})))
 
        [:div {:key (:id shape) :class "text-shape"}
         (for [[style text] style-text-blocks]

--- a/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
@@ -78,7 +78,7 @@
 
 (mf/defc text-panel*
   [{:keys [shapes resolved-tokens color-space on-font-shorthand]}]
-  (let [shorthand* (mf/use-state (generate-typography-shorthand shapes))
+  (let [shorthand* (mf/use-state #(generate-typography-shorthand shapes))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-font-shorthand shapes)
@@ -90,10 +90,10 @@
      (for [shape shapes]
        (let [style-text-blocks (get-style-text shape)
              composite-typography-token (get-resolved-token :typography shape resolved-tokens)]
-         [:div {:key (:id shape) :class "text-shape"}
+         [:div {:key (:id shape) :class (stl/css :text-shape)}
           (for [[style text] style-text-blocks]
 
-            [:div {:key (:id shape) :class "text-properties"}
+            [:div {:key (:id shape) :class (stl/css :text-properties)}
 
              (when (:fills style)
                (for [[idx fill] (map-indexed vector (:fills style))]

--- a/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
@@ -19,7 +19,6 @@
    [app.util.timers :as tm]
    [app.util.webapi :as wapi]
    [cuerdas.core :as str]
-   [me.flowthing.pp :as pp]
    [rumext.v2 :as mf]))
 
 (defn- get-applied-tokens-in-shape
@@ -82,128 +81,129 @@
   (let [shorthand* (mf/use-state (generate-typography-shorthand shapes))
         shorthand (deref shorthand*)]
     (mf/use-effect
+     (mf/deps shorthand on-font-shorthand shapes)
      (fn []
-       (when on-font-shorthand
-         (on-font-shorthand {:panel :text
-                             :property shorthand}))))
-   [:div {:class (stl/css :text-panel)}
-   (for [shape shapes]
-     (let [style-text-blocks (get-style-text shape)
-           composite-typography-token (get-resolved-token :typography shape resolved-tokens)]
-       [:div {:key (:id shape) :class "text-shape"}
-        (for [[style text] style-text-blocks]
+       (reset! shorthand* (generate-typography-shorthand shapes))
+       (on-font-shorthand {:panel :text
+                           :property shorthand})))
+    [:div {:class (stl/css :text-panel)}
+     (for [shape shapes]
+       (let [style-text-blocks (get-style-text shape)
+             composite-typography-token (get-resolved-token :typography shape resolved-tokens)]
+         [:div {:key (:id shape) :class "text-shape"}
+          (for [[style text] style-text-blocks]
 
-          [:div {:key (:id shape) :class "text-properties"}
+            [:div {:key (:id shape) :class "text-properties"}
 
-           (when (:fills style)
-             (for [[idx fill] (map-indexed vector (:fills style))]
-               [:> typography-color-row* {:key idx
-                                          :fill fill
-                                          :shape shape
-                                          :resolved-tokens resolved-tokens
-                                          :color-space color-space}]))
+             (when (:fills style)
+               (for [[idx fill] (map-indexed vector (:fills style))]
+                 [:> typography-color-row* {:key idx
+                                            :fill fill
+                                            :shape shape
+                                            :resolved-tokens resolved-tokens
+                                            :color-space color-space}]))
 
            ;; Typography style
-           (when (and (not composite-typography-token)
-                      (:typography-ref-id style))
-             [:> typography-name-block* {:style style}])
+             (when (and (not composite-typography-token)
+                        (:typography-ref-id style))
+               [:> typography-name-block* {:style style}])
 
            ;; Composite Typography token
-           (when (and (not (:typography-ref-id style))
-                      composite-typography-token)
-             [:> properties-row* {:term "Typography"
-                                  :detail (:name composite-typography-token)
-                                  :token composite-typography-token
-                                  :property (:name composite-typography-token)
-                                  :copiable true}])
+             (when (and (not (:typography-ref-id style))
+                        composite-typography-token)
+               [:> properties-row* {:term "Typography"
+                                    :detail (:name composite-typography-token)
+                                    :token composite-typography-token
+                                    :property (:name composite-typography-token)
+                                    :copiable true}])
 
-           (when (:font-id style)
-             (let [name (get (fonts/get-font-data (:font-id style)) :name)
-                   resolved-token (get-resolved-token :font-family shape resolved-tokens)]
-               [:> properties-row* {:term "Font Family"
-                                    :detail name
-                                    :token resolved-token
-                                    :property (str "font-family: \"" name "\";")
-                                    :copiable true}]))
+             (when (:font-id style)
+               (let [name (get (fonts/get-font-data (:font-id style)) :name)
+                     resolved-token (get-resolved-token :font-family shape resolved-tokens)]
+                 [:> properties-row* {:term "Font Family"
+                                      :detail name
+                                      :token resolved-token
+                                      :property (str "font-family: \"" name "\";")
+                                      :copiable true}]))
 
-           (when (:font-style style)
-             [:> properties-row* {:term "Font Style"
-                                  :detail (:font-style style)
-                                  :property (str "font-style: " (:font-style style) ";")
-                                  :copiable true}])
+             (when (:font-style style)
+               [:> properties-row* {:term "Font Style"
+                                    :detail (:font-style style)
+                                    :property (str "font-style: " (:font-style style) ";")
+                                    :copiable true}])
 
-           (when (:font-size style)
-             (let [font-size (fmt/format-pixels (:font-size style))
-                   resolved-token (get-resolved-token :font-size shape resolved-tokens)]
-               [:> properties-row* {:term "Font Size"
-                                    :detail font-size
-                                    :token resolved-token
-                                    :property (str "font-size: " font-size ";")
-                                    :copiable true}]))
-           (when (:font-weight style)
-             (let [resolved-token (get-resolved-token :font-weight shape resolved-tokens)]
-               [:> properties-row* {:term "Font Weight"
-                                    :detail (:font-weight style)
-                                    :token resolved-token
-                                    :property (str "font-weight: " (:font-weight style) ";")
-                                    :copiable true}]))
+             (when (:font-size style)
+               (let [font-size (fmt/format-pixels (:font-size style))
+                     resolved-token (get-resolved-token :font-size shape resolved-tokens)]
+                 [:> properties-row* {:term "Font Size"
+                                      :detail font-size
+                                      :token resolved-token
+                                      :property (str "font-size: " font-size ";")
+                                      :copiable true}]))
+             (when (:font-weight style)
+               (let [resolved-token (get-resolved-token :font-weight shape resolved-tokens)]
+                 [:> properties-row* {:term "Font Weight"
+                                      :detail (:font-weight style)
+                                      :token resolved-token
+                                      :property (str "font-weight: " (:font-weight style) ";")
+                                      :copiable true}]))
 
-           (when (:line-height style)
-             (let [line-height (:line-height style)
-                   resolved-token (get-resolved-token :line-height shape resolved-tokens)]
-               [:> properties-row* {:term "Line Height"
-                                    :detail (str line-height)
-                                    :token resolved-token
-                                    :property (str "line-height: " line-height ";")
-                                    :copiable true}]))
+             (when (:line-height style)
+               (let [line-height (:line-height style)
+                     resolved-token (get-resolved-token :line-height shape resolved-tokens)]
+                 [:> properties-row* {:term "Line Height"
+                                      :detail (str line-height)
+                                      :token resolved-token
+                                      :property (str "line-height: " line-height ";")
+                                      :copiable true}]))
 
-           (when (:letter-spacing style)
-             (let [letter-spacing (fmt/format-pixels (:letter-spacing style))
-                   resolved-token (get-resolved-token :letter-spacing shape resolved-tokens)]
-               [:> properties-row* {:term "Letter Spacing"
-                                    :detail letter-spacing
-                                    :token resolved-token
-                                    :property (str "letter-spacing: " letter-spacing ";")
-                                    :copiable true}]))
+             (when (:letter-spacing style)
+               (let [letter-spacing (fmt/format-pixels (:letter-spacing style))
+                     resolved-token (get-resolved-token :letter-spacing shape resolved-tokens)]
+                 [:> properties-row* {:term "Letter Spacing"
+                                      :detail letter-spacing
+                                      :token resolved-token
+                                      :property (str "letter-spacing: " letter-spacing ";")
+                                      :copiable true}]))
 
-           (when (:text-decoration style)
-             (let [resolved-token (get-resolved-token :text-decoration shape resolved-tokens)]
-               [:> properties-row* {:term "Text Decoration"
-                                    :detail (:text-decoration style)
-                                    :token resolved-token
-                                    :property (str "text-decoration: " (:text-decoration style) ";")
-                                    :copiable true}]))
+             (when (:text-decoration style)
+               (let [resolved-token (get-resolved-token :text-decoration shape resolved-tokens)]
+                 [:> properties-row* {:term "Text Decoration"
+                                      :detail (:text-decoration style)
+                                      :token resolved-token
+                                      :property (str "text-decoration: " (:text-decoration style) ";")
+                                      :copiable true}]))
 
-           (when (:text-transform style)
-             (let [resolved-token (get-resolved-token :text-case shape resolved-tokens)]
-               [:> properties-row* {:term "Text Transform"
-                                    :detail (:text-transform style)
-                                    :token resolved-token
-                                    :property (str "text-transform: " (:text-transform style) ";")
-                                    :copiable true}]))
-           (when text
-             (let [copied* (mf/use-state false)
-                   copied (deref copied*)
+             (when (:text-transform style)
+               (let [resolved-token (get-resolved-token :text-case shape resolved-tokens)]
+                 [:> properties-row* {:term "Text Transform"
+                                      :detail (:text-transform style)
+                                      :token resolved-token
+                                      :property (str "text-transform: " (:text-transform style) ";")
+                                      :copiable true}]))
+             (when text
+               (let [copied* (mf/use-state false)
+                     copied (deref copied*)
 
-                   text (str/trim text)
+                     text (str/trim text)
 
-                   copy-text
-                   (mf/use-fn
-                    (mf/deps copied)
-                    (fn []
-                      (let [formatted-text (if (= (:text-transform style) "uppercase")
-                                             (.toUpperCase text)
-                                             text)]
-                        (reset! copied* true)
-                        (wapi/write-to-clipboard formatted-text)
-                        (tm/schedule 1000 #(reset! copied* false)))))]
-               [:div {:class (stl/css :text-content-wrapper)}
-                [:> property-detail-copiable* {:copied copied
-                                               :on-click copy-text}
-                 [:span {:class (stl/css :text-content)
-                         :style {:font-family (:font-family style)
-                                 :font-weight (:font-weight style)
-                                 :text-transform (:text-transform style)
-                                 :letter-spacing (fmt/format-pixels (:letter-spacing style))
-                                 :font-style (:font-style style)}}
-                  text]]]))])]))]))
+                     copy-text
+                     (mf/use-fn
+                      (mf/deps copied)
+                      (fn []
+                        (let [formatted-text (if (= (:text-transform style) "uppercase")
+                                               (.toUpperCase text)
+                                               text)]
+                          (reset! copied* true)
+                          (wapi/write-to-clipboard formatted-text)
+                          (tm/schedule 1000 #(reset! copied* false)))))]
+                 [:div {:class (stl/css :text-content-wrapper)}
+                  [:> property-detail-copiable* {:copied copied
+                                                 :on-click copy-text}
+                   [:span {:class (stl/css :text-content)
+                           :style {:font-family (:font-family style)
+                                   :font-weight (:font-weight style)
+                                   :text-transform (:text-transform style)
+                                   :letter-spacing (fmt/format-pixels (:letter-spacing style))
+                                   :font-style (:font-style style)}}
+                    text]]]))])]))]))

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -34,7 +34,6 @@
   [{:keys [class term color format token]}]
   (let [copied* (mf/use-state false)
         copied (deref copied*)
-
         color-value (:color color)
         color-gradient (:gradient color)
         color-image (:image color)

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -47,9 +47,9 @@
          (fn []
            (reset! expanded* (not expanded))))
 
-        _ (pp/pprint "style-box*")
-        _ (pp/pprint panel)
-        _ (pp/pprint shorthand)
+        ;; _ (pp/pprint "style-box*")
+        ;; _ (pp/pprint panel)
+        ;; _ (pp/pprint shorthand)
 
         copy-shorthand
         (mf/use-fn

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -12,7 +12,6 @@
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.util.i18n :refer [tr]]
    [app.util.webapi :as wapi]
-   [cljs.pprint :as pp]
    [rumext.v2 :as mf]))
 
 (defn- panel->title
@@ -46,10 +45,6 @@
          (mf/deps expanded)
          (fn []
            (reset! expanded* (not expanded))))
-
-        ;; _ (pp/pprint "style-box*")
-        ;; _ (pp/pprint panel)
-        ;; _ (pp/pprint shorthand)
 
         copy-shorthand
         (mf/use-fn

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -12,6 +12,7 @@
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.util.i18n :refer [tr]]
    [app.util.webapi :as wapi]
+   [cljs.pprint :as pp]
    [rumext.v2 :as mf]))
 
 (defn- panel->title
@@ -46,10 +47,15 @@
          (fn []
            (reset! expanded* (not expanded))))
 
+        _ (pp/pprint "style-box*")
+        _ (pp/pprint panel)
+        _ (pp/pprint shorthand)
+
         copy-shorthand
         (mf/use-fn
+         (mf/deps shorthand)
          (fn []
-           (wapi/write-to-clipboard (str "Style: " title))))]
+           (wapi/write-to-clipboard (str shorthand))))]
     [:article {:class (stl/css :style-box)}
      [:header {:class (stl/css :disclosure-header)}
       [:button {:class (stl/css :disclosure-button)

--- a/frontend/src/app/main/ui/inspect/styles/style_box.scss
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.scss
@@ -17,6 +17,7 @@
 
 .disclosure-header {
   display: flex;
+  align-items: center;
   gap: var(--title-gap);
   padding-block: var(--title-padding);
 }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1905,7 +1905,7 @@ msgstr "Info"
 #: src/app/main/ui/inspect/styles/style_box.cljs:66
 #, fuzzy
 msgid "inspect.tabs.styles.panel.copy-style-shorthand"
-msgstr ""
+msgstr "Copy CSS shorthand to clipboard"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
 msgid "inspect.tabs.styles.panel.copy-to-clipboard"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1897,6 +1897,23 @@ msgstr "Calculado"
 msgid "inspect.tabs.info"
 msgstr "Información"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:66
+#, fuzzy
+msgid "inspect.tabs.styles.panel.copy-style-shorthand"
+msgstr "Copiar CSS shorthand al portapapeles"
+
+#: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
+msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgstr "Copiar al portapapeles"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
+msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgstr "Sets activos"
+
+#: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
+msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgstr "Temas activos"
+
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
 msgid "inspect.tabs.styles.panel.geometry"
 msgstr "Tamaño y posición"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11876

<!-- Reference the related GitHub/Taiga ticket. -->

### Requirements
This task requires the config flag `enable-inspect-styles`

### Summary

This PR allow the user to copy a shorthand for each panel, grouping multiple properties together.

### Steps to reproduce 

Find multiple elements that use shorthandable properties (as padding, margin, box-shadow, background, etc.)

- Check that those elements have a shorthand button on the `styles` tab panel
- Click on the button and check that the available shorthands are copied into your clipboard,

<img width="318" height="162" alt="Screenshot from 2025-10-28 12-34-51" src="https://github.com/user-attachments/assets/bcfc87f6-59c6-4783-a55d-1fe64798d21f" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
