### PR TITLE
:wrench: Fix text-related playgrounds (wasm)

### DIFF
--- a/frontend/resources/wasm-playground/clips.html
+++ b/frontend/resources/wasm-playground/clips.html
@@ -79,6 +79,7 @@
       setShapeChildren([frameUuid]);
 
       performance.mark('render:begin');
+      Module._set_view(1, 0, 0);
       Module._render(Date.now());
       performance.mark('render:end');
       const { duration } = performance.measure('render', 'render:begin', 'render:end');

--- a/frontend/resources/wasm-playground/js/lib.js
+++ b/frontend/resources/wasm-playground/js/lib.js
@@ -32,7 +32,7 @@ export function assignCanvas(canvas) {
 
 export function hexToU32ARGB(hex, opacity = 1) {
   const rgb = parseInt(hex.slice(1), 16);
-  const a = Math.floor(opacity * 0xFF);
+  const a = Math.floor(opacity * 0xff);
   const argb = (a << 24) | rgb;
   return argb >>> 0;
 }
@@ -42,9 +42,9 @@ export function getRandomInt(min, max) {
 }
 
 export function getRandomColor() {
-  const r = getRandomInt(0, 256).toString(16).padStart(2, '0');
-  const g = getRandomInt(0, 256).toString(16).padStart(2, '0');
-  const b = getRandomInt(0, 256).toString(16).padStart(2, '0');
+  const r = getRandomInt(0, 256).toString(16).padStart(2, "0");
+  const g = getRandomInt(0, 256).toString(16).padStart(2, "0");
+  const b = getRandomInt(0, 256).toString(16).padStart(2, "0");
   return `#${r}${g}${b}`;
 }
 
@@ -103,12 +103,12 @@ export function addShapeSolidStrokeFill(argb) {
 
 function serializePathAttrs(svgAttrs) {
   return Object.entries(svgAttrs).reduce((acc, [key, value]) => {
-    return acc + key + '\0' + value + '\0';
-  }, '');
+    return acc + key + "\0" + value + "\0";
+  }, "");
 }
 
 export function draw_star(x, y, width, height) {
-  const len = 11; // 1 MOVE + 9 LINE + 1 CLOSE 
+  const len = 11; // 1 MOVE + 9 LINE + 1 CLOSE
   const ptr = allocBytes(len * 28);
   const heap = getHeapU32();
   const dv = new DataView(heap.buffer);
@@ -120,7 +120,7 @@ export function draw_star(x, y, width, height) {
 
   const star = [];
   for (let i = 0; i < 10; i++) {
-    const angle = Math.PI / 5 * i - Math.PI / 2;
+    const angle = (Math.PI / 5) * i - Math.PI / 2;
     const r = i % 2 === 0 ? outerRadius : innerRadius;
     const px = cx + r * Math.cos(angle);
     const py = cy + r * Math.sin(angle);
@@ -149,7 +149,7 @@ export function draw_star(x, y, width, height) {
   Module._set_shape_path_content();
 
   const str = serializePathAttrs({
-    "fill": "none",
+    fill: "none",
     "stroke-linecap": "round",
     "stroke-linejoin": "round",
   });
@@ -158,7 +158,6 @@ export function draw_star(x, y, width, height) {
   Module.stringToUTF8(str, offset, size);
   Module._set_shape_path_attrs(3);
 }
-  
 
 export function setShapeChildren(shapeIds) {
   const offset = allocBytes(shapeIds.length * 16);
@@ -227,17 +226,23 @@ export function setupInteraction(canvas) {
     }
   });
 
-  canvas.addEventListener("mouseup", () => { isPanning = false; });
-  canvas.addEventListener("mouseout", () => { isPanning = false; });
+  canvas.addEventListener("mouseup", () => {
+    isPanning = false;
+  });
+  canvas.addEventListener("mouseout", () => {
+    isPanning = false;
+  });
 }
 
 export function addTextShape(x, y, fontSize, text) {
   const numLeaves = 1; // Single text leaf for simplicity
   const paragraphAttrSize = 48;
-  const leafAttrSize = 56;
-  const fillSize = 160;
+  // const leafAttrSize = 56;
+  const singleFillSize = 160;
   const textBuffer = new TextEncoder().encode(text);
   const textSize = textBuffer.byteLength;
+
+  const leafSize = 1340; // leaf attrs + 8 fills
 
   // Calculate fills
   const fills = [
@@ -247,12 +252,7 @@ export function addTextShape(x, y, fontSize, text) {
       opacity: getRandomFloat(0.5, 1.0),
     },
   ];
-  const totalFills = fills.length;
-  const totalFillsSize = totalFills * fillSize;
-
-  // Calculate metadata and total buffer size
-  const metadataSize = paragraphAttrSize + leafAttrSize + totalFillsSize;
-  const totalSize = metadataSize + textSize;
+  const totalSize = paragraphAttrSize + leafSize + textSize;
 
   // Allocate buffer
   const bufferPtr = allocBytes(totalSize);
@@ -282,32 +282,33 @@ export function addTextShape(x, y, fontSize, text) {
   const leafOffset = paragraphAttrSize;
   dview.setUint8(leafOffset, 0); // font-style: normal
   dview.setFloat32(leafOffset + 4, fontSize, true); // font-size
-  dview.setUint32(leafOffset + 8, 400, true); // font-weight: normal
-  dview.setUint32(leafOffset + 12, 0, true); // font-id (UUID part 1)
-  dview.setUint32(leafOffset + 16, 0, true); // font-id (UUID part 2)
-  dview.setUint32(leafOffset + 20, 0, true); // font-id (UUID part 3)
-  dview.setInt32(leafOffset + 24, 0, true); // font-id (UUID part 4)
-  dview.setInt32(leafOffset + 28, 0, true); // font-family hash
-  dview.setUint32(leafOffset + 32, 0, true); // font-variant-id (UUID part 1)
-  dview.setUint32(leafOffset + 36, 0, true); // font-variant-id (UUID part 2)
-  dview.setUint32(leafOffset + 40, 0, true); // font-variant-id (UUID part 3)
-  dview.setInt32(leafOffset + 44, 0, true); // font-variant-id (UUID part 4)
-  dview.setInt32(leafOffset + 48, textSize, true); // text-length
-  dview.setInt32(leafOffset + 52, totalFills, true); // total fills count
+  dview.setFloat32(leafOffset + 8, 0, true); // letter-spacing
+  dview.setUint32(leafOffset + 12, 400, true); // font-weight: normal
+  dview.setUint32(leafOffset + 16, 0, true); // font-id (UUID part 1)
+  dview.setUint32(leafOffset + 20, 0, true); // font-id (UUID part 2)
+  dview.setUint32(leafOffset + 24, 0, true); // font-id (UUID part 3)
+  dview.setInt32(leafOffset + 28, 0, true); // font-id (UUID part 4)
+  dview.setInt32(leafOffset + 32, 0, true); // font-family hash
+  dview.setUint32(leafOffset + 36, 0, true); // font-variant-id (UUID part 1)
+  dview.setUint32(leafOffset + 40, 0, true); // font-variant-id (UUID part 2)
+  dview.setUint32(leafOffset + 44, 0, true); // font-variant-id (UUID part 3)
+  dview.setInt32(leafOffset + 48, 0, true); // font-variant-id (UUID part 4)
+  dview.setInt32(leafOffset + 52, textSize, true); // text-length
+  dview.setInt32(leafOffset + 56, fills.length, true); // total fills count
 
   // Serialize fills
-  let fillOffset = leafOffset + leafAttrSize;
+  let fillOffset = leafOffset + 60;
   fills.forEach((fill) => {
     if (fill.type === "solid") {
       const argb = hexToU32ARGB(fill.color, fill.opacity);
       dview.setUint8(fillOffset, 0x00, true); // Fill type: solid
       dview.setUint32(fillOffset + 4, argb, true);
-      fillOffset += fillSize; // Move to the next fill
+      fillOffset += singleFillSize; // Move to the next fill
     }
   });
 
   // Add text content
-  const textOffset = metadataSize;
+  const textOffset = leafSize;
   heap.set(textBuffer, textOffset);
 
   // Call the WebAssembly function

--- a/frontend/resources/wasm-playground/js/lib.js
+++ b/frontend/resources/wasm-playground/js/lib.js
@@ -147,16 +147,6 @@ export function draw_star(x, y, width, height) {
   dv.setUint16(ptr + offset + 0, 4, true); // CLOSE
 
   Module._set_shape_path_content();
-
-  const str = serializePathAttrs({
-    fill: "none",
-    "stroke-linecap": "round",
-    "stroke-linejoin": "round",
-  });
-  const size = str.length;
-  offset = allocBytes(size);
-  Module.stringToUTF8(str, offset, size);
-  Module._set_shape_path_attrs(3);
 }
 
 export function setShapeChildren(shapeIds) {

--- a/frontend/resources/wasm-playground/masks.html
+++ b/frontend/resources/wasm-playground/masks.html
@@ -38,7 +38,6 @@
       init(Module);
       assignCanvas(canvas);
       Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
-      Module._set_view(1, 0, 0);
       Module._init_shapes_pool(shapes + 1);
       setupInteraction(canvas);
 
@@ -78,6 +77,7 @@
       Module._set_shape_masked_group(true);
       setShapeChildren(group_children);
 
+      Module._set_view(1, 0, 0);
       Module._render(Date.now());
     });
     

--- a/frontend/resources/wasm-playground/paths.html
+++ b/frontend/resources/wasm-playground/paths.html
@@ -41,7 +41,6 @@
       init(Module);
       assignCanvas(canvas);
       Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
-      Module._set_view(1, 0, 0);
       Module._init_shapes_pool(shapes + 1);
       setupInteraction(canvas);
 
@@ -74,6 +73,7 @@
       setShapeChildren(children);
 
       performance.mark('render:begin');
+      Module._set_view(1, 0, 0);
       Module._render(Date.now());
       performance.mark('render:end');
       const { duration } = performance.measure('render', 'render:begin', 'render:end');

--- a/frontend/resources/wasm-playground/plus.html
+++ b/frontend/resources/wasm-playground/plus.html
@@ -65,7 +65,6 @@
       init(Module);
       assignCanvas(canvas);
       Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
-      Module._set_view(1, 0, 0);
       Module._init_shapes_pool(shapes + 1);
       setupInteraction(canvas);
 
@@ -98,6 +97,7 @@
       setShapeChildren(children);
 
       performance.mark('render:begin');
+      Module._set_view(1, 0, 0);
       Module._render(Date.now());
       performance.mark('render:end');
       const { duration } = performance.measure('render', 'render:begin', 'render:end');

--- a/frontend/resources/wasm-playground/rects.html
+++ b/frontend/resources/wasm-playground/rects.html
@@ -40,7 +40,6 @@
       init(Module);
       assignCanvas(canvas);
       Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
-      Module._set_view(1, 0, 0);
       Module._init_shapes_pool(shapes + 1);
       setupInteraction(canvas);
 
@@ -71,6 +70,7 @@
       setShapeChildren(children);
 
       performance.mark('render:begin');
+      Module._set_view(1, 0, 0);
       Module._render(Date.now());
       performance.mark('render:end');
       const { duration } = performance.measure('render', 'render:begin', 'render:end');

--- a/frontend/resources/wasm-playground/texts.html
+++ b/frontend/resources/wasm-playground/texts.html
@@ -56,7 +56,6 @@
       init(Module);
       assignCanvas(canvas);
       Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
-      Module._set_view(1, 0, 0);
       Module._init_shapes_pool(texts + 1);
       setupInteraction(canvas);
 
@@ -95,6 +94,7 @@
       setShapeChildren(children);
 
       performance.mark('render:begin');
+      Module._set_view(1, 0, 0);
       Module._render(Date.now());
       performance.mark('render:end');
       const { duration } = performance.measure('render', 'render:begin', 'render:end');

--- a/frontend/text-editor/src/playground/text.js
+++ b/frontend/text-editor/src/playground/text.js
@@ -38,27 +38,21 @@ export const TextTransform = {
 };
 
 export class TextSpan {
-  static BYTE_LENGTH = 60;
+  static BYTE_LENGTH = 1340;
 
   static fromDOM(spanElement, fontManager) {
     const elementStyle = spanElement.style; //window.getComputedStyle(leafElement);
-    const fontSize = parseFloat(
-      elementStyle.getPropertyValue("font-size"),
-    );
+    const fontSize = parseFloat(elementStyle.getPropertyValue("font-size"));
     const fontStyle =
       FontStyle.fromStyle(elementStyle.getPropertyValue("font-style")) ??
       FontStyle.NORMAL;
-    const fontWeight = parseInt(
-      elementStyle.getPropertyValue("font-weight"),
-    );
+    const fontWeight = parseInt(elementStyle.getPropertyValue("font-weight"));
     const letterSpacing = parseFloat(
       elementStyle.getPropertyValue("letter-spacing"),
     );
     const fontFamily = elementStyle.getPropertyValue("font-family");
     console.log("fontFamily", fontFamily);
-    const fontStyles = fontManager.fonts.get(
-      fontFamily,
-    );
+    const fontStyles = fontManager.fonts.get(fontFamily);
     const textDecoration = TextDecoration.fromStyle(
       elementStyle.getPropertyValue("text-decoration"),
     );
@@ -75,7 +69,7 @@ export class TextSpan {
         currentFontStyle.styleAsNumber === fontStyle,
     );
     if (!font) {
-      throw new Error(`Invalid font "${fontFamily}"`)
+      throw new Error(`Invalid font "${fontFamily}"`);
     }
     return new TextSpan({
       fontId: font.id, // leafElement.style.getPropertyValue("--font-id"),
@@ -134,7 +128,7 @@ export class TextSpan {
   }
 
   get leafByteLength() {
-    return this.fills.length * Fill.BYTE_LENGTH + TextSpan.BYTE_LENGTH;
+    return TextLeaf.BYTE_LENGTH;
   }
 }
 


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/task/12410

This fixes wasm crashes in our text-related playgrounds.

<img width="1520" height="1144" alt="Screenshot 2025-10-24 at 2 31 34 PM" src="https://github.com/user-attachments/assets/2999ec4e-3fab-49c3-ac9b-9e55bace0d60" />

<img width="815" height="585" alt="Screenshot 2025-10-24 at 2 31 52 PM" src="https://github.com/user-attachments/assets/dd7b2ad1-fd92-4888-acfb-9daccbbe5634" />


For the **text editor playground**:

- Update serialization
- Fixes trying to get a caret of a shape without calling `use_shape` first.

For the **wasm playground**:

- Update serialization

See https://github.com/penpot/penpot/blob/develop/render-wasm/docs/test_playground.md for running the playgrounds.