### PR TITLE
:lipstick: Fix spelling of 'smtp' in email configuration section

### DIFF
--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -314,7 +314,7 @@ If you're using the official <code class="language-bash">docker-compose.yml</cod
 
 ## Email configuration
 
-By default, <code class="language-bash">smpt</code> flag is disabled, the email will be
+By default, <code class="language-bash">smtp</code> flag is disabled, the email will be
 printed to the console, which means that the emails will be shown in the stdout.
 
 Note that if you plan to invite members to a team, it is recommended that you enable SMTP


### PR DESCRIPTION
Corrected the spelling of 'smtp' in the documentation.

### Related Ticket
n/a

### Summary
Fix typo in the documentation.

### Steps to reproduce 
n/a

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
