### PR TITLE
:tada: Add design tokens to plugins API

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -310,6 +310,10 @@
    schema:text-decoration
    schema:dimensions])
 
+(defn token-attr?
+  [attr]
+  (contains? all-keys attr))
+
 (defn shape-attr->token-attrs
   ([shape-attr] (shape-attr->token-attrs shape-attr nil))
   ([shape-attr changed-sub-attr]
@@ -403,15 +407,15 @@
     :text    text-attributes
     nil))
 
-(defn appliable-attrs
+(defn appliable-attrs-for-shape
   "Returns intersection of shape `attributes` for `shape-type`."
   [attributes shape-type is-layout]
   (set/intersection attributes (shape-type->attributes shape-type is-layout)))
 
-(defn any-appliable-attr?
+(defn any-appliable-attr-for-shape?
   "Checks if `token-type` supports given shape `attributes`."
   [attributes token-type is-layout]
-  (seq (appliable-attrs attributes token-type is-layout)))
+  (d/not-empty? (appliable-attrs-for-shape attributes token-type is-layout)))
 
 ;; Token attrs that are set inside content blocks of text shapes, instead
 ;; at the shape level.

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -758,7 +758,7 @@
   (theme-active? [_ id] "predicate if token theme is active")
   (activate-theme [_ id] "adds theme from the active-themes")
   (deactivate-theme [_ id] "removes theme from the active-themes")
-  (toggle-theme-active? [_ id] "toggles theme in the active-themes")
+  (toggle-theme-active [_ id] "toggles theme in the active-themes")
   (get-hidden-theme [_] "get the hidden temporary theme"))
 
 (def schema:token-themes
@@ -901,6 +901,7 @@
   (delete-token [_ set-id token-id] "delete a token from a set")
   (toggle-set-in-theme [_ theme-id set-name] "toggle a set used / not used in a theme")
   (get-active-themes-set-names [_] "set of set names that are active in the the active themes")
+  (token-set-active? [_ set-name] "if a set is active in any of the active themes")
   (sets-at-path-all-active? [_ group-path] "compute active state for child sets at `group-path`.
 Will return a value that matches this schema:
 `:none`    None of the nested sets are active
@@ -1206,7 +1207,7 @@ Will return a value that matches this schema:
     (when-let [theme (get-theme this id)]
       (contains? active-themes (get-theme-path theme))))
 
-  (toggle-theme-active? [this id]
+  (toggle-theme-active [this id]
     (if (theme-active? this id)
       (deactivate-theme this id)
       (activate-theme this id)))
@@ -1269,6 +1270,10 @@ Will return a value that matches this schema:
     (into #{}
           (mapcat :sets)
           (get-active-themes this)))
+
+  (token-set-active? [this set-name]
+    (let [set-names (get-active-themes-set-names this)]
+      (contains? set-names set-name)))
 
   (sets-at-path-all-active? [this group-path]
     (let [active-set-names (get-active-themes-set-names this)

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1558,7 +1558,7 @@
                                                                  :external-id "test-id-01"
                                                                  :modified-at now
                                                                  :sets #{"core"}))
-                          (ctob/toggle-theme-active? (thi/id :theme-1)))
+                          (ctob/toggle-theme-active (thi/id :theme-1)))
            result   (ctob/export-dtcg-json tokens-lib)
            expected {"$themes" [{"description" ""
                                  "group" "group-1"
@@ -1612,7 +1612,7 @@
                                                                  :external-id "test-id-01"
                                                                  :modified-at now
                                                                  :sets #{"some/set"}))
-                          (ctob/toggle-theme-active? (thi/id :theme-1)))
+                          (ctob/toggle-theme-active (thi/id :theme-1)))
            result   (ctob/export-dtcg-multi-file tokens-lib)
            expected {"$themes.json" [{"description" ""
                                       "group" "group-1"

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -55,10 +55,7 @@
 
 (defn generic-attribute-actions [attributes title {:keys [token selected-shapes on-update-shape hint allowed-shape-attributes]}]
   (let [allowed-attributes (set/intersection attributes allowed-shape-attributes)
-        on-update-shape-fn
-        (or on-update-shape
-            (-> (dwta/get-token-properties token)
-                (:on-update-shape)))
+        on-update-shape-fn (or on-update-shape (dwta/get-update-shape-fn token))
 
         {:keys [selected-pred shape-ids]}
         (attribute-actions token selected-shapes allowed-attributes)]

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
@@ -166,7 +166,7 @@
    ;; Edge-case for allowing margin attribute on shapes inside layout parent
    (and selected-inside-layout? (set/subset? ctt/spacing-margin-keys attrs))
    (some (fn [shape]
-           (ctt/any-appliable-attr? attrs (:type shape) (:layout shape)))
+           (ctt/any-appliable-attr-for-shape? attrs (:type shape) (:layout shape)))
          selected-shapes)))
 
 (def token-types-with-status-icon

--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -33,15 +33,12 @@
         can-edit?
         (mf/use-ctx ctx/can-edit?)
 
-        active-token-sets-names
-        (mf/with-memo [tokens-lib]
-          (some-> tokens-lib (ctob/get-active-themes-set-names)))
-
         token-set-active?
         (mf/use-fn
-         (mf/deps active-token-sets-names)
+         (mf/deps tokens-lib)
          (fn [name]
-           (contains? active-token-sets-names name)))
+           (when tokens-lib
+             (ctob/token-set-active? tokens-lib name))))
 
         token-set-group-active?
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/tokens/sets/helpers.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/helpers.cljs
@@ -28,7 +28,8 @@
         (if-let [parent-path (ctob/get-set-path parent-set)]
           (->> (concat parent-path (ctob/split-set-name name))
                (ctob/join-set-path))
-          (ctob/normalize-set-name name))]
+          (ctob/normalize-set-name name))
+        token-set (ctob/make-token-set :name name)]
 
     (st/emit! (ptk/data-event ::ev/event {::ev/name "create-token-set" :name name})
-              (dwtl/create-token-set name))))
+              (dwtl/create-token-set token-set))))

