### PR TITLE
:recycle: Copy shorthands using user selected color space

### DIFF
--- a/frontend/playwright/ui/specs/inspect-tab.spec.js
+++ b/frontend/playwright/ui/specs/inspect-tab.spec.js
@@ -120,6 +120,16 @@ const openInspectTab = async (workspacePage) => {
   await inspectButton.click();
 };
 
+const selectColorSpace = async (workspacePage, colorSpace) => {
+  const sidebar = workspacePage.page.getByTestId("right-sidebar");
+  const colorSpaceSelector = sidebar.getByLabel("Select color space");
+  await colorSpaceSelector.click();
+  const colorSpaceOption = sidebar.getByRole("option", {
+    name: colorSpace,
+  });
+  await colorSpaceOption.click();
+};
+
 test.describe("Inspect tab - Styles", () => {
   test("Open Inspect tab", async ({ page }) => {
     const workspacePage = new WorkspacePage(page);
@@ -381,6 +391,46 @@ test.describe("Inspect tab - Styles", () => {
       const propertyRowCount = await propertyRow.count();
 
       expect(propertyRowCount).toBeGreaterThanOrEqual(1);
+    });
+
+    test("Change color space and ensure fill and shorthand changes", async ({
+      page,
+    }) => {
+      const workspacePage = new WorkspacePage(page);
+      await setupFile(workspacePage);
+
+      await selectLayer(workspacePage, shapeToLayerName.fill.solid);
+      await openInspectTab(workspacePage);
+      const panel = await getPanelByTitle(workspacePage, "Fill");
+      await expect(panel).toBeVisible();
+
+      const propertyRow = panel.getByTestId("property-row");
+      const backgroundRow = propertyRow.filter({
+        hasText: "Background",
+      });
+      await expect(backgroundRow).toBeVisible();
+
+      // Ensure initial value and copied value are in HEX format
+      expect(backgroundRow).toContainText("#0438d5 100%");
+
+      await copyPropertyFromPropertyRow(panel, "Background");
+
+      const backgroundHEX = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      expect(backgroundHEX).toContain("background: #0438d5;");
+
+      // Change color space to RGBA
+      await selectColorSpace(workspacePage, "rgba");
+
+      // Ensure new value and copied value are in RGBA format
+      expect(backgroundRow).toContainText("4, 56, 213, 1");
+
+      await copyPropertyFromPropertyRow(panel, "Background");
+      const backgroundRGBA = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      expect(backgroundRGBA).toContain("background: rgba(4, 56, 213, 1);");
     });
 
     test("Shape - Fill - Gradient", async ({ page }) => {

--- a/frontend/playwright/ui/specs/inspect-tab.spec.js
+++ b/frontend/playwright/ui/specs/inspect-tab.spec.js
@@ -418,7 +418,7 @@ test.describe("Inspect tab - Styles", () => {
       const backgroundHEX = await page.evaluate(() =>
         navigator.clipboard.readText(),
       );
-      expect(backgroundHEX).toContain("background: #0438d5;");
+      expect(backgroundHEX).toContain("background: #0438d5FF;");
 
       // Change color space to RGBA
       await selectColorSpace(workspacePage, "rgba");

--- a/frontend/src/app/main/ui/inspect/common/colors.cljs
+++ b/frontend/src/app/main/ui/inspect/common/colors.cljs
@@ -6,8 +6,6 @@
 
 (ns app.main.ui.inspect.common.colors
   (:require
-   [app.common.data.macros :as dm]
-   [app.common.types.color :as cc]
    [app.main.store :as st]
    [okulary.core :as l]
    [rumext.v2 :as mf]))
@@ -27,15 +25,3 @@
   (let [library (mf/with-memo [ref-file]
                   (make-colors-library-ref :files ref-file))]
     (mf/deref library)))
-
-(defn color->color-space->css-format
-  [color color-space]
-  (let [color-value (:color color)
-        color-opacity (or (:opacity color) 1)]
-    (case color-space
-      "hex"  color
-      "rgba" (let [[r g b a] (cc/hex->rgba color-value color-opacity)]
-               (dm/str "rgba(" (cc/format-rgba [r g b a]) ")"))
-      "hsla" (let [[h s l a] (cc/hex->hsla color-value color-opacity)]
-               (dm/str "hsla(" (cc/format-hsla [h s l a]) ")"))
-      (:color color))))

--- a/frontend/src/app/main/ui/inspect/common/colors.cljs
+++ b/frontend/src/app/main/ui/inspect/common/colors.cljs
@@ -29,11 +29,13 @@
     (mf/deref library)))
 
 (defn color->color-space->css-format
-  [color opacity color-space]
-  (case color-space
-    "hex"  color
-    "rgba" (let [[r g b a] (cc/hex->rgba color opacity)]
-             (dm/str "rgba(" (cc/format-rgba [r g b a]) ")"))
-    "hsla" (let [[h s l a] (cc/hex->hsla color opacity)]
-             (dm/str "hsla(" (cc/format-hsla [h s l a]) ")"))
-    (:color color)))
+  [color color-space]
+  (let [color-value (:color color)
+        color-opacity (or (:opacity color) 1)]
+    (case color-space
+      "hex"  color
+      "rgba" (let [[r g b a] (cc/hex->rgba color-value color-opacity)]
+               (dm/str "rgba(" (cc/format-rgba [r g b a]) ")"))
+      "hsla" (let [[h s l a] (cc/hex->hsla color-value color-opacity)]
+               (dm/str "hsla(" (cc/format-hsla [h s l a]) ")"))
+      (:color color))))

--- a/frontend/src/app/main/ui/inspect/common/colors.cljs
+++ b/frontend/src/app/main/ui/inspect/common/colors.cljs
@@ -6,6 +6,8 @@
 
 (ns app.main.ui.inspect.common.colors
   (:require
+   [app.common.data.macros :as dm]
+   [app.common.types.color :as cc]
    [app.main.store :as st]
    [okulary.core :as l]
    [rumext.v2 :as mf]))
@@ -25,3 +27,13 @@
   (let [library (mf/with-memo [ref-file]
                   (make-colors-library-ref :files ref-file))]
     (mf/deref library)))
+
+(defn color->color-space->css-format
+  [color opacity color-space]
+  (case color-space
+    "hex"  color
+    "rgba" (let [[r g b a] (cc/hex->rgba color opacity)]
+             (dm/str "rgba(" (cc/format-rgba [r g b a]) ")"))
+    "hsla" (let [[h s l a] (cc/hex->hsla color opacity)]
+             (dm/str "hsla(" (cc/format-hsla [h s l a]) ")"))
+    (:color color)))

--- a/frontend/src/app/main/ui/inspect/right_sidebar.cljs
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.cljs
@@ -122,7 +122,8 @@
      (fn []
        (if (seq shapes)
          (st/emit! (ptk/event ::ev/event {::ev/name "inspect-mode-click-element"}))
-         (handle-change-tab (if (contains? cf/flags :inspect-styles) :styles :info)))))
+         (handle-change-tab (if (contains? cf/flags :inspect-styles) :styles :info)))
+       (reset! color-space* "hex")))
 
     [:aside {:class (stl/css-case :settings-bar-right true
                                   :viewer-code (= from :viewer))}

--- a/frontend/src/app/main/ui/inspect/right_sidebar.cljs
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.cljs
@@ -166,12 +166,14 @@
             [:div {:class (stl/css :inspect-tab-switcher-controls)}
              [:div {:class (stl/css :inspect-tab-switcher-controls-color-space)}
               [:> select* {:class (stl/css :inspect-tab-switcher-controls-color-space-select)
+                           :aria-label (tr "inspect.tabs.switcher.color-space.label")
                            :options color-spaces
                            :default-selected "hex"
                            :variant "ghost"
                            :on-change handle-change-color-space}]]
              [:div {:class (stl/css :inspect-tab-switcher-controls-tab)}
               [:> select* {:options tabs
+                           :aria-label (tr "inspect.tabs.switcher.inspect-tab.label")
                            :default-selected (name @section)
                            :on-change handle-change-tab}]]]]
            nil)

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -41,14 +41,13 @@
    (fn [acc fill]
      (let [color-type (types.fills/fill->color fill)
            color-value (:color color-type)
-           color-opacity (:opacity color-type)
            color-gradient (:gradient color-type)
            gradient-data  {:type color-type
                            :stops (:stops color-gradient)}
            color-image (:image color-type)
            prefix (if color-value "background-color: " "background-image: ")
            value (cond
-                   color-value (isc/color->color-space->css-format color-value color-opacity color-space)
+                   color-value (isc/color->color-space->css-format color-type color-space)
                    color-gradient (uc/gradient->css gradient-data)
                    color-image (str "url('" (cfg/resolve-file-media color-image) "')")
                    :else "")

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -10,7 +10,6 @@
    [app.common.types.fills :as types.fills]
    [app.config :as cfg]
    [app.main.ui.inspect.attributes.common :as cmm]
-   [app.main.ui.inspect.common.colors :as isc]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.util.color :as uc]
    [rumext.v2 :as mf]))
