### PR TITLE
:sparkles: Improvements to the auth internal flows changes

### DIFF
--- a/backend/resources/log4j2-devenv-repl.xml
+++ b/backend/resources/log4j2-devenv-repl.xml
@@ -25,8 +25,7 @@
     <Logger name="app.storage.tmp" level="info" />
     <Logger name="app.worker" level="trace" />
     <Logger name="app.msgbus" level="info" />
-    <Logger name="app.http.websocket" level="info" />
-    <Logger name="app.http.sse" level="info" />
+    <Logger name="app.http" level="info" />
     <Logger name="app.util.websocket" level="info" />
     <Logger name="app.redis" level="info" />
     <Logger name="app.rpc.rlimit" level="info" />

--- a/backend/resources/log4j2-devenv.xml
+++ b/backend/resources/log4j2-devenv.xml
@@ -25,8 +25,7 @@
     <Logger name="app.storage.tmp" level="info" />
     <Logger name="app.worker" level="trace" />
     <Logger name="app.msgbus" level="info" />
-    <Logger name="app.http.websocket" level="info" />
-    <Logger name="app.http.sse" level="info" />
+    <Logger name="app.http" level="info" />
     <Logger name="app.util.websocket" level="info" />
     <Logger name="app.redis" level="info" />
     <Logger name="app.rpc.rlimit" level="info" />

--- a/backend/src/app/http/session.clj
+++ b/backend/src/app/http/session.clj
@@ -93,15 +93,15 @@
     (update-session [_ session]
       (let [modified-at (ct/now)]
         (if (string? (:id session))
-          (let [params (-> session
-                           (assoc :id (uuid/next))
-                           (assoc :created-at modified-at)
-                           (assoc :modified-at modified-at))]
-            (db/insert! pool :http-session-v2 params))
-
+          (db/insert! pool :http-session-v2
+                      (-> session
+                          (assoc :id (uuid/next))
+                          (assoc :created-at modified-at)
+                          (assoc :modified-at modified-at)))
           (db/update! pool :http-session-v2
                       {:modified-at modified-at}
-                      {:id (:id session)}))))
+                      {:id (:id session)}
+                      {::db/return-keys true}))))
 
     (delete-session [_ id]
       (if (string? id)

--- a/backend/src/app/http/session.clj
+++ b/backend/src/app/http/session.clj
@@ -158,14 +158,15 @@
 
 (defn- assign-token
   [cfg session]
-  (let [token (tokens/generate cfg
-                               {:iss "authentication"
-                                :aud "penpot"
-                                :sid (:id session)
-                                :iat (:modified-at session)
-                                :uid (:profile-id session)
-                                :sso-provider-id (:sso-provider-id session)
-                                :sso-session-id (:sso-session-id session)})]
+  (let [claims {:iss "authentication"
+                :aud "penpot"
+                :sid (:id session)
+                :iat (:modified-at session)
+                :uid (:profile-id session)
+                :sso-provider-id (:sso-provider-id session)
+                :sso-session-id (:sso-session-id session)}
+        header {:kid 1 :ver 1}
+        token  (tokens/generate cfg claims header)]
     (assoc session :token token)))
 
 (defn create-fn
@@ -225,13 +226,14 @@
   [handler {:keys [::manager] :as cfg}]
   (assert (manager? manager) "expected valid session manager")
   (fn [request]
-    (let [{:keys [type token claims]} (get request ::http/auth-data)]
+    (let [{:keys [type token claims metadata]} (get request ::http/auth-data)]
       (cond
         (= type :cookie)
-        (let [session (if-let [sid (:sid claims)]
-                        (read-session manager sid)
+        (let [session (case (:ver metadata)
                         ;; BACKWARD COMPATIBILITY WITH OLD TOKENS
-                        (read-session manager token))
+                        0 (read-session manager token)
+                        1 (some->> (:sid claims) (read-session manager))
+                        nil)
 
               request (cond-> request
                         (some? session)
@@ -240,7 +242,7 @@
 
               response (handler request)]
 
-          (if (renew-session? session)
+          (if (and session (renew-session? session))
             (let [session (->> session
                                (update-session manager)
                                (assign-token cfg))]
@@ -248,11 +250,11 @@
             response))
 
         (= type :bearer)
-        (let [session (if-let [sid (:sid claims)]
-                        (read-session manager sid)
+        (let [session (case (:ver metadata)
                         ;; BACKWARD COMPATIBILITY WITH OLD TOKENS
-                        (read-session manager token))
-
+                        0 (read-session manager token)
+                        1 (some->> (:sid claims) (read-session manager))
+                        nil)
               request (cond-> request
                         (some? session)
                         (-> (assoc ::profile-id (:profile-id session))

--- a/backend/src/app/loggers/database.clj
+++ b/backend/src/app/loggers/database.clj
@@ -49,7 +49,7 @@
           ctx  (-> context
                    (assoc :tenant (cf/get :tenant))
                    (assoc :host (cf/get :host))
-                   (assoc :public-uri (cf/get :public-uri))
+                   (assoc :public-uri (str (cf/get :public-uri)))
                    (assoc :logger/name logger)
                    (assoc :logger/level level)
                    (dissoc :request/params :value :params :data))]

--- a/backend/src/app/tokens.clj
+++ b/backend/src/app/tokens.clj
@@ -15,19 +15,25 @@
    [buddy.sign.jwe :as jwe]))
 
 (defn generate
-  [{:keys [::setup/props] :as cfg} claims]
-  (assert (contains? cfg ::setup/props))
+  ([cfg claims] (generate cfg claims nil))
+  ([{:keys [::setup/props] :as cfg} claims header]
+   (assert (contains? props :tokens-key) "expect props to have tokens-key")
 
-  (let [tokens-key
-        (get props :tokens-key)
+   (let [tokens-key
+         (get props :tokens-key)
 
-        payload
-        (-> claims
-            (update :iat (fn [v] (or v (ct/now))))
-            (d/without-nils)
-            (t/encode))]
+         payload
+         (-> claims
+             (update :iat (fn [v] (or v (ct/now))))
+             (d/without-nils)
+             (t/encode))]
 
-    (jwe/encrypt payload tokens-key {:alg :a256kw :enc :a256gcm})))
+     (jwe/encrypt payload tokens-key {:alg :a256kw :enc :a256gcm :header header}))))
+
+(defn decode-header
+  [token]
+  (ex/ignoring
+   (jwe/decode-header token)))
 
 (defn decode
   [{:keys [::setup/props] :as cfg} token]


### PR DESCRIPTION
### Summary

This PR fixes some issues and add improvements for properly handle backward compatibility with tokens in case we decide change the secret key.


### How to test

- You should be login without problems
- Old authenticated users are still logged (tokens created before SSO changes)

