### PR TITLE
:whale: Use the secret key both in the backend and the exporter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 #### Backend RPC API changes
 
 The backend RPC API URLS are changed from `/api/rpc/command/<name>` to
-`/api/main/methods/<name>` (the previou PATH is preserved for backward
+`/api/main/methods/<name>`. The previous PATH is preserved for backward
 compatibility; however, if you are a user of this API, it is strongly
 recommended that you adapt your code to use the new PATH.
 
@@ -35,7 +35,7 @@ If you have SSO/Social-Auth configured on your on-premise instance,
 the following actions are required before update:
 
 Update your OAuth or SSO provider configuration (e.g., Okta, Google,
-Azure AD, etc.) to use the new callback URL.  Failure to update may
+Azure AD, etc.) to use the new callback URL. Failure to update may
 result in authentication failures after upgrading.
 
 **Reason for change:**
@@ -43,6 +43,15 @@ result in authentication failures after upgrading.
 This update standardizes all authentication flows under the single URL
 and makis it more modular, enabling the ability to configure SSO auth
 provider dinamically.
+
+
+#### Changes on default docker compose
+
+We have updated the `docker/images/docker-compose.yaml` with a small
+change related to the `PENPOT_SECRET_KEY`. Since this version, this
+environment variable is also required on exporter. So if you are using
+penpot on-premise you will need to apply the same changes on your own
+`docker-compose.yaml` file.
 
 
 ### :rocket: Epics and highlights
@@ -53,7 +62,6 @@ provider dinamically.
 
 - Select boards to export as PDF [Taiga #12320](https://tree.taiga.io/project/penpot/issue/12320)
 - Toggle for switching boolean property values [Taiga #12341](https://tree.taiga.io/project/penpot/us/12341)
-- Add auth flow changes [Taiga #12333](https://tree.taiga.io/project/penpot/us/12333)
 
 ### :bug: Bugs fixed
 

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -19,7 +19,7 @@
 ##
 ## You can read more about all available flags and other
 ## environment variables here:
-## https://help.penpot.app/technical-guide/configuration/#advanced-configuration
+## https://help.penpot.app/technical-guide/configuration/#penpot-configuration
 #
 # WARNING: if you're exposing Penpot to the internet, you should remove the flags
 # 'disable-secure-session-cookies' and 'disable-email-verification'
@@ -37,6 +37,15 @@ x-body-size: &penpot-http-body-size
   # Max multipart body size (350MiB)
   PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE: 367001600
 
+## Penpot SECRET KEY. It serves as a master key from which other keys for subsystems
+## (eg http sessions, or invitations) are derived.
+##
+## We recommend to use a trully randomly generated
+## 512 bits base64 encoded string here. You can generate one with:
+##
+## python3 -c "import secrets; print(secrets.token_urlsafe(64))"
+x-secret-key: &penpot-secret-key
+  PENPOT_SECRET_KEY: change-this-insecure-key
 
 networks:
   penpot:
@@ -120,20 +129,7 @@ services:
     ## Configuration envronment variables for the backend container.
 
     environment:
-      << : [*penpot-flags, *penpot-public-uri, *penpot-http-body-size]
-
-      ## Penpot SECRET KEY. It serves as a master key from which other keys for subsystems
-      ## (eg http sessions, or invitations) are derived.
-      ##
-      ## If you leave it commented, all created sessions and invitations will
-      ## become invalid on container restart.
-      ##
-      ## If you going to uncomment this, we recommend to use a trully randomly generated
-      ## 512 bits base64 encoded string here.  You can generate one with:
-      ##
-      ## python3 -c "import secrets; print(secrets.token_urlsafe(64))"
-
-      # PENPOT_SECRET_KEY: my-insecure-key
+      << : [*penpot-flags, *penpot-public-uri, *penpot-http-body-size, *penpot-secret-key]
 
       ## The PREPL host. Mainly used for external programatic access to penpot backend
       ## (example: admin). By default it will listen on `localhost` but if you are going to use
@@ -202,6 +198,7 @@ services:
       - penpot
 
     environment:
+      << : [*penpot-secret-key]
       # Don't touch it; this uses an internal docker network to
       # communicate with the frontend.
       PENPOT_PUBLIC_URI: http://penpot-frontend:8080


### PR DESCRIPTION
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnl2cno5djlqZnhnaHlpN2ZsN2g0cWZwb3czNTlicDl4ZnFhdXVrMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JbTng2zZKteUd9K2DJ/giphy.gif)

This PR adds the secret key configuration for backend and exporter; currently the secret key is not necessary in the exporter but it will be soon and this update anticipates the need for the change.