### PR TITLE
 💄 Use '100dvh' instead of '100vh' if is possible

### DIFF
--- a/frontend/resources/wasm-playground/clips.html
+++ b/frontend/resources/wasm-playground/clips.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       height: 100vh;
+      height: 100dvh;
       overflow: hidden;
     }
     canvas {
@@ -85,7 +86,7 @@
       const { duration } = performance.measure('render', 'render:begin', 'render:end');
       // alert(`render time: ${duration.toFixed(2)}ms`);
     });
-    
+
   </script>
 </body>
 </html>

--- a/frontend/resources/wasm-playground/masks.html
+++ b/frontend/resources/wasm-playground/masks.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       height: 100vh;
+      height: 100dvh;
       overflow: hidden;
     }
     canvas {
@@ -50,7 +51,7 @@
       Module._set_shape_type(3);
       Module._set_shape_selrect(100, 100, 200, 200);
       addShapeSolidFill(hexToU32ARGB("#aabbcc", 1));
-      
+
       const group_children = [];
 
       let uuid = "a822d9e3-16c5-802c-8006-2d6d04f9c3e5";
@@ -80,7 +81,7 @@
       Module._set_view(1, 0, 0);
       Module._render(Date.now());
     });
-    
+
   </script>
 </body>
 </html>

--- a/frontend/resources/wasm-playground/paths.html
+++ b/frontend/resources/wasm-playground/paths.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       height: 100vh;
+      height: 100dvh;
       overflow: hidden;
     }
     canvas {
@@ -79,7 +80,7 @@
       const { duration } = performance.measure('render', 'render:begin', 'render:end');
       // alert(`render time: ${duration.toFixed(2)}ms`);
     });
-    
+
   </script>
 </body>
 </html>

--- a/frontend/resources/wasm-playground/plus.html
+++ b/frontend/resources/wasm-playground/plus.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       height: 100vh;
+      height: 100dvh;
       overflow: hidden;
     }
     canvas {
@@ -51,14 +52,14 @@
       dv.setFloat32(ptr + offset + 24, y1, true);
       offset += 28;
 
-      // LINE     
+      // LINE
       dv.setUint16(ptr + offset + 0, 2, true); // LINE
       dv.setFloat32(ptr + offset + 20, x2, true);
       dv.setFloat32(ptr + offset + 24, y2, true);
       offset += 28;
 
       Module._set_shape_path_content();
-      Module._set_shape_selrect(x1, y1, x2, y2);      
+      Module._set_shape_selrect(x1, y1, x2, y2);
     }
 
     initWasmModule().then(Module => {
@@ -103,7 +104,7 @@
       const { duration } = performance.measure('render', 'render:begin', 'render:end');
       // alert(`render time: ${duration.toFixed(2)}ms`);
     });
-    
+
   </script>
 </body>
 </html>

--- a/frontend/resources/wasm-playground/rects.html
+++ b/frontend/resources/wasm-playground/rects.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       height: 100vh;
+      height: 100dvh;
       overflow: hidden;
     }
     canvas {
@@ -63,7 +64,7 @@
 
         Module._add_shape_center_stroke(10, 0,  0, 0);
         const argb2 = hexToU32ARGB(color, getRandomFloat(0.1, 1.0));
-        addShapeSolidStrokeFill(argb2);        
+        addShapeSolidStrokeFill(argb2);
       }
 
       useShape("00000000-0000-0000-0000-000000000000");
@@ -76,7 +77,7 @@
       const { duration } = performance.measure('render', 'render:begin', 'render:end');
       // alert(`render time: ${duration.toFixed(2)}ms`);
     });
-    
+
   </script>
 </body>
 </html>

--- a/frontend/resources/wasm-playground/texts.html
+++ b/frontend/resources/wasm-playground/texts.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       height: 100vh;
+      height: 100dvh;
       overflow: hidden;
     }
     canvas {

--- a/frontend/src/app/main/ui/dashboard.scss
+++ b/frontend/src/app/main/ui/dashboard.scss
@@ -13,6 +13,7 @@
   grid-template-columns: deprecated.$s-40 deprecated.$s-256 1fr;
   grid-template-rows: deprecated.$s-52 1fr;
   height: 100vh;
+  height: 100dvh;
 }
 
 .dashboard-content {

--- a/frontend/src/app/main/ui/debug/icons_preview.scss
+++ b/frontend/src/app/main/ui/debug/icons_preview.scss
@@ -4,6 +4,7 @@
   display: grid;
   row-gap: 1rem;
   height: 100vh;
+  height: 100dvh;
   overflow-y: auto;
   padding: 1rem;
 }

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -12,6 +12,7 @@
   min-width: deprecated.$s-252;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   position: relative;
   left: unset;
   right: unset;

