### PR TITLE
:bug: Fix paragraph with text spans with multiple styles

### DIFF
--- a/frontend/text-editor/src/editor/content/dom/Style.js
+++ b/frontend/text-editor/src/editor/content/dom/Style.js
@@ -339,13 +339,14 @@ export function setStylesFromObject(element, allowedStyles, styleObject) {
         continue;
       }
       let styleValue = styleObject[styleName];
+      if (!styleValue)
+        continue;
+
       if (styleName === "font-family") {
         styleValue = sanitizeFontFamily(styleValue);
       }
 
-      if (styleValue) {
-        setStyle(element, styleName, styleValue, styleUnit);
-      }
+      setStyle(element, styleName, styleValue, styleUnit);
     }
   return element;
 }

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -238,7 +238,11 @@ export class SelectionController extends EventTarget {
   #applyStylesFromElementToCurrentStyle(element) {
     for (let index = 0; index < element.style.length; index++) {
       const styleName = element.style.item(index);
+      if (styleName === "--fills") {
+        continue;
+      }
       let styleValue = element.style.getPropertyValue(styleName);
+
       if (styleName === "font-family") {
         styleValue = sanitizeFontFamily(styleValue);
       }

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -1939,11 +1939,21 @@ export class SelectionController extends EventTarget {
         const textSpan = this.startTextSpan;
         const midText = startNode.splitText(startOffset);
         const endText = midText.splitText(endOffset - startOffset);
-        const midTextSpan = createTextSpanFrom(textSpan, midText, newStyles);
-        textSpan.after(midTextSpan);
-        if (endText.length > 0) {
-          const endTextSpan = createTextSpan(endText, textSpan.style);
-          midTextSpan.after(endTextSpan);
+
+        // Only create text span if midText is not empty
+        if (midText.nodeValue && midText.nodeValue.length > 0) {
+          const midTextSpan = createTextSpanFrom(textSpan, midText, newStyles);
+          textSpan.after(midTextSpan);
+          if (endText.length > 0) {
+            const endTextSpan = createTextSpan(endText, textSpan.style);
+            midTextSpan.after(endTextSpan);
+          }
+        } else {
+          // If midText is empty, just create endTextSpan if needed
+          if (endText.length > 0) {
+            const endTextSpan = createTextSpan(endText, textSpan.style);
+            textSpan.after(endTextSpan);
+          }
         }
 
         // NOTE: This is necessary because sometimes
@@ -1996,7 +2006,8 @@ export class SelectionController extends EventTarget {
         // new text span.
         if (
           this.#textNodeIterator.currentNode === startNode &&
-          startOffset > 0
+          startOffset > 0 &&
+          startOffset < (startNode.nodeValue?.length || 0)
         ) {
           const newTextSpan = splitTextSpan(textSpan, startOffset);
           setTextSpanStyles(newTextSpan, newStyles);
@@ -2018,7 +2029,8 @@ export class SelectionController extends EventTarget {
           // If we're at end node
         } else if (
           this.#textNodeIterator.currentNode === endNode &&
-          endOffset < endNode.nodeValue.length
+          endOffset < endNode.nodeValue.length &&
+          endOffset > 0
         ) {
           const newTextSpan = splitTextSpan(textSpan, endOffset);
           setTextSpanStyles(textSpan, newStyles);

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -1974,7 +1974,7 @@ export class SelectionController extends EventTarget {
       // the styles are applied to the current caret
       else if (
         this.startOffset === this.endOffset &&
-        this.endOffset === endNode.nodeValue.length
+        this.endOffset === endNode.nodeValue?.length
       ) {
         const newTextSpan = createVoidTextSpan(newStyles);
         this.endTextSpan.after(newTextSpan);
@@ -2026,14 +2026,14 @@ export class SelectionController extends EventTarget {
           (this.#textNodeIterator.currentNode !== startNode &&
             this.#textNodeIterator.currentNode !== endNode) ||
           (this.#textNodeIterator.currentNode === endNode &&
-            endOffset === endNode.nodeValue.length)
+            endOffset === endNode.nodeValue?.length)
         ) {
           setTextSpanStyles(textSpan, newStyles);
 
           // If we're at end node
         } else if (
           this.#textNodeIterator.currentNode === endNode &&
-          endOffset < endNode.nodeValue.length &&
+          endOffset < endNode.nodeValue?.length &&
           endOffset > 0
         ) {
           const newTextSpan = splitTextSpan(textSpan, endOffset);

--- a/frontend/text-editor/src/editor/controllers/StyleDeclaration.js
+++ b/frontend/text-editor/src/editor/controllers/StyleDeclaration.js
@@ -81,6 +81,8 @@ export class StyleDeclaration {
       return this.setProperty(name, value);
     } else if (currentValue === "" && ["initial", "none"].includes(value)) {
       return this.setProperty(name, value);
+    } else if (currentValue !== value && name === "--fills") {
+      return this.setProperty(name, value);
     } else if (currentValue !== value) {
       return this.setProperty(name, "mixed");
     }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12797
https://tree.taiga.io/project/penpot/issue/12831

### Summary

This PR fixes these issues, one per commit:

- When merging styles in a paragraph with text spans with different fills, we were raising an internal error
- After some recent changes to support certain font-variant formats, "italic" variants stopped working. This fixes it.
- When doing a "select all" in a paragraph with mixed text spans, sometimes it couldn't not be parsed correctly and we were raising an internal error
- When selecting a word or the entire paragraph, and changing the font-size of a word, it should not change the span's color

### Steps to reproduce 

[screen-recorder-wed-dec-03-2025-08-56-04.webm](https://github.com/user-attachments/assets/9fb46ef4-33d1-4ce2-a2c7-d169af231088)

1. Create a paragraph with several lines
2. Change the color and variant of some words or set of words
3. Change other text style properties, and check it does not raise any error
4. Select all the content (via double click or ctrl+A) and check it does not raise any error


### Checklist

- [x] Choose the correct target branch;
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.