### PR TITLE
:sparkles: Improve text shape selection

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -309,7 +309,7 @@
 
         [{:keys [x y width height]} transform]
         (if render-wasm?
-          (let [{:keys [width height]} (wasm.api/get-text-dimensions shape-id)
+          (let [{:keys [height]} (wasm.api/get-text-dimensions shape-id)
                 selrect-transform (mf/deref refs/workspace-selrect)
                 [selrect transform] (dsh/get-selrect selrect-transform shape)
 
@@ -320,7 +320,7 @@
                     "bottom" (- y (- height (:height selrect)))
                     "center" (- y (/ (- height (:height selrect)) 2))
                     y)]
-            [(assoc selrect :y y :width width :height height) transform])
+            [(assoc selrect :y y :width (:width selrect) :height (:height selrect)) transform])
 
           (let [bounds (gst/shape->rect shape)
                 x      (mth/min (dm/get-prop bounds :x)
@@ -342,8 +342,8 @@
 
           (not render-wasm?)
           (obj/merge!
-           #js {"--editor-container-width" (dm/str (:width shape) "px")
-                "--editor-container-height" (dm/str (:height shape) "px")})
+           #js {"--editor-container-width" (dm/str width "px")
+                "--editor-container-height" (dm/str height "px")})
 
           ;; Transform is necessary when there is a text overflow and the vertical
           ;; aligment is center or bottom.

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
@@ -8,6 +8,8 @@
 .text-editor-container {
   height: 100%;
   position: relative;
+
+  cursor: text;
 }
 
 .text-editor-selection-imposter {

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -316,7 +316,7 @@
                                      (not (contains? child-parent? %)))
                                 (and (features/active-feature? @st/state "render-wasm/v1")
                                      (cfh/text-shape? objects %)
-                                     (not (wasm.api/intersect-position % @last-point-ref)))))))
+                                     (not (wasm.api/intersect-position-in-shape % @last-point-ref)))))))
 
                remove-measure-xf
                (cond

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -119,6 +119,7 @@
     :shape-id id
     :dimensions (get-text-dimensions id)}))
 
+
 (defn- ensure-text-content
   "Guarantee that the shape always sends a valid text tree to WASM. When the
   content is nil (freshly created text) we fall back to
@@ -831,11 +832,11 @@
      (mem/free)
      {:x x :y y :width width :height height :max-width max-width})))
 
-(defn intersect-position
+(defn intersect-position-in-shape
   [id position]
   (let [buffer (uuid/get-u32 id)
         result
-        (h/call wasm/internal-module "_intersect_position"
+        (h/call wasm/internal-module "_intersect_position_in_shape"
                 (aget buffer 0)
                 (aget buffer 1)
                 (aget buffer 2)

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -341,7 +341,7 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
 }
 
 #[no_mangle]
-pub extern "C" fn intersect_position(
+pub extern "C" fn intersect_position_in_shape(
     a: u32,
     b: u32,
     c: u32,
@@ -355,7 +355,7 @@ pub extern "C" fn intersect_position(
             return false;
         };
         if let Type::Text(content) = &shape.shape_type {
-            return content.intersect_position(shape, x_pos, y_pos);
+            return content.intersect_position_in_shape(shape, x_pos, y_pos);
         }
     });
     false


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12541

### Summary


When the editor is on edit mode, the cursor is shown as `text` in the entire shape, not only where the text is present

### Steps to reproduce 

Create a text shape and write some content
Resize it and make the text shape bigger than the text
Select the text and / or enter the edition mode, and check the cursor is type `text` (it shows a caret) in the entire shape  

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
