### PR TITLE
:bug: Fix mismatch between fonts for rendered and selected text when no fallback fonts apply

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -352,7 +352,7 @@
           (obj/merge!
            #js {"--editor-container-width" (dm/str width "px")
                 "--editor-container-height" (dm/str height "px")
-                "--fallback-families" (dm/str (str/join ", " fallback-families))})
+                "--fallback-families" (if (seq fallback-families) (dm/str (str/join ", " fallback-families)) "sourcesanspro")})
 
           (not render-wasm?)
           (obj/merge!


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12801

### Summary

This fixes mismatch in fonts for selected text that doesn't have fallback fonts.

<img width="535" height="146" alt="Screenshot" src="https://github.com/user-attachments/assets/784737e8-575b-49d0-8f2d-205dfde51238" />

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
