### PR TITLE
:recycle: Use ESM target for frontend module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,23 +182,14 @@ jobs:
       - name: Build Bundle
         working-directory: ./frontend
         run: |
-          corepack enable;
-          corepack install;
-          yarn install
-          yarn run build:app:assets
-          yarn run build:app
-          yarn run build:app:libs
-
-      - name: Build WASM
-        working-directory: "./render-wasm"
-        run: |
-          ./build release
+          ./scripts/build 0.0.0
 
       - name: Store Bundle Cache
         uses: actions/cache@v4
         with:
           key: "integration-bundle-${{ github.sha }}"
           path: frontend/resources/public
+
 
   test-integration-1:
     name: "Integration Tests 1/4"

--- a/common/src/app/common/exceptions.cljc
+++ b/common/src/app/common/exceptions.cljc
@@ -14,8 +14,7 @@
    [app.common.schema :as sm]
    [clojure.core :as c]
    [clojure.spec.alpha :as s]
-   [cuerdas.core :as str]
-   [expound.alpha :as expound])
+   [cuerdas.core :as str])
   #?(:clj
      (:import
       clojure.lang.IPersistentMap)))
@@ -109,13 +108,6 @@
     (and (= (:reason data) :integrant.core/build-failed-spec)
          (contains? data :explain))
     (explain (:explain data) opts)
