### PR TITLE
:bug: Fix race condition on file export process

### DIFF
--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -28,8 +28,8 @@
   com.google.guava/guava {:mvn/version "33.4.8-jre"}
 
   funcool/yetti
-  {:git/tag "v11.6"
-   :git/sha "94dc017"
+  {:git/tag "v11.8"
+   :git/sha "1d1b33f"
    :git/url "https://github.com/funcool/yetti.git"
    :exclusions [org.slf4j/slf4j-api]}
 

--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -550,7 +550,7 @@
   [cfg data file-id]
   (let [library-ids (get-libraries cfg [file-id])]
     (reduce (fn [data library-id]
-              (if-let [library (get-file cfg library-id)]
+              (if-let [library (get-file cfg library-id :include-deleted? true)]
                 (ctf/absorb-assets data (:data library))
                 data))
             data

--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -228,6 +228,7 @@
     (db/tx-run! cfg (fn [cfg]
                       (cond-> (bfc/get-file cfg file-id
                                             {:realize? true
+                                             :include-deleted? true
                                              :lock-for-update? true})
                         detach?
                         (-> (ctf/detach-external-references file-id)
@@ -285,14 +286,12 @@
 
     (let [file (cond-> (select-keys file bfc/file-attrs)
                  (:options data)
-                 (assoc :options (:options data))
+                 (assoc :options (:options data)))
 
-                 :always
-                 (dissoc :data))
-
-          file (cond-> file
-                 :always
-                 (encode-file))
+          file (-> file
+                   (dissoc :data)
+                   (dissoc :deleted-at)
+                   (encode-file))
 
           path (str "files/" file-id ".json")]
       (write-entry! output path file))

--- a/backend/src/app/rpc.clj
+++ b/backend/src/app/rpc.clj
@@ -64,9 +64,13 @@
   (let [mdata    (meta result)
         response (if (fn? result)
                    (result request)
-                   (let [result (rph/unwrap result)]
-                     {::yres/status  (::http/status mdata 200)
-                      ::yres/headers (::http/headers mdata {})
+                   (let [result  (rph/unwrap result)
+                         status  (::http/status mdata 200)
+                         headers (cond-> (::http/headers mdata {})
+                                   (yres/stream-body? result)
+                                   (assoc "content-type" "application/octet-stream"))]
+                     {::yres/status  status
+                      ::yres/headers headers
                       ::yres/body    result}))]
     (-> response
         (handle-response-transformation request mdata)

--- a/backend/src/app/rpc/helpers.clj
+++ b/backend/src/app/rpc/helpers.clj
@@ -11,7 +11,7 @@
    [app.common.data.macros :as dm]
    [app.http :as-alias http]
    [app.rpc :as-alias rpc]
-   [yetti.response :as-alias yres]))
+   [yetti.response :as yres]))
 
 ;; A utilty wrapper object for wrap service responses that does not
 ;; implements the IObj interface that make possible attach metadata to
@@ -78,3 +78,8 @@
                (let [exp (if (integer? max-age) max-age (inst-ms max-age))
                      val (dm/fmt "max-age=%" (int (/ exp 1000.0)))]
                  (update response ::yres/headers assoc "cache-control" val)))))
+
+(defn stream
+  "A convenience allias for yetti.response/stream-body"
+  [f]
+  (yres/stream-body f))


### PR DESCRIPTION
### Summary

When a file is deleted in the middle of an exportation process can cause export a corrupted/broken file. This is because the exportation process is not transactional and abruptly deleted files can cause several internal queries raise not-found exception and abort the exportation in the middle.

This PR fixes this by relaxing deletion flag check, allowing to internal code to access resources marked as deleted-at.

### Steps to reproduce

As all race conditions are very difficult to reproduce. There are no specific tests for this.

