### PR TITLE
:bug: Fix editor not using fallback fonts for selected text

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -33,6 +33,7 @@
    [app.util.object :as obj]
    [app.util.text.content :as content]
    [app.util.text.content.styles :as styles]
+   [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
 (defn get-contrast-color [background-color]
@@ -268,7 +269,7 @@
     "bottom" "flex-end"
     nil))
 
-;;
+
 ;; Text Editor Wrapper
 ;; This is an SVG element that wraps the HTML editor.
 ;;
@@ -280,6 +281,11 @@
   [{:keys [shape modifiers canvas-ref] :as props} _]
   (let [shape-id  (dm/get-prop shape :id)
         modifiers (dm/get-in modifiers [shape-id :modifiers])
+        fallback-fonts (wasm.api/get-fallback-fonts (:content shape) false)
+        fallback-families (map (fn [font]
+                                 (let [lang (str/replace (:font-id font) #"gfont\-noto\-sans\-" "")
+                                       lang (if (>= (count lang) 3) (str/capital lang) (str/upper lang))]
+                                   (str/concat "\"Noto Sans " lang "\""))) fallback-fonts)
 
         clip-id   (dm/str "text-edition-clip" shape-id)
 
@@ -341,7 +347,8 @@
           render-wasm?
           (obj/merge!
            #js {"--editor-container-width" (dm/str width "px")
-                "--editor-container-height" (dm/str height "px")})
+                "--editor-container-height" (dm/str height "px")
+                "--fallback-families" (dm/str (str/join ", " fallback-families))})
 
           (not render-wasm?)
           (obj/merge!

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -269,6 +269,11 @@
     "bottom" "flex-end"
     nil))
 
+(defn- font-family-from-font-id [font-id]
+  (if (str/includes? font-id "gfont-noto-sans")
+    (let [lang (str/replace font-id #"gfont\-noto\-sans\-" "")]
+      (if (>= (count lang) 3) (str/capital lang) (str/upper lang)))
+    "Noto Color Emoji"))
 
 ;; Text Editor Wrapper
 ;; This is an SVG element that wraps the HTML editor.
@@ -281,11 +286,10 @@
   [{:keys [shape modifiers canvas-ref] :as props} _]
   (let [shape-id  (dm/get-prop shape :id)
         modifiers (dm/get-in modifiers [shape-id :modifiers])
-        fallback-fonts (wasm.api/get-fallback-fonts (:content shape) false)
+
+        fallback-fonts (wasm.api/fonts-from-text-content (:content shape) false)
         fallback-families (map (fn [font]
-                                 (let [lang (str/replace (:font-id font) #"gfont\-noto\-sans\-" "")
-                                       lang (if (>= (count lang) 3) (str/capital lang) (str/upper lang))]
-                                   (str/concat "\"Noto Sans " lang "\""))) fallback-fonts)
+                                 (font-family-from-font-id (:font-id font))) fallback-fonts)
 
         clip-id   (dm/str "text-edition-clip" shape-id)
 

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -785,7 +785,7 @@
                     hidden)))
         shadows))
 
-(defn get-fallback-fonts [content write-text-content?]
+(defn fonts-from-text-content [content fallback-fonts-only?]
   (let [paragraph-set (first (get content :children))
         paragraphs    (get paragraph-set :children)
         total         (count paragraphs)]
@@ -806,7 +806,7 @@
                   langs  (t/collect-used-languages langs text)]
 
               ;; FIXME: this should probably be somewhere else
-              (when write-text-content? (t/write-shape-text spans paragraph text))
+              (when fallback-fonts-only? (t/write-shape-text spans paragraph text))
 
               (recur (inc index)
                      emoji?
@@ -818,7 +818,7 @@
                   (f/add-noto-fonts langs))
               fallback-fonts (filter #(get % :is-fallback) updated-fonts)]
 
-          fallback-fonts)))))
+          (if fallback-fonts-only? updated-fonts fallback-fonts))))))
 
 (defn set-shape-text-content
   "This function sets shape text content and returns a stream that loads the needed fonts asynchronously"
@@ -829,7 +829,7 @@
   (set-shape-vertical-align (get content :vertical-align))
 
   (let [fonts         (fonts/get-content-fonts content)
-        fallback-fonts (get-fallback-fonts content true)
+        fallback-fonts (fonts-from-text-content content true)
         all-fonts (concat fonts fallback-fonts)
         result (f/store-fonts shape-id all-fonts)]
     (f/load-fallback-fonts-for-editor! fallback-fonts)

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -785,19 +785,10 @@
                     hidden)))
         shadows))
 
-(defn set-shape-text-content
-  "This function sets shape text content and returns a stream that loads the needed fonts asynchronously"
-  [shape-id content]
-
-  (h/call wasm/internal-module "_clear_shape_text")
-
-  (set-shape-vertical-align (get content :vertical-align))
-
+(defn get-fallback-fonts [content write-text-content?]
   (let [paragraph-set (first (get content :children))
         paragraphs    (get paragraph-set :children)
-        fonts         (fonts/get-content-fonts content)
         total         (count paragraphs)]
-
     (loop [index  0
            emoji? false
            langs  #{}]
@@ -814,20 +805,36 @@
                   emoji? (if emoji? emoji? (t/contains-emoji? text))
                   langs  (t/collect-used-languages langs text)]
 
-              (t/write-shape-text spans paragraph text)
+              ;; FIXME: this should probably be somewhere else
+              (when write-text-content? (t/write-shape-text spans paragraph text))
+
               (recur (inc index)
                      emoji?
                      langs))))
 
         (let [updated-fonts
-              (-> fonts
+              (-> #{}
                   (cond-> ^boolean emoji? (f/add-emoji-font))
                   (f/add-noto-fonts langs))
-              result (f/store-fonts shape-id updated-fonts)]
+              fallback-fonts (filter #(get % :is-fallback) updated-fonts)]
 
-          (h/call wasm/internal-module "_update_shape_text_layout")
+          fallback-fonts)))))
 
