### PR TITLE
:wrench: Deactivate debug traces for fonts module

### DIFF
--- a/frontend/src/app/main/fonts.cljs
+++ b/frontend/src/app/main/fonts.cljs
@@ -23,7 +23,7 @@
    [okulary.core :as l]
    [promesa.core :as p]))
 
-(log/set-level! :debug)
+(log/set-level! :warn)
 
 (def google-fonts
   (preload-gfonts "fonts/gfonts.2025.05.19.json"))


### PR DESCRIPTION
To avoid innecesary traces in console while debugging other things.