### PR TITLE
:bug: Fix correct alignment of property names

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -672,6 +672,7 @@
 
 .variant-property-name {
   @include t.use-typography("body-small");
+  margin-inline-start: var(--sp-s);
   color: var(--color-foreground-secondary);
   display: block;
   overflow: hidden;


### PR DESCRIPTION
### Related Ticket

Taiga [#12525](https://tree.taiga.io/project/penpot/task/12525)

### Summary

Correct the margin of the variant property names.

### Steps to reproduce 

Check that the property names of a variant should have a small margin at the beginning.