### PR TITLE
:sparkles: Make automatic workflows not dependent on yarn

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint:
-    name: "Code Linter"
+    name: "Linter"
     runs-on: ubuntu-24.04
     container: penpotapp/devenv:latest
 
@@ -30,10 +30,7 @@ jobs:
 
       - name: Check clojure code format
         run: |
-          corepack enable;
-          corepack install;
-          yarn install
-          yarn run fmt:clj:check
+          ./scripts/lint
 
   test-common:
     name: "Common Tests"
@@ -52,10 +49,7 @@ jobs:
       - name: Run tests on NODE
         working-directory: ./common
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run test;
+          ./scripts/test
 
   test-frontend:
     name: "Frontend Tests"
@@ -69,25 +63,12 @@ jobs:
       - name: Unit Tests
         working-directory: ./frontend
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run test;
+          ./scripts/test
 
       - name: Component Tests
         working-directory: ./frontend
         run: |
-            yarn run playwright install chromium --with-deps;
-            yarn run build:storybook
-
-            npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-              "npx http-server storybook-static --port 6006 --silent" \
-              "npx wait-on tcp:6006 && yarn test:storybook"
-
-      - name: Check SCSS Format
-        working-directory: ./frontend
-        run: |
-          yarn run lint:scss;
+          ./scripts/test-components
 
   test-render-wasm:
     name: "Render WASM Tests"
@@ -164,11 +145,7 @@ jobs:
       - name: Run tests
         working-directory: ./library
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run build:bundle;
-          yarn run test;
+          ./scripts/test
 
   build-integration:
     name: "Build Integration Bundle"
@@ -219,11 +196,7 @@ jobs:
       - name: Run Tests
         working-directory: ./frontend
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run playwright install chromium --with-deps;
-          yarn run test:e2e -x --workers=2 --reporter=list --shard="1/4";
+          ./scripts/test-e2e --shard="1/4";
 
       - name: Upload test result
         uses: actions/upload-artifact@v4
@@ -253,11 +226,7 @@ jobs:
       - name: Run Tests
         working-directory: ./frontend
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run playwright install chromium --with-deps;
-          yarn run test:e2e -x --workers=2 --reporter=list --shard "2/4";
+          ./scripts/test-e2e --shard="2/4";
 
       - name: Upload test result
         uses: actions/upload-artifact@v4
@@ -287,11 +256,7 @@ jobs:
       - name: Run Tests
         working-directory: ./frontend
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run playwright install chromium --with-deps;
-          yarn run test:e2e -x --workers=2 --reporter=list --shard "3/4";
+          ./scripts/test-e2e --shard="3/4";
 
       - name: Upload test result
         uses: actions/upload-artifact@v4
@@ -303,7 +268,7 @@ jobs:
           retention-days: 3
 
   test-integration-4:
-    name: "Integration Tests 3/4"
+    name: "Integration Tests 4/4"
     runs-on: ubuntu-24.04
     container: penpotapp/devenv:latest
     needs: build-integration
@@ -321,11 +286,7 @@ jobs:
       - name: Run Tests
         working-directory: ./frontend
         run: |
-          corepack enable;
-          corepack install;
-          yarn install;
-          yarn run playwright install chromium --with-deps;
-          yarn run test:e2e -x --workers=2 --reporter=list --shard "4/4";
+          ./scripts/test-e2e --shard="4/4";
 
       - name: Upload test result
         uses: actions/upload-artifact@v4

--- a/common/scripts/test
+++ b/common/scripts/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+corepack enable;
+corepack install;
+yarn install;
+yarn run test;

--- a/frontend/scripts/test
+++ b/frontend/scripts/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+corepack enable;
+corepack install;
+yarn install;
+
+yarn run lint:scss;
+yarn run test;

--- a/frontend/scripts/test-components
+++ b/frontend/scripts/test-components
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+corepack enable;
+corepack install;
+yarn install;
+
+yarn run playwright install chromium --with-deps;
+yarn run build:storybook
+
+exec npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+    "npx http-server storybook-static --port 6006 --silent" \
+    "npx wait-on tcp:6006 && yarn test:storybook"

--- a/frontend/scripts/test-e2e
+++ b/frontend/scripts/test-e2e
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+corepack enable;
+corepack install;
+yarn install;
+yarn run playwright install chromium --with-deps;
+yarn run test:e2e -x --workers=2 --reporter=list "$@";

--- a/library/scripts/test
+++ b/library/scripts/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+corepack enable;
+corepack install;
+yarn install;
+
+yarn run build:bundle;
+yarn run test;

--- a/package.json
+++ b/package.json
@@ -11,14 +11,8 @@
   },
   "type": "module",
   "scripts": {
-    "fmt:clj:check": "cljfmt check --parallel=true common/src/ common/test/ frontend/src/ frontend/test/ backend/src/ backend/test/ exporter/src/ library/src",
-    "fmt:clj": "cljfmt fix --parallel=true common/src/ common/test/ frontend/src/ frontend/test/ backend/src/ backend/test/ exporter/src/ library/src",
-    "lint:clj:common": "clj-kondo --parallel=true --lint common/src",
-    "lint:clj:frontend": "clj-kondo --parallel=true --lint frontend/src",
-    "lint:clj:backend": "clj-kondo --parallel=true --lint backend/src",
-    "lint:clj:exporter": "clj-kondo --parallel=true --lint exporter/src",
-    "lint:clj:library": "clj-kondo --parallel=true --lint library/src",
-    "lint:clj": "yarn run lint:clj:common && yarn run lint:clj:frontend && yarn run lint:clj:backend && yarn run lint:clj:exporter && yarn run lint:clj:library"
+    "lint": "./scripts/lint",
+    "fmt": "./scripts/fmt"
   },
   "devDependencies": {
     "@types/node": "^20.12.7"

--- a/scripts/fmt
+++ b/scripts/fmt
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cljfmt --parallel=true \
+       common/src/ \
+       common/test/ \
+       frontend/src/ \
+       frontend/test/ \
+       backend/src/ \
+       backend/test/ \
+       exporter/src/ \
+       library/src;

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cljfmt check --parallel=true \
+       common/src/ \
+       common/test/ \
+       frontend/src/ \
+       frontend/test/ \
+       backend/src/ \
+       backend/test/ \
+       exporter/src/ \
+       library/src;
+
+clj-kondo --parallel=true --lint common/src;
+clj-kondo --parallel=true --lint frontend/src;
+clj-kondo --parallel=true --lint backend/src;
+clj-kondo --parallel=true --lint exporter/src/;
+clj-kondo --parallel=true --lint library/src;


### PR DESCRIPTION
## Summary

Adapt CI flow to not use directly yarn and use scripts, this will facilitate a future possible migration to pnpm