-
-    (and (contains? data ::s/problems)
-         (contains? data ::s/value)
-         (contains? data ::s/spec))
-    (binding [s/*explain-out* expound/printer]
-      (with-out-str
-        (s/explain-out (update data ::s/problems #(take (:length opts 10) %)))))
 
     (contains? data ::sm/explain)
     (sm/humanize-explain (::sm/explain data) opts)))

--- a/common/src/app/common/logging.cljc
+++ b/common/src/app/common/logging.cljc
@@ -43,8 +43,6 @@
   "
   #?(:cljs (:require-macros [app.common.logging :as l]))
   (:require
-   #?(:clj  [clojure.edn :as edn]
-      :cljs [cljs.reader :as edn])
    [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.pprint :as pp]

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -18,7 +18,6 @@
    [app.common.logic.shapes :as cls]
    [app.common.logic.variant-properties :as clvp]
    [app.common.path-names :as cpn]
-   [app.common.spec :as us]
    [app.common.types.component :as ctk]
    [app.common.types.components-list :as ctkl]
    [app.common.types.container :as ctn]
@@ -35,8 +34,7 @@
    [app.common.types.typography :as cty]
    [app.common.types.variant :as ctv]
    [app.common.uuid :as uuid]
-   [clojure.set :as set]
-   [clojure.spec.alpha :as s]))
+   [clojure.set :as set]))
 
 ;; Change this to :info :debug or :trace to debug this module, or :warn to reset to default
 (log/set-level! :warn)
@@ -473,10 +471,10 @@
   If an asset id is given, only shapes linked to this particular asset will
   be synchronized."
   [changes file-id asset-type asset-id library-id libraries current-file-id]
-  (s/assert #{:colors :components :typographies} asset-type)
-  (s/assert (s/nilable ::us/uuid) asset-id)
-  (s/assert ::us/uuid file-id)
-  (s/assert ::us/uuid library-id)
+  (assert (contains? #{:colors :components :typographies} asset-type))
+  (assert (or (nil? asset-id) (uuid? asset-id)))
+  (assert (uuid? file-id))
+  (assert (uuid? library-id))
 
   (container-log :info asset-id
                  :msg "Sync file with library"
@@ -510,10 +508,10 @@
   If an asset id is given, only shapes linked to this particular asset will
   be synchronized."
   [changes file-id asset-type asset-id library-id libraries current-file-id]
-  (s/assert #{:colors :components :typographies} asset-type)
-  (s/assert (s/nilable ::us/uuid) asset-id)
-  (s/assert ::us/uuid file-id)
-  (s/assert ::us/uuid library-id)
+  (assert (contains? #{:colors :components :typographies} asset-type))
+  (assert (or (nil? asset-id) (uuid? asset-id)))
+  (assert (uuid? file-id))
+  (assert (uuid? library-id))
 
   (container-log :info asset-id
                  :msg "Sync local components with library"

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -8,6 +8,8 @@
   (:refer-clojure :exclude [deref merge parse-uuid parse-long parse-double parse-boolean type keys])
   #?(:cljs (:require-macros [app.common.schema :refer [ignoring]]))
   (:require
+   #?(:clj [malli.dev.pretty :as mdp])
+   #?(:clj [malli.dev.virhe :as v])
    [app.common.data :as d]
    [app.common.math :as mth]
    [app.common.pprint :as pp]
@@ -19,8 +21,6 @@
    [clojure.core :as c]
    [cuerdas.core :as str]
    [malli.core :as m]
-   [malli.dev.pretty :as mdp]
-   [malli.dev.virhe :as v]
    [malli.error :as me]
    [malli.generator :as mg]
    [malli.registry :as mr]
@@ -245,27 +245,30 @@
                                      :level (d/nilv level 8)
                                      :length (d/nilv length 12)})))))
 
-(defmethod v/-format ::schemaless-explain
-  [_ explanation printer]
-  {:body [:group
-          (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
-          (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer)]})
+#?(:clj
+   (defmethod v/-format ::schemaless-explain
+     [_ explanation printer]
+     {:body [:group
+             (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
+             (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer)]}))
 
-(defmethod v/-format ::explain
-  [_ {:keys [schema] :as explanation} printer]
-  {:body [:group
-          (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
-          (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer) :break :break
-          (v/-block "Schema" (v/-visit schema printer) printer)]})
+#?(:clj
+   (defmethod v/-format ::explain
+     [_ {:keys [schema] :as explanation} printer]
+     {:body [:group
+             (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
+             (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer) :break :break
+             (v/-block "Schema" (v/-visit schema printer) printer)]}))
 
-(defn pretty-explain
-  "A helper that allows print a console-friendly output for the
-  explain; should not be used for other purposes"
-  [explain & {:keys [variant message]
-              :or {variant ::explain
-                   message "Validation Error"}}]
-  (let [explain (fn [] (me/with-error-messages explain))]
-    ((mdp/prettifier variant message explain default-options))))
+#?(:clj
+   (defn pretty-explain
+     "A helper that allows print a console-friendly output for the explain;
+  should not be used for other purposes"
+     [explain & {:keys [variant message]
+                 :or {variant ::explain
+                      message "Validation Error"}}]
+     (let [explain (fn [] (me/with-error-messages explain))]
+       ((mdp/prettifier variant message explain default-options)))))
 
 (defmacro ignoring
   [expr]

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -1003,6 +1003,9 @@
 (def valid-safe-number?
   (lazy-validator ::safe-number))
 
+(def valid-safe-int?
+  (lazy-validator ::safe-int))
+
 (def valid-text?
   (validator ::text))
 

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -299,6 +299,13 @@
                                   ::explain explain}))))
         value))))
 
+(defn coercer
+  [schema & {:as opts}]
+  (let [decode-fn (decoder schema json-transformer)
+        check-fn  (check-fn schema opts)]
+    (fn [data]
+      (-> data decode-fn check-fn))))
+
 (defn check
   "A helper intended to be used on assertions for validate/check the
   schema over provided data. Raises an assertion exception.

--- a/frontend/deps.edn
+++ b/frontend/deps.edn
@@ -20,8 +20,8 @@
    :git/url "https://github.com/funcool/beicon.git"}
 
   funcool/rumext
-  {:git/tag "v2.24"
-   :git/sha "17a0c94"
+  {:git/tag "v2.25"
+   :git/sha "27e5a1a"
    :git/url "https://github.com/funcool/rumext.git"}
 
   instaparse/instaparse {:mvn/version "1.5.0"}
@@ -42,7 +42,7 @@
   :dev
   {:extra-paths ["dev"]
    :extra-deps
-   {thheller/shadow-cljs {:mvn/version "3.2.0"}
+   {thheller/shadow-cljs {:mvn/version "3.2.2"}
     com.bhauman/rebel-readline {:mvn/version "RELEASE"}
     org.clojure/tools.namespace {:mvn/version "RELEASE"}
     criterium/criterium {:mvn/version "RELEASE"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,9 +45,9 @@
     "translations": "node ./scripts/translations.js",
     "watch:app:assets": "node ./scripts/watch.js",
     "watch:app:libs": "node ./scripts/build-libs.js --watch",
-    "watch:app:main": "clojure -M:dev:shadow-cljs watch main storybook",
+    "watch:app:main": "clojure -M:dev:shadow-cljs watch main worker storybook",
     "clear:shadow-cache": "rm -rf .shadow-cljs",
-    "watch:app": "yarn run clear:shadow-cache && yarn run build:app:worker && concurrently \"yarn run watch:app:main\" \"yarn run watch:app:libs\"",
+    "watch:app": "yarn run clear:shadow-cache && concurrently \"yarn run watch:app:main\" \"yarn run watch:app:libs\"",
     "watch": "yarn run watch:app:assets",
     "watch:storybook": "yarn run build:storybook:assets && concurrently \"storybook dev -p 6006 --no-open\" \"yarn run watch:storybook:assets\"",
     "watch:storybook:assets": "node ./scripts/watch-storybook.js"

--- a/frontend/playwright/ui/pages/BasePage.js
+++ b/frontend/playwright/ui/pages/BasePage.js
@@ -73,7 +73,7 @@ export class BasePage {
   }
 
   static async mockConfigFlags(page, flags) {
-    const url = "**/js/config.js?ts=*";
+    const url = "**/js/config.js";
     return await page.route(url, (route) =>
       route.fulfill({
         status: 200,

--- a/frontend/resources/templates/index.mustache
+++ b/frontend/resources/templates/index.mustache
@@ -25,14 +25,14 @@
     <link rel="icon" href="images/favicon.png" />
     {{# manifest}}
     <script>window.penpotWorkerURI="{{& worker_main}}"</script>
-    <script defer src="{{& config}}"></script>
-    <script defer src="{{& polyfills}}"></script>
+    <script src="{{& config}}"></script>
+    <script src="{{& polyfills}}"></script>
     {{/manifest}}
 
-    <script>
-      window.penpotTranslations = JSON.parse({{& translations}});
-      window.penpotVersion = "%version%";
-      window.penpotBuildDate = "%buildDate%";
+    <script type="module">
+      globalThis.penpotTranslations = JSON.parse({{& translations}});
+      globalThis.penpotVersion = "%version%";
+      globalThis.penpotBuildDate = "%buildDate%";
     </script>
     <!--cookie-consent-->
   </head>
@@ -44,9 +44,11 @@
     <section id="modal"></section>
 
     {{# manifest}}
-    <script defer src="js/libs.js?ts={{& ts}}"></script>
-    <script defer src="{{& shared}}"></script>
-    <script defer src="{{& main}}"></script>
+    <script type="module" src="{{& libs}}"></script>
+    <script type="module">
+      import { init } from "{{& main}}";
+      init();
+    </script>
     {{/manifest}}
   </body>
 </html>

--- a/frontend/resources/templates/rasterizer.mustache
+++ b/frontend/resources/templates/rasterizer.mustache
@@ -19,9 +19,11 @@
   </head>
   <body>
     {{# manifest}}
-    <script src="js/libs.js?ts={{& ts}}"></script>
-    <script src="{{& shared}}"></script>
-    <script src="{{& rasterizer}}"></script>
+    <script type="module" src="{{& libs}}"></script>
+    <script type="module">
+      import { init } from "{{& rasterizer}}";
+      init();
+    </script>
     {{/manifest}}
   </body>
 </html>

--- a/frontend/resources/templates/render.mustache
+++ b/frontend/resources/templates/render.mustache
@@ -18,9 +18,11 @@
   <body>
     <div id="app"></div>
     {{# manifest}}
-    <script src="js/libs.js?ts={{& ts}}"></script>
-    <script src="{{& shared}}"></script>
-    <script src="{{& render}}"></script>
+    <script type="module" src="{{& libs}}"></script>
+    <script type="module">
+      import { init } from "{{& render}}";
+      init();
+    </script>
     {{/manifest}}
   </body>
 </html>

--- a/frontend/scripts/_helpers.js
+++ b/frontend/scripts/_helpers.js
@@ -193,26 +193,30 @@ async function readShadowManifest() {
 
     const index = {
       ts: ts,
-      config: "js/config.js?ts=" + ts,
-      polyfills: "js/polyfills.js?ts=" + ts,
-      worker_main: "js/worker/main.js?ts=" + ts,
+      config: "./js/config.js",
+      polyfills: "./js/polyfills.js",
+      worker_main: "./js/worker/main.js",
+      libs: "./js/libs.js",
     };
 
     for (let item of content) {
-      index[item.name] = "js/" + item["output-name"];
+      index[item.name] = "./js/" + item["output-name"] + "";
     }
 
     return index;
   } catch (cause) {
-    return {
+    const index = {
       ts: ts,
-      config: "js/config.js?ts=" + ts,
-      polyfills: "js/polyfills.js?ts=" + ts,
-      main: "js/main.js?ts=" + ts,
-      shared: "js/shared.js?ts=" + ts,
-      worker_main: "js/worker/main.js?ts=" + ts,
-      rasterizer: "js/rasterizer.js?ts=" + ts,
+      config: "./js/config.js",
+      polyfills: "./js/polyfills.js",
+      main: "./js/main.js",
+      shared: "./js/shared.js",
+      worker_main: "./js/worker/main.js",
+      rasterizer: "./js/rasterizer.js",
+      libs: "./js/libs.js",
     };
+
+    return index;
   }
 }
 

--- a/frontend/scripts/build
+++ b/frontend/scripts/build
@@ -26,7 +26,10 @@ yarn install || exit 1;
 rm -rf resources/public;
 rm -rf target/dist;
 
-yarn run build:app:main --config-merge "{:release-version \"${CURRENT_HASH}-${TS}\"}" $EXTRA_PARAMS || exit 1
+mkdir -p resources/public;
+mkdir -p target/dist;
+
+yarn run build:app:main $EXTRA_PARAMS || exit 1
 
 if [ "$INCLUDE_WASM" = "yes" ];  then
     yarn run build:wasm || exit 1;
@@ -35,18 +38,17 @@ fi
 yarn run build:app:libs || exit 1;
 yarn run build:app:assets || exit 1;
 
-mkdir -p target/dist;
-rsync -avr resources/public/ target/dist/
-
-sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./target/dist/index.html;
-sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./target/dist/render.html;
-sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./target/dist/rasterizer.html;
-sed -i -re "s/\%buildDate\%/$BUILD_DATE/g" ./target/dist/index.html;
-sed -i -re "s/\%buildDate\%/$BUILD_DATE/g" ./target/dist/rasterizer.html;
+sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./resources/public/index.html;
+sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./resources/public/render.html;
+sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./resources/public/rasterizer.html;
+sed -i -re "s/\%buildDate\%/$BUILD_DATE/g" ./resources/public/index.html;
+sed -i -re "s/\%buildDate\%/$BUILD_DATE/g" ./resources/public/rasterizer.html;
 
 if [ "$INCLUDE_WASM" = "yes" ];  then
-    sed -i "s/version=develop/version=$CURRENT_VERSION/g" ./target/dist/js/render_wasm.js;
+    sed -i "s/version=develop/version=$CURRENT_VERSION/g" ./resources/public/js/render_wasm.js;
 fi
+
+rsync -avr resources/public/ target/dist/;
 
 if [ "$INCLUDE_STORYBOOK" = "yes" ];  then
     # build storybook

--- a/frontend/scripts/build-libs.js
+++ b/frontend/scripts/build-libs.js
@@ -31,9 +31,9 @@ const rebuildNotify = {
 const config = {
   entryPoints: ["target/index.js"],
   bundle: true,
-  format: "iife",
+  format: "esm",
   banner: {
-    js: '"use strict"; var global = globalThis;',
+    js: '"use strict";\nvar global = globalThis;',
   },
   outfile: "resources/public/js/libs.js",
   plugins: [fixReactVirtualized, rebuildNotify],

--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -77,6 +77,7 @@
      :source-map true
      :elide-asserts true
      :anon-fn-naming-policy :off
+     :cross-chunk-method-motion false
      :source-map-detail-level :all}}}
 
   :worker

--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -6,13 +6,12 @@
 
  :builds
  {:main
-  {:target :browser
+  {:target :esm
    :output-dir "resources/public/js/"
    :asset-path "/js"
    :devtools {:watch-dir "resources/public"
               :reload-strategy :full}
    :build-options {:manifest-name "manifest.json"}
-   :module-loader true
    :modules
    {:shared
     {:entries []}
@@ -20,7 +19,7 @@
     :main
     {:entries [app.main app.plugins.api]
      :depends-on #{:shared}
-     :init-fn app.main/init}
+     :exports {init app.main/init}}
 
     :util-highlight
     {:entries [app.util.code-highlight]
@@ -50,12 +49,12 @@
     :render
     {:entries [app.render]
      :depends-on #{:shared}
-     :init-fn app.render/init}
+     :exports {init app.render/init}}
 
     :rasterizer
     {:entries [app.rasterizer]
      :depends-on #{:shared}
-     :init-fn app.rasterizer/init}}
+     :exports {init app.rasterizer/init}}}
 
    :js-options
    {:entry-keys ["module" "browser" "main"]
@@ -75,8 +74,6 @@
     :compiler-options
     {:fn-invoke-direct true
      :optimizations #shadow/env ["PENPOT_BUILD_OPTIMIZATIONS" :as :keyword :default :advanced]
-     :output-wrapper true
-     :rename-prefix-namespace "PENPOT"
      :source-map true
      :elide-asserts true
      :anon-fn-naming-policy :off

--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -8,7 +8,6 @@
   (:require
    [app.common.data :as d]
    [app.common.schema :as sm]
-   [app.common.spec :as us]
    [app.common.types.profile :refer [schema:profile]]
    [app.common.uuid :as uuid]
    [app.config :as cf]
@@ -484,7 +483,7 @@
 
 (defn delete-access-token
   [{:keys [id] :as params}]
-  (us/assert! ::us/uuid id)
+  (assert (uuid? id))
   (ptk/reify ::delete-access-token
     ptk/WatchEvent
     (watch [_ _ _]

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -31,27 +31,28 @@
    [app.main.ui.static :as static]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
+   [app.util.modules :as mod]
    [app.util.theme :as theme]
    [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (def auth-page
-  (mf/lazy-component app.main.ui.auth/auth))
+  (mf/lazy #(mod/load 'app.main.ui.auth/auth-page*)))
 
-(def verify-token-page
-  (mf/lazy-component app.main.ui.auth.verify-token/verify-token))
+(def verify-token-page*
+  (mf/lazy #(mod/load 'app.main.ui.auth.verify-token/verify-token-page*)))
 
 (def viewer-page*
-  (mf/lazy-component app.main.ui.viewer/viewer*))
+  (mf/lazy #(mod/load 'app.main.ui.viewer/viewer-page*)))
 
 (def dashboard-page*
-  (mf/lazy-component app.main.ui.dashboard/dashboard*))
+  (mf/lazy #(mod/load 'app.main.ui.dashboard/dashboard-page*)))
 
 (def settings-page*
-  (mf/lazy-component app.main.ui.settings/settings*))
+  (mf/lazy #(mod/load 'app.main.ui.settings/settings-page*)))
 
 (def workspace-page*
-  (mf/lazy-component app.main.ui.workspace/workspace*))
+  (mf/lazy #(mod/load 'app.main.ui.workspace/workspace-page*)))
 
 (mf/defc workspace-legacy-redirect*
   {::mf/props :obj
@@ -189,7 +190,7 @@
        [:? [:& auth-page {:route route}]]
 
        :auth-verify-token
-       [:? [:& verify-token-page {:route route}]]
+       [:? [:& verify-token-page* {:route route}]]
 
        (:settings-profile
         :settings-password

--- a/frontend/src/app/main/ui/auth.cljs
+++ b/frontend/src/app/main/ui/auth.cljs
@@ -19,8 +19,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(mf/defc auth
-  {::mf/props :obj}
+(mf/defc auth*
   [{:keys [route]}]
   (let [section (dm/get-in route [:data :name])
         is-register (or
@@ -69,3 +68,9 @@
 
       (when (= section :auth-register)
         [:& terms-register])]]))
+
+
+(mf/defc auth-page*
+  {::mf/lazy-load true}
+  [props]
+  [:> auth* props])

--- a/frontend/src/app/main/ui/auth/verify_token.cljs
+++ b/frontend/src/app/main/ui/auth/verify_token.cljs
@@ -61,9 +61,9 @@
    (rt/nav :auth-login)
    (ntf/warn (tr "errors.unexpected-token"))))
 
-(mf/defc verify-token
-  [{:keys [route] :as props}]
-  (let [token (get-in route [:query-params :token])
+(mf/defc verify-token*
+  [{:keys [route]}]
+  (let [token     (get-in route [:query-params :token])
         bad-token (mf/use-state false)]
 
     (mf/with-effect []
@@ -99,3 +99,8 @@
       [:> static/invalid-token {}]
       [:> loader*  {:title (tr "labels.loading")
                     :overlay true}])))
+
+(mf/defc verify-token-page*
+  {::mf/lazy-load true}
+  [props]
+  [:> verify-token* props])

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -247,7 +247,6 @@
           (swap! storage/session dissoc :template))))))
 
 (mf/defc dashboard*
-  {::mf/props :obj}
   [{:keys [profile project-id team-id search-term plugin-url template section]}]
   (let [team            (mf/deref refs/team)
         projects        (mf/deref refs/projects)
@@ -313,3 +312,8 @@
         :section section
         :search-term search-term
         :team team}]]]))
+
+(mf/defc dashboard-page*
+  {::mf/lazy-load true}
+  [props]
+  [:> dashboard* props])

--- a/frontend/src/app/main/ui/settings.cljs
+++ b/frontend/src/app/main/ui/settings.cljs
@@ -78,3 +78,9 @@
 
           :settings-notifications
           [:& notifications-page* {:profile profile}])]]]]))
+
+(mf/defc settings-page*
+  {::mf/lazy-load true}
+  [props]
+  [:> settings* props])
+

--- a/frontend/src/app/main/ui/viewer.cljs
+++ b/frontend/src/app/main/ui/viewer.cljs
@@ -624,7 +624,6 @@
 ;; --- Component: Viewer
 
 (mf/defc viewer*
-  {::mf/props :obj}
   [{:keys [file-id share-id page-id] :as props}]
   (mf/with-effect [file-id page-id share-id]
     (let [params {:file-id file-id
@@ -643,3 +642,8 @@
     [:> loader*  {:title (tr "labels.loading")
                   :overlay true}]))
 
+
+(mf/defc viewer-page*
+  {::mf/lazy-load true}
+  [props]
+  [:> viewer* props])

--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -165,7 +165,7 @@
                    (dsh/lookup-page state file-id page-id))))
              st/state))
 
-(mf/defc workspace-page*
+(mf/defc workspace-inner*
   {::mf/private true}
   [{:keys [page-id file-id file layout wglobal]}]
   (let [page-ref (mf/with-memo [file-id page-id]
@@ -252,10 +252,16 @@
                             :touch-action "none"}}
           [:> context-menu*]
           (if (and file-loaded? page-id)
-            [:> workspace-page*
+            [:> workspace-inner*
              {:page-id page-id
               :file-id file-id
               :file file
               :wglobal wglobal
               :layout layout}]
             [:> workspace-loader*])]]]]]]))
+
+(mf/defc workspace-page*
+  {::mf/lazy-load true}
+  [props]
+  [:> workspace* props])
+

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -11,7 +11,6 @@
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.path-names :as cpn]
-   [app.common.spec :as us]
    [app.common.thumbnails :as thc]
    [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
@@ -38,7 +37,6 @@
    [app.util.i18n :as i18n :refer [c tr]]
    [app.util.strings :refer [matches-search]]
    [app.util.timers :as ts]
-   [cljs.spec.alpha :as s]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -96,10 +94,6 @@
       (cpn/join-path)
       (str (str/slice (:path asset) (count path)))
       (cpn/merge-path-item (:name asset))))
-
-(s/def ::asset-name ::us/not-empty-string)
-(s/def ::name-group-form
-  (s/keys :req-un [::asset-name]))
 
 (def initial-context-menu-state
   {:open? false :top nil :left nil})

--- a/frontend/src/app/plugins/comments.cljs
+++ b/frontend/src/app/plugins/comments.cljs
@@ -7,7 +7,7 @@
 (ns app.plugins.comments
   (:require
    [app.common.geom.point :as gpt]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.main.data.comments :as dc]
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace.comments :as dwc]
@@ -118,7 +118,8 @@
        (fn [position]
          (let [position (parser/parse-point position)]
            (cond
-             (or (not (us/safe-number? (:x position))) (not (us/safe-number? (:y position))))
+             (or (not (sm/valid-safe-number? (:x position)))
+                 (not (sm/valid-safe-number? (:y position))))
              (u/display-not-valid :position "Not valid point")
 
              (not (r/check-permission plugin-id "comment:write"))

--- a/frontend/src/app/plugins/flex.cljs
+++ b/frontend/src/app/plugins/flex.cljs
@@ -7,7 +7,7 @@
 (ns app.plugins.flex
   (:require
    [app.common.data :as d]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.common.types.shape.layout :as ctl]
    [app.main.data.workspace.shape-layout :as dwsl]
    [app.main.data.workspace.transforms :as dwt]
@@ -133,7 +133,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :rowGap value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -148,7 +148,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :columnGap value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -163,7 +163,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :verticalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -178,7 +178,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :horizontalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -194,7 +194,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :topPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -209,7 +209,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :rightPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -224,7 +224,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :bottomPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -239,7 +239,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :leftPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -296,7 +296,7 @@
      :set
      (fn [_ value]
        (cond
-         (us/safe-int? value)
+         (sm/valid-safe-int? value)
          (u/display-not-valid :zIndex value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -359,7 +359,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :verticalMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -374,7 +374,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :horizontalMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -389,7 +389,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :topMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -404,7 +404,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :rightMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -419,7 +419,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :bottomMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -434,7 +434,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :leftMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -449,7 +449,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :maxWidth value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -464,7 +464,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :minWidth value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -479,7 +479,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :maxHeight value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -494,7 +494,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :minHeight value)
 
          (not (r/check-permission plugin-id "content:write"))

--- a/frontend/src/app/plugins/grid.cljs
+++ b/frontend/src/app/plugins/grid.cljs
@@ -7,7 +7,7 @@
 (ns app.plugins.grid
   (:require
    [app.common.data :as d]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.common.types.shape.layout :as ctl]
    [app.main.data.workspace.shape-layout :as dwsl]
    [app.main.data.workspace.transforms :as dwt]
@@ -126,7 +126,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :rowGap value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -141,7 +141,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :columnGap value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -156,7 +156,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :verticalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -171,7 +171,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :horizontalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -186,7 +186,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :topPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -201,7 +201,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :rightPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -216,7 +216,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :bottomPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -231,7 +231,7 @@
      :set
      (fn [_ value]
        (cond
-         (not (us/safe-int? value))
+         (not (sm/valid-safe-int? value))
          (u/display-not-valid :leftPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
@@ -248,7 +248,7 @@
           (u/display-not-valid :addRow-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
-               (not (us/safe-number? value)))
+               (not (sm/valid-safe-number? value)))
           (u/display-not-valid :addRow-value value)
 
           (not (r/check-permission plugin-id "content:write"))
@@ -261,14 +261,14 @@
     (fn [index type value]
       (let [type (keyword type)]
         (cond
-          (not (us/safe-int? index))
+          (not (sm/valid-safe-int? index))
           (u/display-not-valid :addRowAtIndex-index index)
 
           (not (contains? ctl/grid-track-types type))
           (u/display-not-valid :addRowAtIndex-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
-               (not (us/safe-number? value)))
+               (not (sm/valid-safe-number? value)))
           (u/display-not-valid :addRowAtIndex-value value)
 
           (not (r/check-permission plugin-id "content:write"))
@@ -285,7 +285,7 @@
           (u/display-not-valid :addColumn-type type)
 
           (and (or (= :percent type) (= :flex type) (= :lex type))
-               (not (us/safe-number? value)))
+               (not (sm/valid-safe-number? value)))
           (u/display-not-valid :addColumn-value value)
 
           (not (r/check-permission plugin-id "content:write"))
@@ -297,14 +297,14 @@
     :addColumnAtIndex
     (fn [index type value]
       (cond
-        (not (us/safe-int? index))
+        (not (sm/valid-safe-int? index))
         (u/display-not-valid :addColumnAtIndex-index index)
 
         (not (contains? ctl/grid-track-types type))
         (u/display-not-valid :addColumnAtIndex-type type)
 
         (and (or (= :percent type) (= :flex type) (= :fixed type))
-             (not (us/safe-number? value)))
+             (not (sm/valid-safe-number? value)))
         (u/display-not-valid :addColumnAtIndex-value value)
 
         (not (r/check-permission plugin-id "content:write"))
@@ -317,7 +317,7 @@
     :removeRow
     (fn [index]
       (cond
-        (not (us/safe-int? index))
+        (not (sm/valid-safe-int? index))
         (u/display-not-valid :removeRow index)
 
         (not (r/check-permission plugin-id "content:write"))
@@ -329,7 +329,7 @@
     :removeColumn
     (fn [index]
       (cond
-        (not (us/safe-int? index))
+        (not (sm/valid-safe-int? index))
         (u/display-not-valid :removeColumn index)
 
         (not (r/check-permission plugin-id "content:write"))
@@ -342,14 +342,14 @@
     (fn [index type value]
       (let [type (keyword type)]
         (cond
-          (not (us/safe-int? index))
+          (not (sm/valid-safe-int? index))
           (u/display-not-valid :setColumn-index index)
 
           (not (contains? ctl/grid-track-types type))
           (u/display-not-valid :setColumn-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
-               (not (us/safe-number? value)))
+               (not (sm/valid-safe-number? value)))
           (u/display-not-valid :setColumn-value value)
 
           (not (r/check-permission plugin-id "content:write"))
@@ -362,14 +362,14 @@
     (fn [index type value]
       (let [type (keyword type)]
         (cond
-          (not (us/safe-int? index))
+          (not (sm/valid-safe-int? index))
           (u/display-not-valid :setRow-index index)
 
           (not (contains? ctl/grid-track-types type))
           (u/display-not-valid :setRow-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
-               (not (us/safe-number? value)))
+               (not (sm/valid-safe-number? value)))
           (u/display-not-valid :setRow-value value)
 
           (not (r/check-permission plugin-id "content:write"))
@@ -393,10 +393,10 @@
         (not (shape-proxy? child))
         (u/display-not-valid :appendChild-child child)
 
-        (or (< row 0) (not (us/safe-int? row)))
+        (or (< row 0) (not (sm/valid-safe-int? row)))
         (u/display-not-valid :appendChild-row row)
 
-        (or (< column 0) (not (us/safe-int? column)))
+        (or (< column 0) (not (sm/valid-safe-int? column)))
         (u/display-not-valid :appendChild-column column)
 
         (not (r/check-permission plugin-id "content:write"))
@@ -431,7 +431,7 @@
          (let [cell (locate-cell self)
                shape (u/proxy->shape self)]
            (cond
-             (not (us/safe-int? value))
+             (not (sm/valid-safe-int? value))
              (u/display-not-valid :row-value value)
 
              (nil? cell)
@@ -451,7 +451,7 @@
          (let [shape (u/proxy->shape self)
                cell (locate-cell self)]
            (cond
-             (not (us/safe-int? value))
+             (not (sm/valid-safe-int? value))
              (u/display-not-valid :rowSpan-value value)
 
              (nil? cell)
@@ -471,7 +471,7 @@
          (let [shape (u/proxy->shape self)
                cell (locate-cell self)]
            (cond
-             (not (us/safe-int? value))
+             (not (sm/valid-safe-int? value))
              (u/display-not-valid :column-value value)
 
              (nil? cell)
@@ -491,7 +491,7 @@
          (let [shape (u/proxy->shape self)
                cell (locate-cell self)]
            (cond
-             (not (us/safe-int? value))
+             (not (sm/valid-safe-int? value))
              (u/display-not-valid :columnSpan-value value)
 
              (nil? cell)

--- a/frontend/src/app/plugins/page.cljs
+++ b/frontend/src/app/plugins/page.cljs
@@ -10,7 +10,7 @@
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.geom.point :as gpt]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.common.types.color :as cc]
    [app.common.uuid :as uuid]
    [app.main.data.comments :as dc]
@@ -299,7 +299,7 @@
     (fn [orientation value board]
       (let [shape (u/proxy->shape board)]
         (cond
-          (not (us/safe-number? value))
+          (not (sm/valid-safe-number? value))
           (u/display-not-valid :addRulerGuide "Value not a safe number")
 
           (not (contains? #{"vertical" "horizontal"} orientation))
@@ -345,8 +345,8 @@
           (or (not (string? content)) (empty? content))
           (u/display-not-valid :addCommentThread "Content not valid")
 
-          (or (not (us/safe-number? (:x position)))
-              (not (us/safe-number? (:y position))))
+          (or (not (sm/valid-safe-number? (:x position)))
+              (not (sm/valid-safe-number? (:y position))))
           (u/display-not-valid :addCommentThread "Position not valid")
 
           (and (some? board) (or (not (shape/shape-proxy? board)) (not (cfh/frame-shape? shape))))

--- a/frontend/src/app/plugins/ruler_guides.cljs
+++ b/frontend/src/app/plugins/ruler_guides.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.main.data.workspace.guides :as dwgu]
    [app.main.store :as st]
    [app.plugins.format :as format]
@@ -77,7 +77,7 @@
      :set
      (fn [self value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :position "Not valid position")
 
          (not (r/check-permission plugin-id "content:write"))

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -14,7 +14,6 @@
    [app.common.path-names :as cpn]
    [app.common.record :as crc]
    [app.common.schema :as sm]
-   [app.common.spec :as us]
    [app.common.svg.path :as svg.path]
    [app.common.types.color :as clr]
    [app.common.types.component :as ctk]
@@ -325,7 +324,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (or (not (us/safe-int? value)) (< value 0))
+                  (or (not (sm/valid-safe-int? value)) (< value 0))
                   (u/display-not-valid :borderRadius value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -341,7 +340,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (not (us/safe-int? value))
+                  (not (sm/valid-safe-int? value))
                   (u/display-not-valid :borderRadiusTopLeft value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -357,7 +356,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (not (us/safe-int? value))
+                  (not (sm/valid-safe-int? value))
                   (u/display-not-valid :borderRadiusTopRight value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -373,7 +372,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (not (us/safe-int? value))
+                  (not (sm/valid-safe-int? value))
                   (u/display-not-valid :borderRadiusBottomRight value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -389,7 +388,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (not (us/safe-int? value))
+                  (not (sm/valid-safe-int? value))
                   (u/display-not-valid :borderRadiusBottomLeft value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -405,7 +404,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (or (not (us/safe-number? value)) (< value 0) (> value 1))
+                  (or (not (sm/valid-safe-number? value)) (< value 0) (> value 1))
                   (u/display-not-valid :opacity value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -492,7 +491,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (not (us/safe-number? value))
+                  (not (sm/valid-safe-number? value))
                   (u/display-not-valid :x value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -510,7 +509,7 @@
             (fn [self value]
               (let [id (obj/get self "$id")]
                 (cond
-                  (not (us/safe-number? value))
+                  (not (sm/valid-safe-number? value))
                   (u/display-not-valid :y value)
 
                   (not (r/check-permission plugin-id "content:write"))
@@ -555,7 +554,7 @@
             :set
             (fn [self value]
               (cond
-                (not (us/safe-number? value))
+                (not (sm/valid-safe-number? value))
                 (u/display-not-valid :parentX value)
 
                 (not (r/check-permission plugin-id "content:write"))
@@ -582,7 +581,7 @@
             :set
             (fn [self value]
               (cond
-                (not (us/safe-number? value))
+                (not (sm/valid-safe-number? value))
                 (u/display-not-valid :parentY value)
 
                 (not (r/check-permission plugin-id "content:write"))
@@ -609,7 +608,7 @@
             :set
             (fn [self value]
               (cond
-                (not (us/safe-number? value))
+                (not (sm/valid-safe-number? value))
                 (u/display-not-valid :frameX value)
 
                 (not (r/check-permission plugin-id "content:write"))
@@ -636,7 +635,7 @@
             :set
             (fn [self value]
               (cond
-                (not (us/safe-number? value))
+                (not (sm/valid-safe-number? value))
                 (u/display-not-valid :frameY value)
 
                 (not (r/check-permission plugin-id "content:write"))
@@ -795,10 +794,10 @@
            :resize
            (fn [width height]
              (cond
-               (or (not (us/safe-number? width)) (<= width 0))
+               (or (not (sm/valid-safe-number? width)) (<= width 0))
                (u/display-not-valid :resize width)
 
-               (or (not (us/safe-number? height)) (<= height 0))
+               (or (not (sm/valid-safe-number? height)) (<= height 0))
                (u/display-not-valid :resize height)
 
                (not (r/check-permission plugin-id "content:write"))
@@ -1048,10 +1047,10 @@
                  (not (cfh/text-shape? shape))
                  (u/display-not-valid :getRange-shape "shape is not text")
 
-                 (or (not (us/safe-int? start)) (< start 0) (> start end))
+                 (or (not (sm/valid-safe-int? start)) (< start 0) (> start end))
                  (u/display-not-valid :getRange-start start)
 
-                 (not (us/safe-int? end))
+                 (not (sm/valid-safe-int? end))
                  (u/display-not-valid :getRange-end end)
 
                  :else
@@ -1078,7 +1077,7 @@
            :setParentIndex
            (fn [index]
              (cond
-               (not (us/safe-int? index))
+               (not (sm/valid-safe-int? index))
                (u/display-not-valid :setParentIndex index)
 
                (not (r/check-permission plugin-id "content:write"))
@@ -1230,7 +1229,7 @@
            (fn [orientation value]
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
-                 (not (us/safe-number? value))
+                 (not (sm/valid-safe-number? value))
                  (u/display-not-valid :addRulerGuide "Value not a safe number")
 
                  (not (contains? #{"vertical" "horizontal"} orientation))

--- a/frontend/src/app/plugins/viewport.cljs
+++ b/frontend/src/app/plugins/viewport.cljs
@@ -7,7 +7,7 @@
 (ns app.plugins.viewport
   (:require
    [app.common.data.macros :as dm]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.main.data.workspace.viewport :as dwv]
    [app.main.data.workspace.zoom :as dwz]
    [app.main.store :as st]
@@ -37,10 +37,10 @@
        (let [new-x (obj/get value "x")
              new-y (obj/get value "y")]
          (cond
-           (not (us/safe-number? new-x))
+           (not (sm/valid-safe-number? new-x))
            (u/display-not-valid :center-x new-x)
 
-           (not (us/safe-number? new-y))
+           (not (sm/valid-safe-number? new-y))
            (u/display-not-valid :center-y new-y)
 
            :else
@@ -62,7 +62,7 @@
      :set
      (fn [value]
        (cond
-         (not (us/safe-number? value))
+         (not (sm/valid-safe-number? value))
          (u/display-not-valid :zoom value)
 
          :else

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -40,6 +40,7 @@
    [app.util.debug :as dbg]
    [app.util.functions :as fns]
    [app.util.globals :as ug]
+   [app.util.modules :as mod]
    [app.util.text.content :as tc]
    [beicon.v2.core :as rx]
    [promesa.core :as p]
@@ -1361,7 +1362,7 @@
   (delay
     (if (exists? js/dynamicImport)
       (let [uri (cf/resolve-static-asset "js/render_wasm.js")]
-        (->> (js/dynamicImport (str uri))
+        (->> (mod/import uri)
              (p/mcat init-wasm-module)
              (p/fmap
               (fn [default]

--- a/frontend/src/app/util/globals.js
+++ b/frontend/src/app/util/globals.js
@@ -20,7 +20,7 @@ goog.provide("app.util.globals");
 goog.scope(function () {
   var self = app.util.globals;
 
-  self.global = goog.global;
+  self.global = globalThis;
 
   function createMockedEventEmitter(k) {
     /* Allow mocked objects to be event emitters, so other modules

--- a/frontend/src/app/util/i18n.cljs
+++ b/frontend/src/app/util/i18n.cljs
@@ -92,8 +92,9 @@
   is executed in the critical part (application bootstrap) and used in
   many parts of the application."
   [data]
-  (reset! locale (or (get storage/global ::locale) (autodetect)))
-  (set! translations data))
+  (set! translations data)
+  (reset! locale (or (get storage/global ::locale) (autodetect))))
+
 
 (defn set-locale!
   [lname]

--- a/frontend/src/app/util/modules.clj
+++ b/frontend/src/app/util/modules.clj
@@ -1,0 +1,17 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.util.modules
+  (:refer-clojure :exclude [load resolve]))
+
+(defmacro load
+  [thing]
+  `(-> (shadow.esm/load-by-name ~thing)
+       (.then (fn [f#] (cljs.core/js-obj "default" (f#))))))
+
+(defmacro load-fn
+  [thing]
+  `(shadow.esm/load-by-name ~thing))

--- a/frontend/src/app/util/modules.cljs
+++ b/frontend/src/app/util/modules.cljs
@@ -4,13 +4,13 @@
 ;;
 ;; Copyright (c) KALEIDOS INC
 
-(ns app.util.code-highlight
+(ns app.util.modules
+  (:refer-clojure :exclude [import])
+  (:require-macros [app.util.modules])
   (:require
-   ["@penpot/hljs" :as hljs]
-   [app.util.dom :as dom]))
+   [shadow.esm :refer [dynamic-import]]))
 
-(defn highlight!
-  {:lazy-loadable true}
-  [node]
-  (dom/set-data! node "highlighted" nil)
-  (hljs/highlightElement node))
+(defn import
+  "Dynamic esm module import import"
+  [path]
+  (dynamic-import (str path)))

--- a/frontend/src/app/util/worker.cljs
+++ b/frontend/src/app/util/worker.cljs
@@ -101,8 +101,8 @@
               (rx/push! bus message))))
 
         handle-error
-        (fn [error]
-          (on-error worker (.-data error)))]
+        (fn [event]
+          (on-error worker (.-data event)))]
 
     (.addEventListener instance "message" handle-message)
     (.addEventListener instance "error" handle-error)

--- a/frontend/src/app/worker/thumbnails.cljs
+++ b/frontend/src/app/worker/thumbnails.cljs
@@ -20,12 +20,12 @@
    [app.render-wasm.api :as wasm.api]
    [app.render-wasm.wasm :as wasm]
    [app.util.http :as http]
+   [app.util.modules :as mod]
    [app.worker.impl :as impl]
    [beicon.v2.core :as rx]
    [okulary.core :as l]
    [promesa.core :as p]
-   [rumext.v2 :as mf]
-   [shadow.esm :refer (dynamic-import)]))
+   [rumext.v2 :as mf]))
 
 (log/set-level! :trace)
 
@@ -101,7 +101,7 @@
 (def init-wasm
   (delay
     (let [uri (cf/resolve-static-asset "js/render_wasm.js")]
-      (-> (dynamic-import (str uri))
+      (-> (mod/import (str uri))
           (p/then #(wasm.api/init-wasm-module %))
           (p/then #(set! wasm/internal-module %))))))
 


### PR DESCRIPTION
## Summary

Unify all build targets to the most modern one: ESM. Now, worker and applitation compiles to an ESM module and can use more easily ESM dynamic imports from the code without workarounds.

This PR also comes with config simplification for nginx, firstly applied to devenv but later will need to be migrated to our production/deployment configuration files and docker images configuration files (will come in a separate PR).

**MERGE with REBASE** because several commits should be backported to `staging`

## Technical details

You can observe that this PR adds small components like this: 
<img width="677" height="135" alt="image" src="https://github.com/user-attachments/assets/df9709f1-b315-450f-88d0-0f094863afcf" />

This is because the  `React.lazy` (`mf/lazy` with rumext) caches the promise once it is resolved. In development mode it generates the problem with hot reloading, but that only happens with the _entry pont_ components, so we create a small components just for be the entrypoint.

## How to test

You should be able to make clean build and penpot is still accessible in development and production builds