### PR TITLE
:bug: Relax schema for importing plain path data related to curve-to command

### DIFF
--- a/common/src/app/common/types/path/impl.cljc
+++ b/common/src/app/common/types/path/impl.cljc
@@ -498,10 +498,10 @@
     [:map
      [:x schema:safe-number]
      [:y schema:safe-number]
-     [:c1x schema:safe-number]
-     [:c1y schema:safe-number]
-     [:c2x schema:safe-number]
-     [:c2y schema:safe-number]]]])
+     [:c1x {:optional true} schema:safe-number]
+     [:c1y {:optional true} schema:safe-number]
+     [:c2x {:optional true} schema:safe-number]
+     [:c2y {:optional true} schema:safe-number]]]])
 
 (def ^:private schema:segment
   [:multi {:title "PathSegment"

--- a/common/test/common_tests/types/path_data_test.cljc
+++ b/common/test/common_tests/types/path_data_test.cljc
@@ -116,6 +116,27 @@
     (t/is (= sample-content
              (vec pdata)))))
 
+
+;; Test the specific case where cuve-to commands comes without the
+;; optional attrs
+(t/deftest path-data-plain-to-binary-2
+  (let [plain-content
+        [{:command :move-to :params {:x 480.0 :y 839.0}}
+         {:command :line-to :params {:x 439.0 :y 802.0}}
+         {:command :curve-to :params {:x 264.0 :y 634.0}}
+         {:command :curve-to :params {:x 154.0 :y 508.0}}]
+
+        binary-content
+        (path/content plain-content)]
+
+    #?(:clj
+       (t/is (= "M480.0,839.0L439.0,802.0C264.0,634.0,264.0,634.0,264.0,634.0C154.0,508.0,154.0,508.0,154.0,508.0"
+                (str binary-content)))
+
+       :cljs
+       (t/is (= "M480,839L439,802C264,634,264,634,264,634C154,508,154,508,154,508"
+                (str binary-content))))))
+
 (t/deftest path-data-from-binary
   (let [barray #?(:clj (byte-array sample-bytes)
                   :cljs (js/Int8Array.from sample-bytes))


### PR DESCRIPTION
### Summary

The current schema strictly checks for existence of `:c1x`, `:c1y`, `:c2x` and `:c2y` attr of plain curve-to segments. This fails in some cases where that attrs are not present and the implementation already covers the case where that attributes does not exists.

For avoid unnecessary validation errors, that attrs are marked as optional.

### How to test

No specific tests are required, unit tests included.