### PR TITLE
:bug: Fix viewport not being fully drawn on first load until a mouse …

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -1042,6 +1042,7 @@
      (process-pending shapes thumbnails full noop-fn
                       (fn []
                         (when render-callback (render-callback))
+                        (render-finish)
                         (ug/dispatch! (ug/event "penpot:wasm:set-objects")))))))
 
 (defn clear-focus-mode


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12805

### Summary

This fixes our image fills and other async content not being displayed after `set-objects` has fully finished, unless it received a change in viewport, mouse over, or similar.

https://github.com/user-attachments/assets/3d99a84f-53bd-4614-90b5-af355f3d95c2

### Steps to reproduce 

1. Import & open the file `Variants examples v1` (attached in the Taiga ticket)
2. Go to the `Cover` page

Expected behavior (with this fix):

- All content is drawn

Actual behavior (without this fix):

- Some content is not drawn until mouse over or a viewport change.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
