### PR TITLE
:recycle: Replace shadow form

### DIFF
--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -1239,8 +1239,12 @@ test.describe("Tokens: Apply token", () => {
       // Fill in the shadow values
       const offsetXInput = firstShadowFields.getByLabel("X");
       const offsetYInput = firstShadowFields.getByLabel("Y");
-      const blurInput = firstShadowFields.getByLabel("Blur");
-      const spreadInput = firstShadowFields.getByLabel("Spread");
+      const blurInput = firstShadowFields.getByRole("textbox", {
+        name: "Blur",
+      });
+      const spreadInput = firstShadowFields.getByRole("textbox", {
+        name: "Spread",
+      });
 
       await offsetXInput.fill("2");
       await offsetYInput.fill("2");
@@ -1261,9 +1265,10 @@ test.describe("Tokens: Apply token", () => {
       await valueSaturationSelector.click({ position: { x: 50, y: 50 } });
 
       // Verify that a color value was set
-      const colorInput = firstShadowFields.getByLabel("Color");
-      const firstColorValue = await colorInput.inputValue();
-      await expect(firstColorValue).toMatch(/^rgb(.*)$/);
+      const colorInput = firstShadowFields.getByRole("textbox", {
+        name: "Color",
+      });
+      await expect(colorInput).toHaveValue(/^rgb(.*)$/);
 
       // Wait for validation to complete
       await expect(
@@ -1281,11 +1286,15 @@ test.describe("Tokens: Apply token", () => {
       const firstShadowFields = tokensUpdateCreateModal.getByTestId(
         "shadow-input-fields-0",
       );
-      const colorInput = firstShadowFields.getByLabel("Color");
+      const colorInput = firstShadowFields.getByRole("textbox", {
+        name: "Color",
+      });
       const firstColorValue = await colorInput.inputValue();
 
       // User adds a second shadow
-      const addButton = firstShadowFields.getByTestId("shadow-add-button-0");
+      const addButton = tokensUpdateCreateModal.getByRole("button", {
+        name: "Add Shadow",
+      });
       await addButton.click();
 
       const secondShadowFields = tokensUpdateCreateModal.getByTestId(
@@ -1294,8 +1303,7 @@ test.describe("Tokens: Apply token", () => {
       await expect(secondShadowFields).toBeVisible();
 
       // User adds a third shadow
-      const addButton2 = secondShadowFields.getByTestId("shadow-add-button-1");
-      await addButton2.click();
+      await addButton.click();
 
       const thirdShadowFields = tokensUpdateCreateModal.getByTestId(
         "shadow-input-fields-2",
@@ -1305,9 +1313,15 @@ test.describe("Tokens: Apply token", () => {
       // User adds values for the third shadow
       const thirdOffsetXInput = thirdShadowFields.getByLabel("X");
       const thirdOffsetYInput = thirdShadowFields.getByLabel("Y");
-      const thirdBlurInput = thirdShadowFields.getByLabel("Blur");
-      const thirdSpreadInput = thirdShadowFields.getByLabel("Spread");
-      const thirdColorInput = thirdShadowFields.getByLabel("Color");
+      const thirdBlurInput = thirdShadowFields.getByRole("textbox", {
+        name: "Blur",
+      });
+      const thirdSpreadInput = thirdShadowFields.getByRole("textbox", {
+        name: "Spread",
+      });
+      const thirdColorInput = thirdShadowFields.getByRole("textbox", {
+        name: "Color",
+      });
 
       await thirdOffsetXInput.fill("10");
       await thirdOffsetYInput.fill("10");
@@ -1316,15 +1330,13 @@ test.describe("Tokens: Apply token", () => {
       await thirdColorInput.fill("#FF0000");
 
       // User removes the 2nd shadow
-      const removeButton2 = secondShadowFields.getByTestId(
-        "shadow-remove-button-1",
-      );
+      const removeButton2 = secondShadowFields.getByRole("button", {
+        name: "Remove Shadow",
+      });
       await removeButton2.click();
 
-      // Verify second shadow is removed
-      await expect(
-        secondShadowFields.getByTestId("shadow-add-button-3"),
-      ).not.toBeVisible();
+      // Verify that we have only two shadow fields
+      await expect(thirdShadowFields).not.toBeVisible();
 
       // Verify that the first shadow kept its values
       const firstOffsetXValue = await firstShadowFields
@@ -1334,13 +1346,13 @@ test.describe("Tokens: Apply token", () => {
         .getByLabel("Y")
         .inputValue();
       const firstBlurValue = await firstShadowFields
-        .getByLabel("Blur")
+        .getByRole("textbox", { name: "Blur" })
         .inputValue();
       const firstSpreadValue = await firstShadowFields
-        .getByLabel("Spread")
+        .getByRole("textbox", { name: "Spread" })
         .inputValue();
       const firstColorValueAfter = await firstShadowFields
-        .getByLabel("Color")
+        .getByRole("textbox", { name: "Color" })
         .inputValue();
 
       await expect(firstOffsetXValue).toBe("2");
@@ -1349,7 +1361,7 @@ test.describe("Tokens: Apply token", () => {
       await expect(firstSpreadValue).toBe("0");
       await expect(firstColorValueAfter).toBe(firstColorValue);
 
-      // Verify that the third shadow (now second) kept its values
+      // Verify that the second kept its values (after shadow 3)
       // After removing index 1, the third shadow becomes the second shadow at index 1
       const newSecondShadowFields = tokensUpdateCreateModal.getByTestId(
         "shadow-input-fields-1",
@@ -1363,13 +1375,13 @@ test.describe("Tokens: Apply token", () => {
         .getByLabel("Y")
         .inputValue();
       const secondBlurValue = await newSecondShadowFields
-        .getByLabel("Blur")
+        .getByRole("textbox", { name: "Blur" })
         .inputValue();
       const secondSpreadValue = await newSecondShadowFields
-        .getByLabel("Spread")
+        .getByRole("textbox", { name: "Spread" })
         .inputValue();
       const secondColorValue = await newSecondShadowFields
-        .getByLabel("Color")
+        .getByRole("textbox", { name: "Color" })
         .inputValue();
 
       await expect(secondOffsetXValue).toBe("10");
@@ -1386,7 +1398,9 @@ test.describe("Tokens: Apply token", () => {
       const newSecondShadowFields = tokensUpdateCreateModal.getByTestId(
         "shadow-input-fields-1",
       );
-      const colorInput = firstShadowFields.getByLabel("Color");
+      const colorInput = firstShadowFields.getByRole("textbox", {
+        name: "Color",
+      });
       const firstColorValue = await colorInput.inputValue();
 
       // Switch to reference tab
@@ -1414,13 +1428,13 @@ test.describe("Tokens: Apply token", () => {
         .getByLabel("Y")
         .inputValue();
       const restoredFirstBlur = await firstShadowFields
-        .getByLabel("Blur")
+        .getByRole("textbox", { name: "Blur" })
         .inputValue();
       const restoredFirstSpread = await firstShadowFields
-        .getByLabel("Spread")
+        .getByRole("textbox", { name: "Spread" })
         .inputValue();
       const restoredFirstColor = await firstShadowFields
-        .getByLabel("Color")
+        .getByRole("textbox", { name: "Color" })
         .inputValue();
 
       await expect(restoredFirstOffsetX).toBe("2");
@@ -1437,13 +1451,13 @@ test.describe("Tokens: Apply token", () => {
         .getByLabel("Y")
         .inputValue();
       const restoredSecondBlur = await newSecondShadowFields
-        .getByLabel("Blur")
+        .getByRole("textbox", { name: "Blur" })
         .inputValue();
       const restoredSecondSpread = await newSecondShadowFields
-        .getByLabel("Spread")
+        .getByRole("textbox", { name: "Spread" })
         .inputValue();
       const restoredSecondColor = await newSecondShadowFields
-        .getByLabel("Color")
+        .getByRole("textbox", { name: "Color" })
         .inputValue();
 
       await expect(restoredSecondOffsetX).toBe("10");

--- a/frontend/src/app/main/data/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/errors.cljs
@@ -108,6 +108,10 @@
    {:error/code :error.style-dictionary/invalid-token-value-shadow-spread
     :error/fn #(tr "workspace.tokens.shadow-spread-range")}
 
+   :error.style-dictionary/invalid-token-value-shadow
+   {:error/code :error.style-dictionary/invalid-token-value-shadow
+    :error/fn #(tr "workspace.tokens.invalid-token-value-shadow" %)}
+
    :error/unknown
    {:error/code :error/unknown
     :error/fn #(tr "labels.unknown-error")}})

--- a/frontend/src/app/main/ui/ds/controls/select.cljs
+++ b/frontend/src/app/main/ui/ds/controls/select.cljs
@@ -118,6 +118,7 @@
         (mf/use-fn
          (mf/deps disabled)
          (fn [event]
+           (dom/prevent-default event)
            (dom/stop-propagation event)
            (when-not disabled
              (swap! is-open* not))))

--- a/frontend/src/app/main/ui/ds/controls/utilities/input_field.cljs
+++ b/frontend/src/app/main/ui/ds/controls/utilities/input_field.cljs
@@ -53,10 +53,15 @@
                                                 "true")
                                 :aria-describedby (when has-hint
                                                     (str id "-hint"))
-                                :aria-labelledby tooltip-id
                                 :type (d/nilv type "text")
                                 :id id
                                 :max-length (d/nilv max-length max-input-length)})
+
+        props (if (and aria-label (not (some? icon)))
+                (mf/spread-props props
+                                 {:aria-label aria-label})
+                (mf/spread-props props
+                                 {:aria-labelledby tooltip-id}))
         inside-class (stl/css-case :input-wrapper true
                                    :has-hint has-hint
                                    :hint-type-hint (= hint-type "hint")

--- a/frontend/src/app/main/ui/ds/utilities/swatch.scss
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.scss
@@ -15,7 +15,7 @@
 }
 
 .swatch {
-  --border-color: var(--color-background-quaternary);
+  --border-color: var(--color-accent-primary-muted);
   --border-radius: #{$br-4};
   --border-color-active: var(--color-foreground-primary);
   --border-color-active-inset: var(--color-background-primary);

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/border_radius.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/border_radius.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
    [app.main.ui.ds.notifications.context-notification :refer [context-notification*]]
    [app.main.ui.forms :as fc]
-   [app.main.ui.workspace.tokens.management.create.form-input-token :refer [form-input-token*]]
+   [app.main.ui.workspace.tokens.management.create.input-token :refer [input-token*]]
    [app.util.dom :as dom]
    [app.util.forms :as fm]
    [app.util.i18n :refer [tr]]
@@ -187,7 +187,7 @@
            {:level :warning :appearance :ghost} (tr "workspace.tokens.warning-name-change")]])]
 
       [:div {:class (stl/css :input-row)}
-       [:> form-input-token*
+       [:> input-token*
         {:placeholder (tr "workspace.tokens.token-value-enter")
          :label (tr "workspace.tokens.token-value")
          :name :value

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/border_radius.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/border_radius.cljs
@@ -168,7 +168,9 @@
      [:div {:class (stl/css :token-rows)}
 
       [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :form-modal-title)}
-       (tr "workspace.tokens.create-token" token-type)]
+       (if (= action "edit")
+         (tr "workspace.tokens.edit-token" token-type)
+         (tr "workspace.tokens.create-token" token-type))]
 
       [:div {:class (stl/css :input-row)}
        [:> fc/form-input* {:id "token-name"

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/color.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/color.cljs
@@ -51,6 +51,7 @@
         #(not (cft/token-name-path-exists? % tokens-tree))]]]
 
      [:value [::sm/text {:error/fn token-value-error-fn}]]
+     [:color-result {:optional true} ::sm/any]
 
      [:description {:optional true}
       [:string {:max 2048 :error/fn #(tr "errors.field-max-length" 2048)}]]]
@@ -168,7 +169,9 @@
      [:div {:class (stl/css :token-rows)}
 
       [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :form-modal-title)}
-       (tr "workspace.tokens.create-token" token-type)]
+       (if (= action "edit")
+         (tr "workspace.tokens.edit-token" token-type)
+         (tr "workspace.tokens.create-token" token-type))]
 
       [:div {:class (stl/css :input-row)}
        [:> fc/form-input* {:id "token-name"

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/color.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/color.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
    [app.main.ui.ds.notifications.context-notification :refer [context-notification*]]
    [app.main.ui.forms :as fc]
-   [app.main.ui.workspace.tokens.management.create.form-color-input-token :refer [form-color-input-token*]]
+   [app.main.ui.workspace.tokens.management.create.color-input-token :refer [color-input-token*]]
    [app.util.dom :as dom]
    [app.util.forms :as fm]
    [app.util.i18n :refer [tr]]
@@ -188,7 +188,7 @@
            {:level :warning :appearance :ghost} (tr "workspace.tokens.warning-name-change")]])]
 
       [:div {:class (stl/css :input-row)}
-       [:> form-color-input-token*
+       [:> color-input-token*
         {:placeholder (tr "workspace.tokens.token-value-enter")
          :label (tr "workspace.tokens.token-value")
          :name :value

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/color_input_token.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/color_input_token.cljs
@@ -4,7 +4,7 @@
 ;;
 ;; Copyright (c) KALEIDOS INC
 
-(ns app.main.ui.workspace.tokens.management.create.form-color-input-token
+(ns app.main.ui.workspace.tokens.management.create.color-input-token
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.colors :as color]
@@ -102,7 +102,7 @@
        :on-finish-drag on-finish-drag
        :on-change on-change'}]]))
 
-(mf/defc form-color-input-token*
+(mf/defc color-input-token*
   [{:keys [name tokens token] :rest props}]
 
   (let [form       (mf/use-ctx fc/context)
@@ -259,33 +259,33 @@
        [:> ramp* {:color value :on-change on-change-value}])]))
 
 (defn- on-composite-indexed-input-token-change
-  ([form field index value]
-   (on-composite-indexed-input-token-change form field index value false))
-  ([form field index value trim?]
+  ([form field index value composite-type]
+   (on-composite-indexed-input-token-change form field index value composite-type false))
+  ([form field index value composite-type trim?]
    (letfn [(clean-errors [errors]
              (-> errors
                  (dissoc field)
                  (not-empty)))]
      (swap! form (fn [state]
                    (-> state
-                       (assoc-in [:data :value :shadows index field] (if trim? (str/trim value) value))
+                       (assoc-in [:data :value composite-type index field] (if trim? (str/trim value) value))
                        (update :errors clean-errors)
                        (update :extra-errors clean-errors)))))))
 
-(mf/defc color-input-indexed*
-  [{:keys [name tokens token index] :rest props}]
+(mf/defc color-input-token-indexed*
+  [{:keys [name tokens token index composite-type] :rest props}]
 
   (let [form       (mf/use-ctx fc/context)
         input-name name
 
         error
-        (get-in @form [:errors :value :shadows index input-name])
+        (get-in @form [:errors :value composite-type index input-name])
 
         value
-        (get-in @form [:data :value :shadows index input-name] "")
+        (get-in @form [:data :value composite-type index input-name] "")
 
         color-resolved
-        (get-in @form [:data :value :shadows index :color-result] "")
+        (get-in @form [:data :value composite-type index :color-result] "")
 
         valid-color (or (tinycolor/valid-color value)
                         (tinycolor/valid-color color-resolved))
@@ -309,7 +309,7 @@
 
         resolve-stream
         (mf/with-memo [token]
-          (if-let [value (get-in token [:value :shadows index input-name])]
+          (if-let [value (get-in token [:value composite-type index input-name])]
             (rx/behavior-subject value)
             (rx/subject)))
 
@@ -363,7 +363,7 @@
                                  (tinycolor/set-alpha (or alpha 1))
                                  (tinycolor/->string format))]
              (when (not= value color-value)
-               (on-composite-indexed-input-token-change form input-name index color-value true)
+               (on-composite-indexed-input-token-change form input-name index color-value composite-type true)
                (rx/push! resolve-stream color-value)))))
 
         on-change
@@ -374,7 +374,7 @@
                  value (if (tinycolor/hex-without-hash-prefix? raw-value)
                          (dm/str "#" raw-value)
                          raw-value)]
-             (on-composite-indexed-input-token-change form input-name index value true)
+             (on-composite-indexed-input-token-change form input-name index value composite-type true)
              (rx/push! resolve-stream value))))
 
         props
@@ -390,7 +390,7 @@
                                   :hint-message (:message error)})
           props)]
 
-    (mf/with-effect [resolve-stream tokens token input-name index]
+    (mf/with-effect [resolve-stream tokens token input-name index composite-type]
       (let [subs (->> resolve-stream
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token))
@@ -404,24 +404,24 @@
                          (cond
                            (and error (str/empty? (:error/value error)))
                            (do
-                             (swap! form update-in [:errors :value :shadows index] dissoc input-name)
-                             (swap! form update-in [:data :value :shadows index] dissoc input-name)
-                             (swap! form assoc-in [:data :value :shadows index :color-result] "")
+                             (swap! form update-in [:errors :value composite-type index] dissoc input-name)
+                             (swap! form update-in [:data :value composite-type index] dissoc input-name)
+                             (swap! form assoc-in [:data :value composite-type index :color-result] "")
                              (swap! form update :extra-errors dissoc :value)
                              (reset! hint* {}))
 
                            (some? error)
                            (let [error' (:message error)]
-                             (swap! form assoc-in  [:extra-errors :value :shadows index input-name] {:message error'})
-                             (swap! form assoc-in [:data :value :shadows index :color-result] "")
+                             (swap! form assoc-in  [:extra-errors :value composite-type index input-name] {:message error'})
+                             (swap! form assoc-in [:data :value composite-type index :color-result] "")
                              (reset! hint* {:message error' :type "error"}))
 
                            :else
                            (let [message (tr "workspace.tokens.resolved-value" (dwtf/format-token-value value))
-                                 input-value (get-in @form [:data :value :shadows index input-name] "")]
+                                 input-value (get-in @form [:data :value composite-type index input-name] "")]
                              (swap! form update :errors dissoc :value)
                              (swap! form update :extra-errors dissoc :value)
-                             (swap! form assoc-in [:data :value :shadows index :color-result] (dwtf/format-token-value value))
+                             (swap! form assoc-in [:data :value composite-type index :color-result] (dwtf/format-token-value value))
                              (if (= input-value (str value))
                                (reset! hint* {})
                                (reset! hint* {:message message :type "hint"})))))))]

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/combobox_token_fonts.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/combobox_token_fonts.cljs
@@ -24,7 +24,6 @@
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
-
 (defn- resolve-value
   [tokens prev-token value]
   (let [token
@@ -117,7 +116,6 @@
 
         props
         (mf/spread-props props   {:on-change on-change
-                                  ;; TODO: Review this value vs default-value
                                   :value (or value "")
                                   :hint-message (:message hint)
                                   :slot-end font-selector-button
@@ -242,7 +240,6 @@
 
         props
         (mf/spread-props props   {:on-change on-change
-                                  ;; TODO: Review this value vs default-value
                                   :value (or value "")
                                   :hint-message (:message hint)
                                   :slot-end font-selector-button

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/dimensions.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/dimensions.cljs
@@ -167,7 +167,9 @@
                   :on-submit on-submit}
      [:div {:class (stl/css :token-rows)}
       [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :form-modal-title)}
-       (tr "workspace.tokens.create-token" token-type)]
+       (if (= action "edit")
+         (tr "workspace.tokens.edit-token" token-type)
+         (tr "workspace.tokens.create-token" token-type))]
 
       [:div {:class (stl/css :input-row)}
        [:> fc/form-input* {:id "token-name"

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/dimensions.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/dimensions.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
    [app.main.ui.ds.notifications.context-notification :refer [context-notification*]]
    [app.main.ui.forms :as fc]
-   [app.main.ui.workspace.tokens.management.create.form-input-token :refer [form-input-token*]]
+   [app.main.ui.workspace.tokens.management.create.input-token :refer [input-token*]]
    [app.util.dom :as dom]
    [app.util.forms :as fm]
    [app.util.i18n :refer [tr]]
@@ -186,7 +186,7 @@
            {:level :warning :appearance :ghost} (tr "workspace.tokens.warning-name-change")]])]
 
       [:div {:class (stl/css :input-row)}
-       [:> form-input-token*
+       [:> input-token*
         {:placeholder (tr "workspace.tokens.token-value-enter")
          :label (tr "workspace.tokens.token-value")
          :name :value

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/font_family.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/font_family.cljs
@@ -165,7 +165,9 @@
      [:div {:class (stl/css :token-rows)}
 
       [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :form-modal-title)}
-       (tr "workspace.tokens.create-token" token-type)]
+       (if (= action "edit")
+         (tr "workspace.tokens.edit-token" token-type)
+         (tr "workspace.tokens.create-token" token-type))]
 
       [:div {:class (stl/css :input-row)}
        [:> fc/form-input* {:id "token-name"

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form_input_token.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form_input_token.cljs
@@ -88,6 +88,7 @@
           props)]
 
     (mf/with-effect [resolve-stream tokens token input-name]
+
       (let [subs (->> resolve-stream
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token))
@@ -125,7 +126,7 @@
                        (update :errors clean-errors)
                        (update :extra-errors clean-errors)))))))
 
-(mf/defc token-composite-value-input*
+(mf/defc form-input-token-composite*
   [{:keys [name tokens token] :rest props}]
 
   (let [form       (mf/use-ctx fc/context)
@@ -200,6 +201,108 @@
                            :else
                            (let [message (tr "workspace.tokens.resolved-value" (dwtf/format-token-value value))
                                  input-value (get-in @form [:data :value input-name] "")]
+                             (swap! form update :errors dissoc :value)
+                             (swap! form update :extra-errors dissoc :value)
+                             (if (= input-value (str value))
+                               (reset! hint* {})
+                               (reset! hint* {:message message :type "hint"})))))
+                       (fn [cause]
+                         (js/console.log "MUU" cause))))]
+        (fn []
+          (rx/dispose! subs))))
+
+    [:> input* props]))
+
+(defn- on-composite-indexed-input-token-change
+  ([form field index value]
+   (on-composite-indexed-input-token-change form field index value false))
+  ([form field index value trim?]
+   (letfn [(clean-errors [errors]
+             (-> errors
+                 (dissoc field)
+                 (not-empty)))]
+     (swap! form (fn [state]
+                   (-> state
+                       (assoc-in [:data :value :shadows index field] (if trim? (str/trim value) value))
+                       (update :errors clean-errors)
+                       (update :extra-errors clean-errors)))))))
+
+(mf/defc form-input-token-indexed*
+  [{:keys [name tokens token index] :rest props}]
+
+  (let [form       (mf/use-ctx fc/context)
+        input-name name
+
+        error
+        (get-in @form [:errors :value :shadows index input-name])
+
+        value-from-form
+        (get-in @form [:data :value :shadows index input-name] "")
+
+        resolve-stream
+        (mf/with-memo [token index input-name]
+          (if-let [value (get-in token [:value :shadows index input-name])]
+            (rx/behavior-subject value)
+            (rx/subject)))
+
+        hint*
+        (mf/use-state {})
+
+        hint
+        (deref hint*)
+
+        on-change
+        (mf/use-fn
+         (mf/deps resolve-stream input-name index)
+         (fn [event]
+           (let [value (-> event dom/get-target dom/get-input-value)]
+             (on-composite-indexed-input-token-change form input-name index value true)
+             (rx/push! resolve-stream value))))
+
+        props
+        (mf/spread-props props {:on-change on-change
+                                :value value-from-form
+                                :variant "comfortable"
+                                :hint-message (:message hint)
+                                :hint-type (:type hint)})
+        props
+        (if error
+          (mf/spread-props props {:hint-type "error"
+                                  :hint-message (:message error)})
+          props)
+
+        props
+        (if (and (not error) (= input-name :reference))
+          (mf/spread-props props {:hint-formated true})
+          props)]
+
+    (mf/with-effect [resolve-stream tokens token input-name index]
+      (let [subs (->> resolve-stream
+                      (rx/debounce 300)
+                      (rx/mapcat (partial resolve-value tokens token))
+                      (rx/map (fn [result]
+                                (d/update-when result :error
+                                               (fn [error]
+                                                 (assoc error :message ((:error/fn error) (:error/value error)))))))
+
+                      (rx/subs!
+                       (fn [{:keys [error value]}]
+                         (cond
+                           (and error (str/empty? (:error/value error)))
+                           (do
+                             (swap! form update-in [:errors :value :shadows index] dissoc input-name)
+                             (swap! form update-in [:data :value :shadows index] dissoc input-name)
+                             (swap! form update :extra-errors dissoc :value)
+                             (reset! hint* {}))
+
+                           (some? error)
+                           (let [error' (:message error)]
+                             (swap! form assoc-in  [:extra-errors :value :shadows index input-name] {:message error'})
+                             (reset! hint* {:message error' :type "error"}))
+
+                           :else
+                           (let [message (tr "workspace.tokens.resolved-value" (dwtf/format-token-value value))
+                                 input-value (get-in @form [:data :value :shadows index input-name] "")]
                              (swap! form update :errors dissoc :value)
                              (swap! form update :extra-errors dissoc :value)
                              (if (= input-value (str value))

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form_select_token.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form_select_token.cljs
@@ -1,0 +1,31 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.main.ui.workspace.tokens.management.create.form-select-token
+  (:require
+   [app.main.ui.ds.controls.select :refer [select*]]
+   [app.main.ui.forms :as fc]
+   [rumext.v2 :as mf]))
+
+(mf/defc select-composite*
+  [{:keys [name index] :rest props}]
+  (let [form       (mf/use-ctx fc/context)
+        input-name name
+
+        value
+        (get-in @form [:data :value :shadows index input-name] false)
+
+        on-change
+        (mf/use-fn
+         (mf/deps input-name)
+         (fn [type]
+           (let [is-inner? (= type "inner")]
+             (swap! form assoc-in [:data :value :shadows index input-name] is-inner?))))
+
+        props (mf/spread-props props {:default-selected (if value "inner" "drop")
+                                      :variant "ghost"
+                                      :on-change on-change})]
+    [:> select* props]))

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/input_token.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/input_token.cljs
@@ -4,7 +4,7 @@
 ;;
 ;; Copyright (c) KALEIDOS INC
 
-(ns app.main.ui.workspace.tokens.management.create.form-input-token
+(ns app.main.ui.workspace.tokens.management.create.input-token
   (:require
    [app.common.data :as d]
    [app.common.types.tokens-lib :as ctob]
@@ -39,7 +39,7 @@
                 (rx/of {:value resolved-value})
                 (rx/of {:error (first errors)}))))))))
 
-(mf/defc form-input-token*
+(mf/defc input-token*
   [{:keys [name tokens token] :rest props}]
 
   (let [form       (mf/use-ctx fc/context)
@@ -126,7 +126,7 @@
                        (update :errors clean-errors)
                        (update :extra-errors clean-errors)))))))
 
-(mf/defc form-input-token-composite*
+(mf/defc input-token-composite*
   [{:keys [name tokens token] :rest props}]
 
   (let [form       (mf/use-ctx fc/context)
@@ -214,34 +214,34 @@
     [:> input* props]))
 
 (defn- on-composite-indexed-input-token-change
-  ([form field index value]
-   (on-composite-indexed-input-token-change form field index value false))
-  ([form field index value trim?]
+  ([form field index value composite-type]
+   (on-composite-indexed-input-token-change form field index value composite-type false))
+  ([form field index value composite-type trim?]
    (letfn [(clean-errors [errors]
              (-> errors
                  (dissoc field)
                  (not-empty)))]
      (swap! form (fn [state]
                    (-> state
-                       (assoc-in [:data :value :shadows index field] (if trim? (str/trim value) value))
+                       (assoc-in [:data :value composite-type index field] (if trim? (str/trim value) value))
                        (update :errors clean-errors)
                        (update :extra-errors clean-errors)))))))
 
-(mf/defc form-input-token-indexed*
-  [{:keys [name tokens token index] :rest props}]
+(mf/defc input-token-indexed*
+  [{:keys [name tokens token index composite-type] :rest props}]
 
   (let [form       (mf/use-ctx fc/context)
         input-name name
 
         error
-        (get-in @form [:errors :value :shadows index input-name])
+        (get-in @form [:errors :value composite-type index input-name])
 
         value-from-form
-        (get-in @form [:data :value :shadows index input-name] "")
+        (get-in @form [:data :value composite-type index input-name] "")
 
         resolve-stream
         (mf/with-memo [token index input-name]
-          (if-let [value (get-in token [:value :shadows index input-name])]
+          (if-let [value (get-in token [:value composite-type index input-name])]
             (rx/behavior-subject value)
             (rx/subject)))
 
@@ -256,7 +256,7 @@
          (mf/deps resolve-stream input-name index)
          (fn [event]
            (let [value (-> event dom/get-target dom/get-input-value)]
-             (on-composite-indexed-input-token-change form input-name index value true)
+             (on-composite-indexed-input-token-change form input-name index value composite-type true)
              (rx/push! resolve-stream value))))
 
         props
@@ -276,7 +276,7 @@
           (mf/spread-props props {:hint-formated true})
           props)]
 
-    (mf/with-effect [resolve-stream tokens token input-name index]
+    (mf/with-effect [resolve-stream tokens token input-name index composite-type]
       (let [subs (->> resolve-stream
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token))
@@ -290,19 +290,19 @@
                          (cond
                            (and error (str/empty? (:error/value error)))
                            (do
-                             (swap! form update-in [:errors :value :shadows index] dissoc input-name)
-                             (swap! form update-in [:data :value :shadows index] dissoc input-name)
+                             (swap! form update-in [:errors :value composite-type index] dissoc input-name)
+                             (swap! form update-in [:data :value composite-type index] dissoc input-name)
                              (swap! form update :extra-errors dissoc :value)
                              (reset! hint* {}))
 
                            (some? error)
                            (let [error' (:message error)]
-                             (swap! form assoc-in  [:extra-errors :value :shadows index input-name] {:message error'})
+                             (swap! form assoc-in  [:extra-errors :value composite-type index input-name] {:message error'})
                              (reset! hint* {:message error' :type "error"}))
 
                            :else
                            (let [message (tr "workspace.tokens.resolved-value" (dwtf/format-token-value value))
-                                 input-value (get-in @form [:data :value :shadows index input-name] "")]
+                                 input-value (get-in @form [:data :value composite-type index input-name] "")]
                              (swap! form update :errors dissoc :value)
                              (swap! form update :extra-errors dissoc :value)
                              (if (= input-value (str value))

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/select_token.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/select_token.cljs
@@ -4,26 +4,26 @@
 ;;
 ;; Copyright (c) KALEIDOS INC
 
-(ns app.main.ui.workspace.tokens.management.create.form-select-token
+(ns app.main.ui.workspace.tokens.management.create.select-token
   (:require
    [app.main.ui.ds.controls.select :refer [select*]]
    [app.main.ui.forms :as fc]
    [rumext.v2 :as mf]))
 
 (mf/defc select-composite*
-  [{:keys [name index] :rest props}]
+  [{:keys [name index composite-type] :rest props}]
   (let [form       (mf/use-ctx fc/context)
         input-name name
 
         value
-        (get-in @form [:data :value :shadows index input-name] false)
+        (get-in @form [:data :value composite-type index input-name] false)
 
         on-change
         (mf/use-fn
          (mf/deps input-name)
          (fn [type]
            (let [is-inner? (= type "inner")]
-             (swap! form assoc-in [:data :value :shadows index input-name] is-inner?))))
+             (swap! form assoc-in [:data :value composite-type index input-name] is-inner?))))
 
         props (mf/spread-props props {:default-selected (if value "inner" "drop")
                                       :variant "ghost"

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/shadow.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/shadow.scss
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+@use "ds/typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+
+.form-wrapper {
+  width: $sz-384;
+  position: relative;
+}
+
+.token-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-l);
+}
+
+.inputs-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-m);
+  border-inline-start: $b-1 solid var(--color-accent-primary-muted);
+  padding-inline-start: var(--sp-m);
+}
+
+.input-row {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+}
+
+.input-row-reference {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+  border-inline-start: $b-1 solid var(--color-accent-primary-muted);
+  padding-inline-start: var(--sp-m);
+}
+
+.title-bar {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: var(--sp-xs);
+}
+
+.title {
+  @include t.use-typography("body-small");
+  color: var(--color-foreground-primary);
+  display: flex;
+  align-items: center;
+}
+
+.form-modal-title {
+  @include t.use-typography("headline-medium");
+  color: var(--color-foreground-primary);
+  display: flex;
+  align-items: center;
+}
+
+.button-row {
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: end;
+  gap: var(--sp-m);
+  padding-block-start: var(--sp-s);
+}
+
+.with-delete {
+  grid-template-columns: 1fr auto auto;
+}
+
+.warning-name-change-notification-wrapper {
+  margin-block-start: var(--sp-l);
+}
+
+.delete-btn {
+  justify-self: start;
+}
+
+.visible-label {
+  @include t.use-typography("headline-small");
+  color: var(--color-foreground-secondary);
+  line-height: $sz-32;
+}
+
+.select-wrapper {
+  display: grid;
+  grid-template-columns: 1fr auto;
+}

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/text_case.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/text_case.cljs
@@ -168,7 +168,9 @@
      [:div {:class (stl/css :token-rows)}
 
       [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :form-modal-title)}
-       (tr "workspace.tokens.create-token" token-type)]
+       (if (= action "edit")
+         (tr "workspace.tokens.edit-token" token-type)
+         (tr "workspace.tokens.create-token" token-type))]
 
       [:div {:class (stl/css :input-row)}
        [:> fc/form-input* {:id "token-name"

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/text_case.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/text_case.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
    [app.main.ui.ds.notifications.context-notification :refer [context-notification*]]
    [app.main.ui.forms :as fc]
-   [app.main.ui.workspace.tokens.management.create.form-input-token :refer [form-input-token*]]
+   [app.main.ui.workspace.tokens.management.create.input-token :refer [input-token*]]
    [app.util.dom :as dom]
    [app.util.forms :as fm]
    [app.util.i18n :refer [tr]]
@@ -187,7 +187,7 @@
            {:level :warning :appearance :ghost} (tr "workspace.tokens.warning-name-change")]])]
 
       [:div {:class (stl/css :input-row)}
-       [:> form-input-token*
+       [:> input-token*
         {:placeholder (tr "workspace.tokens.text-case-value-enter")
          :label (tr "workspace.tokens.token-value")
          :name :value

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/typography.cljs
@@ -26,7 +26,7 @@
    [app.main.ui.ds.notifications.context-notification :refer [context-notification*]]
    [app.main.ui.forms :as forms]
    [app.main.ui.workspace.tokens.management.create.combobox-token-fonts :refer [font-picker-composite-combobox*]]
-   [app.main.ui.workspace.tokens.management.create.form-input-token :refer [form-input-token-composite*]]
+   [app.main.ui.workspace.tokens.management.create.input-token :refer [input-token-composite*]]
    [app.util.dom :as dom]
    [app.util.forms :as fm]
    [app.util.i18n :refer [tr]]
@@ -97,7 +97,7 @@
         :token font-family-sub-token
         :tokens tokens}]]
      [:div {:class (stl/css :input-row)}
-      [:> form-input-token-composite*
+      [:> input-token-composite*
        {:aria-label "Font Size"
         :icon i/text-font-size
         :placeholder (tr "workspace.tokens.font-size-value-enter")
@@ -105,7 +105,7 @@
         :token font-size-sub-token
         :tokens tokens}]]
      [:div {:class (stl/css :input-row)}
-      [:> form-input-token-composite*
+      [:> input-token-composite*
        {:aria-label "Font Weight"
         :icon i/text-font-weight
         :placeholder (tr "workspace.tokens.font-weight-value-enter")
@@ -113,7 +113,7 @@
         :token font-weight-sub-token
         :tokens tokens}]]
      [:div {:class (stl/css :input-row)}
-      [:> form-input-token-composite*
+      [:> input-token-composite*
        {:aria-label "Line Height"
         :icon i/text-lineheight
         :placeholder (tr "workspace.tokens.line-height-value-enter")
@@ -121,7 +121,7 @@
         :token line-height-sub-token
         :tokens tokens}]]
      [:div {:class (stl/css :input-row)}
-      [:> form-input-token-composite*
+      [:> input-token-composite*
        {:aria-label "Letter Spacing"
         :icon i/text-letterspacing
         :placeholder (tr "workspace.tokens.letter-spacing-value-enter-composite")
@@ -129,7 +129,7 @@
         :token letter-spacing-sub-token
         :tokens tokens}]]
      [:div {:class (stl/css :input-row)}
-      [:> form-input-token-composite*
+      [:> input-token-composite*
        {:aria-label "Text Case"
         :icon i/text-mixed
         :placeholder (tr "workspace.tokens.text-case-value-enter")
@@ -137,7 +137,7 @@
         :token text-case-sub-token
         :tokens tokens}]]
      [:div {:class (stl/css :input-row)}
-      [:> form-input-token-composite*
+      [:> input-token-composite*
        {:aria-label "Text Decoration"
         :icon i/text-underlined
         :placeholder (tr "workspace.tokens.text-decoration-value-enter")
@@ -148,7 +148,7 @@
 (mf/defc reference-form*
   [{:keys [token tokens] :as props}]
   [:div {:class (stl/css :input-row)}
-   [:> form-input-token-composite*
+   [:> input-token-composite*
     {:placeholder (tr "workspace.tokens.reference-composite")
      :aria-label (tr "labels.reference")
      :icon i/text-typography

--- a/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
@@ -43,6 +43,7 @@
     :stroke-width "stroke-size"
     :dimensions "expand"
     :sizing "expand"
+    :shadow "drop-shadow"
     "add"))
 
 (mf/defc token-group*

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7753,6 +7753,10 @@ msgstr "Invalid token value: only none, underline and strike-through are accepte
 msgid "workspace.tokens.invalid-token-value-typography"
 msgstr "Invalid value: must reference a composite typography token."
 
+#: src/app/main/data/workspace/tokens/errors.cljs
+msgid "workspace.tokens.invalid-token-value-shadow"
+msgstr "Invalid value: must reference a composite shadow token."
+
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
 msgid "workspace.tokens.invalid-value"
 msgstr "Invalid token value: %s"
@@ -7869,6 +7873,10 @@ msgstr "Reference is not valid or is not in any active set"
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:775
 msgid "workspace.tokens.reference-composite"
 msgstr "Enter a token typography alias"
+
+#: src/app/main/ui/workspace/tokens/management/create/form.cljs:775
+msgid "workspace.tokens.reference-composite-shadow"
+msgstr "Enter a token shadow alias"
 
 #: src/app/main/ui/workspace/tokens/style_dictionary.cljs
 #, unused

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7674,6 +7674,10 @@ msgstr "Tipo de sombra no válida: solo se aceptan 'innerShadow' o 'dropShadow'"
 msgid "workspace.tokens.invalid-token-value-typography"
 msgstr "Valor no válido: debe hacer referencia a un token tipográfico compuesto."
 
+#: src/app/main/data/workspace/tokens/errors.cljs
+msgid "workspace.tokens.invalid-token-value-shadow"
+msgstr "Valor no válido: debe hacer referencia a un token de sombra compuesto."
+
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
 msgid "workspace.tokens.invalid-value"
 msgstr "Valor de token no válido: %s"


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
This PR Solves these task 
- https://tree.taiga.io/project/penpot/task/12611
- https://tree.taiga.io/project/penpot/task/12421

### Summary
Implement shadow token creation and edition with the new form system

### Steps to reproduce 

Create a new shadow token, with one or more sets of shadows.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
