### PR TITLE
:bug: Fix default font size in text spans

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -699,17 +699,17 @@
 
       (if (< index total)
         (let [paragraph (nth paragraphs index)
-              leaves    (get paragraph :children)]
-          (if (empty? (seq leaves))
+              spans    (get paragraph :children)]
+          (if (empty? (seq spans))
             (recur (inc index)
                    emoji?
                    langs)
 
-            (let [text   (apply str (map :text leaves))
+            (let [text   (apply str (map :text spans))
                   emoji? (if emoji? emoji? (t/contains-emoji? text))
                   langs  (t/collect-used-languages langs text)]
 
-              (t/write-shape-text leaves paragraph text)
+              (t/write-shape-text spans paragraph text)
               (recur (inc index)
                      emoji?
                      langs))))

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -221,21 +221,16 @@ fn draw_text(
 
     for paragraph_builder_group in paragraph_builder_groups {
         let mut group_offset_y = global_offset_y;
-        let total_paragraphs = paragraph_builder_group.len();
+        let group_len = paragraph_builder_group.len();
 
         for (paragraph_index, paragraph_builder) in paragraph_builder_group.iter_mut().enumerate() {
             let mut paragraph = paragraph_builder.build();
             paragraph.layout(text_width);
-            let _paragraph_height = paragraph.height();
-            // FIXME: I've kept the _paragraph_height variable to have
-            // a reminder in the future to keep digging why the ideographic_baseline
-            // works so well and not the paragraph_height. I think we should test
-            // this more.
             let xy = (shape.selrect().x(), shape.selrect().y() + group_offset_y);
             paragraph.paint(canvas, xy);
 
-            if paragraph_index == total_paragraphs - 1 {
-                group_offset_y += paragraph.ideographic_baseline();
+            if paragraph_index == group_len - 1 {
+                group_offset_y += paragraph.height();
             }
 
             for line_metrics in paragraph.get_line_metrics().iter() {

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -630,6 +630,7 @@ pub struct TextSpan {
     text: String,
     font_family: FontFamily,
     font_size: f32,
+    line_height: f32,
     letter_spacing: f32,
     font_weight: i32,
     font_variant_id: Uuid,
@@ -645,6 +646,7 @@ impl TextSpan {
         text: String,
         font_family: FontFamily,
         font_size: f32,
+        line_height: f32,
         letter_spacing: f32,
         text_decoration: Option<TextDecoration>,
         text_transform: Option<TextTransform>,
@@ -657,6 +659,7 @@ impl TextSpan {
             text,
             font_family,
             font_size,
+            line_height,
             letter_spacing,
             text_decoration,
             text_transform,
@@ -680,10 +683,9 @@ impl TextSpan {
         content_bounds: &Rect,
         fallback_fonts: &HashSet<String>,
         remove_alpha: bool,
-        paragraph_line_height: f32, // Add this parameter
+        paragraph_line_height: f32,
     ) -> skia::textlayout::TextStyle {
         let mut style = skia::textlayout::TextStyle::default();
-
         let mut paint = paint::Paint::default();
 
         if remove_alpha {
@@ -693,9 +695,14 @@ impl TextSpan {
             paint = merge_fills(&self.fills, *content_bounds);
         }
 
-        style.set_height(paragraph_line_height);
-        style.set_height_override(true);
+        // FIXME
+        if self.line_height <= 0.0 {
+            style.set_height(paragraph_line_height);
+        } else {
+            style.set_height(self.line_height);
+        }
 
+        style.set_height_override(true);
         style.set_foreground_paint(&paint);
         style.set_decoration_type(match self.text_decoration {
             Some(text_decoration) => text_decoration,

--- a/render-wasm/src/wasm/fills.rs
+++ b/render-wasm/src/wasm/fills.rs
@@ -75,6 +75,7 @@ pub extern "C" fn set_shape_fills() {
         // Skip the first 4 bytes (header with fill count) and parse only the actual fills
         let fills = parse_fills_from_bytes(&bytes[4..], num_fills);
         shape.set_fills(fills);
+        mem::free_bytes();
     });
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12439

### Summary

This PR introduces several fixes related to text height:
- Font size was not being properly set when not present in the text span, but in the paragraph
- Same with line-height
- Offset-y was not being properly calculated, `ideographic_baseline` is not correct to calculate the offset, we're using `height` instead (although this needs to be reviewed)

### Steps to reproduce 

- Compare the avataaars library file against production

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