-          result)))))
+(defn set-shape-text-content
+  "This function sets shape text content and returns a stream that loads the needed fonts asynchronously"
+  [shape-id content]
+
+  (h/call wasm/internal-module "_clear_shape_text")
+
+  (set-shape-vertical-align (get content :vertical-align))
+
+  (let [fonts         (fonts/get-content-fonts content)
+        fallback-fonts (get-fallback-fonts content true)
+        all-fonts (concat fonts fallback-fonts)
+        result (f/store-fonts shape-id all-fonts)]
+    (f/load-fallback-fonts-for-editor! fallback-fonts)
+    (h/call wasm/internal-module "_update_shape_text_layout")
+    result))
 
 (defn set-shape-grow-type
   [grow-type]

--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -266,6 +266,12 @@
 
     (store-font-id shape-id font-data asset-id emoji? fallback?)))
 
+;; FIXME: This is a temporary function to load the fallback fonts for the editor.
+;; Once we render the editor content within wasm, we can remove this function.
+(defn load-fallback-fonts-for-editor!
+  [fonts]
+  (doseq [font fonts]
+    (fonts/ensure-loaded! (:font-id font) (:font-variant-id font))))
 
 (defn store-fonts
   [shape-id fonts]

--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -283,7 +283,8 @@
                :font-variant-id "regular"
                :style 0
                :weight 400
-               :is-emoji true}))
+               :is-emoji true
+               :is-fallback true}))
 
 (def noto-fonts
   {:japanese    {:font-id "gfont-noto-sans-jp"      :font-variant-id "regular" :style 0 :weight 400 :is-fallback true}

--- a/frontend/src/app/util/text/content/styles.cljs
+++ b/frontend/src/app/util/text/content/styles.cljs
@@ -38,7 +38,7 @@
     (str v "px")
 
     (and (= k :font-family) (seq v))
-    (str/quote v)
+    (str/concat (str/quote v) ", var(--fallback-families)")
 
     :else
     v))
@@ -53,7 +53,7 @@
     (str/slice v 0 -2)
 
     (= k :font-family)
-    (str/unquote v)
+    (str/unquote (str/replace v ", var(--fallback-families)" ""))
 
     :else
     v))

--- a/frontend/src/app/util/text/content/styles.cljs
+++ b/frontend/src/app/util/text/content/styles.cljs
@@ -38,7 +38,8 @@
     (str v "px")
 
     (and (= k :font-family) (seq v))
-    (str/concat (str/quote v) ", var(--fallback-families)")
+    ;; pick just first family, avoid quoting twice, and add var(--fallback-families)
+    (str/concat (str/quote (str/unquote (first (str/split v ",")))) ", var(--fallback-families)")
 
     :else
     v))

--- a/frontend/text-editor/src/editor/content/dom/Style.js
+++ b/frontend/text-editor/src/editor/content/dom/Style.js
@@ -19,10 +19,14 @@ const DEFAULT_FONT_WEIGHT = "400";
  * @param {string} value
  */
 export function sanitizeFontFamily(value) {
-  if (value && value.length > 0 && !value.startsWith('"')) {
-    return `"${value}"`;
-  } else {
+  if (!value || value === "") {
+    return "var(--fallback-families)";
+  } else if (value.endsWith(" var(--fallback-families)")) {
     return value;
+  } else if (value.startsWith('"')) {
+    return `${value}, var(--fallback-families)`;
+  } else {
+    return `"${value}", var(--fallback-families)`;
   }
 }
 

--- a/frontend/text-editor/src/editor/content/dom/Style.js
+++ b/frontend/text-editor/src/editor/content/dom/Style.js
@@ -19,6 +19,23 @@ const DEFAULT_FONT_WEIGHT = "400";
  * @param {string} value
  */
 export function sanitizeFontFamily(value) {
+  // NOTE: This is a fix for a bug introduced earlier that have might modified the font-family in the model
+  // adding extra double quotes.
+  if (value && value.startsWith('""')) {
+    //remove the first and last quotes
+    value = value.slice(1).replace(/"([^"]*)$/, "$1");
+
+    // remove quotes from font-family in 1-word font-families
+    // and repeated values
+    value = [
+      ...new Set(
+        value
+          .split(", ")
+          .map((x) => (x.includes(" ") ? x : x.replace(/"/g, ""))),
+      ),
+    ].join(", ");
+  }
+
   if (!value || value === "") {
     return "var(--fallback-families)";
   } else if (value.endsWith(" var(--fallback-families)")) {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12719

### Summary

This makes the text editor to use our Noto Sans fallback fonts when displaying characters (i.e. when selecting a chunk of text) not available in the user selected font family.

<img width="769" height="184" alt="Screenshot 2025-11-27 at 10 23 13 AM" src="https://github.com/user-attachments/assets/ad8411f6-3300-47de-8790-918ac9bd7a0b" />

### Steps to reproduce 

1. Create a text shape with some text with non-latin characters, like Arabic.
2. Keep the default font or select another one that does not contain Arabic text.
3. Select a word

Expected behavior:

- The selected text and the rendered text should use the same font.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
