### PR TITLE
:recycle: Follow translations guidelines

### DIFF
--- a/frontend/src/app/main/ui/inspect/right_sidebar.cljs
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.cljs
@@ -106,14 +106,14 @@
           (if (contains? cf/flags :inspect-styles)
             [{:label (tr "labels.styles")
               :id "styles"}
-             {:label (tr "inspect.tabs.computed")
+             {:label (tr "labels.computed")
               :id "computed"}
-             {:label (tr "inspect.tabs.code")
+             {:label (tr "labels.code")
               :data-testid "code"
               :id "code"}]
-            [{:label (tr "inspect.tabs.info")
+            [{:label (tr "labels.info")
               :id "info"}
-             {:label (tr "inspect.tabs.code")
+             {:label (tr "labels.code")
               :data-testid "code"
               :id "code"}]))]
 
@@ -133,7 +133,7 @@
            [:*
             [:div {:class (stl/css :layers-icon)}
              [:> icon* {:icon-id i/layers :size "s"}]]
-            [:span {:class (stl/css :layer-title)} (tr "inspect.tabs.code.selected.multiple" (count shapes))]]
+            [:span {:class (stl/css :layer-title)} (tr "inspect.multiple-selected" (count shapes))]]
            [:*
             [:div {:class (stl/css :shape-icon)}
              ;; Use the shape icon utility to get the correct icon for the first shape
@@ -162,16 +162,18 @@
         [:div {:class (stl/css :inspect-content)}
          (if (contains? cf/flags :inspect-styles)
            [:div {:class (stl/css :inspect-tab-switcher)}
-            [:span {:class (stl/css :inspect-tab-switcher-label)} (tr "inspect.tabs.switcher.label")]
+            [:span {:class (stl/css :inspect-tab-switcher-label)} (tr "inspect.layer-info")]
             [:div {:class (stl/css :inspect-tab-switcher-controls)}
              [:div {:class (stl/css :inspect-tab-switcher-controls-color-space)}
               [:> select* {:class (stl/css :inspect-tab-switcher-controls-color-space-select)
+                           :aria-label (tr "inspect.color-space-label")
                            :options color-spaces
                            :default-selected "hex"
                            :variant "ghost"
                            :on-change handle-change-color-space}]]
              [:div {:class (stl/css :inspect-tab-switcher-controls-tab)}
               [:> select* {:options tabs
+                           :aria-label (tr "inspect.tabs-switcher-label")
                            :default-selected (name @section)
                            :on-change handle-change-tab}]]]]
            nil)

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -257,19 +257,3 @@
           ;; DEFAULT WIP
           [:> style-box* {:panel panel}
            [:div color-space]])])]))
-
-
-;; WIP
-;; Panel list as stylebox children
-#_(case option
-    :geometry         [:> geometry-panel {}]
-    :layout           [:> layout-panel {}]
-    :layout-element   [:> layout-element-panel {}]
-    :fill             [:> fill-panel {:color-space color-space}]
-    :stroke           [:> stroke-panel {:color-space color-space}]
-    :text             [:> text-panel {:color-space color-space}]
-    :shadow           [:> shadow-panel {}]
-    :blur             [:> blur-panel {}]
-    :svg              [:> svg-panel {}]
-    :variant          [:> variant-panel* {}]
-    :visibility       [:> visibility-panel* {}])

--- a/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.cljs
@@ -18,10 +18,10 @@
    (when (seq theme-paths)
      (let [theme-list (str/join ", " theme-paths)]
        [:> properties-row* {:class (stl/css :token-theme)
-                            :term (tr "inspect.tabs.styles.panel.tokens.active-themes")
+                            :term (tr "inspect.tabs.styles.active-themes")
                             :detail theme-list}]))
    (when (seq set-names)
      (let [sets-list (str/join ", " set-names)]
        [:> properties-row* {:class (stl/css :token-sets)
-                            :term (tr "inspect.tabs.styles.panel.tokens.active-sets")
+                            :term (tr "inspect.tabs.styles.active-sets")
                             :detail sets-list}]))])

