### PR TITLE
:bug: Change internal ordering on how email parts are assembled

### DIFF
--- a/backend/src/app/email.clj
+++ b/backend/src/app/email.clj
@@ -106,16 +106,16 @@
       (let [content-part      (MimeBodyPart.)
             alternative-mpart (MimeMultipart. "alternative")]
 
+        (when-let [content (get body "text/plain")]
+          (let [text-part (MimeBodyPart.)]
+            (.setText text-part ^String content ^String charset)
+            (.addBodyPart alternative-mpart text-part)))
+
         (when-let [content (get body "text/html")]
           (let [html-part (MimeBodyPart.)]
             (.setContent html-part ^String content
                          (str "text/html; charset=" charset))
             (.addBodyPart alternative-mpart html-part)))
-
-        (when-let [content (get body "text/plain")]
-          (let [text-part (MimeBodyPart.)]
-            (.setText text-part ^String content ^String charset)
-            (.addBodyPart alternative-mpart text-part)))
 
         (.setContent content-part alternative-mpart)
         (.addBodyPart mixed-mpart content-part))


### PR DESCRIPTION
### Summary

This fixes the html email rendering on gmail. Other clients (like proton, emailcatcher) properly renders html independently of the order of parts on the multipart email structure but gmail requires that html should be the last one.

### Related Ticket

https://tree.taiga.io/project/penpot/issue/12807
