### PR TITLE
:bug: Fix text selection

### DIFF
--- a/frontend/text-editor/package.json
+++ b/frontend/text-editor/package.json
@@ -9,6 +9,7 @@
     "coverage": "vitest run --coverage",
     "wasm:update": "cp ../resources/public/js/render_wasm.wasm ./src/wasm/render_wasm.wasm && cp ../resources/public/js/render_wasm.js ./src/wasm/render_wasm.js",
     "test": "vitest --run",
+    "fmt:js": "yarn run prettier -c src/**/*.js",
     "test:watch": "vitest",
     "test:watch:ui": "vitest --ui",
     "test:watch:e2e": "vitest --browser"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12374

### Summary

This PR fixes some issues in Firefox when selecting the whole text using ctrl+a and removing or replacing the selected content, and some corner cases when the first line was a breaking line

https://github.com/user-attachments/assets/d396293c-592e-4a09-bfae-f8ebf4107964

### Steps to reproduce 

- Create a text shape
- Select all text using ctrl+a
- Delete content
- Same as above, but type any letter to replace the selected content
- Try on different browsers

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
