### PR TITLE
:tada: Use textures directly for images

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -329,6 +329,19 @@ impl RenderState {
         self.images.add(id, is_thumbnail, image_data)
     }
 
+    /// Adds an image from an existing WebGL texture, avoiding re-decoding
+    pub fn add_image_from_gl_texture(
+        &mut self,
+        id: Uuid,
+        is_thumbnail: bool,
+        texture_id: u32,
+        width: i32,
+        height: i32,
+    ) -> Result<(), String> {
+        self.images
+            .add_image_from_gl_texture(id, is_thumbnail, texture_id, width, height)
+    }
+
     pub fn has_image(&self, id: &Uuid, is_thumbnail: bool) -> bool {
         self.images.contains(id, is_thumbnail)
     }

--- a/render-wasm/src/wasm/fills/image.rs
+++ b/render-wasm/src/wasm/fills/image.rs
@@ -89,3 +89,55 @@ pub extern "C" fn store_image() {
 
     mem::free_bytes();
 }
+
+/// Stores an image from an existing WebGL texture, avoiding re-decoding
+/// Expected memory layout:
+/// - bytes 0-15: shape UUID
+/// - bytes 16-31: image UUID  
+/// - bytes 32-35: is_thumbnail flag (u32)
+/// - bytes 36-39: GL texture ID (u32)
+/// - bytes 40-43: width (i32)
+/// - bytes 44-47: height (i32)
+#[no_mangle]
+pub extern "C" fn store_image_from_texture() {
+    let bytes = mem::bytes();
+
+    if bytes.len() < 48 {
+        eprintln!("store_image_from_texture: insufficient data");
+        mem::free_bytes();
+        return;
+    }
+
+    let ids = ShapeImageIds::try_from(bytes[0..IMAGE_IDS_SIZE].to_vec()).unwrap();
+
+    // Read is_thumbnail flag (4 bytes as u32)
+    let is_thumbnail_bytes = &bytes[IMAGE_IDS_SIZE..IMAGE_HEADER_SIZE];
+    let is_thumbnail_value = u32::from_le_bytes(is_thumbnail_bytes.try_into().unwrap());
+    let is_thumbnail = is_thumbnail_value != 0;
+
+    // Read GL texture ID (4 bytes as u32)
+    let texture_id_bytes = &bytes[36..40];
+    let texture_id = u32::from_le_bytes(texture_id_bytes.try_into().unwrap());
+
+    // Read width and height (8 bytes as two i32s)
+    let width_bytes = &bytes[40..44];
+    let width = i32::from_le_bytes(width_bytes.try_into().unwrap());
+
+    let height_bytes = &bytes[44..48];
+    let height = i32::from_le_bytes(height_bytes.try_into().unwrap());
+
+    with_state_mut!(state, {
+        if let Err(msg) = state.render_state_mut().add_image_from_gl_texture(
+            ids.image_id,
+            is_thumbnail,
+            texture_id,
+            width,
+            height,
+        ) {
+            eprintln!("store_image_from_texture error: {}", msg);
+        }
+        state.touch_shape(ids.shape_id);
+    });
+
+    mem::free_bytes();
+}


### PR DESCRIPTION
### Related Ticket

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
