### PR TITLE
:bug: Fix paste crash

### DIFF
--- a/frontend/text-editor/src/editor/clipboard/cut.js
+++ b/frontend/text-editor/src/editor/clipboard/cut.js
@@ -15,5 +15,6 @@
  *
  * @param {ClipboardEvent} event
  * @param {TextEditor} editor
+ * @param {SelectionController} selectionController
  */
-export function cut(event, editor) {}
+export function cut(event, editor, selectionController) {}

--- a/frontend/text-editor/src/editor/clipboard/paste.js
+++ b/frontend/text-editor/src/editor/clipboard/paste.js
@@ -17,7 +17,7 @@ import {
  * @param {DataTransfer} clipboardData
  * @returns {DocumentFragment}
  */
-function getFormattedFragmentFromClipboardData(clipboardData) {
+function getFormattedFragmentFromClipboardData(selectionController, clipboardData) {
   return mapContentFragmentFromHTML(
     clipboardData.getData("text/html"),
     selectionController.currentStyle,
@@ -30,7 +30,7 @@ function getFormattedFragmentFromClipboardData(clipboardData) {
  * @param {DataTransfer} clipboardData
  * @returns {DocumentFragment}
  */
-function getPlainFragmentFromClipboardData(clipboardData) {
+function getPlainFragmentFromClipboardData(selectionController, clipboardData) {
   return mapContentFragmentFromString(
     clipboardData.getData("text/plain"),
     selectionController.currentStyle,
@@ -44,11 +44,11 @@ function getPlainFragmentFromClipboardData(clipboardData) {
  * @param {DataTransfer} clipboardData
  * @returns {DocumentFragment|null}
  */
-function getFragmentFromClipboardData(clipboardData) {
+function getFragmentFromClipboardData(selectionController, clipboardData) {
   if (clipboardData.types.includes("text/html")) {
-    return getFormattedFragmentFromClipboardData(clipboardData)
+    return getFormattedFragmentFromClipboardData(selectionController, clipboardData)
   } else if (clipboardData.types.includes("text/plain")) {
-    return getPlainFragmentFromClipboardData(clipboardData)
+    return getPlainFragmentFromClipboardData(selectionController, clipboardData)
   }
   return null
 }
@@ -71,9 +71,9 @@ export function paste(event, editor, selectionController) {
 
   let fragment = null;
   if (editor?.options?.allowHTMLPaste) {
-    fragment = getFragmentFromClipboardData(event.clipboardData);
+    fragment = getFragmentFromClipboardData(selectionController, event.clipboardData);
   } else {
-    fragment = getPlainFragmentFromClipboardData(event.clipboardData);
+    fragment = getPlainFragmentFromClipboardData(selectionController, event.clipboardData);
   }
 
   if (!fragment) {


### PR DESCRIPTION
### Summary
Fix crash in new render when pasting text

### Steps to reproduce 

- Create text
- Insert some text
- Copy/paste the selected text inside the same box

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
