### PR TITLE
:bug: Fix precision issues on worker task scheduling mechanism

### DIFF
--- a/backend/src/app/tasks/file_gc.clj
+++ b/backend/src/app/tasks/file_gc.clj
@@ -218,6 +218,9 @@
     (when (or (nil? revn) (= revn (:revn file)))
       file)))
 
+;; FIXME: we should skip files that does not match the revn on the
+;; props and add proper schema for this task props
+
 (defn- process-file!
   [cfg {:keys [file-id] :as props}]
   (if-let [file (get-file cfg props)]

--- a/backend/src/app/worker/runner.clj
+++ b/backend/src/app/worker/runner.clj
@@ -158,7 +158,9 @@
             (inst-ms (:scheduled-at task)))
       (l/wrn :hint "skiping task, rescheduled"
              :task-id task-id
-             :runner-id id)
+             :runner-id id
+             :scheduled-at (ct/format-inst (:scheduled-at task))
+             :expected-scheduled-at (ct/format-inst scheduled-at))
 
       :else
       (let [result (run-task cfg task)]
@@ -179,7 +181,8 @@
                           {:error explain
                            :status "retry"
                            :modified-at now
-                           :scheduled-at (ct/plus now delay)
+                           :scheduled-at (-> (ct/plus now delay)
+                                             (ct/truncate :millisecond))
                            :retry-num nretry}
                           {:id (:id task)})
               nil))


### PR DESCRIPTION
### Summary

This PR add additional fixes to the runner issue (regression introduced on the current version) related to the scheduled-at field precision.

The concrete case happens when worker scheduler emits to Redis queues task to execute with the scheduled-at serialized among the task key. The scheduled-at is used for check possible rescheduling of the task and skip executing when task scheduled-at and the value received from Redis queue is not the same. But when we serialize scheduled-at with nanosecond precision, it loss precision to milliseconds making the checking flaky and report false rescheduling.

The solution is reduce the scheduled-at column precision to milliseconds for make the value match exactly and avoid precision issue.

### Steps to reproduce 

It happens randomly, when the rounding after serialization round trip does not match exactly with the value stored on DB.

**MERGE with REBASE**

