### PR TITLE
:bug: Fix misaligned right sidebar menus

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.scss
@@ -7,7 +7,13 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .element-set {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+}
+
+.element-title {
+  grid-column: span 8;
 }
 
 .title-spacing-blur {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.scss
@@ -7,7 +7,13 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .element-set {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+}
+
+.element-title {
+  grid-column: span 8;
 }
 
 .title-spacing-selected-colors {
@@ -25,6 +31,7 @@
 }
 
 .element-content {
+  grid-column: span 8;
   @include deprecated.flexColumn;
   margin-bottom: deprecated.$s-8;
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.scss
@@ -7,7 +7,13 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .element-set {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+}
+
+.element-title {
+  grid-column: span 8;
 }
 
 .title-spacing-export {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -316,16 +316,17 @@
          #(st/emit! (dw/add-frame-grid id)))]
 
     [:div {:class (stl/css :element-set)}
-     [:> title-bar* {:collapsable  has-frame-grids?
-                     :collapsed    (not open?)
-                     :on-collapsed toggle-content
-                     :class        (stl/css-case :title-spacing-board-grid (not has-frame-grids?))
-                     :title        (tr "workspace.options.guides.title")}
+     [:div {:class (stl/css :element-title)}
+      [:> title-bar* {:collapsable  has-frame-grids?
+                      :collapsed    (not open?)
+                      :on-collapsed toggle-content
+                      :class        (stl/css-case :title-spacing-board-grid (not has-frame-grids?))
+                      :title        (tr "workspace.options.guides.title")}
 
-      [:> icon-button* {:variant "ghost"
-                        :aria-label (tr "workspace.options.guides.add-guide")
-                        :on-click handle-create-grid
-                        :icon i/add}]]
+       [:> icon-button* {:variant "ghost"
+                         :aria-label (tr "workspace.options.guides.add-guide")
+                         :on-click handle-create-grid
+                         :icon i/add}]]]
 
      (when (and open? (seq frame-grids))
        [:div  {:class (stl/css :element-set-content)}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
@@ -7,7 +7,13 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .element-set {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+}
+
+.element-title {
+  grid-column: span 8;
 }
 
 .title-spacing-board-grid {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/grid_cell.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/grid_cell.scss
@@ -12,8 +12,19 @@
   gap: deprecated.$s-16;
 }
 
+.grid-cell-menu {
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+}
+
 .grid-cell-menu-title {
+  grid-column: span 8;
   font-size: deprecated.$fs-11;
+}
+
+.grid-cell-menu-container {
+  grid-column: span 8;
 }
 
 .row {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.scss
@@ -7,8 +7,13 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .element-set {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+
   .element-title {
+    grid-column: span 8;
+
     .title-spacing-layout {
       padding-left: deprecated.$s-2;
       margin: 0;

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.scss
@@ -7,14 +7,17 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .element-set {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
 }
 
 .element-title {
-  margin: 0;
+  grid-column: span 8;
 }
 
 .element-content {
+  grid-column: span 8;
   @include deprecated.flexColumn;
   margin-top: deprecated.$s-4;
 }


### PR DESCRIPTION
### Related Ticket

Taiga [#12457](https://tree.taiga.io/project/penpot/issue/12457)

### Summary

The menus 'export', 'blur', 'shadow', 'stroke', etc. are misaligned to the right in the right sidebar. This only occurs in Firefox because the scroll bar does not consume any space. This also solves #7226.

### Steps to reproduce 

Make sure that all the items in the right-hand sidebar are aligned correctly in Firefox.