### PR TITLE
:lipstick: Limit inspect layer info message to avoid overflow

### DIFF
--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -124,8 +124,7 @@
 .inspect-tab-switcher-label {
   @include use-typography("body-medium");
   color: var(--color-foreground-primary);
-  flex: 0;
-  min-inline-size: fit-content;
+  flex: 0 1 40%;
 }
 
 .inspect-tab-switcher-controls {

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1853,7 +1853,7 @@ msgstr "Select a shape, board or group to inspect their properties and code"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:166
 msgid "inspect.layer-info"
-msgstr "Select inspect tab"
+msgstr "Layer info"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:137
 msgid "inspect.multiple-selected"

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -1819,7 +1819,7 @@ msgstr "Jāatlasa apveids, plātne vai kopa, lai apskatītu to īpašības un ko
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:166
 msgid "inspect.layer-info"
-msgstr "Atlasīt izpētīšanas cilni"
+msgstr "Slāņa informācija"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:137
 msgid "inspect.multiple-selected"


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/12766

### Summary

- Limit maximum size of text in info layer to avoid full tab overflow.
- Fix broken translations (probably on previous conflicts)

### Steps to reproduce 

> [!IMPORTANT]
> Ensure that works in both the inspect tab and the view mode

Open inspect tab and ensure it does not overflow on English language.
Change the text `info layer` with the DevTools for something larger as `Atlasīt izpētīšanas cilni` and ensure it does not overflow. It should wrap.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
