### PR TITLE
:bug: Fix invalid fills schema when binary fills are used

### DIFF
--- a/common/src/app/common/types/fills.cljc
+++ b/common/src/app/common/types/fills.cljc
@@ -11,6 +11,7 @@
    [app.common.exceptions :as ex]
    [app.common.flags :as flags]
    [app.common.schema :as sm]
+   [app.common.schema.generators :as sg]
    [app.common.types.color :as types.color]
    [app.common.types.fills.impl :as impl]
    [clojure.core :as c]
@@ -49,11 +50,18 @@
     (= 1 (count result))))
 
 (def schema:fill
-  [:and schema:fill-attrs
-   [:fn has-valid-fill-attrs?]])
+  [:and schema:fill-attrs [:fn has-valid-fill-attrs?]])
 
 (def check-fill
   (sm/check-fn schema:fill))
+
+(def ^:private schema:fills-as-vector
+  [:vector {:gen/max 2} schema:fill])
+
+(def schema:fills
+  [:or {:gen/gen (sg/generator schema:fills-as-vector)}
+   schema:fills-as-vector
+   [:fn impl/fills?]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; CONSTRUCTORS

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -19,7 +19,7 @@
    [app.common.schema.generators :as sg]
    [app.common.transit :as t]
    [app.common.types.color :as clr]
-   [app.common.types.fills :refer [schema:fill fill->color]]
+   [app.common.types.fills :refer [schema:fills fill->color]]
    [app.common.types.grid :as ctg]
    [app.common.types.path :as path]
    [app.common.types.plugins :as ctpg]
@@ -192,8 +192,7 @@
    [:locked {:optional true} :boolean]
    [:hidden {:optional true} :boolean]
    [:masked-group {:optional true} :boolean]
-   [:fills {:optional true}
-    [:vector {:gen/max 2} schema:fill]]
+   [:fills {:optional true} schema:fills]
    [:proportion {:optional true} ::sm/safe-number]
    [:proportion-lock {:optional true} :boolean]
    [:constraints-h {:optional true}

--- a/common/src/app/common/types/shape/text.cljc
+++ b/common/src/app/common/types/shape/text.cljc
@@ -7,7 +7,7 @@
 (ns app.common.types.shape.text
   (:require
    [app.common.schema :as sm]
-   [app.common.types.fills :refer [schema:fill]]))
+   [app.common.types.fills :refer [schema:fills]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; SCHEMA
@@ -32,8 +32,7 @@
           [:type [:= "paragraph"]]
           [:key {:optional true} :string]
           [:fills {:optional true}
-           [:maybe
-            [:vector {:gen/max 2}  schema:fill]]]
+           [:maybe schema:fills]]
           [:font-family {:optional true} ::sm/text]
           [:font-size {:optional true} ::sm/text]
           [:font-style {:optional true} ::sm/text]
@@ -49,8 +48,7 @@
              [:text :string]
              [:key {:optional true} :string]
              [:fills {:optional true}
-              [:maybe
-               [:vector {:gen/max 2} schema:fill]]]
+              [:maybe schema:fills]]
              [:font-family {:optional true} ::sm/text]
              [:font-size {:optional true} ::sm/text]
              [:font-style {:optional true} ::sm/text]
@@ -71,7 +69,7 @@
     [:y ::sm/safe-number]
     [:width ::sm/safe-number]
     [:height ::sm/safe-number]
-    [:fills [:vector {:gen/max 2} schema:fill]]
+    [:fills schema:fills]
     [:font-family {:optional true} ::sm/text]
     [:font-size {:optional true} ::sm/text]
     [:font-style {:optional true} ::sm/text]


### PR DESCRIPTION
### Summary

Fix the exception of invalid schema when pasting text and binary-fills are enabled

### Steps to reproduce 

- Use `enable-frontend-binary-fills` flag on frontend
- Copy plain text, and paste
- Exception is raised

This PR fixes the issue.
