### PR TITLE
:bug: Fix flex children subgrid gap

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.scss
@@ -21,6 +21,7 @@
 
 .flex-element-menu {
   @include sidebar.option-grid-structure;
+  gap: var(--sp-xs);
 }
 
 .behaviour-menu {


### PR DESCRIPTION
### Related Ticket

Flex children subgrid is broken
<img width="581" height="528" alt="Screenshot from 2025-11-07 12-55-27" src="https://github.com/user-attachments/assets/fd4d836e-8155-4054-932f-1f3024f453da" />


### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
