### PR TITLE
:lipstick: Fix minor style details on DS select ghost variant

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/select.scss
+++ b/frontend/src/app/main/ui/ds/controls/select.scss
@@ -58,14 +58,24 @@
 
 .variant-ghost {
   --select-background-color: transparent;
+  --select-text-color: var(--color-foreground-secondary);
+
   inline-size: fit-content;
+  padding-inline: var(--sp-xxs);
 
   & .arrow {
     margin-inline-start: var(--sp-xs);
   }
 
+  &:is(:hover, [aria-expanded="true"]) {
+    --select-text-color: var(--color-foreground-primary);
+    --select-icon-color: var(--color-foreground-primary);
+  }
+
   &:is(:focus-visible, :disabled) {
     --select-background-color: transparent;
+    --select-text-color: var(--color-foreground-primary);
+    --select-icon-color: var(--color-foreground-primary);
   }
 }
 


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/12284

### Summary

These changes only affect to the [GHOST variant of the select component](https://hourly.penpot.dev/storybook/?path=/story/controls-select--ghost), not the other ones.

- The padding inline should be 2px
- The text color` color-foreground-secondary` , not white. It should be white only on hover/focus/active states

### Steps to reproduce 

- Open storybook on the [GHOST variant of the select component](https://hourly.penpot.dev/storybook/?path=/story/controls-select--ghost)
- Ensure that it follows the aforementioned improvements.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