--- a/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
@@ -51,7 +51,7 @@
               true))  ;; if still no library exists, cannot be duplicate
     :type-properties {:error/fn #(tr "workspace.tokens.theme-name-already-exists")}}))
 
-(defn- validate-theme-name
+(defn validate-theme-name
   [tokens-lib group theme-id name]
   (let [schema     (theme-name-schema {:tokens-lib tokens-lib :theme-id theme-id :group group})
         validation (m/explain schema (str/trim name))]
@@ -151,7 +151,7 @@
               [:div {:on-click (fn [e]
                                  (dom/prevent-default e)
                                  (dom/stop-propagation e)
-                                 (st/emit! (dwtl/toggle-token-theme-active? id)))}
+                                 (st/emit! (dwtl/toggle-token-theme-active id)))}
                [:& switch {:name (tr "workspace.tokens.theme-name" name)
                            :on-change (constantly nil)
                            :selected? selected?}]]]

--- a/frontend/src/app/main/ui/workspace/tokens/themes/theme_selector.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/theme_selector.cljs
@@ -31,7 +31,7 @@
                  selected? (get active-theme-paths theme-id)
                  select-theme (fn [e]
                                 (dom/stop-propagation e)
-                                (st/emit! (dwtl/toggle-token-theme-active? id))
+                                (st/emit! (dwtl/toggle-token-theme-active id))
                                 (on-close))]]
        [:li {:key theme-id
              :role "option"

--- a/frontend/src/app/plugins/library.cljs
+++ b/frontend/src/app/plugins/library.cljs
@@ -28,6 +28,7 @@
    [app.plugins.register :as r]
    [app.plugins.shape :as shape]
    [app.plugins.text :as text]
+   [app.plugins.tokens :as tokens]
    [app.plugins.utils :as u]
    [app.util.object :as obj]
    [beicon.v2.core :as rx]
@@ -958,6 +959,12 @@
                              (map first)
                              (map #(lib-component-proxy plugin-id file-id %)))]
          (apply array components)))}
