### PR TITLE
:bug: Fix visual feedback on padding/margin/gaps modified

### DIFF
--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -372,6 +372,9 @@
 (def workspace-modifiers
   (l/derived :workspace-modifiers st/state))
 
+(def workspace-wasm-modifiers
+  (l/derived :workspace-wasm-modifiers st/state))
+
 (def ^:private workspace-modifiers-with-objects
   (l/derived
    (fn [state]

--- a/frontend/src/app/main/ui/flex_controls/padding.cljs
+++ b/frontend/src/app/main/ui/flex_controls/padding.cljs
@@ -6,6 +6,7 @@
 
 (ns app.main.ui.flex-controls.padding
   (:require
+   [app.common.data.macros :as dm]
    [app.common.geom.point :as gpt]
    [app.common.types.modifiers :as ctm]
    [app.main.data.workspace.modifiers :as dwm]
@@ -20,8 +21,9 @@
    [rumext.v2 :as mf]))
 
 (mf/defc padding-display
-  [{:keys [frame-id zoom hover-all? hover-v? hover-h? padding-num padding on-pointer-enter on-pointer-leave
-           rect-data hover? selected? mouse-pos hover-value on-move-selected on-context-menu]}]
+  [{:keys [frame-id zoom hover-all? hover-v? hover-h? padding-num padding on-pointer-enter
+           on-pointer-leave rect-data hover? selected? mouse-pos hover-value on-move-selected
+           on-context-menu on-change]}]
   (let [resizing?            (mf/use-var false)
         start                (mf/use-var nil)
         original-value       (mf/use-var 0)
@@ -61,10 +63,11 @@
                  layout-padding-type
                  (if (= (:p1 padding) (:p2 padding) (:p3 padding) (:p4 padding)) :simple :multiple)]
              [val
-              (dwm/create-modif-tree [frame-id]
-                                     (-> (ctm/empty)
-                                         (ctm/change-property  :layout-padding layout-padding)
-                                         (ctm/change-property  :layout-padding-type layout-padding-type)))])))
+              (dwm/create-modif-tree
+               [frame-id]
+               (-> (ctm/empty)
+                   (ctm/change-property  :layout-padding layout-padding)
+                   (ctm/change-property  :layout-padding-type layout-padding-type)))])))
 
         on-lost-pointer-capture
         (mf/use-fn
@@ -86,7 +89,7 @@
 
         on-pointer-move
         (mf/use-fn
-         (mf/deps calc-modifiers)
+         (mf/deps calc-modifiers on-change)
          (fn [event]
            (let [pos (dom/get-client-position event)]
              (reset! mouse-pos (point->viewport pos))
@@ -96,7 +99,10 @@
                  (reset! hover-value val)
                  (if (features/active-feature? @st/state "render-wasm/v1")
                    (st/emit! (dwm/set-wasm-modifiers modifiers))
-                   (st/emit! (dwm/set-modifiers modifiers))))))))]
+                   (st/emit! (dwm/set-modifiers modifiers)))
+
+                 (when on-change
+                   (on-change modifiers)))))))]
 
     [:g.padding-rect
      [:rect.info-area
@@ -132,77 +138,108 @@
          :on-lost-pointer-capture on-lost-pointer-capture
          :on-pointer-move on-pointer-move
          :on-context-menu on-context-menu
-         :class (when (or hover? selected?)
-                  (if (= (:resize-axis rect-data) :x) (cur/get-dynamic "resize-ew" 0) (cur/get-dynamic "resize-ew" 90)))
-         :style {:fill (if (or hover? selected?) fcc/distance-color "none")
-                 :opacity (if selected? 0 1)}}])]))
+         :class
+         (when (or hover? selected?)
+           (if (= (:resize-axis rect-data) :x)
+             (cur/get-dynamic "resize-ew" 0)
+             (cur/get-dynamic "resize-ew" 90)))
+
+         :style
+         {:fill (if (or hover? selected?) fcc/distance-color "none")
+          :opacity (if selected? 0 1)}}])]))
 
 (mf/defc padding-rects
   [{:keys [frame zoom alt? shift? on-move-selected on-context-menu]}]
   (let [frame-id                           (:id frame)
         paddings-selected                  (mf/deref refs/workspace-paddings-selected)
+        current-modifiers                  (mf/use-state nil)
+
+        frame
+        (ctm/apply-structure-modifiers frame (dm/get-in @current-modifiers [frame-id :modifiers]))
+
         hover-value                        (mf/use-state 0)
         mouse-pos                          (mf/use-state nil)
         hover                              (mf/use-state nil)
+
         hover-all?                         (and (not (nil? @hover)) alt?)
         hover-v?                           (and (or (= @hover :p1) (= @hover :p3)) shift?)
         hover-h?                           (and (or (= @hover :p2) (= @hover :p4)) shift?)
         padding                            (:layout-padding frame)
         {:keys [width height x1 x2 y1 y2]} (:selrect frame)
-        on-pointer-enter                   (fn [hover-type val]
-                                             (reset! hover hover-type)
-                                             (reset! hover-value val))
-        on-pointer-leave                   #(reset! hover nil)
         pill-width                         (/ fcc/flex-display-pill-width zoom)
         pill-height                        (/ fcc/flex-display-pill-height zoom)
-        hover?                             #(or hover-all?
-                                                (and (or (= % :p1) (= % :p3)) hover-v?)
-                                                (and (or (= % :p2) (= % :p4)) hover-h?)
-                                                (= @hover %))
-        negate                             {:p1 (if (:flip-y frame) true false)
-                                            :p2 (if (:flip-x frame) true false)
-                                            :p3 (if (:flip-y frame) true false)
-                                            :p4 (if (:flip-x frame) true false)}
-        negate                             (cond-> negate
-                                             (not= :auto (:layout-item-h-sizing frame)) (assoc :p2 (not (:p2 negate)))
-                                             (not= :auto (:layout-item-v-sizing frame)) (assoc :p3 (not (:p3 negate))))
 
-        padding-rect-data                  {:p1 {:key (str frame-id "-p1")
-                                                 :x x1
-                                                 :y (if (:flip-y frame) (- y2 (:p1 padding)) y1)
-                                                 :width width
-                                                 :height (:p1 padding)
-                                                 :initial-value (:p1 padding)
-                                                 :resize-type (if (:flip-y frame) :bottom :top)
-                                                 :resize-axis :y
-                                                 :resize-negate? (:p1 negate)}
-                                            :p2 {:key (str frame-id "-p2")
-                                                 :x (if (:flip-x frame) x1 (- x2 (:p2 padding)))
-                                                 :y y1
-                                                 :width (:p2 padding)
-                                                 :height height
-                                                 :initial-value (:p2 padding)
-                                                 :resize-type :left
-                                                 :resize-axis :x
-                                                 :resize-negate? (:p2 negate)}
-                                            :p3 {:key (str frame-id "-p3")
-                                                 :x x1
-                                                 :y (if (:flip-y frame) y1 (- y2 (:p3 padding)))
-                                                 :width width
-                                                 :height (:p3 padding)
-                                                 :initial-value (:p3 padding)
-                                                 :resize-type :bottom
-                                                 :resize-axis :y
-                                                 :resize-negate? (:p3 negate)}
-                                            :p4 {:key (str frame-id "-p4")
-                                                 :x (if (:flip-x frame) (- x2 (:p4 padding)) x1)
-                                                 :y y1
-                                                 :width (:p4 padding)
-                                                 :height height
-                                                 :initial-value (:p4 padding)
-                                                 :resize-type (if (:flip-x frame) :right :left)
-                                                 :resize-axis :x
-                                                 :resize-negate? (:p4 negate)}}]
+        negate
+        {:p1 (if (:flip-y frame) true false)
+         :p2 (if (:flip-x frame) true false)
+         :p3 (if (:flip-y frame) true false)
+         :p4 (if (:flip-x frame) true false)}
+
+        negate
+        (cond-> negate
+          (not= :auto (:layout-item-h-sizing frame)) (assoc :p2 (not (:p2 negate)))
+          (not= :auto (:layout-item-v-sizing frame)) (assoc :p3 (not (:p3 negate))))
+
+        padding-rect-data
+        {:p1 {:key (str frame-id "-p1")
+              :x x1
+              :y (if (:flip-y frame) (- y2 (:p1 padding)) y1)
+              :width width
+              :height (:p1 padding)
+              :initial-value (:p1 padding)
+              :resize-type (if (:flip-y frame) :bottom :top)
+              :resize-axis :y
+              :resize-negate? (:p1 negate)}
+         :p2 {:key (str frame-id "-p2")
+              :x (if (:flip-x frame) x1 (- x2 (:p2 padding)))
+              :y y1
+              :width (:p2 padding)
+              :height height
+              :initial-value (:p2 padding)
+              :resize-type :left
+              :resize-axis :x
+              :resize-negate? (:p2 negate)}
+         :p3 {:key (str frame-id "-p3")
+              :x x1
+              :y (if (:flip-y frame) y1 (- y2 (:p3 padding)))
+              :width width
+              :height (:p3 padding)
+              :initial-value (:p3 padding)
+              :resize-type :bottom
+              :resize-axis :y
+              :resize-negate? (:p3 negate)}
+         :p4 {:key (str frame-id "-p4")
+              :x (if (:flip-x frame) (- x2 (:p4 padding)) x1)
+              :y y1
+              :width (:p4 padding)
+              :height height
+              :initial-value (:p4 padding)
+              :resize-type (if (:flip-x frame) :right :left)
+              :resize-axis :x
+              :resize-negate? (:p4 negate)}}
+
+        on-pointer-enter
+        (mf/use-fn
+         (fn [hover-type val]
+           (reset! hover hover-type)
+           (reset! hover-value val)))
+
+        on-pointer-leave
+        (mf/use-fn
+         (fn []
+           (reset! hover nil)))
+
+        on-change
+        (mf/use-fn
+         (fn [modifiers]
+           (reset! current-modifiers modifiers)))
+
+        hover?
+        (fn [value]
+          (or hover-all?
+              (and (or (= value :p1) (= value :p3)) hover-v?)
+              (and (or (= value :p2) (= value :p4)) hover-h?)
+              (= @hover value)))]
 
     [:g.paddings {:pointer-events "visible"}
      (for [[padding-num rect-data] padding-rect-data]
@@ -221,9 +258,11 @@
          :on-pointer-leave on-pointer-leave
          :on-move-selected on-move-selected
          :on-context-menu on-context-menu
+         :on-change on-change
          :hover?  (hover? padding-num)
          :selected? (get paddings-selected padding-num)
          :rect-data rect-data}])
