### PR TITLE
:paperclip: Add migration to fix text attrs with blank strings

### DIFF
--- a/common/src/app/common/types/shape/text.cljc
+++ b/common/src/app/common/types/shape/text.cljc
@@ -74,9 +74,9 @@
     [:fills [:vector {:gen/max 2} schema:fill]]
     [:font-family {:optional true} ::sm/text]
     [:font-size {:optional true} ::sm/text]
-    [:font-style {:optional true} :string]
-    [:font-weight {:optional true} :string]
+    [:font-style {:optional true} ::sm/text]
+    [:font-weight {:optional true} ::sm/text]
     [:rtl {:optional true} :boolean]
     [:text {:optional true} :string]
-    [:text-decoration {:optional true} :string]
-    [:text-transform {:optional true} :string]]])
+    [:text-decoration {:optional true} ::sm/text]
+    [:text-transform {:optional true} ::sm/text]]])


### PR DESCRIPTION
### Related Ticket

Completing this PR -> https://github.com/penpot/penpot/pull/7646

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
