### PR TITLE
:bug: Fix conflicting shortcut in text editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ### :sparkles: New features & Enhancements
 
 ### :bug: Bugs fixed
+
 - Fix text line-height values are wrong [Taiga #12252](https://tree.taiga.io/project/penpot/issue/12252)
 
 - Fix pan cursor not disabling viewport guides [Github #6985](https://github.com/penpot/penpot/issues/6985)
@@ -19,7 +20,7 @@
 - Fix on copy instance inside a components chain touched are missing [Taiga #12371](https://tree.taiga.io/project/penpot/issue/12371)
 - Fix problem with multiple selection and shadows [Github #7437](https://github.com/penpot/penpot/issues/7437)
 - Fix search shortcut [Taiga #10265](https://tree.taiga.io/project/penpot/issue/10265)
-
+- Fix shortcut conflict in text editor (increase/decrease font size vs word selection)
 
 ## 2.11.0 (Unreleased)
 

--- a/frontend/src/app/main/data/workspace/text/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/text/shortcuts.cljs
@@ -231,13 +231,13 @@
                    :subsections [:text-editor]
                    :fn #(update-attrs-when-no-readonly {:text-decoration "toggle-line-through"})}
 
-   :font-size-inc {:tooltip (ds/meta-shift ds/right-arrow)
-                   :command (ds/c-mod "shift+right")
+   :font-size-inc {:tooltip (ds/meta-shift ">")
+                   :command (ds/c-mod "shift+.")
                    :subsections [:text-editor]
                    :fn #(update-attrs-when-no-readonly {:font-size-inc true})}
 
-   :font-size-dec {:tooltip (ds/meta-shift ds/left-arrow)
-                   :command (ds/c-mod "shift+left")
+   :font-size-dec {:tooltip (ds/meta-shift "<")
+                   :command (ds/c-mod "shift+,")
                    :subsections [:text-editor]
                    :fn #(update-attrs-when-no-readonly {:font-size-dec true})}
 

--- a/frontend/src/app/util/text_editor.cljs
+++ b/frontend/src/app/util/text_editor.cljs
@@ -101,8 +101,10 @@
               (impl/updateBlockData state block-key (clj->js attrs)))))
 
         state (impl/applyInlineStyle state (legacy.txt/attrs-to-styles attrs))
-        selected (impl/getSelectedBlocks state)]
-    (reduce update-blocks state selected)))
+        selection-after-apply (impl/getSelection state)
+        selected (impl/getSelectedBlocks state)
+        state (reduce update-blocks state selected)]
+    (impl/setSelection state selection-after-apply)))
 
 (defn update-editor-current-inline-styles-fn
   [state update-fn]


### PR DESCRIPTION
### Summary

Currently `Ctrl+Shift+Left|Right` are assigned to increase / decrease font size in the text editor. This conflicts with the standard behaviour of selecting full words (which is of course supported by the underlying `draft-js`). 

This PR changes the shortcuts to the standard (Adobe, Figma) of `Ctrl+Shift+<|>` . I am aware that this an UX change that might have to be discussed, so I'm leaving this PR here for that purpose.

In my opinion, it's a no-brainer, since not being able to select words is extremely inconvenient, and every major player seems to use the shortcuts proposed here.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.