+
      (when @hover
        [:& fcc/flex-display-pill
         {:height pill-height

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -54,14 +54,10 @@
    [app.util.debug :as dbg]
    [app.util.text-editor :as ted]
    [beicon.v2.core :as rx]
-   [okulary.core :as l]
    [promesa.core :as p]
    [rumext.v2 :as mf]))
 
 ;; --- Viewport
-
-(def workspace-wasm-modifiers
-  (l/derived :workspace-wasm-modifiers st/state))
 
 (defn apply-modifiers-to-selected
   [selected objects modifiers]
@@ -98,7 +94,7 @@
         ;; DEREFS
         drawing           (mf/deref refs/workspace-drawing)
         focus             (mf/deref refs/workspace-focus-selected)
-        wasm-modifiers    (mf/deref workspace-wasm-modifiers)
+        wasm-modifiers    (mf/deref refs/workspace-wasm-modifiers)
 
         workspace-editor-state (mf/deref refs/workspace-editor-state)
 

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -290,7 +290,7 @@ fn propagate_reflow(
             let mut skip_reflow = false;
             if shape.is_layout_horizontal_fill() || shape.is_layout_vertical_fill() {
                 if let Some(parent_id) = shape.parent_id {
-                    if !reflown.contains(&parent_id) {
+                    if parent_id != Uuid::nil() && !reflown.contains(&parent_id) {
                         // If this is a fill layout but the parent has not been reflown yet
                         // we wait for the next iteration for reflow
                         skip_reflow = true;


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12784

### Summary

I solved the issue but it lacked visual feedback when you moved the gap/margin/padding. This MR fix that problem.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
