### PR TITLE
:sparkles: Use setup script on exporter instead of direct commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ node_modules
 /playwright/.cache/
 /render-wasm/target/
 /**/.yarn/*
+/.pnpm-store

--- a/docker/images/Dockerfile.exporter
+++ b/docker/images/Dockerfile.exporter
@@ -113,9 +113,7 @@ WORKDIR /opt/penpot/exporter
 USER penpot:penpot
 
 RUN set -ex; \
-    corepack install; \
-    yarn install; \
-    yarn run playwright install chromium; \
+    ./setup \
     rm -rf /opt/penpot/.yarn
 
 CMD ["node", "app.js"]

--- a/exporter/scripts/build
+++ b/exporter/scripts/build
@@ -18,4 +18,15 @@ cp ../.yarnrc.yml target/;
 cp yarn.lock target/;
 cp package.json target/;
 
+cat <<EOF | tee target/setup
+#/usr/bin/env bash
+set -e;
+corepack enable;
+corepack install;
+yarn install
+yarn run playwright install chromium;
+EOF
+
+chmod +x target/setup;
+
 sed -i -re "s/\%version\%/$CURRENT_VERSION/g" ./target/app.js;


### PR DESCRIPTION
### Summary

An other step in making the build steps not dependent on yarn.
