### PR TITLE
:bug: Fix crash when using decimal values for X/Y or width/height

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,7 @@
 - Fix focus mode persisting across page/file navigation [Taiga #12469](https://tree.taiga.io/project/penpot/issue/12469)
 - Fix shadow color validation [Github #7705](https://github.com/penpot/penpot/pull/7705)
 - Fix exception on selection blend-mode using keyboard [Github #7710](https://github.com/penpot/penpot/pull/7710)
+- Fix crash when using decimal (floating-point) values for X/Y or width/height [Taiga #12543](https://tree.taiga.io/project/penpot/issue/12543)
 
 ## 2.10.1
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -303,7 +303,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (do
                (st/emit! (udw/trigger-bounding-box-cloaking ids))
                (binding [cts/*wasm-sync* true]
@@ -334,7 +334,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (do
                (st/emit! (udw/trigger-bounding-box-cloaking ids))
                (binding [cts/*wasm-sync* true]
@@ -359,7 +359,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (do
                (st/emit! (udw/trigger-bounding-box-cloaking ids))
                (binding [cts/*wasm-sync* true]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12543

### Summary

UI crash when using decimal values for X/Y or width/height

### Steps to reproduce 

1. Create any element (text, rectangle etc.)
2. Manually enter any decimal value into the X or Y fields and enter Or manually enter decimal value into width or height fields

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
