### PR TITLE
:bug: Fix variant toggle does not work for uppercase or mixed case

### DIFF
--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -320,7 +320,7 @@
                      {"true" true "false" false}]]
     (when (= (count v) 2)
       (some (fn [b]
-              (when (and (contains? b (first v))
-                         (contains? b (last v)))
+              (when (and (contains? b (-> v first str/trim str/lower))
+                         (contains? b (-> v last str/trim str/lower)))
                 b))
             bool-values))))

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -311,16 +311,22 @@
   [variant]
   (cpn/merge-path-item (:name variant) (str/replace (:variant-name variant) #", " " / ")))
 
+(def ^:private boolean-pairs
+  [["on" "off"]
+   ["yes" "no"]
+   ["true" "false"]])
+
 (defn find-boolean-pair
-  "Given a vector, return the map from 'bool-values' that contains both as keys.
-   Returns nil if none match."
-  [v]
-  (let [bool-values [{"on" true   "off" false}
-                     {"yes" true  "no" false}
-                     {"true" true "false" false}]]
+  "Given a vector, return a map that contains the boolean equivalency if the values match
+   with any of the boolean pairs. Returns nil if none match."
+  [[a b :as v]]
+  (let [a' (-> a str/trim str/lower)
+        b' (-> b str/trim str/lower)]
     (when (= (count v) 2)
-      (some (fn [b]
-              (when (and (contains? b (-> v first str/trim str/lower))
-                         (contains? b (-> v last str/trim str/lower)))
-                b))
-            bool-values))))
+      (some (fn [[t f]]
+              (cond (and (= a' t)
+                         (= b' f)) {a true b false}
+                    (and (= b' t)
+                         (= a' f)) {b true a false}
+                    :else nil))
+            boolean-pairs))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -164,6 +164,8 @@
 (t/deftest find-boolean-pair
   (t/testing "find-boolean-pair"
     (t/is (= (ctv/find-boolean-pair ["off" "on"]) {"on" true "off" false}))
+    (t/is (= (ctv/find-boolean-pair ["OfF" "oN"]) {"on" true "off" false}))
+    (t/is (= (ctv/find-boolean-pair [" OfF" "oN "]) {"on" true "off" false}))
     (t/is (= (ctv/find-boolean-pair ["on" "off"]) {"on" true "off" false}))
     (t/is (= (ctv/find-boolean-pair ["off" "on" "other"]) nil))
     (t/is (= (ctv/find-boolean-pair ["yes" "no"]) {"yes" true "no" false}))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -163,11 +163,11 @@
 
 (t/deftest find-boolean-pair
   (t/testing "find-boolean-pair"
-    (t/is (= (ctv/find-boolean-pair ["off" "on"]) {"on" true "off" false}))
-    (t/is (= (ctv/find-boolean-pair ["OfF" "oN"]) {"on" true "off" false}))
-    (t/is (= (ctv/find-boolean-pair [" OfF" "oN "]) {"on" true "off" false}))
-    (t/is (= (ctv/find-boolean-pair ["on" "off"]) {"on" true "off" false}))
+    (t/is (= (ctv/find-boolean-pair ["off" "on"])         {"on" true "off" false}))
+    (t/is (= (ctv/find-boolean-pair ["OfF" "oN"])         {"oN" true "OfF" false}))
+    (t/is (= (ctv/find-boolean-pair [" ofF" "oN "])       {"oN " true " ofF" false}))
+    (t/is (= (ctv/find-boolean-pair ["on" "off"])         {"on" true "off" false}))
+    (t/is (= (ctv/find-boolean-pair ["yes" "no"])         {"yes" true "no" false}))
+    (t/is (= (ctv/find-boolean-pair ["false" "true"])     {"true" true "false" false}))
     (t/is (= (ctv/find-boolean-pair ["off" "on" "other"]) nil))
-    (t/is (= (ctv/find-boolean-pair ["yes" "no"]) {"yes" true "no" false}))
-    (t/is (= (ctv/find-boolean-pair ["false" "true"]) {"true" true "false" false}))
-    (t/is (= (ctv/find-boolean-pair ["hello" "bye"]) nil))))
+    (t/is (= (ctv/find-boolean-pair ["hello" "bye"])      nil))))


### PR DESCRIPTION
### Related Ticket

Taiga [#12545](https://tree.taiga.io/project/penpot/task/12545)

### Summary

The variants switch does not appear when the accepted strings (`on`/`off`, `yes`/`no`, `true`/`false`) are uppercase or mixed case.

### Steps to reproduce 

Check that it still works when different cases are used (e.g. `yEs`/`nO`, `oFf`/`oN`).