### PR TITLE
:bug: Fix crash when using a font family with a number in its name

### DIFF
--- a/frontend/src/app/util/text/content/styles.cljs
+++ b/frontend/src/app/util/text/content/styles.cljs
@@ -37,17 +37,23 @@
          (not= (str/slice v -2) "px"))
     (str v "px")
 
+    (and (= k :font-family) (seq v))
+    (str/quote v)
+
     :else
     v))
 
 (defn normalize-attr-value
-  "This function strips units from attr values"
+  "This function strips units from attr values and un-scapes font-family"
   [k v]
   (cond
     (and (or (= k :font-size)
              (= k :letter-spacing))
          (= (str/slice v -2) "px"))
     (str/slice v 0 -2)
+
+    (= k :font-family)
+    (str/unquote v)
 
     :else
     v))

--- a/frontend/text-editor/src/editor/TextEditor.js
+++ b/frontend/text-editor/src/editor/TextEditor.js
@@ -209,7 +209,7 @@ export class TextEditor extends EventTarget {
     const rotation = transform?.rotation ?? 0.0;
     const scale = transform?.scale ?? 1.0;
     this.#updatePositionFromCanvas();
-    this.#element.style.transformOrigin = 'top left';
+    this.#element.style.transformOrigin = "top left";
     this.#element.style.transform = `scale(${scale}) translate(${x}px, ${y}px) rotate(${rotation}deg)`;
   }
 
@@ -225,7 +225,7 @@ export class TextEditor extends EventTarget {
       y: viewport.y + shape.selrect.y,
       rotation: shape.rotation,
       scale: viewport.zoom,
-    })
+    });
   }
 
   /**

--- a/frontend/text-editor/src/editor/content/dom/Content.js
+++ b/frontend/text-editor/src/editor/content/dom/Content.js
@@ -75,26 +75,43 @@ export function mapContentFragmentFromDocument(document, root, styleDefaults) {
         currentParagraph = createParagraph(undefined, currentStyle);
       }
     }
-    const textSpan = createTextSpan(new Text(currentNode.nodeValue), currentStyle);
+    const textSpan = createTextSpan(
+      new Text(currentNode.nodeValue),
+      currentStyle,
+    );
     const fontSize = textSpan.style.getPropertyValue("font-size");
     if (!fontSize) {
       console.warn("font-size", fontSize);
-      textSpan.style.setProperty("font-size", styleDefaults?.getPropertyValue("font-size") ?? DEFAULT_FONT_SIZE);
+      textSpan.style.setProperty(
+        "font-size",
+        styleDefaults?.getPropertyValue("font-size") ?? DEFAULT_FONT_SIZE,
+      );
     }
     const fontFamily = textSpan.style.getPropertyValue("font-family");
     if (!fontFamily) {
       console.warn("font-family", fontFamily);
-      textSpan.style.setProperty("font-family", styleDefaults?.getPropertyValue("font-family") ?? DEFAULT_FONT_FAMILY);
+      const fontFamilyValue =
+        styleDefaults?.getPropertyValue("font-family") ?? DEFAULT_FONT_FAMILY;
+      const quotedFontFamily = fontFamilyValue.startsWith('"')
+        ? fontFamilyValue
+        : `"${fontFamilyValue}"`;
+      textSpan.style.setProperty("font-family", quotedFontFamily);
     }
     const fontWeight = textSpan.style.getPropertyValue("font-weight");
     if (!fontWeight) {
       console.warn("font-weight", fontWeight);
-      textSpan.style.setProperty("font-weight", styleDefaults?.getPropertyValue("font-weight") ?? DEFAULT_FONT_WEIGHT)
+      textSpan.style.setProperty(
+        "font-weight",
+        styleDefaults?.getPropertyValue("font-weight") ?? DEFAULT_FONT_WEIGHT,
+      );
     }
-    const fills = textSpan.style.getPropertyValue('--fills');
+    const fills = textSpan.style.getPropertyValue("--fills");
     if (!fills) {
       console.warn("fills", fills);
-      textSpan.style.setProperty("--fills", styleDefaults?.getPropertyValue("--fills") ?? DEFAULT_FILLS);
+      textSpan.style.setProperty(
+        "--fills",
+        styleDefaults?.getPropertyValue("--fills") ?? DEFAULT_FILLS,
+      );
     }
 
     currentParagraph.appendChild(textSpan);

--- a/frontend/text-editor/src/editor/content/dom/TextSpan.js
+++ b/frontend/text-editor/src/editor/content/dom/TextSpan.js
@@ -115,7 +115,6 @@ export function createTextSpan(textOrLineBreak, styles, attrs) {
     textOrLineBreak instanceof Text &&
     textOrLineBreak.nodeValue.length === 0
   ) {
-    console.trace("nodeValue", textOrLineBreak.nodeValue);
     throw new TypeError("Invalid text span child, cannot be an empty text");
   }
 
@@ -182,7 +181,6 @@ export function createVoidTextSpan(styles) {
  * @returns {HTMLSpanElement}
  */
 export function setTextSpanStyles(element, styles) {
-  console.log("setTextSpanStyles styles", element, styles);
   return setStyles(element, STYLES, styles);
 }
 

--- a/frontend/text-editor/src/editor/content/dom/TextSpan.js
+++ b/frontend/text-editor/src/editor/content/dom/TextSpan.js
@@ -118,6 +118,7 @@ export function createTextSpan(textOrLineBreak, styles, attrs) {
     console.trace("nodeValue", textOrLineBreak.nodeValue);
     throw new TypeError("Invalid text span child, cannot be an empty text");
   }
+
   return createElement(TAG, {
     attributes: { id: createRandomId(), ...attrs },
     data: { itype: TYPE },
@@ -181,6 +182,7 @@ export function createVoidTextSpan(styles) {
  * @returns {HTMLSpanElement}
  */
 export function setTextSpanStyles(element, styles) {
+  console.log("setTextSpanStyles styles", element, styles);
   return setStyles(element, STYLES, styles);
 }
 

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -789,7 +789,6 @@ export class SelectionController extends EventTarget {
     if (this.#savedSelection) {
       return this.#savedSelection.focusNode;
     }
-    if (!this.#focusNode) console.trace("focusNode", this.#focusNode);
     return this.#focusNode;
   }
 

--- a/frontend/text-editor/src/playground/text.js
+++ b/frontend/text-editor/src/playground/text.js
@@ -71,6 +71,7 @@ export class TextSpan {
     if (!font) {
       throw new Error(`Invalid font "${fontFamily}"`);
     }
+
     return new TextSpan({
       fontId: font.id, // leafElement.style.getPropertyValue("--font-id"),
       fontFamilyHash: 0,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12587

### Summary

This fixes requests to `/update-file` for text shapes with empty font family (or sometimes using `sourcesanspro` instead of the real one).

The issue was that we needed to quote the font family name for font that had numbers in their name (like `Font Awesome 7 Free`) when using `CSStyleDeclaration.setProperty`.

### Steps to reproduce 

See ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