--- a/frontend/src/app/main/ui/inspect/styles/panels/visibility.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/visibility.cljs
@@ -32,7 +32,7 @@
   [{:keys [shapes objects resolved-tokens]}]
   [:div {:class (stl/css :visibility-panel)}
    (for [shape shapes]
-     [:div {:key (:id shape) :class "visibility-shape"}
+     [:div {:key (:id shape) :class (stl/css :visibility-shape)}
       (for [property properties]
         (when-let [value (css/get-css-value objects shape property)]
           (let [property-name (cmm/get-css-rule-humanized property)

--- a/frontend/src/app/main/ui/inspect/styles/property_detail_copiable.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/property_detail_copiable.cljs
@@ -48,6 +48,6 @@
    [:> icon* {:class (stl/css :property-detail-icon)
               :icon-id (if copied i/tick i/clipboard)
               :size "s"
-              :aria-label (tr "inspect.tabs.styles.panel.copy-to-clipboard")}]])
+              :aria-label (tr "inspect.tabs.styles.copy-to-clipboard")}]])
 
 

--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -99,7 +99,7 @@
                        :content #(mf/html
                                   [:div {:class (stl/css :tooltip-token)}
                                    [:div {:class (stl/css :tooltip-token-title)}
-                                    (tr "inspect.tabs.styles.token.resolved-value")]
+                                    (tr "inspect.tabs.styles.token-resolved-value")]
                                    [:div {:class (stl/css :tooltip-token-value)}
                                     (:resolved-value token)]])}
           [:> property-detail-copiable* {:color color

--- a/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/properties_row.cljs
@@ -57,7 +57,7 @@
                           :content #(mf/html
                                      [:div {:class (stl/css :tooltip-token)}
                                       [:div {:class (stl/css :tooltip-token-title)}
-                                       (tr "inspect.tabs.styles.token.resolved-value")]
+                                       (tr "inspect.tabs.styles.token-resolved-value")]
                                       [:div {:class (stl/css :tooltip-token-value)}
                                        (cond
                                          (= :typography token-type)

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -17,9 +17,9 @@
 (defn- panel->title
   [type]
   (case type
-    :variant    (tr "inspect.tabs.styles.panel.variant")
-    :token      (tr "inspect.tabs.styles.panel.token")
-    :geometry   (tr "inspect.tabs.styles.panel.geometry")
+    :variant    (tr "inspect.tabs.styles.variants-panel")
+    :token      (tr "inspect.tabs.styles.token-panel")
+    :geometry   (tr "inspect.tabs.styles.geometry-panel")
     :fill       (tr "labels.fill")
     :stroke     (tr "labels.stroke")
     :text       (tr "labels.text")
@@ -57,14 +57,15 @@
                 :aria-expanded expanded
                 :aria-controls (str "style-box-" (d/name panel))
                 :on-click toggle-panel
-                :aria-label (tr "inspect.tabs.styles.panel.toggle-style" title)}
+                :aria-label (tr "inspect.tabs.styles.toggle-style" title)}
        [:> icon* {:icon-id (if expanded "arrow-down" "arrow")
                   :class (stl/css :disclosure-icon)
                   :size "s"}]]
       [:span {:class (stl/css :panel-title)} title]
       (when shorthand
         [:> icon-button* {:variant "ghost"
-                          :aria-label (tr "inspect.tabs.styles.panel.copy-style-shorthand")
+                          :tooltip-placement "top-left"
+                          :aria-label (tr "inspect.tabs.styles.copy-shorthand")
                           :on-click copy-shorthand
                           :icon i/clipboard}])]
      (when expanded

--- a/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.cljs
@@ -88,7 +88,7 @@
 (defn group->paths
   "Given a map with :group string (slash-separated), returns a set of vectors
    representing the cumulative group hierarchy.
-   
+
    Example:
    {:group \"test/gracia\"}
    => #{[\"test\"] [\"test\" \"gracia\"]}"
@@ -176,7 +176,7 @@
       [:button {:class (stl/css :set-title-btn)
                 :aria-controls (str "set-panel-" (d/name name))
                 :aria-expanded (not collapsed)
-                :aria-label (tr "inspect.tabs.styles.panel.toggle-style" name)
+                :aria-label (tr "inspect.tabs.styles.toggle-style" name)
                 :on-click toggle-set}
        [:> i/icon* {:icon-id icon-id
                     :size "s"
@@ -227,13 +227,13 @@
 (defn- filter-combined-tokens
   "Filters the combined-tokens structure by token name.
    Removes sets or groups if they end up with no tokens.
-   
-   Input: 
+
+   Input:
    [{:group \"brand\", :sets [\"light\" \"dark\"], :tokens [{:name \"background\"} {:name \"foreground\"}]}
     {:group nil, :sets [\"primitivos\"], :tokens [{:name \"blue-100\"} {:name \"red-100\"}]}]
-   
+
    (filter-combined-tokens ... \"blue\")
-   Output: 
+   Output:
    [{:group nil, :sets [\"primitivos\"], :tokens [{:name \"blue-100\"}]}]
    => keeps only tokens matching \"blue\", and removes sets/groups if no tokens match."
 
@@ -253,9 +253,9 @@
 
 (defn- sort-combined-tokens
   "Sorts tokens alphabetically by :name inside each group/set.
-   Input: 
+   Input:
    [{:group \"brand\", :sets [\"light\" \"dark\"], :tokens [{:name \"foreground\"} {:name \"background\"}]}]
-   
+
    Output:
    [{:group \"brand\", :sets [\"light\" \"dark\"], :tokens [{:name \"background\"} {:name \"foreground\"}]}]"
   [combined-tokens]

--- a/frontend/translations/ar.po
+++ b/frontend/translations/ar.po
@@ -1216,7 +1216,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "قناع"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s محدد"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -1142,7 +1142,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Màscara"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s seleccionats"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -1629,7 +1629,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maska"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s vybráno"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -1841,7 +1841,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maske"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Ausgewählt(e)"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1869,7 +1869,7 @@ msgid "inspect.tabs.info"
 msgstr "Info"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Info zur Ebene"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/el.po
+++ b/frontend/translations/el.po
@@ -651,7 +651,7 @@ msgid "inspect.tabs.code.selected.image"
 msgstr "Εικόνα"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Επιλεγμένα"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1931,7 +1931,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Mask"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Selected"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1950,54 +1950,55 @@ msgstr "SVG"
 msgid "inspect.tabs.code.selected.text"
 msgstr "Text"
 
-#: src/app/main/ui/inspect/right_sidebar.cljs:109
-msgid "inspect.tabs.computed"
-msgstr "Computed"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:114
-msgid "inspect.tabs.info"
-msgstr "Info"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:66
 #, fuzzy
-msgid "inspect.tabs.styles.panel.copy-style-shorthand"
+msgid "inspect.tabs.styles.copy-shorthand"
 msgstr "Copy CSS shorthand to clipboard"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgid "inspect.tabs.styles.copy-to-clipboard"
 msgstr "Copy to clipboard"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
+msgid "inspect.tabs.styles.geometry-panel"
 msgstr "Size & Position"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
+msgid "inspect.tabs.styles.toggle-style"
 msgstr "Toggle panel %s"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
+msgid "inspect.tabs.styles.token-panel"
 msgstr "Token Sets & Themes"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgid "inspect.tabs.styles.active-sets"
 msgstr "Active sets"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgid "inspect.tabs.styles.active-themes"
 msgstr "Active themes"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
+msgid "inspect.tabs.styles.variants-panel"
 msgstr "Variant Properties"
 
 #: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
+msgid "inspect.tabs.styles.token-resolved-value"
 msgstr "Resolved value:"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Layer info"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:165
+msgid "inspect.color-space-label"
+msgstr "Select color space"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:165
+msgid "inspect.tabs-switcher-label"
+msgstr "Select inspect tab"
 
 #: src/app/main/ui/dashboard/comments.cljs:96
 msgid "label.mark-all-as-read"
@@ -2818,6 +2819,18 @@ msgstr "Your account"
 #, unused
 msgid "labels.youtube"
 msgstr "YouTube"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:109
+msgid "labels.computed"
+msgstr "Computed"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:111
+msgid "labels.code"
+msgstr "Code"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:114
+msgid "labels.info"
+msgstr "Info"
 
 #: src/app/main/ui/ds/product/loader.cljs:21
 msgid "loader.tips.01.message"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1926,7 +1926,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Máscara"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Seleccionado"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1945,53 +1945,45 @@ msgstr "SVG"
 msgid "inspect.tabs.code.selected.text"
 msgstr "Texto"
 
-#: src/app/main/ui/inspect/right_sidebar.cljs:109
-msgid "inspect.tabs.computed"
-msgstr "Calculado"
-
-#: src/app/main/ui/inspect/right_sidebar.cljs:114
-msgid "inspect.tabs.info"
-msgstr "Información"
-
 #: src/app/main/ui/inspect/styles/style_box.cljs:66
 #, fuzzy
-msgid "inspect.tabs.styles.panel.copy-style-shorthand"
+msgid "inspect.tabs.styles.copy-shorthand"
 msgstr "Copiar CSS shorthand al portapapeles"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgid "inspect.tabs.styles.copy-to-clipboard"
 msgstr "Copiar al portapapeles"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgid "inspect.tabs.styles.active-sets"
 msgstr "Sets activos"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgid "inspect.tabs.styles.active-themes"
 msgstr "Temas activos"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
+msgid "inspect.tabs.styles.geometry-panel"
 msgstr "Tamaño y posición"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
+msgid "inspect.tabs.styles.toggle-style"
 msgstr "Alternar panel %s"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
+msgid "inspect.tabs.styles.token-panel"
 msgstr "Sets y temas de tokens"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
+msgid "inspect.tabs.styles.variants-panel"
 msgstr "Propiedades de las variantes"
 
 #: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
+msgid "inspect.tabs.styles.token-resolved-value"
 msgstr "Valor resuelto:"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Info. de capa"
 
 #: src/app/main/ui/dashboard/comments.cljs:96
@@ -2801,6 +2793,14 @@ msgstr "Tu cuenta"
 #, unused
 msgid "labels.youtube"
 msgstr "YouTube"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:109
+msgid "labels.computed"
+msgstr "Calculado"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:111
+msgid "labels.code"
+msgstr "Información"
 
 #: src/app/main/ui/ds/product/loader.cljs:21
 msgid "loader.tips.01.message"

--- a/frontend/translations/eu.po
+++ b/frontend/translations/eu.po
@@ -1242,7 +1242,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maskara"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s aukeratuta"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/fa.po
+++ b/frontend/translations/fa.po
@@ -1206,7 +1206,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "ماسک"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s انتخاب شد"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -1868,7 +1868,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Masque"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Sélectionné"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1896,7 +1896,7 @@ msgid "inspect.tabs.info"
 msgstr "Information"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Info sur la couche"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/ha.po
+++ b/frontend/translations/ha.po
@@ -1296,7 +1296,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "marfi"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s zavavve"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -1829,7 +1829,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "מסכה"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s נבחרו"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1857,39 +1857,39 @@ msgid "inspect.tabs.info"
 msgstr "מידע"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgid "inspect.tabs.styles.copy-to-clipboard"
 msgstr "העתקה ללוח הגזירים"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
+msgid "inspect.tabs.styles.geometry-panel"
 msgstr "גודל ומקום"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
+msgid "inspect.tabs.styles.toggle-style"
 msgstr "החלפת חשיפת הלוח %s"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
+msgid "inspect.tabs.styles.token-panel"
 msgstr "ערכות אסימונים וערכות עיצוב"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgid "inspect.tabs.styles.active-sets"
 msgstr "ערכות פעילות"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgid "inspect.tabs.styles.active-themes"
 msgstr "ערכות עיצוב פעילות"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
+msgid "inspect.tabs.styles.variants-panel"
 msgstr "מאפייני הגוון"
 
 #: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
+msgid "inspect.tabs.styles.token-resolved-value"
 msgstr "ערך פתור:"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "פרטי שכבה"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/hi.po
+++ b/frontend/translations/hi.po
@@ -1786,7 +1786,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "मास्क"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s चयनित"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/hr.po
+++ b/frontend/translations/hr.po
@@ -1621,7 +1621,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maska"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Označeno"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -1713,7 +1713,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Topeng"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Dipilih"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/ig.po
+++ b/frontend/translations/ig.po
@@ -1137,7 +1137,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "kpuchie"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s a họrọ"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -1886,7 +1886,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maschera"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s selezionati"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1914,39 +1914,39 @@ msgid "inspect.tabs.info"
 msgstr "Informazione"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgid "inspect.tabs.styles.copy-to-clipboard"
 msgstr "Copia negli appunti"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
+msgid "inspect.tabs.styles.geometry-panel"
 msgstr "Dimensione e posizione"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
+msgid "inspect.tabs.styles.toggle-style"
 msgstr "Attiva/disattiva pannello %s"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
+msgid "inspect.tabs.styles.token-panel"
 msgstr "Set di token e temi"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgid "inspect.tabs.styles.active-sets"
 msgstr "Set attivi"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgid "inspect.tabs.styles.active-themes"
 msgstr "Temi attivi"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
+msgid "inspect.tabs.styles.variants-panel"
 msgstr "Proprietà delle varianti"
 
 #: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
+msgid "inspect.tabs.styles.token-resolved-value"
 msgstr "Valore risolto:"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Informazioni livello"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -1860,7 +1860,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maska"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "Atlasīti: %s"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1888,7 +1888,7 @@ msgid "inspect.tabs.info"
 msgstr "Infomācija"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Informācija par slāni"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/ms.po
+++ b/frontend/translations/ms.po
@@ -1349,7 +1349,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maska"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Dipilih"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -1887,7 +1887,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Masker"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Geselecteerd"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1915,39 +1915,39 @@ msgid "inspect.tabs.info"
 msgstr "Informatie"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgid "inspect.tabs.styles.copy-to-clipboard"
 msgstr "Kopiëren naar klembord"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
+msgid "inspect.tabs.styles.geometry-panel"
 msgstr "Grootte & positie"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
+msgid "inspect.tabs.styles.toggle-style"
 msgstr "Paneel &s wisselen"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
+msgid "inspect.tabs.styles.token-panel"
 msgstr "Tokens & thema's"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgid "inspect.tabs.styles.active-sets"
 msgstr "Actieve verzamelingen"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgid "inspect.tabs.styles.active-themes"
 msgstr "Actieve thema's"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
+msgid "inspect.tabs.styles.variants-panel"
 msgstr "Variant eigenschappen"
 
 #: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
+msgid "inspect.tabs.styles.token-resolved-value"
 msgstr "Opgeloste waarde:"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Laaginfo"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/pl.po
+++ b/frontend/translations/pl.po
@@ -1222,7 +1222,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maska"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s wybrano"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/pt_BR.po
+++ b/frontend/translations/pt_BR.po
@@ -1585,7 +1585,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Máscara"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s selecionados"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -1634,7 +1634,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Máscara"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Selecionados"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -1517,7 +1517,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Mască"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Selectate"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/ru.po
+++ b/frontend/translations/ru.po
@@ -1561,7 +1561,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Маска"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "Выделено: %s"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/sr.po
+++ b/frontend/translations/sr.po
@@ -1400,7 +1400,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Маска"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Изабрано"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -1624,7 +1624,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Mask"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s valda"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -1871,7 +1871,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Maskele"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Seçildi"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1899,39 +1899,39 @@ msgid "inspect.tabs.info"
 msgstr "Bilgi"
 
 #: src/app/main/ui/inspect/styles/property_detail_copiable.cljs:52
-msgid "inspect.tabs.styles.panel.copy-to-clipboard"
+msgid "inspect.tabs.styles.copy-to-clipboard"
 msgstr "Panoya kopyala"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:22
-msgid "inspect.tabs.styles.panel.geometry"
+msgid "inspect.tabs.styles.geometry-panel"
 msgstr "Boyut ve Konum"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:59, src/app/main/ui/workspace/colorpicker/color_tokens.cljs:179
-msgid "inspect.tabs.styles.panel.toggle-style"
+msgid "inspect.tabs.styles.toggle-style"
 msgstr "%s panelini aç/kapat"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:21
-msgid "inspect.tabs.styles.panel.token"
+msgid "inspect.tabs.styles.token-panel"
 msgstr "Token Kümeleri ve Temalar"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:26
-msgid "inspect.tabs.styles.panel.tokens.active-sets"
+msgid "inspect.tabs.styles.active-sets"
 msgstr "Etkin kümeler"
 
 #: src/app/main/ui/inspect/styles/panels/tokens_panel.cljs:21
-msgid "inspect.tabs.styles.panel.tokens.active-themes"
+msgid "inspect.tabs.styles.active-themes"
 msgstr "Etkin temalar"
 
 #: src/app/main/ui/inspect/styles/style_box.cljs:20
-msgid "inspect.tabs.styles.panel.variant"
+msgid "inspect.tabs.styles.variants-panel"
 msgstr "Çeşit özellikleri"
 
 #: src/app/main/ui/inspect/styles/rows/color_properties_row.cljs:102, src/app/main/ui/inspect/styles/rows/properties_row.cljs:53
-msgid "inspect.tabs.styles.token.resolved-value"
+msgid "inspect.tabs.styles.token-resolved-value"
 msgstr "Çözülen değer:"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "Katman bilgisi"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/ukr_UA.po
+++ b/frontend/translations/ukr_UA.po
@@ -1826,7 +1826,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Маска"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "Виділено: %s"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/yo.po
+++ b/frontend/translations/yo.po
@@ -1256,7 +1256,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "Ìbòjú"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "%s Ti yàn"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -1764,7 +1764,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "蒙版"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "已选中%s项"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149
@@ -1792,7 +1792,7 @@ msgid "inspect.tabs.info"
 msgstr "信息"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
+msgid "inspect.layer-info"
 msgstr "图层信息"
 
 #: src/app/main/ui/dashboard/comments.cljs:96

--- a/frontend/translations/zh_Hant.po
+++ b/frontend/translations/zh_Hant.po
@@ -1562,7 +1562,7 @@ msgid "inspect.tabs.code.selected.mask"
 msgstr "遮罩"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:136
-msgid "inspect.tabs.code.selected.multiple"
+msgid "inspect.multiple-selected"
 msgstr "已選擇 %s"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:149


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/12622

### Summary

This PR refactors translations IDs so it follows current team agreement on how to manage it.

### Steps to reproduce 

Check that the inspect -> styles tab is being translated

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
