### PR TITLE
:bug: Fix text editor vertical align

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -313,15 +313,17 @@
           (let [{:keys [height]} (wasm.api/get-text-dimensions shape-id)
                 selrect-transform (mf/deref refs/workspace-selrect)
                 [selrect transform] (dsh/get-selrect selrect-transform shape)
-
+                selrect-height (:height selrect)
+                max-height (max height selrect-height)
                 valign (-> shape :content :vertical-align)
-
                 y (:y selrect)
-                y (case valign
-                    "bottom" (- y (- height (:height selrect)))
-                    "center" (- y (/ (- height (:height selrect)) 2))
+                y (if (> height selrect-height)
+                    (case valign
+                      "bottom" (- y (- height selrect-height))
+                      "center" (- y (/ (- height selrect-height) 2))
+                      "top"    y)
                     y)]
-            [(assoc selrect :y y :width (:width selrect) :height (max height (:height selrect))) transform])
+            [(assoc selrect :y y :width (:width selrect) :height max-height) transform])
 
           (let [bounds (gst/shape->rect shape)
                 x      (mth/min (dm/get-prop bounds :x)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12722

### Summary

<img width="1914" height="1047" alt="image" src="https://github.com/user-attachments/assets/ac6779d2-2bfd-4a72-a55d-52f6c2b85141" />

<img width="1914" height="1047" alt="image" src="https://github.com/user-attachments/assets/4bdf3c02-58e5-4dc8-8235-8ab792a6ed19" />

<img width="1914" height="1047" alt="image" src="https://github.com/user-attachments/assets/b2c37ebd-caae-4563-a8cf-87df05e4cbb7" />


### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
