### PR TITLE
:bug: Fix incorrect query for subscription editors

### DIFF
--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -484,7 +484,6 @@
     WHERE tpr1.profile_id = ?
       AND tpr1.is_owner IS true
       AND tpr2.can_edit IS true
-      AND NOT t.is_default
       AND t.deleted_at IS NULL")
 
 (sv/defmethod ::get-subscription-usage


### PR DESCRIPTION
### Summary

Default teams should be present on the query results

https://tree.taiga.io/project/penpot/issue/12486