### PR TITLE
:sparkles: Fix copyright year

### DIFF
--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -64,7 +64,7 @@
       [:div {:class (stl/css :container)} children]]
 
      [:div {:class (stl/css :deco-after2)}
-      [:span (tr "labels.copyright")]
+      [:span (tr "labels.copyright-period")]
       deprecated-icon/logo-error-screen
       [:span (tr "not-found.made-with-love")]]]))
 

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -1763,9 +1763,6 @@ msgstr "Můžete pokračovat s účtem Penpot"
 msgid "labels.copy-invitation-link"
 msgstr "Kopírovat odkaz"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
 
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -1995,10 +1995,6 @@ msgstr "Farbe kopieren"
 msgid "labels.copy-invitation-link"
 msgstr "Link kopieren"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Erstellen"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2135,8 +2135,8 @@ msgid "labels.copy-invitation-link"
 msgstr "Copy link"
 
 #: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
+msgid "labels.copyright-period"
+msgstr "Kaleidos © 2019-present"
 
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
@@ -5574,8 +5574,8 @@ msgstr "Add"
 
 #: src/app/main/ui/workspace/libraries.cljs:107, src/app/main/ui/workspace/libraries.cljs:133
 msgid "workspace.libraries.colors"
-msgid_plural "workspace.libraries.colors" 
-msgstr[0] "1 color" 
+msgid_plural "workspace.libraries.colors"
+msgstr[0] "1 color"
 msgstr[1] "%s colors"
 
 #: src/app/main/ui/workspace/color_palette.cljs:147
@@ -5614,8 +5614,8 @@ msgstr "Save color style"
 
 #: src/app/main/ui/workspace/libraries.cljs:101, src/app/main/ui/workspace/libraries.cljs:125
 msgid "workspace.libraries.components"
-msgid_plural "workspace.libraries.components" 
-msgstr[0] "1 component" 
+msgid_plural "workspace.libraries.components"
+msgstr[0] "1 component"
 msgstr[1] "%s components"
 
 #: src/app/main/ui/workspace/libraries.cljs:349
@@ -5640,8 +5640,8 @@ msgstr "File library"
 
 #: src/app/main/ui/workspace/libraries.cljs:104, src/app/main/ui/workspace/libraries.cljs:129
 msgid "workspace.libraries.graphics"
-msgid_plural "workspace.libraries.graphics" 
-msgstr[0] "1 graphic" 
+msgid_plural "workspace.libraries.graphics"
+msgstr[0] "1 graphic"
 msgstr[1] "%s graphics"
 
 #: src/app/main/ui/workspace/libraries.cljs:316
@@ -5700,8 +5700,8 @@ msgstr "Unlink all typographies"
 
 #: src/app/main/ui/workspace/libraries.cljs:110, src/app/main/ui/workspace/libraries.cljs:137
 msgid "workspace.libraries.typography"
-msgid_plural "workspace.libraries.typography" 
-msgstr[0] "1 typography" 
+msgid_plural "workspace.libraries.typography"
+msgstr[0] "1 typography"
 msgstr[1] "%s typographies"
 
 #: src/app/main/ui/workspace/libraries.cljs:354

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2130,8 +2130,8 @@ msgid "labels.copy-invitation-link"
 msgstr "Copiar enlace"
 
 #: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
+msgid "labels.copyright-period"
+msgstr "© Kaleidos, 2019-presente"
 
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -2022,10 +2022,6 @@ msgstr "Copier la couleur"
 msgid "labels.copy-invitation-link"
 msgstr "Copier le lien"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Créer"

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -2031,10 +2031,6 @@ msgstr "העתקת צבע"
 msgid "labels.copy-invitation-link"
 msgstr "העתקת קישור"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "יצירה"

--- a/frontend/translations/hi.po
+++ b/frontend/translations/hi.po
@@ -1932,10 +1932,6 @@ msgstr "रंग कॉपी करें"
 msgid "labels.copy-invitation-link"
 msgstr "लिंक कॉपी"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "निर्माण"

--- a/frontend/translations/hr.po
+++ b/frontend/translations/hr.po
@@ -1755,10 +1755,6 @@ msgstr "Možeš nastaviti s Penpot računom"
 msgid "labels.copy-invitation-link"
 msgstr "Kopiraj vezu"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Kreiraj"

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -1859,10 +1859,6 @@ msgstr "Salin warna"
 msgid "labels.copy-invitation-link"
 msgstr "Salin tautan"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Buat"

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -2088,10 +2088,6 @@ msgstr "Copia colore"
 msgid "labels.copy-invitation-link"
 msgstr "Copia link"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Crea"

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -2014,10 +2014,6 @@ msgstr "Ievietot krāsu starpliktuvē"
 msgid "labels.copy-invitation-link"
 msgstr "Kopēt saiti"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Izveidot"

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -2089,10 +2089,6 @@ msgstr "Kleur kopiëren"
 msgid "labels.copy-invitation-link"
 msgstr "Link kopiëren"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Aanmaken"

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -1776,10 +1776,6 @@ msgstr "Copiar cor"
 msgid "labels.copy-invitation-link"
 msgstr "Copiar link"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Criar"

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -1758,10 +1758,6 @@ msgstr "Du kan fortsätta med ett Penpot-konto"
 msgid "labels.copy-invitation-link"
 msgstr "Kopiera länk"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Skapa"

--- a/frontend/translations/th.po
+++ b/frontend/translations/th.po
@@ -776,10 +776,6 @@ msgstr "ยืนยันรหัสผ่าน"
 msgid "labels.copy-invitation-link"
 msgstr "คัดลอกลิงก์"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/dashboard/team_form.cljs:100, src/app/main/ui/dashboard/team_form.cljs:120
 msgid "labels.create-team"
 msgstr "สร้างทีมใหม่"

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -2073,10 +2073,6 @@ msgstr "Rengi kopyala"
 msgid "labels.copy-invitation-link"
 msgstr "Bağlantıyı kopyala"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "Oluştur"

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -1916,10 +1916,6 @@ msgstr "复制颜色"
 msgid "labels.copy-invitation-link"
 msgstr "复制链接"
 
-#: src/app/main/ui/static.cljs:63
-msgid "labels.copyright"
-msgstr "Kaleidos @2024"
-
 #: src/app/main/ui/workspace/sidebar/assets/groups.cljs:167, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:205
 msgid "labels.create"
 msgstr "创建"


### PR DESCRIPTION
### Related Ticket

No ticket for this, was a quick request in Mattermost.

### Summary

This fixes our copyright year _and_ the misusing of `@` instead of `©` that appears in the internal error page. It also sets the string as the same value as in kaleidos website (`2019-present`).

<img width="744" height="1034" alt="Screenshot 2025-11-05 at 5 37 36 PM" src="https://github.com/user-attachments/assets/c6b7e657-9ea6-494e-9e88-141c218ef591" />

### Steps to reproduce 

1. Force an internal error (for instance, by blocking a API request).

- Expected behavior: Copyright string should be `Kaleidos © 2019-present`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
