### PR TITLE
:paperclip: manage.sh some systems already report amd64 on uname -m

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -19,7 +19,7 @@ set -e
 
 ARCH=$(uname -m)
 
-if [[ "$ARCH" == "x86_64" || "$ARCH" == "i386" || "$ARCH" == "i686" ]]; then
+if [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" || "$ARCH" == "i386" || "$ARCH" == "i686" ]]; then
     ARCH="amd64"
 elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
     ARCH="arm64"


### PR DESCRIPTION
### Related Ticket

No ticket.

### Summary

manage.sh arch selection is not covering "amd64" answer of "uname -m"

### Steps to reproduce 

run manage.sh on system reporting amd64 and get 

nerfur$ > ./manage.sh                                      
Unknown architecture amd64  

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [X] Include screenshots or videos, if applicable.
- [X] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Refactor any modified SCSS files following the refactor guide.
- [X] Check CI passes successfully.
- [X] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.