### PR TITLE
:bug: Fix paste without selection sends the new element in the back

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,7 @@
 - Fix an error translation [Taiga #12402](https://tree.taiga.io/project/penpot/issue/12402)
 - Fix problem with certain text input in some editable labels (pages, components, tokens...) being in conflict with the drag/drop functionality [Taiga #12316](https://tree.taiga.io/project/penpot/issue/12316)
 - Fix not controlled theme renaming [Taiga #12411](https://tree.taiga.io/project/penpot/issue/12411)
+- Fix paste without selection sends the new element in the back [Taiga #12382](https://tree.taiga.io/project/penpot/issue/12382)
 
 ## 2.10.1
 

--- a/frontend/playwright/ui/specs/variants.spec.js
+++ b/frontend/playwright/ui/specs/variants.spec.js
@@ -150,8 +150,8 @@ test("User copy paste a variant container", async ({ page }) => {
   await workspacePage.clickAt(500, 500);
   await workspacePage.page.keyboard.press("Control+v");
 
-  const variant_original = await findVariant(workspacePage, 0);
-  const variant_duplicate = await findVariant(workspacePage, 1);
+  const variant_original = await findVariant(workspacePage, 1);
+  const variant_duplicate = await findVariant(workspacePage, 0);
 
   // Expand the layers
   await variant_duplicate.container.getByRole("button").first().click();

--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -848,6 +848,10 @@
                              index
                              0)
 
+              index        (if index
+                             index
+                             (dec (count (dm/get-in page-objects [parent-id :shapes]))))
+
               selected     (if (and (ctl/flex-layout? page-objects parent-id) (not (ctl/reverse? page-objects parent-id)))
                              (into (d/ordered-set) (reverse selected))
                              selected)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12382

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
