### PR TITLE
:bug: Fix input confirmation behavior is not uniform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - Fix search shortcut [Taiga #10265](https://tree.taiga.io/project/penpot/issue/10265)
 - Fix shortcut conflict in text editor (increase/decrease font size vs word selection)
 - Fix problem with plugins generating code for pages different than current one [Taiga #12312](https://tree.taiga.io/project/penpot/issue/12312)
+- Fix input confirmation behavior is not uniform [Taiga #12294](https://tree.taiga.io/project/penpot/issue/12294)
 
 ## 2.11.0 (Unreleased)
 

--- a/frontend/src/app/main/ui/components/editable_label.cljs
+++ b/frontend/src/app/main/ui/components/editable_label.cljs
@@ -70,7 +70,7 @@
                :default-value value
                :on-key-up on-key-up
                :max-length max-input-length
-               :on-blur cancel-edition}]
+               :on-blur accept-edition}]
 
       [:span {:class [(stl/css :editable-label-text) class-label]
               :title tooltip}

--- a/frontend/src/app/main/ui/ds/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/ds/controls/combobox.cljs
@@ -202,7 +202,9 @@
                            dom/get-value)]
              (reset! selected-id* value)
              (reset! filter-id* value)
-             (reset! focused-id* nil))))
+             (reset! focused-id* nil)
+             (when (fn? on-change)
+               (on-change value)))))
 
         selected-option
         (mf/with-memo [options selected-id]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12294

### Summary

When user change the value of some inputs, and click on another shape on the workspace, the changed values are not preserved:

* Rename component from the assets tab
* Variants properties

### Steps to reproduce 

ONE

1. Create a variant
2. On the asset panel select the component, and in its context menu select "rename"
3. Change the name, and without pressing enter, click on an empty space on the workspace

The name should have changed, but it has not

TWO
1. Select a component inside the variant
2. On the design panel, click on it's property name to rename it
3. Change the name,  and without pressing enter, click on an empty space on the workspace

The property name should have changed, but it has not


THREE
1. Select a component inside the variant
2. On the design panel, click on it's property value to change it it
3. Write a new value,  and without pressing enter, click on an empty space on the workspace

The property value should have changed, but it has not

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
