### PR TITLE
:sparkles: Drop zoom snap

### DIFF
--- a/frontend/src/app/main/constants.cljs
+++ b/frontend/src/app/main/constants.cljs
@@ -301,6 +301,4 @@
     :width 1280
     :height 720}])
 
-(def zoom-half-pixel-precision 8)
-
 (def max-input-length 255)

--- a/frontend/src/app/main/data/workspace/drawing/box.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/box.cljs
@@ -19,7 +19,6 @@
    [app.common.types.shape-tree :as ctst]
    [app.common.types.shape.layout :as ctl]
    [app.common.uuid :as uuid]
-   [app.main.constants :refer [zoom-half-pixel-precision]]
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace.drawing.common :as common]
    [app.main.snap :as snap]
@@ -83,8 +82,7 @@
             zoom         (dm/get-in state [:workspace-local :zoom] 1)
 
             snap-pixel?  (contains? layout :snap-pixel-grid)
-            snap-prec    (if (>= zoom zoom-half-pixel-precision) 0.5 1)
-            initial      (cond-> @ms/mouse-position snap-pixel? (gpt/round-step snap-prec))
+            initial      (cond-> @ms/mouse-position snap-pixel? (gpt/round-step 1))
 
             page-id      (:current-page-id state)
             objects      (dsh/lookup-page-objects state page-id)
@@ -133,7 +131,7 @@
                             (rx/map (partial array/conj current)))))
                     (rx/map
                      (fn [[_ shift? mod? point]]
-                       #(update-drawing % initial (cond-> point snap-pixel? (gpt/round-step snap-prec)) shift? mod?))))))
+                       #(update-drawing % initial (cond-> point snap-pixel? (gpt/round-step 1)) shift? mod?))))))
 
          (->> (rx/of (common/handle-finish-drawing))
               (rx/delay 100)))))))

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -24,7 +24,6 @@
    [app.common.types.shape.attrs :refer [editable-attrs]]
    [app.common.types.shape.layout :as ctl]
    [app.common.uuid :as uuid]
-   [app.main.constants :refer [zoom-half-pixel-precision]]
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace.comments :as-alias dwcm]
    [app.main.data.workspace.guides :as-alias dwg]
@@ -412,10 +411,7 @@
          (dsh/lookup-page-objects state page-id)
 
          snap-pixel?
-         (and (not ignore-snap-pixel) (contains? (:workspace-layout state) :snap-pixel-grid))
-
-         zoom (dm/get-in state [:workspace-local :zoom])
-         snap-precision (if (>= zoom zoom-half-pixel-precision) 0.5 1)]
+         (and (not ignore-snap-pixel) (contains? (:workspace-layout state) :snap-pixel-grid))]
 
      (as-> objects $
        (apply-text-modifiers $ (get state :workspace-text-modifier))
@@ -423,8 +419,7 @@
        (gm/set-objects-modifiers modif-tree $ (merge
                                                params
                                                {:ignore-constraints ignore-constraints
-                                                :snap-pixel? snap-pixel?
-                                                :snap-precision snap-precision}))))))
+                                                :snap-pixel? snap-pixel?}))))))
 
 (defn- calculate-update-modifiers
   [old-modif-tree state ignore-constraints ignore-snap-pixel modif-tree]
@@ -434,9 +429,6 @@
         snap-pixel?
         (and (not ignore-snap-pixel) (contains? (:workspace-layout state) :snap-pixel-grid))
 
-        zoom (dm/get-in state [:workspace-local :zoom])
-
-        snap-precision (if (>= zoom zoom-half-pixel-precision) 0.5 1)
         objects
         (-> objects
             (apply-text-modifiers (get state :workspace-text-modifier)))]
@@ -446,8 +438,7 @@
      modif-tree
      objects
      {:ignore-constraints ignore-constraints
-      :snap-pixel? snap-pixel?
-      :snap-precision snap-precision})))
+      :snap-pixel? snap-pixel?})))
 
 (defn update-modifiers
   ([modif-tree]

--- a/frontend/src/app/main/data/workspace/path/streams.cljs
+++ b/frontend/src/app/main/data/workspace/path/streams.cljs
@@ -9,7 +9,6 @@
    [app.common.data.macros :as dm]
    [app.common.geom.point :as gpt]
    [app.common.types.path.segment :as path.segm]
-   [app.main.constants :refer [zoom-half-pixel-precision]]
    [app.main.data.workspace.path.state :as pst]
    [app.main.snap :as snap]
    [app.main.store :as st]
@@ -29,16 +28,13 @@
   (= (ptk/type event) :app.main.data.workspace.common/clear-edition-mode))
 
 (defn to-pixel-snap [position]
-  (let [zoom  (get-in @st/state [:workspace-local :zoom] 1)
-        layout      (get @st/state :workspace-layout)
+  (let [layout      (get @st/state :workspace-layout)
         snap-pixel? (contains? layout :snap-pixel-grid)]
 
     (cond
       (or (not snap-pixel?) (not (gpt/point? position)))
       position
 
-      (>= zoom zoom-half-pixel-precision)
-      (gpt/round-step position 0.5)
 
       :else
       (gpt/round position))))


### PR DESCRIPTION
### Summary

The snap-to-pixel grid was not being respected when working below zoom level 8.
In accordance with the behavior specified in the [Penpot documentation](https://help.penpot.app/user-guide/workspace-basics/#snap-to-pixel), the `zoom-half-pixel-precision` constant (previously used as a threshold) has been removed.

This change ensures consistent snap behavior across all zoom levels and aligns it with how other design tools (e.g., Figma) handle pixel snapping.
