### PR TITLE
:bug: Fix wasm crash when loading a file with missing font assets

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -102,12 +102,13 @@
 
 (defn use-shape
   [id]
-  (let [buffer (uuid/get-u32 id)]
-    (h/call wasm/internal-module "_use_shape"
-            (aget buffer 0)
-            (aget buffer 1)
-            (aget buffer 2)
-            (aget buffer 3))))
+  (when wasm/context-initialized?
+    (let [buffer (uuid/get-u32 id)]
+      (h/call wasm/internal-module "_use_shape"
+              (aget buffer 0)
+              (aget buffer 1)
+              (aget buffer 2)
+              (aget buffer 3)))))
 
 (defn set-parent-id
   [id]
@@ -1078,13 +1079,15 @@
 
         ;; Initialize Wasm Render Engine
         (h/call wasm/internal-module "_init" (/ (.-width ^js canvas) dpr) (/ (.-height ^js canvas) dpr))
-        (h/call wasm/internal-module "_set_render_options" flags dpr)))
+        (h/call wasm/internal-module "_set_render_options" flags dpr))
+      (set! wasm/context-initialized? true))
     (set-canvas-size canvas)
     context-init?))
 
 (defn clear-canvas
   []
   ;; TODO: perform corresponding cleaning
+  (set! wasm/context-initialized? false)
   (h/call wasm/internal-module "_clean_up"))
 
 (defn show-grid

--- a/frontend/src/app/render_wasm/wasm.cljs
+++ b/frontend/src/app/render_wasm/wasm.cljs
@@ -3,3 +3,4 @@
 (defonce internal-frame-id nil)
 (defonce internal-module #js {})
 (defonce serializers #js {})
+(defonce context-initialized? false)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12440

### Summary

This fixes a wasm crash that happened when we were doing changes to a shape (for auto-fixing things) before we had initialized the state in the renderer.

### Steps to reproduce 

1. Download the files attached in the Taiga ticket.
2. Import them in the dashboard
3. Open the files

Expected results: no crash in the console.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