+
+    :tokens
+    {:this true
+     :get
+     (fn [_]
+       (tokens/tokens-catalog plugin-id file-id))}
 
     :createColor
     (fn []

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -1,0 +1,396 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.plugins.tokens
+  (:require
+   [app.common.data.macros :as dm]
+   [app.common.types.token :as cto]
+   [app.common.types.tokens-lib :as ctob]
+   [app.common.uuid :as uuid]
+   [app.main.data.workspace.tokens.application :as dwta]
+   [app.main.data.workspace.tokens.library-edit :as dwtl]
+   [app.main.store :as st]
+   [app.main.ui.workspace.tokens.management.create.form :as token-form]
+   [app.main.ui.workspace.tokens.themes.create-modal :as theme-form]
+   [app.plugins.utils :as u]
+   [app.util.object :as obj]
+   [clojure.datafy :refer [datafy]]))
+
+(defn- apply-token-to-shapes
+  [file-id set-id id shape-ids attrs]
+  (let [token (u/locate-token file-id set-id id)
+        kw-attrs (into #{} (map keyword attrs))]
+    (if (some #(not (cto/token-attr? %)) kw-attrs)
+      (u/display-not-valid :applyToSelected attrs)
+      (st/emit!
+       (dwta/toggle-token {:token token
+                           :attrs kw-attrs
+                           :shape-ids shape-ids
+                           :expand-with-children false})))))
+
+(defn token-proxy
+  [plugin-id file-id set-id id]
+  (obj/reify {:name "TokenSetProxy"}
+    :$plugin {:enumerable false :get (constantly plugin-id)}
+    :$file-id {:enumerable false :get (constantly file-id)}
+    :$set-id {:enumerable false :get (constantly set-id)}
+    :$id {:enumerable false :get (constantly id)}
+
+    :id
+    {:get #(dm/str id)}
+
+    :name
+    {:this true
+     :get
+     (fn [_]
+       (let [token (u/locate-token file-id set-id id)]
+         (ctob/get-name token)))
+     :set
+     (fn [_ value]
+       (let [tokens-lib (u/locate-tokens-lib file-id)
+             errors     (token-form/validate-token-name
+                         (ctob/get-tokens tokens-lib set-id)
+                         value)]
+         (cond
+           (some? errors)
+           (u/display-not-valid :name (first errors))
+
+           :else
+           (st/emit! (dwtl/update-token set-id id {:name value})))))}
+
+    :type
+    {:this true
+     :get
+     (fn [_]
+       (let [token (u/locate-token file-id set-id id)]
+         (-> (:type token) (cto/token-type->dtcg-token-type))))}
+
+    :value
+    {:this true
+     :get
+     (fn [_]
+       (let [token (u/locate-token file-id set-id id)]
+         (:value token)))}
+
+    :description
+    {:this true
+     :get
+     (fn [_]
+       (let [token (u/locate-token file-id set-id id)]
+         (ctob/get-description token)))}
+
+    :duplicate
+    (fn []
+      (let [token  (u/locate-token file-id set-id id)
+            token' (ctob/make-token (-> (datafy token)
+                                        (dissoc :id
+                                                :modified-at)))]
+        (st/emit! (dwtl/create-token set-id token'))
+        (token-proxy plugin-id file-id set-id (:id token'))))
+
+    :remove
+    (fn []
+      (st/emit! (dwtl/delete-token set-id id)))
+
+    :applyToShapes
+    (fn [shapes attrs]
+      (apply-token-to-shapes file-id set-id id (map :id shapes) attrs))
+
+    :applyToSelected
+    (fn [attrs]
+      (let [selected (get-in @st/state [:workspace-local :selected])]
+        (apply-token-to-shapes file-id set-id id selected attrs)))))
+
+(defn token-set-proxy
+  [plugin-id file-id id]
+  (obj/reify {:name "TokenSetProxy"}
+    :$plugin {:enumerable false :get (constantly plugin-id)}
+    :$file-id {:enumerable false :get (constantly file-id)}
+    :$id {:enumerable false :get (constantly id)}
+
+    :id
+    {:get #(dm/str id)}
+
+    :name
+    {:this true
+     :get
+     (fn [_]
+       (let [set (u/locate-token-set file-id id)]
+         (ctob/get-name set)))
+     :set
+     (fn [_ value]
+       (let [set (u/locate-token-set file-id id)]
+         (cond
+           (not (string? value))
+           (u/display-not-valid :name value)
+
+           :else
+           (st/emit! (dwtl/update-token-set set value)))))}
+
+    :active
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [tokens-lib (u/locate-tokens-lib file-id)
+             set        (u/locate-token-set file-id id)]
+         (ctob/token-set-active? tokens-lib (ctob/get-name set))))
+     :set
+     (fn [_ value]
+       (let [set (u/locate-token-set file-id id)]
+         (st/emit! (dwtl/set-enabled-token-set (ctob/get-name set) value))))}
+
+    :toggleActive
+    (fn [_]
+      (let [set (u/locate-token-set file-id id)]
+        (st/emit! (dwtl/toggle-token-set (ctob/get-name set)))))
+
+    :tokens
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [file (u/locate-file file-id)
+             tokens-lib (->> file :data :tokens-lib)]
+         (->> (ctob/get-tokens tokens-lib id)
+              (vals)
+              (map #(token-proxy plugin-id file-id id (:id %)))
+              (apply array))))}
+
+    :tokensByType
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [file (u/locate-file file-id)
+             tokens-lib (->> file :data :tokens-lib)
+             tokens (ctob/get-tokens tokens-lib id)]
+         (->> tokens
+              (vals)
+              (sort-by :name)
+              (group-by #(cto/token-type->dtcg-token-type (:type %)))
+              (into [])
+              (mapv (fn [[type tokens]]
+                      #js [(name type)
+                           (->> tokens
+                                (map #(token-proxy plugin-id file-id id (:id %)))
+                                (apply array))]))
+              (apply array))))}
+
+    :getTokenById
+    (fn [token-id]
+      (cond
+        (not (string? token-id))
+        (u/display-not-valid :getTokenById token-id)
+
+        :else
+        (let [token-id (uuid/parse token-id)
+              token (u/locate-token file-id id token-id)]
+          (when (some? token)
+            (token-proxy plugin-id file-id id token-id)))))
+
+    :addToken
+    (fn [type-str name value]
+      (let [type (cto/dtcg-token-type->token-type type-str)]
+        (cond
+          (nil? type)
+          (u/display-not-valid :addTokenType type-str)
+
+          (not (string? name))
+          (u/display-not-valid :addTokenName name)
+
+          :else
+          (let [token (ctob/make-token {:type type
+                                        :name name
+                                        :value value})]
+            (st/emit! (dwtl/create-token id token))
+            (token-proxy plugin-id file-id (:id set) (:id token))))))
+
+    :duplicate
+    (fn []
+      (let [set  (u/locate-token-set file-id id)
+            set' (ctob/make-token-set (-> (datafy set)
+                                          (dissoc :id
+                                                  :modified-at)))]
+        (st/emit! (dwtl/create-token-set set'))
+        (token-set-proxy plugin-id file-id (:id set'))))
+
+    :remove
+    (fn []
+      (st/emit! (dwtl/delete-token-set id)))))
+
+(defn token-theme-proxy
+  [plugin-id file-id id]
+  (obj/reify {:name "TokenThemeProxy"}
+    :$plugin {:enumerable false :get (constantly plugin-id)}
+    :$file-id {:enumerable false :get (constantly file-id)}
+    :$id {:enumerable false :get (constantly id)}
+
+    :id
+    {:get #(dm/str id)}
+
+    :external-id
+    {:this true
+     :get
+     (fn [_]
+       (let [theme (u/locate-token-theme file-id id)]
+         (:external-id theme)))}
+
+    :group
+    {:this true
+     :get
+     (fn [_]
+       (let [theme (u/locate-token-theme file-id id)]
+         (:group theme)))
+     :set
+     (fn [_ value]
+       (let [theme (u/locate-token-theme file-id id)]
+         (cond
+           (not (string? value))
+           (u/display-not-valid :group value)
+
+           :else
+           (st/emit! (dwtl/update-token-theme id (assoc theme :group value))))))}
+
+    :name
+    {:this true
+     :get
+     (fn [_]
+       (let [theme (u/locate-token-theme file-id id)]
+         (:name theme)))
+     :set
+     (fn [_ value]
+       (let [theme (u/locate-token-theme file-id id)
+             errors (theme-form/validate-theme-name
+                     (u/locate-tokens-lib file-id)
+                     (:group theme)
+                     id
+                     value)]
+         (cond
+           (some? errors)
+           (u/display-not-valid :name (first errors))
+
+           :else
+           (st/emit! (dwtl/update-token-theme id (assoc theme :name value))))))}
+
+    :active
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [tokens-lib (u/locate-tokens-lib file-id)]
+         (ctob/theme-active? tokens-lib id)))
+     :set
+     (fn [_ value]
+       (st/emit! (dwtl/set-token-theme-active id value)))}
+
+    :toggleActive
+    (fn [_]
+      (st/emit! (dwtl/toggle-token-theme-active id)))
+
+    :activeSets
+    {:this true :get (fn [_])}
+
+    :addSet
+    (fn [tokenSet]
+      (let [theme (u/locate-token-theme file-id id)]
+        (st/emit! (dwtl/update-token-theme id (ctob/enable-set theme (obj/get tokenSet :name))))))
+
+    :removeSet
+    (fn [tokenSet]
+      (let [theme (u/locate-token-theme file-id id)]
+        (st/emit! (dwtl/update-token-theme id (ctob/disable-set theme (obj/get tokenSet :name))))))
+
+    :duplicate
+    (fn []
+      (let [theme  (u/locate-token-theme file-id id)
+            theme' (ctob/make-token-theme (-> (datafy theme)
+                                              (dissoc :id
+                                                      :modified-at)))]
+        (st/emit! (dwtl/create-token-theme theme'))
+        (token-theme-proxy plugin-id file-id (:id theme'))))
+
+    :remove
+    (fn []
+      (st/emit! (dwtl/delete-token-theme id)))))
+
+(defn tokens-catalog
+  [plugin-id file-id]
+  (obj/reify {:name "TokensCatalog"}
+    :$plugin {:enumerable false :get (constantly plugin-id)}
+    :$id {:enumerable false :get (constantly file-id)}
+
+    :themes
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [file (u/locate-file file-id)
+             tokens-lib (->> file :data :tokens-lib)
+             themes (->> (ctob/get-themes tokens-lib)
+                         (remove #(= (:id %) uuid/zero)))]
+         (apply array (map #(token-theme-proxy plugin-id file-id (ctob/get-id %)) themes))))}
+
+    :sets
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [file (u/locate-file file-id)
+             tokens-lib (->> file :data :tokens-lib)
+             sets (ctob/get-sets tokens-lib)]
+         (apply array (map #(token-set-proxy plugin-id file-id (ctob/get-id %)) sets))))}
+
+    :addTheme
+    (fn [group name]
+      (cond
+        (not (string? group))
+        (u/display-not-valid :addThemeGroup group)
+
+        (not (string? name))
+        (u/display-not-valid :addThemeName name)
+
+        :else
+        (let [theme (ctob/make-token-theme {:group group
+                                            :name name})]
+          (st/emit! (dwtl/create-token-theme theme))
+          (token-theme-proxy plugin-id file-id (:id theme)))))
+
+    :addSet
+    (fn [name]
+      (cond
+        (not (string? name))
+        (u/display-not-valid :addSetName name)
+
+        :else
+        (let [set (ctob/make-token-set {:name name})]
+          (st/emit! (dwtl/create-token-set set))
+          (token-set-proxy plugin-id file-id (:id set)))))
+
+    :getThemeById
+    (fn [theme-id]
+      (cond
+        (not (string? theme-id))
+        (u/display-not-valid :getThemeById theme-id)
+
+        :else
+        (let [theme-id (uuid/parse theme-id)
+              theme (u/locate-token-theme file-id theme-id)]
+          (when (some? theme)
+            (token-theme-proxy plugin-id file-id theme-id)))))
+
+    :getSetById
+    (fn [set-id]
+      (cond
+        (not (string? set-id))
+        (u/display-not-valid :getSetById set-id)
+
+        :else
+        (let [set-id (uuid/parse set-id)
+              set (u/locate-token-set file-id set-id)]
+          (when (some? set)
+            (token-set-proxy plugin-id file-id set-id)))))))
+

--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -11,6 +11,7 @@
    [app.common.data.macros :as dm]
    [app.common.types.container :as ctn]
    [app.common.types.file :as ctf]
+   [app.common.types.tokens-lib :as ctob]
    [app.main.data.helpers :as dsh]
    [app.main.store :as st]
    [app.util.object :as obj]))
@@ -51,6 +52,26 @@
   [file-id id]
   (assert (uuid? id) "Component not valid uuid")
   (dm/get-in (locate-file file-id) [:data :components id]))
+
+(defn locate-tokens-lib
+  [file-id]
+  (let [file (locate-file file-id)]
+    (->> file :data :tokens-lib)))
+
+(defn locate-token-theme
+  [file-id id]
+  (let [tokens-lib (locate-tokens-lib file-id)]
+    (ctob/get-theme tokens-lib id)))
+
+(defn locate-token-set
+  [file-id set-id]
+  (let [tokens-lib (locate-tokens-lib file-id)]
+    (ctob/get-set tokens-lib set-id)))
+
+(defn locate-token
+  [file-id set-id token-id]
+  (let [tokens-lib (locate-tokens-lib file-id)]
+    (ctob/get-token tokens-lib set-id token-id)))
 
 (defn locate-presence
   [session-id]

--- a/frontend/test/frontend_tests/tokens/logic/token_data_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_data_test.cljs
@@ -36,7 +36,7 @@
     done
     (let [file   (setup-file-with-token-lib)
           store  (ths/setup-store file)
-          events [(dwtl/create-token-set "Set B")]]
+          events [(dwtl/create-token-set (ctob/make-token-set :name "Set B"))]]
 
       (tohs/run-store-async
        store done events


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/8990?milestone=486523

### Summary

Add the core endpoints needed for managing Design Tokens from the plugins API.

### Steps to reproduce 

To test it, checkout branch `hiru-plugins-tokens` in the Plugins library:
https://github.com/penpot/penpot-plugins/pull/218

Then execute the demo plugin with
```
npm run start:plugin:poc-tokens
```
And install the plugin at `http://localhost:4309/assets/manifest.json`.

The demo plugin allows you to navigate through themes, sets and tokens in a file, activate and deactivate them, create, delete and rename them, and apply them to the selected shapes in the current file.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