--- a/frontend/src/app/main/ui/settings.scss
+++ b/frontend/src/app/main/ui/settings.scss
@@ -13,6 +13,7 @@
   grid-template-rows: deprecated.$s-48 1fr;
   grid-template-columns: deprecated.$s-40 deprecated.$s-256 1fr;
   height: 100vh;
+  height: 100dvh;
 }
 
 .dashboard-content {

--- a/frontend/src/app/main/ui/viewer.scss
+++ b/frontend/src/app/main/ui/viewer.scss
@@ -8,6 +8,7 @@
 
 .viewer-layout {
   height: 100vh;
+  height: 100dvh;
   display: grid;
   grid-template-rows: deprecated.$s-48 auto;
   grid-template-columns: 1fr;
@@ -41,6 +42,7 @@
   grid-template-rows: deprecated.$s-48 auto;
   grid-template-columns: 1fr;
   height: 100vh;
+  height: 100dvh;
   margin-top: 0;
   user-select: none;
 }
@@ -211,10 +213,12 @@
 [data-fullscreen="true"] .viewer-content {
   transform: translateY(-#{deprecated.$s-48});
   height: 100vh;
+  height: 100dvh;
 }
 
 [data-fullscreen="true"] .viewer-section {
   height: 100vh;
+  height: 100dvh;
 }
 
 [data-force-visible="true"] .viewer-go-next {

--- a/frontend/src/app/main/ui/workspace.scss
+++ b/frontend/src/app/main/ui/workspace.scss
@@ -9,8 +9,11 @@
 .workspace {
   @extend .new-scrollbar;
   width: 100vw;
+  width: 100dvw;
   height: 100vh;
+  height: 100dvh;
   max-height: 100vh;
+  max-height: 100dvh;
   user-select: none;
   display: grid;
   grid-template-areas: "left-sidebar viewport right-sidebar";

--- a/frontend/src/app/main/ui/workspace/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/context_menu.scss
@@ -23,6 +23,7 @@
   border: deprecated.$s-2 solid var(--panel-border-color);
   background-color: var(--menu-background-color);
   max-height: 100vh;
+  max-height: 100dvh;
   overflow-y: auto;
 }
 

--- a/frontend/src/app/main/ui/workspace/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar.scss
@@ -21,7 +21,9 @@
   width: var(--right-sidebar-width);
   background-color: var(--panel-background-color);
   height: 100vh;
+  height: 100dvh;
   max-height: 100vh;
+  max-height: 100dvh;
   z-index: deprecated.$z-index-1;
 
   .resize-area {
@@ -62,6 +64,7 @@
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   height: 100vh;
+  height: 100dvh;
   width: var(--right-sidebar-width);
   background-color: var(--panel-background-color);
   z-index: deprecated.$z-index-1;

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.scss
@@ -30,6 +30,7 @@
   border: deprecated.$s-2 solid var(--color-background-quaternary);
   background-color: var(--color-background-tertiary);
   max-height: 100vh;
+  max-height: 100dvh;
   overflow-y: auto;
 }
 

--- a/frontend/src/app/main/ui/workspace/tokens/sets/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/context_menu.scss
@@ -21,6 +21,7 @@
   border: deprecated.$s-2 solid var(--panel-border-color);
   background-color: var(--menu-background-color);
   max-height: 100vh;
+  max-height: 100dvh;
   overflow-y: auto;
 }
 

--- a/frontend/src/app/util/code_gen/style_css.cljs
+++ b/frontend/src/app/util/code_gen/style_css.cljs
@@ -38,6 +38,7 @@ body {
   align-items: center;
   width: 100vw;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 * {


### PR DESCRIPTION
# 100vh using problem

When using `100vh`, the content may overflow the browser's UI boundaries (for example, in the Zen browser there is a frame around the app content).

Using `100dvh` instead of `100vh` solves this problem.
