### PR TITLE
:bug: Fix hidden advanced frame grid options menu

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
@@ -23,6 +23,7 @@
 
 .element-set-content {
   @include deprecated.flexColumn;
+  grid-column: span 8;
   margin: deprecated.$s-4 0 deprecated.$s-8 0;
 }
 


### PR DESCRIPTION
### Related Ticket

Taiga [#12489](https://tree.taiga.io/project/penpot/issue/12489) & [#12491](https://tree.taiga.io/project/penpot/issue/12491)

### Summary

Advanced options "Use default" and "Set as default" when creating square guides for a board are partially visible, they appear hidden behind workspace viewport.

Drop down custom select options are not visible when creating rows guides for a board.

### Steps to reproduce 

Check that advanced options for guides are now visible.