@@ -39,17 +38,11 @@
   [shape color-space]
   (reduce
    (fn [acc fill]
-     (let [color-type (types.fills/fill->color fill)
-           color-value (:color color-type)
-           color-gradient (:gradient color-type)
-           gradient-data  {:type color-type
-                           :stops (:stops color-gradient)}
-           color-image (:image color-type)
-           prefix (if color-value "background-color: " "background-image: ")
+     (let [color (types.fills/fill->color fill)
+           prefix (if (:color color) "background-color: " "background-image: ")
            value (cond
-                   color-value (isc/color->color-space->css-format color-type color-space)
-                   color-gradient (uc/gradient->css gradient-data)
-                   color-image (str "url('" (cfg/resolve-file-media color-image) "')")
+                   (or (:color color) (:gradient color)) (uc/color->format->background color (keyword color-space))
+                   (:image color) (str "url('" (cfg/resolve-file-media (:image color)) "')")
                    :else "")
            full-value (str prefix value ";")]
        (if (empty? acc)

--- a/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/fill.cljs
@@ -7,10 +7,10 @@
 (ns app.main.ui.inspect.styles.panels.fill
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.data.macros :as dm]
    [app.common.types.fills :as types.fills]
    [app.config :as cfg]
    [app.main.ui.inspect.attributes.common :as cmm]
+   [app.main.ui.inspect.common.colors :as isc]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.util.color :as uc]
    [rumext.v2 :as mf]))
@@ -36,20 +36,21 @@
        (= 0 idx)))
 
 (defn- generate-fill-shorthand
-  [shape]
+  [shape color-space]
   (reduce
    (fn [acc fill]
      (let [color-type (types.fills/fill->color fill)
            color-value (:color color-type)
+           color-opacity (:opacity color-type)
            color-gradient (:gradient color-type)
            gradient-data  {:type color-type
                            :stops (:stops color-gradient)}
            color-image (:image color-type)
            prefix (if color-value "background-color: " "background-image: ")
            value (cond
-                   (:color color-type) (dm/str color-value)
+                   color-value (isc/color->color-space->css-format color-value color-opacity color-space)
                    color-gradient (uc/gradient->css gradient-data)
-                   color-image (str "url(\"" (cfg/resolve-file-media color-image) "\")")
+                   color-image (str "url('" (cfg/resolve-file-media color-image) "')")
                    :else "")
            full-value (str prefix value ";")]
        (if (empty? acc)
@@ -60,12 +61,12 @@
 
 (mf/defc fill-panel*
   [{:keys [shapes resolved-tokens color-space on-fill-shorthand]}]
-  (let [shorthand* (mf/use-state #(generate-fill-shorthand (first shapes)))
+  (let [shorthand* (mf/use-state #(generate-fill-shorthand (first shapes) color-space))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-fill-shorthand shapes)
      (fn []
-       (reset! shorthand* (generate-fill-shorthand (first shapes)))
+       (reset! shorthand* (generate-fill-shorthand (first shapes) color-space))
        (on-fill-shorthand {:panel :fill
                            :property shorthand})))
     [:div {:class (stl/css :fill-panel)}

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -12,6 +12,7 @@
    [app.common.types.color :as ctc]
    [app.config :as cfg]
    [app.main.ui.inspect.attributes.common :as cmm]
+   [app.main.ui.inspect.common.colors :as isc]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
@@ -53,7 +54,7 @@
        (is-first-element? idx)))
 
 (defn- generate-stroke-shorthand
-  [shapes]
+  [shapes color-space]
   (when (= (count shapes) 1)
     (let [shape (first shapes)]
       (reduce
@@ -62,12 +63,14 @@
                stroke-width (:stroke-width stroke)
                stroke-style (:stroke-style stroke)
                color-value (:color stroke-type)
+               stroke-opacity (:opacity stroke-type)
+               formatted-color-value (isc/color->color-space->css-format color-value stroke-opacity color-space)
                color-gradient (:gradient stroke-type)
                gradient-data  {:type (get-in stroke-type [:gradient :type])
                                :stops (get-in stroke-type [:gradient :stops])}
                color-image (:image stroke-type)
                value (cond
-                       color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " color-value ";")
+                       color-value (dm/str "border: " stroke-width "px " (d/name stroke-style) " " formatted-color-value ";")
                        color-gradient (dm/str "border-image: " (uc/gradient->css gradient-data) " 100 / " stroke-width "px;")
                        color-image (dm/str "border-image: url(" (cfg/resolve-file-media color-image) ") 100 / " stroke-width "px;")
                        :else "")]
@@ -79,12 +82,12 @@
 
 (mf/defc stroke-panel*
   [{:keys [shapes objects resolved-tokens color-space on-stroke-shorthand]}]
-  (let [shorthand* (mf/use-state #(generate-stroke-shorthand shapes))
+  (let [shorthand* (mf/use-state #(generate-stroke-shorthand shapes color-space))
         shorthand (deref shorthand*)]
     (mf/use-effect
      (mf/deps shorthand on-stroke-shorthand shapes)
      (fn []
-       (reset! shorthand* (generate-stroke-shorthand shapes))
+       (reset! shorthand* (generate-stroke-shorthand shapes color-space))
        (on-stroke-shorthand {:panel :stroke
                              :property shorthand})))
     [:div {:class (stl/css :stroke-panel)}

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -12,7 +12,6 @@
    [app.common.types.color :as ctc]
    [app.config :as cfg]
    [app.main.ui.inspect.attributes.common :as cmm]
-   [app.main.ui.inspect.common.colors :as isc]
    [app.main.ui.inspect.styles.rows.color-properties-row :refer [color-properties-row*]]
    [app.main.ui.inspect.styles.rows.properties-row :refer [properties-row*]]
    [app.util.code-gen.style-css :as css]
@@ -63,7 +62,7 @@
                stroke-width (:stroke-width stroke)
                stroke-style (:stroke-style stroke)
                color-value (:color stroke-type)
-               formatted-color-value (isc/color->color-space->css-format stroke-type color-space)
+               formatted-color-value (uc/color->format->background stroke-type (keyword color-space))
                color-gradient (:gradient stroke-type)
                gradient-data  {:type (get-in stroke-type [:gradient :type])
                                :stops (get-in stroke-type [:gradient :stops])}

--- a/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/stroke.cljs
@@ -63,8 +63,7 @@
                stroke-width (:stroke-width stroke)
                stroke-style (:stroke-style stroke)
                color-value (:color stroke-type)
-               stroke-opacity (:opacity stroke-type)
-               formatted-color-value (isc/color->color-space->css-format color-value stroke-opacity color-space)
+               formatted-color-value (isc/color->color-space->css-format stroke-type color-space)
                color-gradient (:gradient stroke-type)
                gradient-data  {:type (get-in stroke-type [:gradient :type])
                                :stops (get-in stroke-type [:gradient :stops])}

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -14,7 +14,6 @@
    [app.main.ui.ds.buttons.button :refer [button*]]
    [app.main.ui.ds.tooltip :refer [tooltip*]]
    [app.main.ui.formats :as fmt]
-   [app.main.ui.inspect.common.colors :as isc]
    [app.main.ui.inspect.styles.property-detail-copiable :refer [property-detail-copiable*]]
    [app.util.color :as uc]
    [app.util.i18n :refer [tr]]
@@ -78,9 +77,7 @@
                         #(if (some? token)
                            (:name token)
                            (cond
-                             (:color color) (if (= format "hex")
-                                              (dm/str css-term ": " color-value "; opacity: " color-opacity ";")
-                                              (dm/str css-term ": " (isc/color->color-space->css-format color format) ";"))
+                             (:color color) (dm/str css-term ": " (uc/color->format->background color (keyword format)) ";")
                              (:gradient color) (dm/str css-term ": " (uc/color->background color) ";")
                              (:image color) (dm/str css-term ": url(" color-image-url ") no-repeat center center / cover;")
                              :else "none")))

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -80,7 +80,7 @@
                            (cond
                              (:color color) (if (= format "hex")
                                               (dm/str css-term ": " color-value "; opacity: " color-opacity ";")
-                                              (dm/str css-term ": " (isc/color->color-space->css-format color-value color-opacity format) ";"))
+                                              (dm/str css-term ": " (isc/color->color-space->css-format color format) ";"))
                              (:gradient color) (dm/str css-term ": " (uc/color->background color) ";")
                              (:image color) (dm/str css-term ": url(" color-image-url ") no-repeat center center / cover;")
                              :else "none")))

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -6,6 +6,7 @@
 (ns app.main.ui.inspect.styles.rows.color-properties-row
   (:require-macros [app.main.style :as stl])
   (:require
+
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.types.color :as cc]
@@ -13,6 +14,7 @@
    [app.main.ui.ds.buttons.button :refer [button*]]
    [app.main.ui.ds.tooltip :refer [tooltip*]]
    [app.main.ui.formats :as fmt]
+   [app.main.ui.inspect.common.colors :as isc]
    [app.main.ui.inspect.styles.property-detail-copiable :refer [property-detail-copiable*]]
    [app.util.color :as uc]
    [app.util.i18n :refer [tr]]
@@ -51,15 +53,16 @@
         formatted-color-value (mf/use-memo
                                (mf/deps color format color-opacity)
                                #(cond
-                                  (some? (:color color)) (case format
-                                                           "hex" (dm/str color-value " " color-opacity)
-                                                           "rgba" (let [[r g b a] (cc/hex->rgba color-value color-opacity)
-                                                                        result (cc/format-rgba [r g b a])]
-                                                                    result)
-                                                           "hsla" (let [[h s l a] (cc/hex->hsla color-value color-opacity)
-                                                                        result (cc/format-hsla [h s l a])]
-                                                                    result)
-                                                           color-value)
+                                  (some? (:color color))
+                                  (case format
+                                    "hex" (dm/str color-value " " color-opacity)
+                                    "rgba" (let [[r g b a] (cc/hex->rgba color-value color-opacity)
+                                                 result (cc/format-rgba [r g b a])]
+                                             result)
+                                    "hsla" (let [[h s l a] (cc/hex->hsla color-value color-opacity)
+                                                 result (cc/format-hsla [h s l a])]
+                                             result)
+                                    color-value)
                                   (some? (:gradient color)) (uc/gradient-type->string (:type color-gradient))
                                   (some? (:image color)) (tr "media.image")
                                   :else "none"))
@@ -71,13 +74,13 @@
                      (str/replace #"^-" ""))
 
         copiable-value (mf/use-memo
-                        (mf/deps color formatted-color-value color-opacity color-image-url token)
+                        (mf/deps color token format color-opacity)
                         #(if (some? token)
                            (:name token)
                            (cond
                              (:color color) (if (= format "hex")
                                               (dm/str css-term ": " color-value "; opacity: " color-opacity ";")
-                                              (dm/str css-term ": " formatted-color-value ";"))
+                                              (dm/str css-term ": " (isc/color->color-space->css-format color-value color-opacity format) ";"))
                              (:gradient color) (dm/str css-term ": " (uc/color->background color) ";")
                              (:image color) (dm/str css-term ": url(" color-image-url ") no-repeat center center / cover;")
                              :else "none")))

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -64,6 +64,7 @@
       [:span {:class (stl/css :panel-title)} title]
       (when shorthand
         [:> icon-button* {:variant "ghost"
+                          :tooltip-placement "top-left"
                           :aria-label (tr "inspect.tabs.styles.panel.copy-style-shorthand")
                           :on-click copy-shorthand
                           :icon i/clipboard}])]

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1999,6 +1999,14 @@ msgstr "Resolved value:"
 msgid "inspect.tabs.switcher.label"
 msgstr "Layer info"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:165
+msgid "inspect.tabs.switcher.color-space.label"
+msgstr "Select color space"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:165
+msgid "inspect.tabs.switcher.inspect-tab.label"
+msgstr "Select inspect tab"
+
 #: src/app/main/ui/dashboard/comments.cljs:96
 msgid "label.mark-all-as-read"
 msgstr "Mark all as read"


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/11876

### Summary
This PR fixes two bugs found in the design review in this task:

- Place the tooltip from the shorthand copy button on top left so it does not cover the property title
- The fill and the border shorthand button always copy the color value in hex, ignoring the selection on the top dropdown (hex, rgba, etc) 

### Steps to reproduce 

- Create a shape with a fill and a border
- Copy the shorthand or the property, by default must copy the fill and border radius as HEX values
- Change the color space in the top selector
- Copy again the shorthand and the property, ensure that the copied values are using the right format.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
