### PR TITLE
:recycle: Refactor how shapes are validated after changes apply operation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@ penpot on-premise you will need to apply the same changes on your own
 - Add toggle for switching boolean property values [Taiga #12341](https://tree.taiga.io/project/penpot/us/12341)
 - Make the file export process more reliable [Taiga #12555](https://tree.taiga.io/project/penpot/us/12555)
 - Add auth flow changes [Taiga #12333](https://tree.taiga.io/project/penpot/us/12333)
+- Add new shape validation mechanism for shapes [Github #7696](https://github.com/penpot/penpot/pull/7696)
 
 ### :bug: Bugs fixed
 

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1512,7 +1512,7 @@
                                                   :shapes [(:id shape)]
                                                   :index index-after
                                                   :ignore-touched true
-                                                  :syncing true}))
+                                                  :allow-altering-copies true}))
                      (update :undo-changes conj (make-change
                                                  container
                                                  {:type :mov-objects
@@ -1520,7 +1520,7 @@
                                                   :shapes [(:id shape)]
                                                   :index index-before
                                                   :ignore-touched true
-                                                  :syncing true})))]
+                                                  :allow-altering-copies true})))]
 
     (if (and (ctk/touched-group? parent :shapes-group) omit-touched?)
       changes


### PR DESCRIPTION
### Summary

The idea behind this changes consists on move the general validation loop after shape changes apply operation to validate affected shapes directly on the change implementation. This will allow track what concrete change is introducing the bug on the stack trace.

This is an **experimental change** and is possible we should revert it partially if we detect that validation is not working as we expect, so this PR should be merged with **MERGE with REBASE**.

It also fixes a race condition that happens when an in-flight move-object change tries to move object to an already deleted parent.

### How to test

This affects mainly the changes protocol, so all operations of add shape, mod shape, move shape inside outside parents, sync components, should be tested.