### PR TITLE
:tada: Set default button behaviour as type button instead of submit

### DIFF
--- a/frontend/src/app/main/ui/ds/buttons/button.cljs
+++ b/frontend/src/app/main/ui/ds/buttons/button.cljs
@@ -15,6 +15,7 @@
 (def ^:private schema:button
   [:map
    [:class {:optional true} :string]
+   [:type {:optional true} :enum "button" "submit" "reset"]
    [:icon {:optional true}
     [:and :string [:fn #(contains? icon-list %)]]]
    [:on-ref {:optional true} fn?]
@@ -24,7 +25,7 @@
 
 (mf/defc button*
   {::mf/schema schema:button}
-  [{:keys [variant icon children class on-ref to] :rest props}]
+  [{:keys [variant icon children class on-ref to type] :rest props}]
   (let [variant (d/nilv variant "primary")
         element (if to "a" "button")
         internal-class (stl/css-case :button true
@@ -35,6 +36,7 @@
                                      :button-destructive (= variant "destructive"))
         props (mf/spread-props props {:class [class internal-class]
                                       :href to
+                                      :type (d/nilv type "button")
                                       :ref (fn [node]
                                              (when on-ref
                                                (on-ref node)))})]

--- a/frontend/src/app/main/ui/ds/buttons/button.cljs
+++ b/frontend/src/app/main/ui/ds/buttons/button.cljs
@@ -15,7 +15,7 @@
 (def ^:private schema:button
   [:map
    [:class {:optional true} :string]
-   [:type {:optional true} :enum "button" "submit" "reset"]
+   [:type {:optional true} [:maybe [:enum "button" "submit" "reset"]]]
    [:icon {:optional true}
     [:and :string [:fn #(contains? icon-list %)]]]
    [:on-ref {:optional true} fn?]

--- a/frontend/src/app/main/ui/ds/buttons/button.stories.jsx
+++ b/frontend/src/app/main/ui/ds/buttons/button.stories.jsx
@@ -28,6 +28,7 @@ export default {
     children: "Lorem ipsum",
     disabled: false,
     variant: undefined,
+    type: "button",
   },
   parameters: {
     controls: { exclude: ["children"] },

--- a/frontend/src/app/main/ui/ds/notifications/actionable.cljs
+++ b/frontend/src/app/main/ui/ds/notifications/actionable.cljs
@@ -48,10 +48,12 @@
 
      (when cancel-label
        [:> button* {:variant "secondary"
+                    :type "button"
                     :on-click on-cancel}
         cancel-label])
 
      (when accept-label
        [:> button* {:variant (if (= variant "default") "primary" "destructive")
+                    :type "button"
                     :on-click on-accept}
         accept-label])]))

--- a/frontend/src/app/main/ui/inspect/attributes/common.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/common.cljs
@@ -70,6 +70,7 @@
             [:img {:class (stl/css :resolved-image) :src (cf/resolve-file-media image)}]]
 
            [:> button* {:class (stl/css :download-button)
+                        :type "button"
                         :variant "secondary"
                         :target "_blank"
                         :download name

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -120,6 +120,7 @@
                 :alt (tr "inspect.attributes.image.preview")}]]
         [:> button* {:variant "secondary"
                      :to color-image-url
+                     :type "button"
                      :target "_blank"
                      :download color-image-name}
          (tr "inspect.attributes.image.download")]])]))

--- a/frontend/src/app/main/ui/workspace/plugins.cljs
+++ b/frontend/src/app/main/ui/workspace/plugins.cljs
@@ -79,6 +79,7 @@
 
      [:> button* {:class (stl/css :open-button)
                   :variant "secondary"
+                  :type "button"
                   :on-click handle-open-click
                   :title (when-not can-open? (tr "workspace.plugins.error.need-editor"))
                   :disabled (not can-open?)} (tr "workspace.plugins.button-open")]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -1089,6 +1089,7 @@
 
           (when (and multi all-main? (not any-variant?))
             [:> button* {:variant "secondary"
+                         :type "button"
                          :class (stl/css :component-combine)
                          :on-click on-combine-as-variants}
              (tr "workspace.shape.menu.combine-as-variants")])

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs
@@ -96,6 +96,7 @@
 
       [:div {:class (stl/css :button-row)}
        [:> button* {:variant "primary"
+                    :type "button"
                     :class (stl/css :modal-accept-btn)
                     :on-click on-close}
         (tr "ds.confirm-ok")]]]]))

--- a/frontend/src/app/main/ui/workspace/tokens/settings/menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/settings/menu.cljs
@@ -100,9 +100,11 @@
 
         [:div {:class (stl/css :settings-modal-actions)}
          [:> button* {:on-click modal/hide!
+                      :type "button"
                       :variant "secondary"}
           (tr "labels.cancel")]
          [:> button* {:on-click on-set-font
+                      :type "button"
                       :disabled (not is-valid)
                       :variant "primary"}
           (tr "labels.save")]]]]]]))

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -116,6 +116,7 @@
 
     [:div {:class (stl/css :import-export-button-wrapper)}
      [:> button* {:on-click open-menu
+                  :type "button"
                   :icon i/import-export
                   :variant "secondary"}
       (tr "workspace.tokens.tools")]

--- a/frontend/src/app/main/ui/workspace/tokens/themes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes.cljs
@@ -46,6 +46,7 @@
          [:div {:class (stl/css :theme-selector-wrapper)}
           [:& theme-selector]
           [:> button* {:variant "secondary"
+                       :type "button"
                        :class (stl/css :edit-theme-button)
                        :on-click open-modal}
            (tr "labels.edit")]]


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/12573

### Summary

Since the current default behaviour and use in our app is to use buttons as type buttons, this PR adds this type to the HTML element. Before, since it was unset, the default behaviour was `submit` leading to unexpected behaviours and unnecessary code.

Also reviewed all buttons to explicitly set the type, even if its not required anymore.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
