### PR TITLE
:bug: Fix incorrect token sets migration

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1991,13 +1991,19 @@ Will return a value that matches this schema:
 
 #?(:clj
    (defn- migrate-to-v1-4
-     "Migrate the TokensLib data structure internals to v1.2 version; it
+     "Migrate the TokensLib data structure internals to v1.4 version; it
   expects input from v1.3 version"
      [params]
      (let [migrate-set-node
            (fn recurse [node]
-             (if (token-set-legacy? node)
+             (cond
+               (token-set-legacy? node)
                (make-token-set node)
+
+               (token-set? node)
+               node
+
+               :else
                (d/update-vals node recurse)))]
 
        (update params :sets d/update-vals migrate-set-node))))


### PR DESCRIPTION
### Summary

The current v1.4 tokens lib migration handles incorrectly already migrated sets from the v1.3 migration.
In fact, with the current code the migration v1.4 can be skipped completely  because the operation is already performed in the v1.3 but we keep it just for consistency.

### How to test

There are no easy way to test this, because requires complex setup with old data. The fix is trivial an simple code review is more than enough