### PR TITLE
:bug: Fix theme validation when still no tokens library exists

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
@@ -44,9 +44,11 @@
   (m/-simple-schema
    {:type :token/name-exists
     :pred (fn [name]
-            (let [theme (ctob/get-theme-by-name tokens-lib group name)]
-              (or (nil? theme)
-                  (= (ctob/get-id theme) theme-id))))
+            (if tokens-lib
+              (let [theme (ctob/get-theme-by-name tokens-lib group name)]
+                (or (nil? theme)
+                    (= (ctob/get-id theme) theme-id)))
+              true))  ;; if still no library exists, cannot be duplicate
     :type-properties {:error/fn #(tr "workspace.tokens.theme-name-already-exists")}}))
 
 (defn- validate-theme-name


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12446

### Summary

Error when validating theme name when no tokens library exists in the file.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
