### PR TITLE
:wrench: Update skia-safe dependency

### DIFF
--- a/render-wasm/Cargo.lock
+++ b/render-wasm/Cargo.lock
@@ -202,9 +202,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -214,9 +214,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -252,12 +252,6 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -468,18 +462,27 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -500,11 +503,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -515,9 +518,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "skia-bindings"
-version = "0.87.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704242769235d2ffe66a2a0a3002661262fc4af08d32807c362d7b0160ee703c"
+checksum = "8f6f96e00735f14a781aac8a6870c862b8cc831df6d8e4ad77ab78e11411b9af"
 dependencies = [
  "bindgen",
  "cc",
@@ -532,13 +535,12 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.87.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7d94f3e7537c71ad4cf132eb26e3be8c8a886ed3649c4525c089041fc312b2"
+checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
 dependencies = [
  "base64",
  "bitflags",
- "lazy_static",
  "percent-encoding",
  "skia-bindings",
  "skia-svg-macros",
@@ -579,37 +581,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.22"
+name = "toml_parser"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "unicode-ident"
@@ -775,12 +782,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "xattr"

--- a/render-wasm/Cargo.toml
+++ b/render-wasm/Cargo.toml
@@ -25,7 +25,7 @@ gl = "0.14.0"
 glam = "0.24.2"
 indexmap = "2.7.1"
 macros = { path = "macros" }
-skia-safe = { version = "0.87.0", default-features = false, features = [
+skia-safe = { version = "0.90.0", default-features = false, features = [
   "gl",
   "svg",
   "textlayout",

--- a/render-wasm/_build_env
+++ b/render-wasm/_build_env
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# By default we use WASM as the BUILD_TARGET
+export BUILD_TARGET=${BUILD_TARGET:-"wasm"}
+. ./_common
+
 if [ "$NODE_ENV" = "production" ];  then
     export _BUILD_MODE="release";
 else

--- a/render-wasm/_common
+++ b/render-wasm/_common
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+load_skia_env() {
+  if [ -f ./_skia_env ]; then
+    . ./_skia_env
+    if [ -z "${SKIA_BINARIES_URL}" ] && [ ! -z "${SKIA_BINARIES_WASM_URL}" ] && [ $1 == "wasm" ]; then
+      export SKIA_BINARIES_URL=${SKIA_BINARIES_WASM_URL}
+    elif [ -z "${SKIA_BINARIES_URL}" ] && [ ! -z "${SKIA_BINARIES_LINUX_URL}" ] && [ $1 == "linux" ]; then
+      export SKIA_BINARIES_URL=${SKIA_BINARIES_LINUX_URL}
+    fi
+  fi
+}
+
+load_skia_env ${BUILD_TARGET}

--- a/render-wasm/_skia_env
+++ b/render-wasm/_skia_env
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# WASM binaries
+export SKIA_BINARIES_WASM_URL="https://github.com/penpot/skia-binaries/releases/download/0.90.0/skia-binaries-da4579b39b75fa2187c5-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache-webp.tar.gz"
+
+# Linux binaries
+export SKIA_BINARIES_LINUX_URL="https://github.com/penpot/skia-binaries/releases/download/0.90.0/skia-binaries-da4579b39b75fa2187c5-x86_64-unknown-linux-gnu-gl-svg-textlayout-binary-cache-webp.tar.gz"

--- a/render-wasm/build
+++ b/render-wasm/build
@@ -12,7 +12,7 @@ pushd $_SCRIPT_DIR;
 . ./_build_env
 
 export CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-"wasm32-unknown-emscripten"};
-export SKIA_BINARIES_URL=${SKIA_BINARIES_URL:-"https://github.com/penpot/skia-binaries/releases/download/0.87.0/skia-binaries-e551f334ad5cbdf43abf-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache-webp.tar.gz"}
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL};
 
 cargo build $_CARGO_PARAMS
 

--- a/render-wasm/lint
+++ b/render-wasm/lint
@@ -11,8 +11,7 @@ fi
 . ./_build_env
 
 export CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-"wasm32-unknown-emscripten"};
-export SKIA_BINARIES_URL=${SKIA_BINARIES_URL:-"https://github.com/penpot/skia-binaries/releases/download/0.87.0/skia-binaries-e551f334ad5cbdf43abf-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache-webp.tar.gz"}
-
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL};
 
 ALLOWED_RULES="-D static_mut_refs"
 

--- a/render-wasm/src/math.rs
+++ b/render-wasm/src/math.rs
@@ -356,7 +356,7 @@ impl Bounds {
     }
 
     pub fn from_rect(r: &Rect) -> Self {
-        let [nw, ne, se, sw] = r.to_quad();
+        let [nw, ne, se, sw] = r.to_quad(skia::PathDirection::CW);
         Self::new(nw, ne, se, sw)
     }
 

--- a/render-wasm/test
+++ b/render-wasm/test
@@ -4,10 +4,11 @@ set -x
 _SCRIPT_DIR=$(dirname $0);
 pushd $_SCRIPT_DIR;
 
+export BUILD_TARGET="linux"
 . ./_build_env
 
-export SKIA_BINARIES_URL=${SKIA_BINARIES_URL:-"https://github.com/penpot/skia-binaries/releases/download/0.87.0/skia-binaries-e551f334ad5cbdf43abf-x86_64-unknown-linux-gnu-gl-svg-textlayout-binary-cache-webp.tar.gz"}
 export CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-"x86_64-unknown-linux-gnu"};
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL};
 
 cargo test --bin render_wasm -- --show-output
 

--- a/render-wasm/watch
+++ b/render-wasm/watch
@@ -4,10 +4,11 @@ set -x
 _SCRIPT_DIR=$(dirname $0);
 pushd $_SCRIPT_DIR;
 
+export BUILD_TARGET="linux"
 . ./_build_env
 
 export CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-"wasm32-unknown-emscripten"};
-export SKIA_BINARIES_URL=${SKIA_BINARIES_URL:-"https://github.com/penpot/skia-binaries/releases/download/0.87.0/skia-binaries-e551f334ad5cbdf43abf-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache-webp.tar.gz"}
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL};
 
 _SHARED_FILE=$(find target/wasm32-unknown-emscripten -name render_wasm_shared.js | head -n 1);
 

--- a/render-wasm/watch_test
+++ b/render-wasm/watch_test
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 _SCRIPT_DIR=$(dirname $0);
 
-export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.87.0/skia-binaries-e551f334ad5cbdf43abf-x86_64-unknown-linux-gnu-gl-svg-textlayout-binary-cache-webp.tar.gz"
+export BUILD_TARGET="linux"
+. ./_common
+
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL};
 
 pushd $_SCRIPT_DIR;
 cargo watch -x "test --bin render_wasm -- --show-output"


### PR DESCRIPTION
### Summary

- Updates skia-safe to 0.89.1 (from 0.87)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.
