### PR TITLE
:sparkles: Remove unnecesary report on duplicate email error validation

### DIFF
--- a/backend/src/app/db.clj
+++ b/backend/src/app/db.clj
@@ -704,6 +704,12 @@
   (and (sql-exception? cause)
        (= "40001" (.getSQLState ^java.sql.SQLException cause))))
 
+(defn duplicate-key-error?
+  [cause]
+  (and (sql-exception? cause)
+       (= "23505" (.getSQLState ^java.sql.SQLException cause))))
+
+
 (extend-protocol jdbc.prepare/SettableParameter
   clojure.lang.Keyword
   (set-parameter [^clojure.lang.Keyword v ^PreparedStatement s ^long i]

--- a/backend/src/app/rpc/commands/auth.clj
+++ b/backend/src/app/rpc/commands/auth.clj
@@ -315,16 +315,13 @@
       (-> (db/insert! conn :profile params)
           (profile/decode-row))
       (catch org.postgresql.util.PSQLException cause
-        (let [state (.getSQLState cause)]
-          (if (not= state "23505")
-            (throw cause)
+        (if (db/duplicate-key-error? cause)
+          (ex/raise :type :validation
+                    :code :email-already-exists
+                    :hint "email already exists"
+                    :cause cause)
+          (throw cause))))))
 
-            (do
-              (l/error :hint "not an error" :cause cause)
-              (ex/raise :type :validation
-                        :code :email-already-exists
-                        :hint "email already exists"
-                        :cause cause))))))))
 
 (defn create-profile-rels!
   [conn {:keys [id] :as profile}]


### PR DESCRIPTION
### Summary

Remove unnecessary reporting of duplicate email. This is a controlled situation and should not be logged on reports.
It also improves the condition with more human readable function name instead of just raw sql state code checking.

### Steps to reproduce 

No way to reproduce. Is just an improvement on reporting, only code checking is necessary.
