### PR TITLE
:bug: Restrict shadow colors to plain colors only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,7 @@
 - Fix options button does not work for comments created in the lower part of the screen [Taiga #12422](https://tree.taiga.io/project/penpot/issue/12422)
 - Fix problem when checking usage with removed teams [Taiga #12442](https://tree.taiga.io/project/penpot/issue/12442)
 - Fix focus mode persisting across page/file navigation [Taiga #12469](https://tree.taiga.io/project/penpot/issue/12469)
+- Fix shadow color validation [Github #7705](https://github.com/penpot/penpot/pull/7705)
 
 ## 2.10.1
 

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -36,7 +36,7 @@
 
 (defn type
   [s]
-  (m/-type s))
+  (m/type s default-options))
 
 (defn properties
   [s]
@@ -45,6 +45,10 @@
 (defn type-properties
   [s]
   (m/type-properties s))
+
+(defn children
+  [s]
+  (m/children s default-options))
 
 (defn schema
   [s]
@@ -127,9 +131,19 @@
 
 (defn keys
   "Given a map schema, return all keys as set"
-  [schema]
-  (->> (entries schema)
-       (into #{} xf:map-key)))
+  [schema']
+  (let [schema' (m/schema schema' default-options)]
+    (case (m/type schema')
+      :map
+      (->> (entries schema')
+           (into #{} xf:map-key))
+
+      :merge
+      (->> (m/children schema')
+           (mapcat m/entries)
+           (into #{} xf:map-key))
+
+      (throw (ex-info "not supported schema type" {:type (m/type schema')})))))
 
 (defn update-properties
   [s f & args]

--- a/common/src/app/common/types/shape/shadow.cljc
+++ b/common/src/app/common/types/shape/shadow.cljc
@@ -11,6 +11,14 @@
 
 (def styles #{:drop-shadow :inner-shadow})
 
+(def schema:color
+  [:merge {:title "ShadowColor"}
+   ctc/schema:color-attrs
+   ctc/schema:plain-color])
+
+(def color-attrs
+  (sm/keys schema:color))
+
 (def schema:shadow
   [:map {:title "Shadow"}
    [:id [:maybe ::sm/uuid]]
@@ -20,7 +28,7 @@
    [:blur ::sm/safe-number]
    [:spread ::sm/safe-number]
    [:hidden :boolean]
-   [:color ctc/schema:color]])
+   [:color schema:color]])
 
 (def check-shadow
   (sm/check-fn schema:shadow))


### PR DESCRIPTION
### Summary

Previously, shadows used a general-purpose color schema that allowed to have gradients and images on the data structure. This commit fixes that using a specific schema for shadow colors that only allows plain colors.

A migration is added to clean up existing shadows with non-plain colors.

### How to test

- Files with valid shadows (created previously to this PR) preserves the shadow
- Import the file with incorrect shadow is not allowed but with PR applied it should import correctly

[TestFile.zip](https://github.com/user-attachments/files/23394348/TestFile.zip)

