### PR TITLE
:recycle: Refactor clipboard 

### DIFF
--- a/common/src/app/common/types/text.cljc
+++ b/common/src/app/common/types/text.cljc
@@ -90,6 +90,10 @@
   [{:fill-color clr/black
     :fill-opacity 1}])
 
+(def default-paragraph-attrs
+  {:text-align "left"
+   :text-direction "ltr"})
+
 (def default-text-attrs
   {:font-id "sourcesanspro"
    :font-family "sourcesanspro"

--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -20,8 +20,8 @@
    [app.main.features :as features]
    [app.main.repo :as rp]
    [app.main.router :as rt]
+   [app.util.clipboard :as clipboard]
    [app.util.storage :as storage]
-   [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
    [clojure.string :as str]
    [potok.v2.core :as ptk]))
@@ -417,7 +417,7 @@
              (rx/map (fn [fragment]
                        (assoc cf/public-uri :fragment fragment)))
              (rx/tap (fn [uri]
-                       (wapi/write-to-clipboard (str uri))))
+                       (clipboard/to-clipboard (str uri))))
              (rx/tap on-success)
              (rx/ignore)
              (rx/catch on-error))))))

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -18,6 +18,7 @@
    [app.main.store :as st]
    [app.main.ui.context :as ctx]
    [app.main.ui.debug.icons-preview :refer [icons-preview]]
+   [app.main.ui.debug.playground :refer [playground]]
    [app.main.ui.ds.product.loader :refer [loader*]]
    [app.main.ui.error-boundary :refer [error-boundary*]]
    [app.main.ui.exports.files]
@@ -208,6 +209,10 @@
        :debug-icons-preview
        (when *assert*
          [:& icons-preview])
