### PR TITLE
:bug: Fix after changing a variant property value, the value appears as empty

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/ds/controls/combobox.cljs
@@ -61,6 +61,7 @@
         nodes-ref    (mf/use-ref nil)
         options-ref  (mf/use-ref nil)
         listbox-id   (mf/use-id)
+        value-ref    (mf/use-ref nil)
 
         dropdown-options
         (mf/with-memo [options filter-id]
@@ -200,11 +201,10 @@
            (let [value (-> event
                            dom/get-target
                            dom/get-value)]
+             (mf/set-ref-val! value-ref value)
              (reset! selected-id* value)
              (reset! filter-id* value)
-             (reset! focused-id* nil)
-             (when (fn? on-change)
-               (on-change value)))))
+             (reset! focused-id* nil))))
 
         selected-option
         (mf/with-memo [options selected-id]
@@ -222,6 +222,13 @@
      (mf/deps default-selected)
      (fn []
        (reset! selected-id* default-selected)))
+
+    ;; On componnet unmount, save the new value if needed
+    (mf/with-effect [on-change]
+      (fn []
+        (when-let [value (mf/ref-val value-ref)]
+          (mf/set-ref-val! value-ref nil)
+          (on-change value))))
 
     [:div {:ref combobox-ref
            :class (stl/css-case

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -309,6 +309,13 @@
                  to-space-between-pos (if (= relative-pos :bot) (inc pos) pos)]
              (on-reorder from-pos to-space-between-pos))))
 
+
+        on-prop-value-change
+        (mf/use-fn
+         (mf/deps on-prop-value-change pos)
+         (fn [value]
+           (on-prop-value-change pos value)))
+
         [dprops dref]
         (h/use-sortable
          :data-type "penpot/variant-property"
@@ -350,7 +357,8 @@
                            (get :objects))
 
         props-list     (map :variant-properties components)
-        component-ids  (map :id components)
+        component-ids  (mf/with-memo [components]
+                         (map :id components))
         properties     (if (> (count component-ids) 1)
                          (ctv/compare-properties props-list false)
                          (first props-list))
@@ -413,7 +421,7 @@
                                           :prop prop
                                           :options (get-options (:name prop))
                                           :on-prop-name-blur update-property-name
-                                          :on-prop-value-change (partial update-property-value pos)
+                                          :on-prop-value-change update-property-value
                                           :on-reorder reorder-properties}])]]
 
      (if malformed-msg


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12624

### Summary

After changing a property value, the value appears as empty

### Steps to reproduce 

1. Go to any file in hourly that has a component with variants or create a component with variants.
2. Modify the value of a property
3. See how it figures -- as it was empty

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
