### PR TITLE
:bug: Fix problem with layout z-index

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -739,7 +739,7 @@
 
             (d/nilv align-self 0)
             is-absolute
-            (d/nilv z-index))))
+            (d/nilv z-index 0))))
 
 (defn clear-layout
   []

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1641,9 +1641,9 @@ impl RenderState {
                     }
 
                     children_ids.sort_by(|id1, id2| {
-                        let z1 = tree.get(id1).map_or_else(|| 0, |s| s.z_index());
-                        let z2 = tree.get(id2).map_or_else(|| 0, |s| s.z_index());
-                        z1.cmp(&z2)
+                        let z1 = tree.get(id1).map(|s| s.z_index()).unwrap_or(0);
+                        let z2 = tree.get(id2).map(|s| s.z_index()).unwrap_or(0);
+                        z2.cmp(&z1)
                     });
                 }
 

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -332,6 +332,7 @@ fn propagate_reflow(
         }
         _ => {
             // Other shapes don't have to be reflown
+            reflow_parent = true;
         }
     }
 


### PR DESCRIPTION
### Summary

Fix problem with z-index in flex layout.

### Steps to reproduce 

- Create a flex layout with 3 elements.
- Make one of the elements an absolute position with a negative z-index

The element with negative z-index should be on behind all the elements.

<img width="548" height="1071" alt="image" src="https://github.com/user-attachments/assets/b88a9ee0-b6f1-43ec-a4f2-eacab852b315" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
