### PR TITLE
:bug: Fix incorrect value coercing on legacy select component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,7 @@
 - Fix problem when checking usage with removed teams [Taiga #12442](https://tree.taiga.io/project/penpot/issue/12442)
 - Fix focus mode persisting across page/file navigation [Taiga #12469](https://tree.taiga.io/project/penpot/issue/12469)
 - Fix shadow color validation [Github #7705](https://github.com/penpot/penpot/pull/7705)
+- Fix exception on selection blend-mode using keyboard [Github #7710](https://github.com/penpot/penpot/pull/7710)
 
 ## 2.10.1
 

--- a/frontend/src/app/main/ui/components/select.cljs
+++ b/frontend/src/app/main/ui/components/select.cljs
@@ -89,14 +89,14 @@
                  (let [value (rotate-option-backward options index length)]
                    (swap! state* assoc :current-value value)
                    (when (fn? on-change)
-                     (on-change (dm/str value))))
+                     (on-change value)))
 
                  (or (kbd/right-arrow? e)
                      (kbd/down-arrow? e))
                  (let [value (rotate-option-forward options index)]
                    (swap! state* assoc :current-value value)
                    (when (fn? on-change)
-                     (on-change (dm/str value))))
+                     (on-change value)))
 
                  (or (kbd/enter? e)
                      (kbd/space? e))


### PR DESCRIPTION
### Summary

When a keyboard is used for select a blend mode an exception is raised when file save is triggered. That happens because of incorrect value coerce operation on the legacy select component.

### Steps to reproduce

- Create a frame
- Open blend mode select
- Move down with keyboard down.
- Wait until file saves