+
+       :debug-playground
+       (when *assert*
+         [:& playground])
 
        (:dashboard-search
         :dashboard-recent

--- a/frontend/src/app/main/ui/components/copy_button.cljs
+++ b/frontend/src/app/main/ui/components/copy_button.cljs
@@ -10,10 +10,10 @@
    [app.common.data.macros :as dm]
    [app.main.data.event :as-alias ev]
    [app.main.ui.icons :as deprecated-icon]
+   [app.util.clipboard :as clipboard]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.timers :as tm]
-   [app.util.webapi :as wapi]
    [rumext.v2 :as mf]))
 
 (mf/defc copy-button*
@@ -34,7 +34,7 @@
              (reset! active* true)
              (tm/schedule 1000 #(reset! active* false))
              (when (fn? on-copied) (on-copied event))
-             (wapi/write-to-clipboard
+             (clipboard/to-clipboard
               (if (fn? data) (data) data)))))]
 
     [:button {:class class

--- a/frontend/src/app/main/ui/debug/playground.cljs
+++ b/frontend/src/app/main/ui/debug/playground.cljs
@@ -1,0 +1,51 @@
+(ns app.main.ui.debug.playground
+  #_(:require-macros [app.main.style :as stl])
+  (:require
+   [app.util.clipboard :as clipboard]
+   [beicon.v2.core :as rx]
+   [rumext.v2 :as mf]))
+
+(mf/defc playground-clipboard
+  {::mf/wrap-props false
+   ::mf/private true}
+  []
+  (let [on-paste (mf/use-fn
+                  (fn [e]
+                    (let [stream (clipboard/from-clipboard-event e)]
+                      (rx/sub! stream
+                               (fn [data]
+                                 (js/console.log "data" data))))))
+
+        on-dragover (mf/use-fn
+                     (fn [e]
+                       (.preventDefault e)))
+
+        on-drop (mf/use-fn
+                 (fn [e]
+                   (.preventDefault e)
+                   (let [stream (clipboard/from-drop-event e)]
+                     (rx/sub! stream
+                              (fn [data]
+                                (js/console.log "data" data))))))
+
+        on-click (mf/use-fn
+                  (fn [e]
+                    (js/console.log "event" e)
+                    (let [stream (clipboard/from-clipboard)]
+                      (rx/sub! stream
+                               (fn [data]
+                                 (js/console.log "data" data))))))]
+
+    (.addEventListener js/window "paste" on-paste)
+    (.addEventListener js/window "drop" on-drop)
+    (.addEventListener js/window "dragover" on-dragover)
+
+    [:button#paste {:on-click on-click} "Paste"]))
+
+(mf/defc playground
+  {::mf/wrap-props false
+   ::mf/private true}
+  []
+  [:& playground-clipboard])
+
+

--- a/frontend/src/app/main/ui/inspect/code.cljs
+++ b/frontend/src/app/main/ui/inspect/code.cljs
@@ -23,11 +23,11 @@
    [app.main.ui.hooks.resize :refer [use-resize-hook]]
    [app.main.ui.icons :as deprecated-icon]
    [app.main.ui.shapes.text.fontfaces :refer [shapes->fonts]]
+   [app.util.clipboard :as clipboard]
    [app.util.code-beautify :as cb]
    [app.util.code-gen :as cg]
    [app.util.dom :as dom]
    [app.util.http :as http]
-   [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [okulary.core :as l]
@@ -202,7 +202,7 @@
         (mf/use-fn
          (mf/deps style-code markup-code images-data)
          (fn []
-           (wapi/write-to-clipboard (gen-all-code style-code markup-code images-data))
+           (clipboard/to-clipboard (gen-all-code style-code markup-code images-data))
            (let [origin (if (= :workspace from)
                           "workspace"
                           "viewer")]

--- a/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/text.cljs
@@ -16,8 +16,8 @@
    [app.main.ui.inspect.styles.property-detail-copiable :refer [property-detail-copiable*]]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
+   [app.util.clipboard :as clipboard]
    [app.util.timers :as tm]
-   [app.util.webapi :as wapi]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -88,7 +88,7 @@
                                   (.toUpperCase text)
                                   text)]
              (reset! copied* true)
-             (wapi/write-to-clipboard formatted-text)
+             (clipboard/to-clipboard formatted-text)
              (tm/schedule 1000 #(reset! copied* false)))))
         composite-typography-token (get-resolved-token :typography shape resolved-tokens)]
     [:div {:class (stl/css :text-properties)}

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -14,10 +14,10 @@
    [app.main.ui.ds.tooltip :refer [tooltip*]]
    [app.main.ui.formats :as fmt]
    [app.main.ui.inspect.styles.property-detail-copiable :refer [property-detail-copiable*]]
+   [app.util.clipboard :as clipboard]
    [app.util.color :as uc]
    [app.util.i18n :refer [tr]]
    [app.util.timers :as tm]
-   [app.util.webapi :as wapi]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -86,7 +86,7 @@
          (mf/deps copied formatted-color-value)
          (fn []
            (reset! copied* true)
-           (wapi/write-to-clipboard copiable-value)
+           (clipboard/to-clipboard copiable-value)
            (tm/schedule 1000 #(reset! copied* false))))]
     [:*
      [:dl {:class [(stl/css :property-row) class]

--- a/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
@@ -12,9 +12,9 @@
                                                   format-token-value]]
    [app.main.ui.ds.tooltip :refer [tooltip*]]
    [app.main.ui.inspect.styles.property-detail-copiable :refer [property-detail-copiable*]]
+   [app.util.clipboard :as clipboard]
    [app.util.i18n :refer [tr]]
    [app.util.timers :as tm]
-   [app.util.webapi :as wapi]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -43,7 +43,7 @@
          (mf/deps copied)
          (fn []
            (reset! copied* true)
-           (wapi/write-to-clipboard copiable-value)
+           (clipboard/to-clipboard copiable-value)
            (tm/schedule 1000 #(reset! copied* false))))]
     [:dl {:class [(stl/css :property-row) class]
           :data-testid "property-row"}

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -10,8 +10,8 @@
    [app.common.data :as d]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
+   [app.util.clipboard :as clipboard]
    [app.util.i18n :refer [tr]]
-   [app.util.webapi :as wapi]
    [rumext.v2 :as mf]))
 
 (defn- panel->title
@@ -50,7 +50,7 @@
         (mf/use-fn
          (mf/deps shorthand)
          (fn []
-           (wapi/write-to-clipboard (str shorthand))))]
+           (clipboard/to-clipboard (str shorthand))))]
     [:article {:class (stl/css :style-box)}
      [:header {:class (stl/css :disclosure-header)}
       [:button {:class (stl/css :disclosure-button)

--- a/frontend/src/app/main/ui/routes.cljs
+++ b/frontend/src/app/main/ui/routes.cljs
@@ -48,6 +48,9 @@
    (when *assert*
      ["/debug/icons-preview" :debug-icons-preview])
 
+   (when *assert*
+     ["/debug/playground" :debug-playground])
+
    ;; Used for export
    ["/render-sprite/:file-id" :render-sprite]
 

--- a/frontend/src/app/main/ui/settings/access_tokens.cljs
+++ b/frontend/src/app/main/ui/settings/access_tokens.cljs
@@ -16,10 +16,10 @@
    [app.main.ui.components.context-menu-a11y :refer [context-menu*]]
    [app.main.ui.components.forms :as fm]
    [app.main.ui.icons :as deprecated-icon]
+   [app.util.clipboard :as clipboard]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
-   [app.util.webapi :as wapi]
    [okulary.core :as l]
    [rumext.v2 :as mf]))
 
@@ -97,7 +97,7 @@
          (mf/deps created)
          (fn [event]
            (dom/prevent-default event)
-           (wapi/write-to-clipboard (:token created))
+           (clipboard/to-clipboard (:token created))
            (st/emit! (ntf/show {:level :info
                                 :type :toast
                                 :content (tr "dashboard.access-tokens.copied-success")

--- a/frontend/src/app/main/ui/viewer/share_link.cljs
+++ b/frontend/src/app/main/ui/viewer/share_link.cljs
@@ -21,9 +21,9 @@
    [app.main.store :as st]
    [app.main.ui.components.select :refer [select]]
    [app.main.ui.icons :as deprecated-icon]
+   [app.util.clipboard :as clipboard]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
-   [app.util.webapi :as wapi]
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
@@ -133,7 +133,7 @@
 
         copy-link
         (fn [_]
-          (wapi/write-to-clipboard current-link)
+          (clipboard/to-clipboard current-link)
           (st/emit! (ntf/show {:level :info
                                :type :toast
                                :content (tr "common.share-link.link-copied-success")

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -34,11 +34,11 @@
    [app.main.ui.context :as ctx]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.main.ui.workspace.sidebar.assets.common :as cmm]
+   [app.util.clipboard :as clipboard]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr] :as i18n]
    [app.util.shape-icon :as usi]
    [app.util.timers :as timers]
-   [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
    [okulary.core :as l]
    [potok.v2.core :as ptk]
@@ -181,7 +181,8 @@
         handle-hover-copy-paste
         (mf/use-callback
          (fn []
-           (->> (wapi/read-from-clipboard)
+           (->> (clipboard/from-clipboard)
+                (rx/mapcat #(.text %))
                 (rx/take 1)
                 (rx/subs!
                  (fn [data]

--- a/frontend/src/app/util/clipboard.cljs
+++ b/frontend/src/app/util/clipboard.cljs
@@ -1,0 +1,59 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.util.clipboard
+  (:require
+   ["./clipboard.js" :as clipboard]
+   [app.common.transit :as t]
+   [beicon.v2.core :as rx]))
+
+(def image-types
+  ["image/webp"
+   "image/png"
+   "image/jpeg"
+   "image/svg+xml"])
+
+(def clipboard-settings #js {:decodeTransit t/decode-str})
+
+(defn from-clipboard []
+  (->> (rx/from (clipboard/fromClipboard clipboard-settings))
+       (rx/mapcat #(rx/from %))))
+
+(defn from-data-transfer [data-transfer]
+  (->> (rx/from (clipboard/fromDataTransfer data-transfer clipboard-settings))
+       (rx/mapcat #(rx/from %))))
+
+(defn from-clipboard-data [clipboard-data]
+  (from-data-transfer clipboard-data))
+
+(defn from-clipboard-event [event]
+  (from-clipboard-data (.-clipboardData event)))
+
+(defn from-synthetic-clipboard-event [event]
+  (let [target (.-target ^js event)]
+    (when (and (not (.-isContentEditable ^js target)) ;; ignore when pasting into
+               (not= (.-tagName ^js target) "INPUT")) ;; an editable control
+      (from-clipboard-event (. ^js event getBrowserEvent)))))
+
+(defn from-drop-event [event]
+  (from-data-transfer (.-dataTransfer event)))
+
+(defn to-clipboard
+  [data]
+  (assert (string? data) "`data` should be string")
+  (let [clipboard (unchecked-get js/navigator "clipboard")]
+    (.writeText ^js clipboard data)))
+
+(defn- create-clipboard-item
+  [mimetype promise]
+  (js/ClipboardItem.
+   (js-obj mimetype promise)))
+
+(defn to-clipboard-promise
+  [mimetype promise]
+  (let [clipboard (unchecked-get js/navigator "clipboard")
+        data (create-clipboard-item mimetype promise)]
+    (.write ^js clipboard #js [data])))

--- a/frontend/src/app/util/clipboard.js
+++ b/frontend/src/app/util/clipboard.js
@@ -1,0 +1,151 @@
+/**
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) KALEIDOS INC
+ */
+const maxParseableSize = 16 * 1024 * 1024;
+
+const allowedTypes = [
+  "image/webp",
+  "image/png",
+  "image/jpeg",
+  "image/svg+xml",
+  "application/transit+json",
+  "text/html",
+  "text/plain",
+];
+
+const exclusiveTypes = [
+  "application/transit+json",
+  "text/html",
+  "text/plain"
+];
+
+/**
+ * @typedef {Object} ClipboardSettings
+ * @property {Function} [decodeTransit]
+ */
+
+/**
+ *
+ * @param {string} text
+ * @param {ClipboardSettings} options
+ * @param {Blob} [defaultReturn]
+ * @returns {Blob}
+ */
+function parseClipboardItemText(
+  text,
+  options,
+  defaultReturn = new Blob([text], { type: "text/plain" }),
+) {
+  let decodedTransit = false;
+  try { decodedTransit = options?.decodeTransit?.(text) ?? false }
+  catch (error) { /* NOOP */ }
+  if (/^<svg[\s>]/i.test(text)) {
+    return new Blob([text], { type: "image/svg+xml" });
+  } else if (decodedTransit) {
+    return new Blob([text], { type: "application/transit+json" });
+  }
+  return defaultReturn;
+}
+
+/**
+ *
+ * @param {ClipboardSettings} [options]
+ * @returns {Promise<Array<Blob>>}
+ */
+export async function fromClipboard(options) {
+  const items = await navigator.clipboard.read();
+  console.log("items", items);
+  return Promise.all(
+    Array.from(items).map(async (item) => {
+      const itemAllowedTypes = Array.from(item.types)
+        .filter((type) => allowedTypes.includes(type))
+        .sort((a, b) => allowedTypes.indexOf(a) - allowedTypes.indexOf(b));
+
+      if (
+        itemAllowedTypes.length === 1 &&
+        itemAllowedTypes.at(0) === "text/plain"
+      ) {
+        const blob = await item.getType("text/plain");
+        if (blob.size < maxParseableSize) {
+          const text = await blob.text();
+          return parseClipboardItemText(text, options);
+        }
+        return blob;
+      }
+
+      const type = itemAllowedTypes.at(0);
+      return item.getType(type);
+    }),
+  );
+}
+
+/**
+ *
+ * @param {DataTransfer} dataTransfer
+ * @param {ClipboardSettings} [options]
+ * @returns {Promise<Array<Blob>>}
+ */
+export async function fromDataTransfer(dataTransfer, options) {
+  const items = await Promise.all(
+    Array.from(dataTransfer.items)
+      .filter((item) => allowedTypes.includes(item.type))
+      .sort(
+        (a, b) => allowedTypes.indexOf(a.type) - allowedTypes.indexOf(b.type),
+      )
+      .map(async (item) => {
+        if (item.kind === "file") {
+          return Promise.resolve(item.getAsFile());
+        } else if (item.kind === "string") {
+          return new Promise((resolve) => {
+            const type = item.type;
+            item.getAsString((text) => {
+              if (type === "text/plain") {
+                return resolve(parseClipboardItemText(text, options));
+              }
+              return resolve(new Blob([text], { type }));
+            });
+          });
+        }
+        return Promise.resolve(null);
+      }),
+  );
+  return items
+    .filter((item) => !!item)
+    .reduce((filtered, item) => {
+      if (
+        exclusiveTypes.includes(item.type) &&
+        filtered.find((filteredItem) =>
+          exclusiveTypes.includes(filteredItem.type),
+        )
+      ) {
+        return filtered;
+      }
+      filtered.push(item);
+      return filtered;
+    }, []);
+}
+
+/**
+ *
+ * @param {*} clipboardData
+ * @param {ClipboardSettings} [options]
+ * @returns {Promise<Array<Blob>>}
+ */
+export function fromClipboardData(clipboardData, options) {
+  return fromDataTransfer(clipboardData, options);
+}
+
+/**
+ *
+ * @param {*} e
+ * @param {ClipboardSettings} [options]
+ * @returns {Promise<Array<Blob>>}
+ */
+export function fromClipboardEvent(e, options) {
+  return fromClipboardData(e.clipboardData, options);
+}

--- a/frontend/src/app/util/text/content/from_dom.cljs
+++ b/frontend/src/app/util/text/content/from_dom.cljs
@@ -37,34 +37,36 @@
     (.-textContent element)))
 
 (defn get-attrs-from-styles
-  [element attrs]
+  [element attrs defaults]
   (reduce (fn [acc key]
             (let [style (.-style element)]
               (if (contains? styles/mapping key)
                 (let [style-name (styles/get-style-name-as-css-variable key)
                       [_ style-decode] (get styles/mapping key)
                       value (style-decode (.getPropertyValue style style-name))]
-                  (assoc acc key value))
-                (let [style-name (styles/get-style-name key)]
-                  (assoc acc key (styles/normalize-attr-value key (.getPropertyValue style style-name))))))) {} attrs))
+                  (assoc acc key (if (empty? value) (get defaults key) value)))
+                (let [style-name (styles/get-style-name key)
+                      value (styles/normalize-attr-value key (.getPropertyValue style style-name))]
+                  (assoc acc key (if (empty? value) (get defaults key) value)))))) {} attrs))
 
 (defn get-inline-styles
   [element]
-  (get-attrs-from-styles element txt/text-node-attrs))
+  (get-attrs-from-styles element txt/text-node-attrs (txt/get-default-text-attrs)))
 
 (defn get-paragraph-styles
   [element]
-  (get-attrs-from-styles element (d/concat-set txt/paragraph-attrs txt/text-node-attrs)))
+  (get-attrs-from-styles element (d/concat-set txt/paragraph-attrs txt/text-node-attrs) (d/merge txt/default-paragraph-attrs txt/default-text-attrs)))
 
 (defn get-root-styles
   [element]
-  (get-attrs-from-styles element txt/root-attrs))
+  (get-attrs-from-styles element txt/root-attrs txt/default-root-attrs))
 
 (defn create-inline
   [element]
-  (d/merge {:text (get-inline-text element)
-            :key (.-id element)}
-           (get-inline-styles element)))
+  (let [text (get-inline-text element)]
+    (d/merge {:text text
+              :key (.-id element)}
+             (get-inline-styles element))))
 
 (defn create-paragraph
   [element]
@@ -76,7 +78,7 @@
 (defn create-root
   [element]
   (let [root-styles (get-root-styles element)]
-    (d/merge {:type "root",
+    (d/merge {:type "root"
               :key (.-id element)
               :children [{:type "paragraph-set"
                           :children (mapv create-paragraph (.-children element))}]}


### PR DESCRIPTION
### Summary

Creates a new namespace only for clipboard utilities and changes how pasting works. Now the clipboard works only with Blobs/Files and not strings.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
