### PR TITLE
:lipstick: Avoid code tab overflow

### DIFF
--- a/frontend/src/app/main/ui/inspect/code.scss
+++ b/frontend/src/app/main/ui/inspect/code.scss
@@ -14,7 +14,6 @@
   padding-bottom: deprecated.$s-16;
   overflow-y: auto;
   overflow-x: hidden;
-  scrollbar-gutter: stable;
   padding-inline: var(--sp-m);
 }
 

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -31,6 +31,7 @@
 .tool-windows {
   block-size: 100%;
   display: grid;
+  grid-template-rows: auto 1fr;
   gap: var(--sp-s);
 }
 
@@ -149,7 +150,6 @@
 }
 
 .inspect-content {
-  flex: 1;
   overflow: hidden;
 }
 
@@ -157,6 +157,5 @@
   --tabs-nav-padding-inline-start: 0;
   --tabs-nav-padding-inline-end: var(--sp-m);
 
-  block-size: calc(100vh - px2rem(200)); // TODO: Fix this hardcoded value
   overflow: auto;
 }

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -30,8 +30,7 @@
 
 .tool-windows {
   block-size: 100%;
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--sp-s);
 }
 

--- a/frontend/src/app/main/ui/inspect/styles.scss
+++ b/frontend/src/app/main/ui/inspect/styles.scss
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+@use "ds/_utils.scss" as *;
+
+.styles-tab {
+  block-size: calc(100vh - px2rem(200)); // TODO: Fix this hardcoded value
+}


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/12768

### Summary

This PR fixes an overflow on the code tab.

### Steps to reproduce 

Open inspect
Select code tab

(see linked issue with video)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
