### PR TITLE
:sparkles: Add performance improvements for wasm render

### DIFF
--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -517,8 +517,7 @@
    (when verify?
      (check-changes items))
 
-   (binding [*touched-changes* (volatile! #{})
-             cts/*wasm-sync* (not cts/*wasm-sync-override*)]
+   (binding [*touched-changes* (volatile! #{})]
      (let [result (reduce #(or (process-change %1 %2) %1) data items)
            result (reduce process-touched-change result @*touched-changes*)]
        ;; Validate result shapes (only on the backend)

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -36,12 +36,7 @@
    [app.common.uuid :as uuid]
    [clojure.set :as set]))
 
-(defonce ^:dynamic *wasm-sync* false)
-
-;; This is a temporary workaround so the changes-builder doesn't generate updates
-;; in the WASM model.
-(defonce ^:dynamic *wasm-sync-override* false)
-
+(defonce ^:dynamic *shape-changes* nil)
 (defonce wasm-enabled? false)
 (defonce wasm-create-shape (constantly nil))
 

--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -18,7 +18,6 @@
    [app.main.data.helpers :as dsh]
    [app.main.features :as features]
    [app.main.worker :as mw]
-   [app.render-wasm.api :as wasm.api]
    [app.render-wasm.shape :as wasm.shape]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
@@ -113,15 +112,7 @@
                   (update-in state [:files file-id :data] apply-changes))]
 
             (let [objects (dm/get-in state [:files file-id :data :pages-index (:current-page-id state) :objects])]
-              (run!
-               (fn [[shape-id props]]
-                 (wasm.api/use-shape shape-id)
-                 (let [shape (get objects shape-id)]
-                   (run! (partial wasm.shape/set-shape-wasm-attr! shape) props)))
-               @shape-changes))
-
-            (wasm.api/update-shape-tiles)
-            (wasm.api/request-render "set-wasm-attrs")
+              (wasm.shape/process-shape-changes! objects @shape-changes))
 
             state)
 

--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -7,14 +7,19 @@
 (ns app.main.data.changes
   (:require
    [app.common.data :as d]
+   [app.common.data.macros :as dm]
    [app.common.files.changes :as cpc]
    [app.common.logging :as log]
    [app.common.time :as ct]
+   [app.common.types.shape :as cts]
    [app.common.types.shape-tree :as ctst]
    [app.common.uuid :as uuid]
    [app.main.data.event :as ev]
    [app.main.data.helpers :as dsh]
+   [app.main.features :as features]
    [app.main.worker :as mw]
+   [app.render-wasm.api :as wasm.api]
+   [app.render-wasm.shape :as wasm.shape]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -99,7 +104,29 @@
                     pids (into #{} xf:map-page-id redo-changes)]
                 (reduce #(ctst/update-object-indices %1 %2) fdata pids)))]
 
-        (update-in state [:files file-id :data] apply-changes)))))
+        (if (features/active-feature? state "render-wasm/v1")
+          ;; Update the wasm model
+          (let [shape-changes (volatile! {})
+
+                state
+                (binding [cts/*shape-changes* shape-changes]
+                  (update-in state [:files file-id :data] apply-changes))]
+
+            (let [objects (dm/get-in state [:files file-id :data :pages-index (:current-page-id state) :objects])]
+              (run!
+               (fn [[shape-id props]]
+                 (wasm.api/use-shape shape-id)
+                 (let [shape (get objects shape-id)]
+                   (run! (partial wasm.shape/set-shape-wasm-attr! shape) props)))
+               @shape-changes))
+
+            (wasm.api/update-shape-tiles)
+            (wasm.api/request-render "set-wasm-attrs")
+
+            state)
+
+          ;; wasm renderer deactivated
+          (update-in state [:files file-id :data] apply-changes))))))
 
 (defn commit
   "Create a commit event instance"

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -78,20 +78,19 @@
                   (not-empty))
 
              changes
-             (binding [cts/*wasm-sync-override* true]
-               (-> (pcb/empty-changes it page-id)
-                   (pcb/set-save-undo? save-undo?)
-                   (pcb/set-stack-undo? stack-undo?)
-                   (cls/generate-update-shapes ids
-                                               update-fn
-                                               objects
-                                               {:attrs attrs
-                                                :changed-sub-attr changed-sub-attr
-                                                :ignore-tree ignore-tree
-                                                :ignore-touched ignore-touched
-                                                :with-objects? with-objects?})
-                   (cond-> undo-group
-                     (pcb/set-undo-group undo-group))))
+             (-> (pcb/empty-changes it page-id)
+                 (pcb/set-save-undo? save-undo?)
+                 (pcb/set-stack-undo? stack-undo?)
+                 (cls/generate-update-shapes ids
+                                             update-fn
+                                             objects
+                                             {:attrs attrs
+                                              :changed-sub-attr changed-sub-attr
+                                              :ignore-tree ignore-tree
+                                              :ignore-touched ignore-touched
+                                              :with-objects? with-objects?})
+                 (cond-> undo-group
+                   (pcb/set-undo-group undo-group)))
 
              changes
              (add-undo-group changes state)]

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -314,8 +314,8 @@
                                    :ignore-constraints (contains? layout :scale-text))))))
                             (rx/take-until stopper))
 
-                 ;; The last event we need to use the old method so the elements are correctly positioned until
-                 ;; all the logic is implemented in wasm
+                       ;; The last event we need to use the old method so the elements are correctly
+                       ;; positioned until all the logic is implemented in wasm
                        (->> resize-events-stream
                             (rx/take-until stopper)
                             (rx/last)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -12,7 +12,6 @@
    [app.common.geom.rect :as grc]
    [app.common.geom.shapes :as gsh]
    [app.common.logic.shapes :as cls]
-   [app.common.types.shape :as cts]
    [app.common.types.shape.layout :as ctl]
    [app.common.types.token :as tk]
    [app.main.constants :refer [size-presets]]
@@ -295,9 +294,8 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
-           (binding [cts/*wasm-sync* true]
-             (st/emit! (udw/trigger-bounding-box-cloaking ids)
-                       (udw/update-dimensions ids attr value)))))
+           (st/emit! (udw/trigger-bounding-box-cloaking ids)
+                     (udw/update-dimensions ids attr value))))
 
         on-size-change
         (mf/use-fn
@@ -306,16 +304,14 @@
            (if (or (string? value) (int? value))
              (do
                (st/emit! (udw/trigger-bounding-box-cloaking ids))
-               (binding [cts/*wasm-sync* true]
-                 (run! #(do-size-change value attr) shapes)))
+               (run! #(do-size-change value attr) shapes))
              (do
                (let [resolved-value (:resolved-value (first value))]
                  (st/emit! (udw/trigger-bounding-box-cloaking ids)
                            (dwta/toggle-token {:token (first value)
                                                :attrs #{attr}
                                                :shape-ids ids}))
-                 (binding [cts/*wasm-sync* true]
-                   (run! #(do-size-change resolved-value attr) shapes)))))))
+                 (run! #(do-size-change resolved-value attr) shapes))))))
 
         on-proportion-lock-change
         (mf/use-fn
@@ -337,16 +333,14 @@
            (if (or (string? value) (int? value))
              (do
                (st/emit! (udw/trigger-bounding-box-cloaking ids))
-               (binding [cts/*wasm-sync* true]
-                 (run! #(do-position-change %1 value attr) shapes)))
+               (run! #(do-position-change %1 value attr) shapes))
              (do
                (let [resolved-value (:resolved-value (first value))]
                  (st/emit! (udw/trigger-bounding-box-cloaking ids)
                            (dwta/toggle-token {:token (first value)
                                                :attrs #{attr}
                                                :shape-ids ids}))
-                 (binding [cts/*wasm-sync* true]
-                   (run! #(do-position-change %1 resolved-value attr) shapes)))))))
+                 (run! #(do-position-change %1 resolved-value attr) shapes))))))
 
         ;; ROTATION
         do-rotation-change
@@ -362,16 +356,14 @@
            (if (or (string? value) (int? value))
              (do
                (st/emit! (udw/trigger-bounding-box-cloaking ids))
-               (binding [cts/*wasm-sync* true]
-                 (run! #(do-rotation-change value) shapes)))
+               (run! #(do-rotation-change value) shapes))
              (do
                (let [resolved-value (:resolved-value (first value))]
                  (st/emit! (udw/trigger-bounding-box-cloaking ids)
                            (dwta/toggle-token {:token (first value)
                                                :attrs #{:rotation}
                                                :shape-ids ids}))
-                 (binding [cts/*wasm-sync* true]
-                   (run! #(do-rotation-change resolved-value) shapes)))))))
+                 (run! #(do-rotation-change resolved-value) shapes))))))
 
         on-width-change
         (mf/use-fn (mf/deps on-size-change) #(on-size-change % :width))

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -113,8 +113,7 @@
         objects-modified
         (mf/with-memo
           [base-objects wasm-modifiers]
-          (binding [cts/*wasm-sync* false]
-            (apply-modifiers-to-selected selected base-objects wasm-modifiers)))
+          (apply-modifiers-to-selected selected base-objects wasm-modifiers))
 
         selected-shapes   (->> selected
                                (into [] (keep (d/getf objects-modified)))

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -982,10 +982,6 @@
   []
   (h/call wasm/internal-module "_clean_modifiers"))
 
-(defn clean-geometry-modifiers
-  []
-  (h/call wasm/internal-module "_clean_geometry_modifiers"))
-
 (defn set-modifiers
   [modifiers]
 

--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -259,10 +259,13 @@
           (api/update-shape-tiles)
           (api/request-render "set-wasm-attrs")))))
 
+;; `conj` empty set initialization
+(def conj* (fnil conj #{}))
+
 (defn- impl-assoc
   [self k v]
   (when shape/*shape-changes*
-    (vswap! shape/*shape-changes* update (:id self) (fnil conj #{}) k))
+    (vswap! shape/*shape-changes* update (:id self) conj* k))
 
   (case k
     :id
@@ -284,13 +287,8 @@
 
 (defn- impl-dissoc
   [self k]
-  #_(when ^boolean shape/*wasm-sync*
-      (binding [shape/*wasm-sync* false]
-        (when (shape-in-current-page? (.-id ^ShapeProxy self))
-          (set-wasm-attrs! self k nil))))
-
   (when shape/*shape-changes*
-    (vswap! shape/*shape-changes* update (:id self) (fnil conj #{}) k))
+    (vswap! shape/*shape-changes* update (:id self) conj* k))
 
   (case k
     :id

--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -135,7 +135,10 @@
                       (when (or (= v :path) (= v :bool))
                         (api/set-shape-path-content (:content shape))))
       :bool-type    (api/set-shape-bool-type v)
-      :selrect      (api/set-shape-selrect v)
+      :selrect      (do
+                      (api/set-shape-selrect v)
+                      (when (= (:type shape) :svg-raw)
+                        (api/set-shape-svg-raw-content (api/get-static-markup shape))))
       :show-content (if (= (:type shape) :frame)
                       (api/set-shape-clip-content (not v))
                       (api/set-shape-clip-content false))

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -541,6 +541,7 @@ pub extern "C" fn set_structure_modifiers() {
 
     with_state_mut!(state, {
         let mut structure = HashMap::new();
+        let mut scale_content = HashMap::new();
         for entry in entries {
             match entry.entry_type {
                 StructureEntryType::ScaleContent => {
@@ -548,7 +549,7 @@ pub extern "C" fn set_structure_modifiers() {
                         continue;
                     };
                     for id in shape.all_children(&state.shapes, true, true) {
-                        state.scale_content.insert(id, entry.value);
+                        scale_content.insert(id, entry.value);
                     }
                 }
                 _ => {
@@ -559,6 +560,9 @@ pub extern "C" fn set_structure_modifiers() {
                         .push(entry);
                 }
             }
+        }
+        if !scale_content.is_empty() {
+            state.shapes.set_scale_content(scale_content);
         }
         if !structure.is_empty() {
             state.shapes.set_structure(structure);
@@ -571,16 +575,7 @@ pub extern "C" fn set_structure_modifiers() {
 #[no_mangle]
 pub extern "C" fn clean_modifiers() {
     with_state_mut!(state, {
-        state.scale_content.clear();
-        state.shapes.clean_modifiers();
-        state.shapes.clean_structure();
-    });
-}
-
-#[no_mangle]
-pub extern "C" fn clean_geometry_modifiers() {
-    with_state_mut!(state, {
-        state.shapes.clean_modifiers();
+        state.shapes.clean_all();
     });
 }
 

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -290,15 +290,21 @@ pub extern "C" fn add_shape_child(a: u32, b: u32, c: u32, d: u32) {
 
 fn set_children_set(entries: IndexSet<Uuid>) {
     let mut deleted = IndexSet::new();
+    let mut parent_id = None;
 
     with_current_shape_mut!(state, |shape: &mut Shape| {
+        parent_id = Some(shape.id);
         (_, deleted) = shape.compute_children_differences(&entries);
         shape.children = entries.clone();
     });
 
     with_state_mut!(state, {
+        let Some(parent_id) = parent_id else {
+            return;
+        };
+
         for id in deleted {
-            state.delete_shape(id);
+            state.delete_shape_children(parent_id, id);
         }
     });
 }

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -495,11 +495,7 @@ pub extern "C" fn get_selection_rect() -> *mut u8 {
     with_state_mut!(state, {
         let bbs: Vec<_> = entries
             .iter()
-            .flat_map(|id| {
-                let default = Matrix::default();
-                let modifier = state.modifiers.get(id).unwrap_or(&default);
-                state.shapes.get(id).map(|b| b.bounds().transform(modifier))
-            })
+            .flat_map(|id| state.shapes.get(id).map(|b| b.bounds()))
             .collect();
 
         let result_bound = if bbs.len() == 1 {
@@ -569,9 +565,15 @@ pub extern "C" fn set_structure_modifiers() {
 #[no_mangle]
 pub extern "C" fn clean_modifiers() {
     with_state_mut!(state, {
-        state.structure.clear();
         state.scale_content.clear();
-        // state.modifiers.clear();
+        state.shapes.clean_modifiers();
+        state.shapes.clean_structure();
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn clean_geometry_modifiers() {
+    with_state_mut!(state, {
         state.shapes.clean_modifiers();
     });
 }

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -253,8 +253,8 @@ pub extern "C" fn set_shape_masked_group(masked: bool) {
 
 #[no_mangle]
 pub extern "C" fn set_shape_selrect(left: f32, top: f32, right: f32, bottom: f32) {
-    with_state_mut!(state, {
-        state.set_selrect_for_current_shape(left, top, right, bottom);
+    with_current_shape_mut!(state, |shape: &mut Shape| {
+        shape.set_selrect(left, top, right, bottom);
     });
 }
 

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use utils::uuid_from_u32_quartet;
 use uuid::Uuid;
 
-pub(crate) static mut STATE: Option<Box<State>> = None;
+pub(crate) static mut STATE: Option<Box<State<'static>>> = None;
 
 #[macro_export]
 macro_rules! with_state_mut {

--- a/render-wasm/src/math.rs
+++ b/render-wasm/src/math.rs
@@ -32,6 +32,7 @@ pub fn are_close_points(a: impl Into<(f32, f32)>, b: impl Into<(f32, f32)>) -> b
     is_close_to(a_x, b_x) && is_close_to(a_y, b_y)
 }
 
+#[allow(dead_code)]
 pub fn is_close_matrix(m: &Matrix, other: &Matrix) -> bool {
     is_close_to(m.scale_x(), other.scale_x())
         && is_close_to(m.scale_y(), other.scale_y())

--- a/render-wasm/src/math/bools.rs
+++ b/render-wasm/src/math/bools.rs
@@ -388,8 +388,6 @@ pub fn bool_from_shapes(
     bool_type: BoolType,
     children_ids: &IndexSet<Uuid>,
     shapes: ShapesPoolRef,
-    modifiers: &HashMap<Uuid, Matrix>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Path {
     if children_ids.is_empty() {
         return Path::default();
@@ -399,13 +397,13 @@ pub fn bool_from_shapes(
         return Path::default();
     };
 
-    let mut current_path = child.to_path(shapes, modifiers, structure);
+    let mut current_path = child.to_path(shapes);
 
     for idx in (0..children_ids.len() - 1).rev() {
         let Some(other) = shapes.get(&children_ids[idx]) else {
             continue;
         };
-        let other_path = other.to_path(shapes, modifiers, structure);
+        let other_path = other.to_path(shapes);
 
         let (segs_a, segs_b) = split_segments(&current_path, &other_path);
 
@@ -422,26 +420,15 @@ pub fn bool_from_shapes(
     current_path
 }
 
-pub fn update_bool_to_path(
-    shape: &Shape,
-    shapes: ShapesPoolRef,
-    modifiers: &HashMap<Uuid, Matrix>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
-) -> Shape {
-    let mut shape = shape.clone();
-    let children_ids = shape.modified_children_ids(structure.get(&shape.id), true);
+#[allow(dead_code)]
+pub fn update_bool_to_path(shape: &mut Shape, shapes: ShapesPoolRef) {
+    let children_ids = shape.children_ids(true);
 
     let Type::Bool(bool_data) = &mut shape.shape_type else {
-        return shape;
+        return;
     };
-    bool_data.path = bool_from_shapes(
-        bool_data.bool_type,
-        &children_ids,
-        shapes,
-        modifiers,
-        structure,
-    );
-    shape
+
+    bool_data.path = bool_from_shapes(bool_data.bool_type, &children_ids, shapes);
 }
 
 #[allow(dead_code)]
@@ -450,14 +437,14 @@ pub fn debug_render_bool_paths(
     render_state: &mut RenderState,
     shape: &Shape,
     shapes: ShapesPoolRef,
-    modifiers: &HashMap<Uuid, Matrix>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
+    _modifiers: &HashMap<Uuid, Matrix>,
+    _structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) {
     let canvas = render_state.surfaces.canvas(SurfaceId::Strokes);
 
     let mut shape = shape.clone();
 
-    let children_ids = shape.modified_children_ids(structure.get(&shape.id), true);
+    let children_ids = shape.children_ids(true);
 
     let Type::Bool(bool_data) = &mut shape.shape_type else {
         return;
@@ -471,13 +458,13 @@ pub fn debug_render_bool_paths(
         return;
     };
 
-    let mut current_path = child.to_path(shapes, modifiers, structure);
+    let mut current_path = child.to_path(shapes);
 
     for idx in (0..children_ids.len() - 1).rev() {
         let Some(other) = shapes.get(&children_ids[idx]) else {
             continue;
         };
-        let other_path = other.to_path(shapes, modifiers, structure);
+        let other_path = other.to_path(shapes);
 
         let (segs_a, segs_b) = split_segments(&current_path, &other_path);
 

--- a/render-wasm/src/math/bools.rs
+++ b/render-wasm/src/math/bools.rs
@@ -1,7 +1,7 @@
 use super::Matrix;
 use crate::render::{RenderState, SurfaceId};
 use crate::shapes::{BoolType, Path, Segment, Shape, StructureEntry, ToPath, Type};
-use crate::state::ShapesPool;
+use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
 use bezier_rs::{Bezier, BezierHandles, ProjectionOptions, TValue};
 use glam::DVec2;
@@ -387,7 +387,7 @@ fn beziers_to_segments(beziers: &[(BezierSource, Bezier)]) -> Vec<Segment> {
 pub fn bool_from_shapes(
     bool_type: BoolType,
     children_ids: &IndexSet<Uuid>,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Path {
@@ -424,7 +424,7 @@ pub fn bool_from_shapes(
 
 pub fn update_bool_to_path(
     shape: &Shape,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Shape {
@@ -449,7 +449,7 @@ pub fn update_bool_to_path(
 pub fn debug_render_bool_paths(
     render_state: &mut RenderState,
     shape: &Shape,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) {

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1792,23 +1792,6 @@ impl RenderState {
         }
     }
 
-    /// Processes all ancestors of a shape, invalidating their extended rectangles and updating their tiles
-    ///
-    /// When a shape changes, all its ancestors need to have their extended rectangles recalculated
-    /// because they may contain the changed shape. This function:
-    /// 1. Computes all ancestors of the shape
-    /// 2. Invalidates the extrect cache for each ancestor
-    /// 3. Updates the tiles for each ancestor to ensure proper rendering
-    pub fn process_shape_ancestors(
-        &mut self,
-        shape: &Shape,
-        tree: &mut ShapesPool,
-        modifiers: &HashMap<Uuid, Matrix>,
-    ) {
-        let ancestors = shape.all_ancestors(tree, false);
-        self.invalidate_and_update_tiles(&ancestors, tree, modifiers);
-    }
-
     /// Rebuilds tiles for shapes with modifiers and processes their ancestors
     ///
     /// This function applies transformation modifiers to shapes and updates their tiles.

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -535,7 +535,12 @@ impl RenderState {
 
         match &shape.shape_type {
             Type::SVGRaw(sr) => {
+                if let Some(svg_transform) = shape.svg_transform() {
+                    matrix.pre_concat(&svg_transform);
+                }
+
                 self.surfaces.canvas(fills_surface_id).concat(&matrix);
+
                 if let Some(svg) = shape.svg.as_ref() {
                     svg.render(self.surfaces.canvas(fills_surface_id))
                 } else {
@@ -1574,7 +1579,7 @@ impl RenderState {
         while let Some(shape_id) = nodes.pop() {
             if let Some(shape) = tree.get(&shape_id) {
                 if shape_id != Uuid::nil() {
-                    self.update_tile_for(&shape, tree);
+                    self.update_tile_for(shape, tree);
                 } else {
                     // We only need to rebuild tiles from the first level.
                     let children = shape.children_ids(false);
@@ -1595,7 +1600,7 @@ impl RenderState {
         while let Some(shape_id) = nodes.pop() {
             if let Some(shape) = tree.get(&shape_id) {
                 if shape_id != Uuid::nil() {
-                    self.update_tile_for(&shape, tree);
+                    self.update_tile_for(shape, tree);
                 }
 
                 let children = shape.children_ids(false);

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -22,7 +22,8 @@ pub use surfaces::{SurfaceId, Surfaces};
 
 use crate::performance;
 use crate::shapes::{
-    Blur, BlurType, Corners, Fill, Shadow, Shape, SolidColor, Stroke, StructureEntry, Type,
+    all_with_ancestors, Blur, BlurType, Corners, Fill, Shadow, Shape, SolidColor, Stroke,
+    StructureEntry, Type,
 };
 use crate::state::ShapesPool;
 use crate::tiles::{self, PendingTiles, TileRect};
@@ -1819,20 +1820,8 @@ impl RenderState {
         tree: &mut ShapesPool,
         modifiers: &HashMap<Uuid, Matrix>,
     ) {
-        let mut ancestors = IndexSet::new();
-        for (uuid, matrix) in modifiers {
-            let mut shape = {
-                let Some(shape) = tree.get(uuid) else {
-                    panic!("Invalid current shape")
-                };
-                let shape: Cow<Shape> = Cow::Borrowed(shape);
-                shape
-            };
-
-            shape.to_mut().apply_transform(matrix);
-            ancestors.insert(*uuid);
-            ancestors.extend(shape.all_ancestors(tree, false));
-        }
+        let ids: Vec<_> = modifiers.keys().collect();
+        let ancestors = all_with_ancestors(&ids, tree, false);
         self.invalidate_and_update_tiles(&ancestors, tree, modifiers);
     }
 

--- a/render-wasm/src/render/grid_layout.rs
+++ b/render-wasm/src/render/grid_layout.rs
@@ -4,14 +4,14 @@ use std::collections::HashMap;
 use crate::math::{Matrix, Rect};
 use crate::shapes::modifiers::grid_layout::grid_cell_data;
 use crate::shapes::{Shape, StructureEntry};
-use crate::state::ShapesPool;
+use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
 
 pub fn render_overlay(
     zoom: f32,
     canvas: &skia::Canvas,
     shape: &Shape,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) {

--- a/render-wasm/src/render/grid_layout.rs
+++ b/render-wasm/src/render/grid_layout.rs
@@ -1,21 +1,12 @@
 use skia_safe::{self as skia};
-use std::collections::HashMap;
 
-use crate::math::{Matrix, Rect};
+use crate::math::Rect;
 use crate::shapes::modifiers::grid_layout::grid_cell_data;
-use crate::shapes::{Shape, StructureEntry};
+use crate::shapes::Shape;
 use crate::state::ShapesPoolRef;
-use crate::uuid::Uuid;
 
-pub fn render_overlay(
-    zoom: f32,
-    canvas: &skia::Canvas,
-    shape: &Shape,
-    shapes: ShapesPoolRef,
-    modifiers: &HashMap<Uuid, Matrix>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
-) {
-    let cells = grid_cell_data(shape, shapes, modifiers, structure, true);
+pub fn render_overlay(zoom: f32, canvas: &skia::Canvas, shape: &Shape, shapes: ShapesPoolRef) {
+    let cells = grid_cell_data(shape, shapes, true);
 
     let mut paint = skia::Paint::default();
     paint.set_style(skia::PaintStyle::Stroke);

--- a/render-wasm/src/render/ui.rs
+++ b/render-wasm/src/render/ui.rs
@@ -1,18 +1,9 @@
 use skia_safe::{self as skia, Color4f};
-use std::collections::HashMap;
 
 use super::{RenderState, ShapesPoolRef, SurfaceId};
-use crate::math::Matrix;
 use crate::render::grid_layout;
-use crate::shapes::StructureEntry;
-use crate::uuid::Uuid;
 
-pub fn render(
-    render_state: &mut RenderState,
-    shapes: ShapesPoolRef,
-    modifiers: &HashMap<Uuid, Matrix>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
-) {
+pub fn render(render_state: &mut RenderState, shapes: ShapesPoolRef) {
     let canvas = render_state.surfaces.canvas(SurfaceId::UI);
 
     canvas.clear(Color4f::new(0.0, 0.0, 0.0, 0.0));
@@ -29,7 +20,7 @@ pub fn render(
 
     if let Some(id) = render_state.show_grid {
         if let Some(shape) = shapes.get(&id) {
-            grid_layout::render_overlay(zoom, canvas, shape, shapes, modifiers, structure);
+            grid_layout::render_overlay(zoom, canvas, shape, shapes);
         }
     }
 

--- a/render-wasm/src/render/ui.rs
+++ b/render-wasm/src/render/ui.rs
@@ -1,7 +1,7 @@
 use skia_safe::{self as skia, Color4f};
 use std::collections::HashMap;
 
-use super::{RenderState, ShapesPool, SurfaceId};
+use super::{RenderState, ShapesPoolRef, SurfaceId};
 use crate::math::Matrix;
 use crate::render::grid_layout;
 use crate::shapes::StructureEntry;
@@ -9,7 +9,7 @@ use crate::uuid::Uuid;
 
 pub fn render(
     render_state: &mut RenderState,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) {

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -959,47 +959,6 @@ impl Shape {
         }
     }
 
-    /// Returns all ancestor shapes of this shape, traversing up the parent hierarchy
-    ///
-    /// This function walks up the parent chain starting from this shape's parent,
-    /// collecting all ancestor IDs. It stops when it reaches a nil UUID or when
-    /// an ancestor is hidden (unless include_hidden is true).
-    ///
-    /// # Arguments
-    /// * `shapes` - The shapes pool containing all shapes
-    /// * `include_hidden` - Whether to include hidden ancestors in the result
-    ///
-    /// # Returns
-    /// A set of ancestor UUIDs in traversal order (closest ancestor first)
-    pub fn all_ancestors(&self, shapes: &ShapesPool, include_hidden: bool) -> IndexSet<Uuid> {
-        let mut ancestors = IndexSet::new();
-        let mut current_id = self.id;
-
-        // Traverse upwards using parent_id
-        while let Some(parent_id) = shapes.get(&current_id).and_then(|s| s.parent_id) {
-            // If the parent_id is the zero UUID, there are no more ancestors
-            if parent_id == Uuid::nil() {
-                break;
-            }
-
-            // Check if the ancestor is hidden
-            if let Some(parent) = shapes.get(&parent_id) {
-                if !include_hidden && parent.hidden() {
-                    break;
-                }
-                ancestors.insert(parent_id);
-                current_id = parent_id;
-            } else {
-                // FIXME: This should panic! I've removed it temporarily until
-                // we fix the problems with shapes without parents.
-                // panic!("Parent can't be found");
-                break;
-            }
-        }
-
-        ancestors
-    }
-
     pub fn get_matrix(&self) -> Matrix {
         let mut matrix = Matrix::new_identity();
         matrix.post_translate(self.left_top());

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1151,7 +1151,7 @@ impl Shape {
     pub fn apply_transform(&mut self, transform: &Matrix) {
         self.transform_selrect(transform);
 
-        // We don't need to invalidate this? we can just transform it
+        // TODO: See if we can change this invalidation to a transformation
         self.invalidate_extrect();
         self.invalidate_bounds();
 

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -719,8 +719,7 @@ impl Shape {
     }
 
     pub fn bounds(&self) -> Bounds {
-        *self.bounds
-            .get_or_init(|| self.calculate_bounds())
+        *self.bounds.get_or_init(|| self.calculate_bounds())
     }
 
     pub fn selrect(&self) -> math::Rect {
@@ -944,6 +943,24 @@ impl Shape {
             }
         } else {
             self.children.clone().into_iter().rev().collect()
+        }
+    }
+
+    pub fn children_ids_iter(&self, include_hidden: bool) -> Box<dyn Iterator<Item = &Uuid> + '_> {
+        if include_hidden {
+            return Box::new(self.children.iter().rev());
+        }
+
+        if let Type::Bool(_) = self.shape_type {
+            Box::new([].iter())
+        } else if let Type::Group(group) = self.shape_type {
+            if group.masked {
+                Box::new(self.children.iter().rev().take(self.children.len() - 1))
+            } else {
+                Box::new(self.children.iter().rev())
+            }
+        } else {
+            Box::new(self.children.iter().rev())
         }
     }
 
@@ -1256,6 +1273,36 @@ impl Shape {
             ret
         } else {
             self.children_ids(include_hidden)
+        }
+    }
+
+    pub fn modified_children_ids_iter<'a>(
+        &'a self,
+        structure: Option<&'a Vec<StructureEntry>>,
+        include_hidden: bool,
+    ) -> Box<dyn Iterator<Item = Cow<'a, Uuid>> + 'a> {
+        if let Some(structure) = structure {
+            let mut result: Vec<Cow<'a, Uuid>> = self
+                .children_ids_iter(include_hidden)
+                .map(Cow::Borrowed)
+                .collect();
+            let mut to_remove = HashSet::<Cow<'a, Uuid>>::new();
+
+            for st in structure {
+                match st.entry_type {
+                    StructureEntryType::AddChild => {
+                        result.insert(result.len() - st.index as usize, Cow::Owned(st.id));
+                    }
+                    StructureEntryType::RemoveChild => {
+                        to_remove.insert(Cow::Owned(st.id));
+                    }
+                    _ => {}
+                }
+            }
+
+            Box::new(result.into_iter().filter(move |id| !to_remove.contains(id)))
+        } else {
+            Box::new(self.children_ids_iter(include_hidden).map(Cow::Borrowed))
         }
     }
 

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -182,6 +182,7 @@ pub struct Shape {
     pub layout_item: Option<LayoutItem>,
     pub extrect: OnceCell<math::Rect>,
     pub bounds: OnceCell<math::Bounds>,
+    pub svg_transform: Option<Matrix>,
 }
 
 // Returns all ancestor shapes of this shape, traversing up the parent hierarchy
@@ -263,6 +264,7 @@ impl Shape {
             layout_item: None,
             extrect: OnceCell::new(),
             bounds: OnceCell::new(),
+            svg_transform: None,
         }
     }
 
@@ -391,6 +393,10 @@ impl Shape {
 
     pub fn set_hidden(&mut self, value: bool) {
         self.hidden = value;
+    }
+
+    pub fn svg_transform(&self) -> Option<Matrix> {
+        self.svg_transform
     }
 
     // FIXME: These arguments could be grouped or simplified
@@ -876,7 +882,7 @@ impl Shape {
             }
             Type::Text(text_content) => {
                 // FIXME: we need to recalculate the text bounds here because the shape's selrect
-                let text_bounds = text_content.calculate_bounds(&shape);
+                let text_bounds = text_content.calculate_bounds(shape);
                 text_bounds.to_rect()
             }
             _ => shape.bounds().to_rect(),
@@ -1160,6 +1166,8 @@ impl Shape {
             }
         } else if let Type::Text(text) = &mut self.shape_type {
             text.transform(transform);
+        } else if let Type::SVGRaw(_) = &mut self.shape_type {
+            self.svg_transform = Some(*transform);
         }
     }
 

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -3,7 +3,7 @@ use skia_safe::{self as skia};
 use crate::uuid::Uuid;
 use std::borrow::Cow;
 use std::cell::OnceCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::iter::once;
 
 mod blend;
@@ -196,11 +196,11 @@ pub struct Shape {
 // # Returns
 // A set of ancestor UUIDs in traversal order (closest ancestor first)
 pub fn all_with_ancestors(
-    shapes: &[&Uuid],
+    shapes: &[Uuid],
     shapes_pool: &ShapesPool,
     include_hidden: bool,
 ) -> IndexSet<Uuid> {
-    let mut pending = Vec::from(shapes);
+    let mut pending = Vec::from_iter(shapes.iter());
     let mut result = IndexSet::new();
 
     while !pending.is_empty() {
@@ -677,13 +677,8 @@ impl Shape {
         self.selrect.width()
     }
 
-    pub fn visually_insignificant(
-        &self,
-        scale: f32,
-        shapes_pool: &ShapesPool,
-        modifiers: &HashMap<Uuid, Matrix>,
-    ) -> bool {
-        let extrect = self.extrect(shapes_pool, modifiers);
+    pub fn visually_insignificant(&self, scale: f32, shapes_pool: &ShapesPool) -> bool {
+        let extrect = self.extrect(shapes_pool);
         extrect.width() * scale < MIN_VISIBLE_SIZE && extrect.height() * scale < MIN_VISIBLE_SIZE
     }
 
@@ -726,14 +721,10 @@ impl Shape {
         self.selrect
     }
 
-    pub fn extrect(
-        &self,
-        shapes_pool: &ShapesPool,
-        modifiers: &HashMap<Uuid, Matrix>,
-    ) -> math::Rect {
+    pub fn extrect(&self, shapes_pool: &ShapesPool) -> math::Rect {
         *self
             .extrect
-            .get_or_init(|| self.calculate_extrect(shapes_pool, modifiers))
+            .get_or_init(|| self.calculate_extrect(shapes_pool))
     }
 
     pub fn get_text_content(&self) -> &TextContent {
@@ -843,12 +834,7 @@ impl Shape {
         rect
     }
 
-    fn apply_children_bounds(
-        &self,
-        mut rect: math::Rect,
-        shapes_pool: &ShapesPool,
-        modifiers: &HashMap<Uuid, Matrix>,
-    ) -> math::Rect {
+    fn apply_children_bounds(&self, mut rect: math::Rect, shapes_pool: &ShapesPool) -> math::Rect {
         let include_children = match self.shape_type {
             Type::Group(_) => true,
             Type::Frame(_) => !self.clip_content,
@@ -858,15 +844,7 @@ impl Shape {
         if include_children {
             for child_id in self.children_ids(false) {
                 if let Some(child_shape) = shapes_pool.get(&child_id) {
-                    // Create a copy of the child shape to apply any transformations
-                    let mut transformed_element: Cow<Shape> = Cow::Borrowed(child_shape);
-                    if let Some(modifier) = modifiers.get(&child_id) {
-                        transformed_element.to_mut().apply_transform(modifier);
-                    }
-
-                    // Get the child's extended rectangle and join it with the container's rectangle
-                    let child_extrect = transformed_element.extrect(shapes_pool, modifiers);
-                    rect.join(child_extrect);
+                    rect.join(child_shape.extrect(shapes_pool));
                 }
             }
         }
@@ -874,12 +852,8 @@ impl Shape {
         rect
     }
 
-    pub fn calculate_extrect(
-        &self,
-        shapes_pool: &ShapesPool,
-        modifiers: &HashMap<Uuid, Matrix>,
-    ) -> math::Rect {
-        let shape = self.transformed(modifiers.get(&self.id));
+    pub fn calculate_extrect(&self, shapes_pool: &ShapesPool) -> math::Rect {
+        let shape = self;
         let max_stroke = Stroke::max_bounds_width(shape.strokes.iter(), shape.is_open());
 
         let mut rect = match &shape.shape_type {
@@ -902,7 +876,7 @@ impl Shape {
         rect = self.apply_stroke_bounds(rect, max_stroke);
         rect = self.apply_shadow_bounds(rect);
         rect = self.apply_blur_bounds(rect);
-        rect = self.apply_children_bounds(rect, shapes_pool, modifiers);
+        rect = self.apply_children_bounds(rect, shapes_pool);
 
         rect
     }
@@ -1179,10 +1153,40 @@ impl Shape {
         }
     }
 
-    pub fn transformed(&self, transform: Option<&Matrix>) -> Self {
+    pub fn apply_structure(&mut self, structure: &Vec<StructureEntry>) {
+        let mut result: Vec<Uuid> = Vec::from_iter(self.children.iter().copied());
+        let mut to_remove = HashSet::<&Uuid>::new();
+
+        for st in structure {
+            match st.entry_type {
+                StructureEntryType::AddChild => {
+                    result.insert(result.len() - st.index as usize, st.id);
+                }
+                StructureEntryType::RemoveChild => {
+                    to_remove.insert(&st.id);
+                }
+                _ => {}
+            }
+        }
+
+        self.children = result
+            .iter()
+            .filter(|id| !to_remove.contains(id))
+            .copied()
+            .collect();
+    }
+
+    pub fn transformed(
+        &self,
+        transform: Option<&Matrix>,
+        structure: Option<&Vec<StructureEntry>>) -> Self
+    {
         let mut shape: Cow<Shape> = Cow::Borrowed(self);
         if let Some(transform) = transform {
             shape.to_mut().apply_transform(transform);
+        }
+        if let Some(structure) = structure {
+            shape.to_mut().apply_structure(structure);
         }
         shape.into_owned()
     }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -50,7 +50,7 @@ pub use transform::*;
 use crate::math::{self, Bounds, Matrix, Point};
 use indexmap::IndexSet;
 
-use crate::state::ShapesPool;
+use crate::state::ShapesPoolRef;
 
 const MIN_VISIBLE_SIZE: f32 = 2.0;
 const ANTIALIAS_THRESHOLD: f32 = 15.0;
@@ -197,7 +197,7 @@ pub struct Shape {
 // A set of ancestor UUIDs in traversal order (closest ancestor first)
 pub fn all_with_ancestors(
     shapes: &[Uuid],
-    shapes_pool: &ShapesPool,
+    shapes_pool: ShapesPoolRef,
     include_hidden: bool,
 ) -> IndexSet<Uuid> {
     let mut pending = Vec::from_iter(shapes.iter());
@@ -677,7 +677,7 @@ impl Shape {
         self.selrect.width()
     }
 
-    pub fn visually_insignificant(&self, scale: f32, shapes_pool: &ShapesPool) -> bool {
+    pub fn visually_insignificant(&self, scale: f32, shapes_pool: ShapesPoolRef) -> bool {
         let extrect = self.extrect(shapes_pool);
         extrect.width() * scale < MIN_VISIBLE_SIZE && extrect.height() * scale < MIN_VISIBLE_SIZE
     }
@@ -721,7 +721,7 @@ impl Shape {
         self.selrect
     }
 
-    pub fn extrect(&self, shapes_pool: &ShapesPool) -> math::Rect {
+    pub fn extrect(&self, shapes_pool: ShapesPoolRef) -> math::Rect {
         *self
             .extrect
             .get_or_init(|| self.calculate_extrect(shapes_pool))
@@ -834,7 +834,11 @@ impl Shape {
         rect
     }
 
-    fn apply_children_bounds(&self, mut rect: math::Rect, shapes_pool: &ShapesPool) -> math::Rect {
+    fn apply_children_bounds(
+        &self,
+        mut rect: math::Rect,
+        shapes_pool: ShapesPoolRef,
+    ) -> math::Rect {
         let include_children = match self.shape_type {
             Type::Group(_) => true,
             Type::Frame(_) => !self.clip_content,
@@ -852,7 +856,7 @@ impl Shape {
         rect
     }
 
-    pub fn calculate_extrect(&self, shapes_pool: &ShapesPool) -> math::Rect {
+    pub fn calculate_extrect(&self, shapes_pool: ShapesPoolRef) -> math::Rect {
         let shape = self;
         let max_stroke = Stroke::max_bounds_width(shape.strokes.iter(), shape.is_open());
 
@@ -940,7 +944,7 @@ impl Shape {
 
     pub fn all_children(
         &self,
-        shapes: &ShapesPool,
+        shapes: ShapesPoolRef,
         include_hidden: bool,
         include_self: bool,
     ) -> IndexSet<Uuid> {
@@ -968,7 +972,7 @@ impl Shape {
         matrix
     }
 
-    pub fn get_concatenated_matrix(&self, shapes: &ShapesPool) -> Matrix {
+    pub fn get_concatenated_matrix(&self, shapes: ShapesPoolRef) -> Matrix {
         let mut matrix = Matrix::new_identity();
         let mut current_id = self.id;
         while let Some(parent_id) = shapes.get(&current_id).and_then(|s| s.parent_id) {
@@ -1179,8 +1183,8 @@ impl Shape {
     pub fn transformed(
         &self,
         transform: Option<&Matrix>,
-        structure: Option<&Vec<StructureEntry>>) -> Self
-    {
+        structure: Option<&Vec<StructureEntry>>,
+    ) -> Self {
         let mut shape: Cow<Shape> = Cow::Borrowed(self);
         if let Some(transform) = transform {
             shape.to_mut().apply_transform(transform);

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -13,13 +13,13 @@ use crate::shapes::{
     ConstraintH, ConstraintV, Frame, Group, GrowType, Layout, Modifier, Shape, StructureEntry,
     TransformEntry, Type,
 };
-use crate::state::{ShapesPool, State};
+use crate::state::{ShapesPoolRef, State};
 use crate::uuid::Uuid;
 
 #[allow(clippy::too_many_arguments)]
 fn propagate_children(
     shape: &Shape,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     parent_bounds_before: &Bounds,
     parent_bounds_after: &Bounds,
     transform: Matrix,
@@ -90,7 +90,7 @@ fn propagate_children(
 
 fn calculate_group_bounds(
     shape: &Shape,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Option<Bounds> {
@@ -110,7 +110,7 @@ fn calculate_group_bounds(
 
 fn calculate_bool_bounds(
     shape: &Shape,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
@@ -464,7 +464,7 @@ mod tests {
         let parent_id = Uuid::new_v4();
 
         let shapes = {
-            let mut shapes = ShapesPool::new();
+            let mut shapes = ShapesPoolRef::new();
             shapes.initialize(10);
 
             let child_id = Uuid::new_v4();
@@ -507,7 +507,7 @@ mod tests {
     fn test_group_bounds() {
         let parent_id = Uuid::new_v4();
         let shapes = {
-            let mut shapes = ShapesPool::new();
+            let mut shapes = ShapesPoolRef::new();
             shapes.initialize(10);
 
             let child1_id = Uuid::new_v4();

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -95,7 +95,7 @@ fn calculate_group_bounds(
     let mut result = Vec::<Point>::new();
 
     for child_id in shape.children_ids_iter(true) {
-        let Some(child) = shapes.get(&child_id) else {
+        let Some(child) = shapes.get(child_id) else {
             continue;
         };
 
@@ -109,7 +109,7 @@ fn calculate_bool_bounds(
     shape: &Shape,
     shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
-    modifiers: &HashMap<Uuid, Matrix>
+    modifiers: &HashMap<Uuid, Matrix>,
 ) -> Option<Bounds> {
     let shape_bounds = bounds.find(shape);
     let children_ids = shape.children_ids(true);
@@ -258,7 +258,7 @@ fn propagate_reflow(
     bounds: &mut HashMap<Uuid, Bounds>,
     layout_reflows: &mut Vec<Uuid>,
     reflown: &mut HashSet<Uuid>,
-    modifiers: &HashMap<Uuid, Matrix>
+    modifiers: &HashMap<Uuid, Matrix>,
 ) {
     let Some(shape) = state.shapes.get(id) else {
         return;
@@ -267,7 +267,7 @@ fn propagate_reflow(
     let shapes = &state.shapes;
     let mut reflow_parent = false;
 
-    if reflown.contains(&id) {
+    if reflown.contains(id) {
         return;
     }
 
@@ -403,7 +403,7 @@ pub fn propagate_modifiers(
                     &mut bounds,
                     &mut layout_reflows,
                     &mut reflown,
-                    &mut modifiers,
+                    &modifiers,
                 ),
             }
         }
@@ -429,13 +429,14 @@ mod tests {
 
     use crate::math::{Matrix, Point};
     use crate::shapes::*;
+    use crate::state::ShapesPool;
 
     #[test]
     fn test_propagate_shape() {
         let parent_id = Uuid::new_v4();
 
         let shapes = {
-            let mut shapes = ShapesPoolRef::new();
+            let mut shapes = ShapesPool::new();
             shapes.initialize(10);
 
             let child_id = Uuid::new_v4();
@@ -468,7 +469,6 @@ mod tests {
             transform,
             &HashMap::new(),
             &HashMap::new(),
-            &HashMap::new(),
         );
 
         assert_eq!(result.len(), 1);
@@ -478,7 +478,7 @@ mod tests {
     fn test_group_bounds() {
         let parent_id = Uuid::new_v4();
         let shapes = {
-            let mut shapes = ShapesPoolRef::new();
+            let mut shapes = ShapesPool::new();
             shapes.initialize(10);
 
             let child1_id = Uuid::new_v4();
@@ -500,7 +500,7 @@ mod tests {
         let parent = shapes.get(&parent_id).unwrap();
 
         let bounds =
-            calculate_group_bounds(parent, &shapes, &HashMap::new(), &HashMap::new()).unwrap();
+            calculate_group_bounds(parent, &shapes, &HashMap::new()).unwrap();
 
         assert_eq!(bounds.width(), 3.0);
         assert_eq!(bounds.height(), 3.0);

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -2,7 +2,7 @@
 use crate::math::{self as math, Bounds, Matrix, Point, Vector, VectorExt};
 use crate::shapes::{
     AlignContent, AlignItems, AlignSelf, FlexData, JustifyContent, LayoutData, LayoutItem,
-    Modifier, Shape, StructureEntry,
+    Modifier, Shape,
 };
 use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
@@ -181,11 +181,10 @@ fn initialize_tracks(
     flex_data: &FlexData,
     shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Vec<TrackData> {
     let mut tracks = Vec::<TrackData>::new();
     let mut current_track = TrackData::default();
-    let mut children = shape.modified_children_ids(structure.get(&shape.id), true);
+    let mut children = shape.children_ids(true);
     let mut first = true;
 
     if flex_data.is_reverse() {
@@ -435,7 +434,6 @@ fn calculate_track_data(
     layout_bounds: &Bounds,
     shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Vec<TrackData> {
     let layout_axis = LayoutAxis::new(shape, layout_bounds, layout_data, flex_data);
     let mut tracks = initialize_tracks(
@@ -445,7 +443,6 @@ fn calculate_track_data(
         flex_data,
         shapes,
         bounds,
-        structure,
     );
 
     distribute_fill_main_space(&layout_axis, &mut tracks);
@@ -576,20 +573,11 @@ pub fn reflow_flex_layout(
     flex_data: &FlexData,
     shapes: ShapesPoolRef,
     bounds: &mut HashMap<Uuid, Bounds>,
-    structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> VecDeque<Modifier> {
     let mut result = VecDeque::new();
     let layout_bounds = &bounds.find(shape);
     let layout_axis = LayoutAxis::new(shape, layout_bounds, layout_data, flex_data);
-    let tracks = calculate_track_data(
-        shape,
-        layout_data,
-        flex_data,
-        layout_bounds,
-        shapes,
-        bounds,
-        structure,
-    );
+    let tracks = calculate_track_data(shape, layout_data, flex_data, layout_bounds, shapes, bounds);
 
     for track in tracks.iter() {
         let total_shapes_size = track.shapes.iter().map(|s| s.main_size).sum::<f32>();

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -4,7 +4,7 @@ use crate::shapes::{
     AlignContent, AlignItems, AlignSelf, FlexData, JustifyContent, LayoutData, LayoutItem,
     Modifier, Shape, StructureEntry,
 };
-use crate::state::ShapesPool;
+use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
 
 use std::collections::{HashMap, VecDeque};
@@ -179,7 +179,7 @@ fn initialize_tracks(
     layout_bounds: &Bounds,
     layout_axis: &LayoutAxis,
     flex_data: &FlexData,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Vec<TrackData> {
@@ -433,7 +433,7 @@ fn calculate_track_data(
     layout_data: &LayoutData,
     flex_data: &FlexData,
     layout_bounds: &Bounds,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> Vec<TrackData> {
@@ -574,7 +574,7 @@ pub fn reflow_flex_layout(
     shape: &Shape,
     layout_data: &LayoutData,
     flex_data: &FlexData,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &mut HashMap<Uuid, Bounds>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> VecDeque<Modifier> {

--- a/render-wasm/src/shapes/modifiers/grid_layout.rs
+++ b/render-wasm/src/shapes/modifiers/grid_layout.rs
@@ -4,7 +4,7 @@ use crate::shapes::{
     JustifyContent, JustifyItems, JustifySelf, Layout, LayoutData, LayoutItem, Modifier, Shape,
     StructureEntry, Type,
 };
-use crate::state::ShapesPool;
+use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
 use indexmap::IndexSet;
 use std::collections::{HashMap, VecDeque};
@@ -45,7 +45,7 @@ pub fn calculate_tracks(
     grid_data: &GridData,
     layout_bounds: &Bounds,
     cells: &Vec<GridCell>,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
 ) -> Vec<TrackData> {
     let layout_size = if is_column {
@@ -122,7 +122,7 @@ fn set_auto_base_size(
     column: bool,
     tracks: &mut [TrackData],
     cells: &Vec<GridCell>,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
 ) {
     for cell in cells {
@@ -173,7 +173,7 @@ fn set_auto_multi_span(
     column: bool,
     tracks: &mut [TrackData],
     cells: &[GridCell],
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
 ) {
     // Remove groups with flex (will be set in flex_multi_span)
@@ -248,7 +248,7 @@ fn set_flex_multi_span(
     layout_data: &LayoutData,
     tracks: &mut [TrackData],
     cells: &[GridCell],
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &HashMap<Uuid, Bounds>,
 ) {
     // Remove groups without flex
@@ -539,7 +539,7 @@ fn cell_bounds(
 pub fn create_cell_data<'a>(
     layout_bounds: &Bounds,
     children: &IndexSet<Uuid>,
-    shapes: &'a ShapesPool,
+    shapes: ShapesPoolRef<'a>,
     cells: &Vec<GridCell>,
     column_tracks: &[TrackData],
     row_tracks: &[TrackData],
@@ -602,7 +602,7 @@ pub fn create_cell_data<'a>(
 
 pub fn grid_cell_data<'a>(
     shape: &Shape,
-    shapes: &'a ShapesPool,
+    shapes: ShapesPoolRef<'a>,
     modifiers: &HashMap<Uuid, Matrix>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
     allow_empty: bool,
@@ -723,7 +723,7 @@ pub fn reflow_grid_layout(
     shape: &Shape,
     layout_data: &LayoutData,
     grid_data: &GridData,
-    shapes: &ShapesPool,
+    shapes: ShapesPoolRef,
     bounds: &mut HashMap<Uuid, Bounds>,
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
 ) -> VecDeque<Modifier> {

--- a/render-wasm/src/shapes/shape_to_path.rs
+++ b/render-wasm/src/shapes/shape_to_path.rs
@@ -186,11 +186,10 @@ impl ToPath for Shape {
         modifiers: &HashMap<Uuid, Matrix>,
         structure: &HashMap<Uuid, Vec<StructureEntry>>,
     ) -> Path {
-        let shape = self.transformed(modifiers.get(&self.id));
-        match shape.shape_type {
+        match &self.shape_type {
             Type::Frame(ref frame) => {
-                let children = shape.modified_children_ids(structure.get(&shape.id), true);
-                let mut result = Path::new(rect_segments(&shape, frame.corners));
+                let children = self.modified_children_ids(structure.get(&self.id), true);
+                let mut result = Path::new(rect_segments(&self, frame.corners));
                 for id in children {
                     let Some(shape) = shapes.get(&id) else {
                         continue;
@@ -201,7 +200,7 @@ impl ToPath for Shape {
             }
 
             Type::Group(_) => {
-                let children = shape.modified_children_ids(structure.get(&shape.id), true);
+                let children = self.modified_children_ids(structure.get(&self.id), true);
                 let mut result = Path::default();
                 for id in children {
                     let Some(shape) = shapes.get(&id) else {
@@ -215,13 +214,13 @@ impl ToPath for Shape {
                 Path::new(segments)
             }
 
-            Type::Bool(bool_data) => bool_data.path,
+            Type::Bool(bool_data) => bool_data.path.clone(),
 
-            Type::Rect(ref rect) => Path::new(rect_segments(&shape, rect.corners)),
+            Type::Rect(ref rect) => Path::new(rect_segments(&self, rect.corners)),
 
-            Type::Path(path_data) => path_data,
+            Type::Path(path_data) => path_data.clone(),
 
-            Type::Circle => Path::new(circle_segments(&shape)),
+            Type::Circle => Path::new(circle_segments(&self)),
 
             Type::SVGRaw(_) => Path::default(),
 
@@ -232,7 +231,7 @@ impl ToPath for Shape {
                     result = join_paths(result, Path::from_skia_path(path));
                 }
 
-                Path::new(transform_segments(result.segments().clone(), &shape))
+                Path::new(transform_segments(result.segments().clone(), &self))
             }
         }
     }

--- a/render-wasm/src/shapes/shape_to_path.rs
+++ b/render-wasm/src/shapes/shape_to_path.rs
@@ -4,7 +4,7 @@ use super::{Corners, Path, Segment, Shape, StructureEntry, Type};
 use crate::math;
 
 use crate::shapes::text_paths::TextPaths;
-use crate::state::ShapesPool;
+use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
 use std::collections::HashMap;
 
@@ -13,7 +13,7 @@ const BEZIER_CIRCLE_C: f32 = 0.551_915_05;
 pub trait ToPath {
     fn to_path(
         &self,
-        shapes: &ShapesPool,
+        shapes: ShapesPoolRef,
         modifiers: &HashMap<Uuid, Matrix>,
         structure: &HashMap<Uuid, Vec<StructureEntry>>,
     ) -> Path;
@@ -182,7 +182,7 @@ fn transform_segments(segments: Vec<Segment>, shape: &Shape) -> Vec<Segment> {
 impl ToPath for Shape {
     fn to_path(
         &self,
-        shapes: &ShapesPool,
+        shapes: ShapesPoolRef,
         modifiers: &HashMap<Uuid, Matrix>,
         structure: &HashMap<Uuid, Vec<StructureEntry>>,
     ) -> Path {

--- a/render-wasm/src/shapes/shape_to_path.rs
+++ b/render-wasm/src/shapes/shape_to_path.rs
@@ -175,7 +175,7 @@ impl ToPath for Shape {
         match &self.shape_type {
             Type::Frame(ref frame) => {
                 let children = self.children_ids(true);
-                let mut result = Path::new(rect_segments(&self, frame.corners));
+                let mut result = Path::new(rect_segments(self, frame.corners));
                 for id in children {
                     let Some(shape) = shapes.get(&id) else {
                         continue;
@@ -202,11 +202,11 @@ impl ToPath for Shape {
 
             Type::Bool(bool_data) => bool_data.path.clone(),
 
-            Type::Rect(ref rect) => Path::new(rect_segments(&self, rect.corners)),
+            Type::Rect(ref rect) => Path::new(rect_segments(self, rect.corners)),
 
             Type::Path(path_data) => path_data.clone(),
 
-            Type::Circle => Path::new(circle_segments(&self)),
+            Type::Circle => Path::new(circle_segments(self)),
 
             Type::SVGRaw(_) => Path::default(),
 
@@ -217,7 +217,7 @@ impl ToPath for Shape {
                     result = join_paths(result, Path::from_skia_path(path));
                 }
 
-                Path::new(transform_segments(result.segments().clone(), &self))
+                Path::new(transform_segments(result.segments().clone(), self))
             }
         }
     }

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -114,8 +114,7 @@ impl State {
         // We don't really do a self.shapes.remove so that redo/undo keep working
         if let Some(shape) = self.shapes.get(&id) {
             let tiles::TileRect(rsx, rsy, rex, rey) =
-                self.render_state
-                    .get_tiles_for_shape(shape, &self.shapes, &self.modifiers);
+                self.render_state.get_tiles_for_shape(shape, &self.shapes);
             for x in rsx..=rex {
                 for y in rsy..=rey {
                     let tile = tiles::Tile(x, y);
@@ -159,8 +158,7 @@ impl State {
 
     pub fn update_tile_for_shape(&mut self, shape_id: Uuid) {
         if let Some(shape) = self.shapes.get(&shape_id) {
-            self.render_state
-                .update_tile_for(shape, &self.shapes, &self.modifiers);
+            self.render_state.update_tile_for(shape, &self.shapes);
         }
     }
 
@@ -170,7 +168,7 @@ impl State {
         };
         if !shape.id.is_nil() {
             self.render_state
-                .update_tile_for(&shape.clone(), &self.shapes, &self.modifiers);
+                .update_tile_for(&shape.clone(), &self.shapes);
         }
     }
 
@@ -184,9 +182,9 @@ impl State {
             .rebuild_tiles(&self.shapes, &self.modifiers, &self.structure);
     }
 
-    pub fn rebuild_modifier_tiles(&mut self) {
+    pub fn rebuild_modifier_tiles(&mut self, ids: Vec<Uuid>) {
         self.render_state
-            .rebuild_modifier_tiles(&mut self.shapes, &self.modifiers);
+            .rebuild_modifier_tiles(&mut self.shapes, ids);
     }
 
     pub fn font_collection(&self) -> &FontCollection {
@@ -216,5 +214,9 @@ impl State {
         }
 
         None
+    }
+
+    pub fn set_modifiers(&mut self, modifiers: HashMap<Uuid, skia::Matrix>) {
+        self.shapes.set_modifiers(modifiers);
     }
 }

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -94,9 +94,14 @@ impl<'a> State<'a> {
         self.current_id = Some(id);
     }
 
-    pub fn delete_shape(&mut self, id: Uuid) {
+    pub fn delete_shape_children(&mut self, parent_id: Uuid, id: Uuid) {
         // We don't really do a self.shapes.remove so that redo/undo keep working
-        if let Some(shape) = self.shapes.get(&id) {
+        let Some(shape) = self.shapes.get(&id) else {
+            return;
+        };
+
+        // Only remove the children when is being deleted from the owner
+        if shape.parent_id.is_none() || shape.parent_id == Some(parent_id) {
             let tiles::TileRect(rsx, rsy, rex, rey) =
                 self.render_state.get_tiles_for_shape(shape, &self.shapes);
             for x in rsx..=rex {

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -157,24 +157,6 @@ impl State {
         }
     }
 
-    /// Sets the selection rectangle for the current shape and processes its ancestors
-    ///
-    /// When a shape's selection rectangle changes, all its ancestors need to have their
-    /// extended rectangles recalculated because the shape's bounds may have changed.
-    /// This ensures proper rendering of frames and groups containing the modified shape.
-    // FIXME: PERFORMANCE
-    pub fn set_selrect_for_current_shape(&mut self, left: f32, top: f32, right: f32, bottom: f32) {
-        let shape = {
-            let Some(shape) = self.current_shape_mut() else {
-                panic!("Invalid current shape")
-            };
-            shape.set_selrect(left, top, right, bottom);
-            shape.clone()
-        };
-        self.render_state
-            .process_shape_ancestors(&shape, &mut self.shapes, &self.modifiers);
-    }
-
     pub fn update_tile_for_shape(&mut self, shape_id: Uuid) {
         if let Some(shape) = self.shapes.get(&shape_id) {
             self.render_state

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -23,7 +23,6 @@ pub(crate) struct State<'a> {
     pub text_editor_state: TextEditorState,
     pub current_id: Option<Uuid>,
     pub shapes: ShapesPool<'a>,
-    pub scale_content: HashMap<Uuid, f32>,
 }
 
 impl<'a> State<'a> {
@@ -33,7 +32,6 @@ impl<'a> State<'a> {
             text_editor_state: TextEditorState::new(),
             current_id: None,
             shapes: ShapesPool::new(),
-            scale_content: HashMap::new(),
         }
     }
 
@@ -65,13 +63,13 @@ impl<'a> State<'a> {
 
     pub fn start_render_loop(&mut self, timestamp: i32) -> Result<(), String> {
         self.render_state
-            .start_render_loop(&self.shapes, &self.scale_content, timestamp)?;
+            .start_render_loop(&self.shapes, timestamp)?;
         Ok(())
     }
 
     pub fn process_animation_frame(&mut self, timestamp: i32) -> Result<(), String> {
         self.render_state
-            .process_animation_frame(&self.shapes, &self.scale_content, timestamp)?;
+            .process_animation_frame(&self.shapes, timestamp)?;
         Ok(())
     }
 

--- a/render-wasm/src/state/shapes_pool.rs
+++ b/render-wasm/src/state/shapes_pool.rs
@@ -14,7 +14,7 @@ const SHAPES_POOL_ALLOC_MULTIPLIER: f32 = 1.3;
 
 /// A pool allocator for `Shape` objects that attempts to minimize memory reallocations.
 ///
-/// `ShapesPool` pre-allocates a contiguous vector of `Shape` instances,
+/// `ShapesPoolImpl` pre-allocates a contiguous vector of `Shape` instances,
 /// which can be reused and indexed efficiently. This design helps avoid
 /// memory reallocation overhead by reserving enough space in advance.
 ///
@@ -23,20 +23,25 @@ const SHAPES_POOL_ALLOC_MULTIPLIER: f32 = 1.3;
 /// Shapes are stored in a `Vec<Shape>`, which keeps the `Shape` instances
 /// in a contiguous memory block.
 ///
-pub struct ShapesPool {
+pub struct ShapesPoolImpl<'a> {
     shapes: Vec<Shape>,
     counter: usize,
 
-    shapes_uuid_to_idx: HashMap<Uuid, usize>,
+    shapes_uuid_to_idx: HashMap<&'a Uuid, usize>,
 
-    modified_shape_cache: HashMap<Uuid, OnceCell<Shape>>,
-    modifiers: HashMap<Uuid, skia::Matrix>,
-    structure: HashMap<Uuid, Vec<StructureEntry>>,
+    modified_shape_cache: HashMap<&'a Uuid, OnceCell<Shape>>,
+    modifiers: HashMap<&'a Uuid, skia::Matrix>,
+    structure: HashMap<&'a Uuid, Vec<StructureEntry>>,
 }
 
-impl ShapesPool {
+// Type aliases to avoid writing lifetimes everywhere
+pub type ShapesPool<'a> = ShapesPoolImpl<'a>;
+pub type ShapesPoolRef<'a> = &'a ShapesPoolImpl<'a>;
+pub type ShapesPoolMutRef<'a> = &'a mut ShapesPoolImpl<'a>;
+
+impl<'a> ShapesPoolImpl<'a> {
     pub fn new() -> Self {
-        ShapesPool {
+        ShapesPoolImpl {
             shapes: vec![],
             counter: 0,
             shapes_uuid_to_idx: HashMap::default(),
@@ -68,11 +73,19 @@ impl ShapesPool {
             self.shapes
                 .extend(iter::repeat_with(|| Shape::new(Uuid::nil())).take(additional));
         }
-        let new_shape = &mut self.shapes[self.counter];
+        let idx = self.counter;
+        let new_shape = &mut self.shapes[idx];
         new_shape.id = id;
-        self.shapes_uuid_to_idx.insert(id, self.counter);
+
+        // Get a reference to the id field in the shape
+        // SAFETY: We need to get a reference with lifetime 'a from the shape's id.
+        // This is safe because the shapes Vec is stable and won't be reallocated
+        // (we pre-allocate), and the id field won't move within the Shape.
+        let id_ref: &'a Uuid = unsafe { &*(&self.shapes[idx].id as *const Uuid) };
+
+        self.shapes_uuid_to_idx.insert(id_ref, idx);
         self.counter += 1;
-        new_shape
+        &mut self.shapes[idx]
     }
 
     pub fn len(&self) -> usize {
@@ -80,31 +93,47 @@ impl ShapesPool {
     }
 
     pub fn has(&self, id: &Uuid) -> bool {
-        self.shapes_uuid_to_idx.contains_key(id)
+        self.shapes_uuid_to_idx.contains_key(&id)
     }
 
     pub fn get_mut(&mut self, id: &Uuid) -> Option<&mut Shape> {
-        let idx = *self.shapes_uuid_to_idx.get(id)?;
+        let idx = *self.shapes_uuid_to_idx.get(&id)?;
         Some(&mut self.shapes[idx])
     }
 
-    pub fn get(&self, id: &Uuid) -> Option<&Shape> {
-        let idx = *self.shapes_uuid_to_idx.get(id)?;
-        if self.modifiers.contains_key(id) || self.structure.contains_key(id) {
-            if let Some(cell) = self.modified_shape_cache.get(id) {
-                Some(cell.get_or_init(|| {
-                    let shape = &self.shapes[idx];
-                    shape.transformed(
-                        self.modifiers.get(id),
-                        self.structure.get(id)
-                    )
-                }))
+    pub fn get(&self, id: &Uuid) -> Option<&'a Shape> {
+        let idx = *self.shapes_uuid_to_idx.get(&id)?;
+
+        // SAFETY: We're extending the lifetimes to 'a.
+        // This is safe because:
+        // 1. All internal HashMaps and the shapes Vec have fields with lifetime 'a
+        // 2. The shape at idx won't be moved or reallocated (pre-allocated Vec)
+        // 3. The id is stored in shapes[idx].id which has lifetime 'a
+        // 4. The references won't outlive the ShapesPoolImpl
+        unsafe {
+            let shape_ptr = &self.shapes[idx] as *const Shape;
+            let modifiers_ptr = &self.modifiers as *const HashMap<&'a Uuid, skia::Matrix>;
+            let structure_ptr = &self.structure as *const HashMap<&'a Uuid, Vec<StructureEntry>>;
+            let cache_ptr = &self.modified_shape_cache as *const HashMap<&'a Uuid, OnceCell<Shape>>;
+
+            // Extend the lifetime of id to 'a - safe because it's the same Uuid stored in shapes[idx].id
+            let id_ref: &'a Uuid = &*(id as *const Uuid);
+
+            if (*modifiers_ptr).contains_key(&id_ref) || (*structure_ptr).contains_key(&id_ref) {
+                if let Some(cell) = (*cache_ptr).get(&id_ref) {
+                    Some(cell.get_or_init(|| {
+                        let shape = &*shape_ptr;
+                        shape.transformed(
+                            (*modifiers_ptr).get(&id_ref),
+                            (*structure_ptr).get(&id_ref),
+                        )
+                    }))
+                } else {
+                    Some(&*shape_ptr)
+                }
             } else {
-                let shape = &self.shapes[idx];
-                Some(shape)
+                Some(&*shape_ptr)
             }
-        } else {
-            Some(&self.shapes[idx])
         }
     }
 
@@ -126,23 +155,30 @@ impl ShapesPool {
     pub fn set_modifiers(&mut self, modifiers: HashMap<Uuid, skia::Matrix>) {
         // self.clean_shape_cache();
 
-        // Initialize the cache cells because
-        // later we don't want to have the mutable pointer
-        for key in modifiers.keys() {
-            self.modified_shape_cache.insert(*key, OnceCell::new());
+        // Convert HashMap<Uuid, V> to HashMap<&'a Uuid, V> using references from shapes and
+        // Initialize the cache cells because later we don't want to have the mutable pointer
+        let mut modifiers_with_refs = HashMap::with_capacity(modifiers.len());
+        for (uuid, matrix) in modifiers {
+            if let Some(uuid_ref) = self.get_uuid_ref(&uuid) {
+                self.modified_shape_cache.insert(uuid_ref, OnceCell::new());
+                modifiers_with_refs.insert(uuid_ref, matrix);
+            }
         }
-        self.modifiers = modifiers;
+        self.modifiers = modifiers_with_refs;
     }
 
     #[allow(dead_code)]
     pub fn set_structure(&mut self, structure: HashMap<Uuid, Vec<StructureEntry>>) {
-        // self.clean_shape_cache();
-        // Initialize the cache cells because
-        // later we don't want to have the mutable pointer
-        for key in structure.keys() {
-            self.modified_shape_cache.insert(*key, OnceCell::new());
+        // Convert HashMap<Uuid, V> to HashMap<&'a Uuid, V> using references from shapes and
+        // Initialize the cache cells because later we don't want to have the mutable pointer
+        let mut structure_with_refs = HashMap::with_capacity(structure.len());
+        for (uuid, entries) in structure {
+            if let Some(uuid_ref) = self.get_uuid_ref(&uuid) {
+                self.modified_shape_cache.insert(uuid_ref, OnceCell::new());
+                structure_with_refs.insert(uuid_ref, entries);
+            }
         }
-        self.structure = structure;
+        self.structure = structure_with_refs;
     }
 
     #[allow(dead_code)]
@@ -155,5 +191,14 @@ impl ShapesPool {
     pub fn clean_structure(&mut self) {
         self.clean_shape_cache();
         self.structure = HashMap::default();
+    }
+
+    /// Get a reference to the Uuid stored in a shape, if it exists
+    pub fn get_uuid_ref(&self, id: &Uuid) -> Option<&'a Uuid> {
+        let idx = *self.shapes_uuid_to_idx.get(&id)?;
+        // SAFETY: We're returning a reference with lifetime 'a to a Uuid stored
+        // in the shapes Vec. This is safe because the Vec is stable (pre-allocated)
+        // and won't be reallocated.
+        unsafe { Some(&*(&self.shapes[idx].id as *const Uuid)) }
     }
 }

--- a/render-wasm/src/state/shapes_pool.rs
+++ b/render-wasm/src/state/shapes_pool.rs
@@ -217,7 +217,7 @@ impl<'a> ShapesPoolImpl<'a> {
                     Some(cell.get_or_init(|| {
                         let shape = &*shape_ptr;
                         shape.transformed(
-                            &self,
+                            self,
                             (*modifiers_ptr).get(&id_ref),
                             (*structure_ptr).get(&id_ref),
                         )
@@ -264,7 +264,7 @@ impl<'a> ShapesPoolImpl<'a> {
         }
         self.modifiers = modifiers_with_refs;
 
-        let all_ids = shapes::all_with_ancestors(&ids, &self, true);
+        let all_ids = shapes::all_with_ancestors(&ids, self, true);
         for uuid in all_ids {
             if let Some(uuid_ref) = self.get_uuid_ref(&uuid) {
                 self.modified_shape_cache.insert(uuid_ref, OnceCell::new());
@@ -287,7 +287,7 @@ impl<'a> ShapesPoolImpl<'a> {
         }
         self.structure = structure_with_refs;
 
-        let all_ids = shapes::all_with_ancestors(&ids, &self, true);
+        let all_ids = shapes::all_with_ancestors(&ids, self, true);
         for uuid in all_ids {
             if let Some(uuid_ref) = self.get_uuid_ref(&uuid) {
                 self.modified_shape_cache.insert(uuid_ref, OnceCell::new());
@@ -317,7 +317,9 @@ impl<'a> ShapesPoolImpl<'a> {
     }
 
     pub fn subtree(&self, id: &Uuid) -> ShapesPoolImpl<'a> {
-        let Some(shape) = self.get(id) else { panic!("Subtree not found"); };
+        let Some(shape) = self.get(id) else {
+            panic!("Subtree not found");
+        };
 
         // TODO: Maybe create all_children_iter
         let all_children = shape.all_children(self, true, true);
@@ -327,7 +329,9 @@ impl<'a> ShapesPoolImpl<'a> {
         let mut shapes_uuid_to_idx = HashMap::default();
 
         for id in all_children.iter() {
-            let Some(shape) = self.get(id) else { panic!("Not found"); };
+            let Some(shape) = self.get(id) else {
+                panic!("Not found");
+            };
             shapes.push(shape.clone());
 
             let id_ref: &'a Uuid = unsafe { &*(&self.shapes[idx].id as *const Uuid) };

--- a/render-wasm/src/state/shapes_pool.rs
+++ b/render-wasm/src/state/shapes_pool.rs
@@ -266,8 +266,6 @@ impl<'a> ShapesPoolImpl<'a> {
     }
 
     pub fn set_modifiers(&mut self, modifiers: HashMap<Uuid, skia::Matrix>) {
-        // self.clean_shape_cache();
-
         // Convert HashMap<Uuid, V> to HashMap<&'a Uuid, V> using references from shapes and
         // Initialize the cache cells because later we don't want to have the mutable pointer
 
@@ -394,25 +392,3 @@ impl<'a> ShapesPoolImpl<'a> {
         shape.is_bool()
     }
 }
-
-// fn is_modified_child(
-//     shape: &Shape,
-//     shapes: ShapesPoolRef,
-//     modifiers: &HashMap<Uuid, Matrix>,
-// ) -> bool {
-//     if modifiers.is_empty() {
-//         return false;
-//     }
-//
-//     let ids = shape.all_children(shapes, true, false);
-//     let default = &Matrix::default();
-//     let parent_modifier = modifiers.get(&shape.id).unwrap_or(default);
-//
-//     // Returns true if the transform of any child is different to the parent's
-//     ids.iter().any(|id| {
-//         !math::is_close_matrix(
-//             parent_modifier,
-//             modifiers.get(id).unwrap_or(&Matrix::default()),
-//         )
-//     })
-// }

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -1,6 +1,5 @@
 use crate::uuid::Uuid;
 use crate::view::Viewbox;
-use indexmap::IndexSet;
 use skia_safe as skia;
 use std::collections::{HashMap, HashSet};
 
@@ -114,7 +113,7 @@ pub fn get_tile_rect(tile: Tile, scale: f32) -> skia::Rect {
 
 // This structure is usseful to keep all the shape uuids by shape id.
 pub struct TileHashMap {
-    grid: HashMap<Tile, IndexSet<Uuid>>,
+    grid: HashMap<Tile, HashSet<Uuid>>,
     index: HashMap<Uuid, HashSet<Tile>>,
 }
 
@@ -126,13 +125,13 @@ impl TileHashMap {
         }
     }
 
-    pub fn get_shapes_at(&mut self, tile: Tile) -> Option<&IndexSet<Uuid>> {
+    pub fn get_shapes_at(&mut self, tile: Tile) -> Option<&HashSet<Uuid>> {
         self.grid.get(&tile)
     }
 
     pub fn remove_shape_at(&mut self, tile: Tile, id: Uuid) {
         if let Some(shapes) = self.grid.get_mut(&tile) {
-            shapes.shift_remove(&id);
+            shapes.remove(&id);
         }
 
         if let Some(tiles) = self.index.get_mut(&id) {

--- a/render-wasm/src/wasm/paths.rs
+++ b/render-wasm/src/wasm/paths.rs
@@ -213,7 +213,7 @@ pub extern "C" fn set_shape_path_content() {
 pub extern "C" fn current_to_path() -> *mut u8 {
     let mut result = Vec::<RawSegmentData>::default();
     with_current_shape!(state, |shape: &Shape| {
-        let path = shape.to_path(&state.shapes, &state.modifiers, &state.structure);
+        let path = shape.to_path(&state.shapes);
         result = path
             .segments()
             .iter()

--- a/render-wasm/src/wasm/paths/bools.rs
+++ b/render-wasm/src/wasm/paths/bools.rs
@@ -57,13 +57,7 @@ pub extern "C" fn calculate_bool(raw_bool_type: u8) -> *mut u8 {
     let bool_type = RawBoolType::from(raw_bool_type).into();
     let result;
     with_state!(state, {
-        let path = math::bools::bool_from_shapes(
-            bool_type,
-            &entries,
-            &state.shapes,
-            &state.modifiers,
-            &state.structure,
-        );
+        let path = math::bools::bool_from_shapes(bool_type, &entries, &state.shapes);
         result = path
             .segments()
             .iter()


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12325

### Summary

Changed internal structure so modifiers are not passed around and the transformation are cached in the shapes pool. Also remade the mechanism to get changes from shapes so there are no multiplicity of wasm operations.

Warning: Squash when merging

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
