### PR TITLE
:bug: Fix svg attrs stroke-linecap stroke-linejoin fill-rule

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -468,14 +468,14 @@
   [attrs]
   (let [style (:style attrs)
         ;; Filter to only supported attributes
-        allowed-keys #{:fill :fillRule :strokeLinecap :strokeLinejoin}
+        allowed-keys #{:fill :fillRule :fill-rule :strokeLinecap :stroke-linecap :strokeLinejoin :stroke-linejoin}
         attrs (-> attrs
                   (dissoc :style)
                   (merge style)
                   (select-keys allowed-keys))
-        fill-rule       (-> attrs :fillRule sr/translate-fill-rule)
-        stroke-linecap  (-> attrs :strokeLinecap sr/translate-stroke-linecap)
-        stroke-linejoin (-> attrs :strokeLinejoin sr/translate-stroke-linejoin)
+        fill-rule       (or (-> attrs :fill-rule sr/translate-fill-rule) (-> attrs :fillRule sr/translate-fill-rule))
+        stroke-linecap  (or (-> attrs :stroke-linecap sr/translate-stroke-linecap) (-> attrs :strokeLinecap sr/translate-stroke-linecap))
+        stroke-linejoin (or (-> attrs :stroke-linejoin sr/translate-stroke-linejoin) (-> attrs :strokeLinejoin sr/translate-stroke-linejoin))
         fill-none       (= "none" (-> attrs :fill))]
     (h/call wasm/internal-module "_set_shape_svg_attrs" fill-rule stroke-linecap stroke-linejoin fill-none)))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12735

### Summary

This fixes rendering of some SVG attributes (`stroke-linecap`, `stroke-linejoin`, `fill-rule`)

<img width="820" height="232" alt="Screenshot 2025-11-25 at 9 56 36 AM" src="https://github.com/user-attachments/assets/329b2d4f-8052-49a6-b9c8-84a4a4c8e84f" />

### Steps to reproduce 

See Taiga ticket for sample file.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
