### PR TITLE
:bug: Prevent rendering of unused fill slots in shapes

### DIFF
--- a/common/src/app/common/types/fills/impl.cljc
+++ b/common/src/app/common/types/fills/impl.cljc
@@ -301,11 +301,17 @@
 
      IHeapWritable
      (-get-byte-size [_]
-       (- (.-byteLength dbuffer) 4))
+       ;; Include the 4-byte header with the fill count
+       (+ 4 (* size FILL-U8-SIZE)))
 
      (-write-to [_ heap offset]
-       (let [buffer' (.-buffer ^js/DataView dbuffer)]
-         (.set heap (js/Uint32Array. buffer' 4) offset)))
+       (let [buffer' (.-buffer ^js/DataView dbuffer)
+            ;; Calculate byte size: 4 bytes header + (size * FILL-U8-SIZE)
+             byte-size (+ 4 (* size FILL-U8-SIZE))
+             ;; Create Uint32Array with exact size needed (convert bytes to u32 elements)
+             u32-array (js/Uint32Array. buffer' 0 (/ byte-size 4))]
+         ;; Copy from offset 0 to include the header with fill count
+         (.set heap u32-array offset)))
 
      IBinaryFills
      (-get-image-ids [_]

--- a/render-wasm/src/wasm/fills.rs
+++ b/render-wasm/src/wasm/fills.rs
@@ -70,7 +70,10 @@ pub fn parse_fills_from_bytes(buffer: &[u8], num_fills: usize) -> Vec<shapes::Fi
 pub extern "C" fn set_shape_fills() {
     with_current_shape_mut!(state, |shape: &mut Shape| {
         let bytes = mem::bytes();
-        let fills = parse_fills_from_bytes(&bytes, bytes.len() / RAW_FILL_DATA_SIZE);
+        // The first byte contains the actual number of fills
+        let num_fills = bytes.first().copied().unwrap_or(0) as usize;
+        // Skip the first 4 bytes (header with fill count) and parse only the actual fills
+        let fills = parse_fills_from_bytes(&bytes[4..], num_fills);
         shape.set_fills(fills);
     });
 }


### PR DESCRIPTION
### Related Ticket

When creating a shape with a single fill, the WASM renderer was processing and rendering all 8 fill slots (MAX_FILLS) instead of just the one actually defined generating a lot of unnecessary drawing skia calls. This happened because the binary buffer is always allocated with space for 8 fills, but only the actual number of fills should be rendered.

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
