### PR TITLE
:sparkles: Add parameter to `openPage` to toggle new window behaviour

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -512,6 +512,7 @@
             id (uuid/next)]
         (st/emit! (dw/create-page {:page-id id :file-id file-id}))
         (page/page-proxy plugin-id file-id id)))
+
     :openPage
     (fn [page new-window]
       (let [id (obj/get page "$id")

--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -513,9 +513,10 @@
         (st/emit! (dw/create-page {:page-id id :file-id file-id}))
         (page/page-proxy plugin-id file-id id)))
     :openPage
-    (fn [page]
-      (let [id (obj/get page "$id")]
-        (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window true))))
+    (fn [page new-window]
+      (let [id (obj/get page "$id")
+            new-window (if (boolean? new-window) new-window true)]
+        (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window))))
 
     :alignHorizontal
     (fn [shapes direction]

--- a/frontend/src/app/plugins/page.cljs
+++ b/frontend/src/app/plugins/page.cljs
@@ -263,13 +263,14 @@
           (apply array (keys (dm/get-in page [:plugin-data (keyword "shared" namespace)]))))))
 
     :openPage
-    (fn []
+    (fn [new-window]
       (cond
         (not (r/check-permission plugin-id "content:read"))
         (u/display-not-valid :openPage "Plugin doesn't have 'content:read' permission")
 
         :else
-        (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window true))))
+        (let [new-window (if (boolean? new-window) new-window true)]
+          (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
 
     :createFlow
     (fn [name frame]


### PR DESCRIPTION
### Summary

This PR extends the `:openPage` command in `page-proxy` with an additional parameter to be exposed in the plugins API. This parameter allows toggling the current default behaviour of always opening new `Pages` in separate browser tabs/windows.

I believe this is necessary because it's AFAICT otherwise impossible for plugins to navigate to shapes outside the current page. As it is right now, the plugin is unloaded in the new browser tab, making any action subsequent to `openPage` impossible.

Here's [the accompanying PR](https://github.com/penpot/penpot-plugins/pull/219) for the `penpot-plugins` repo.

### Open questions:

1. In order not to break expectations for API users, I've handled `undefined` in the second argument to have the same behaviour as previously, but I'm not sure how likely this is to happen once the new interfaces are published in npm.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
