### PR TITLE
:sparkles: Add support auto decoding and validation syntax for obj/reify

### DIFF
--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -284,9 +284,9 @@
 (defn check-fn
   "Create a predefined check function"
   [s & {:keys [hint type code]}]
-  (let [s          (schema s)
-        validator* (delay (m/validator s))
-        explainer* (delay (m/explainer s))
+  (let [s          (delay (schema s))
+        validator* (delay (m/validator @s))
+        explainer* (delay (m/explainer @s))
         hint       (or ^boolean hint "check error")
         type       (or ^boolean type :assertion)
         code       (or ^boolean code :data-validation)]

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -304,7 +304,7 @@
 
 (defn coercer
   [schema & {:as opts}]
-  (let [decode-fn (decoder schema json-transformer)
+  (let [decode-fn (lazy-decoder schema json-transformer)
         check-fn  (check-fn schema opts)]
     (fn [data]
       (-> data decode-fn check-fn))))

--- a/frontend/scripts/repl
+++ b/frontend/scripts/repl
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 
-export OPTIONS="-A:dev -J-XX:-OmitStackTraceInFastThrow";
+export JAVA_OPTS="\
+       -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
+       -Djdk.attach.allowAttachSelf \
+       -Dlog4j2.configurationFile=log4j2-devenv-repl.xml \
+       -Djdk.tracePinnedThreads=full \
+       -XX:+EnableDynamicAgentLoading \
+       -XX:-OmitStackTraceInFastThrow                    \
+       -XX:+UnlockDiagnosticVMOptions \
+       -XX:+DebugNonSafepoints \
+       --sun-misc-unsafe-memory-access=allow \
+       --enable-preview \
+       --enable-native-access=ALL-UNNAMED";
+
+export OPTIONS="-A:dev"
 
 set -ex
-exec clojure $OPTIONS -M -m rebel-readline.main
+exec clojure $OPTIONS -M -e "$OPTIONS_EVAL" -m rebel-readline.main

--- a/frontend/src/app/plugins/library.cljs
+++ b/frontend/src/app/plugins/library.cljs
@@ -289,10 +289,10 @@
   (assert (uuid? id))
 
   (obj/reify {:name "LibraryTypographyProxy"}
-    :$plugin {:name "" :enumerable false :get (constantly plugin-id)}
-    :$id {:name "" :enumerable false :get (constantly id)}
-    :$file {:name "" :enumerable false :get (constantly file-id)}
-    :id {:name "" :get (fn [_] (dm/str id))}
+    :$plugin {:enumerable false :get (constantly plugin-id)}
+    :$id {:enumerable false :get (constantly id)}
+    :$file {:enumerable false :get (constantly file-id)}
+    :id {:get (fn [] (dm/str id))}
 
     :name
     {:this true
@@ -629,8 +629,8 @@
     :$file {:enumerable false :get (constantly file-id)}
     :$id {:enumerable false :get (constantly id)}
 
-    :id {:get (fn [_] (dm/str id))}
-    :libraryId {:get (fn [_] (dm/str file-id))}
+    :id {:get (fn [] (dm/str id))}
+    :libraryId {:get (fn [] (dm/str file-id))}
 
     :properties
     {:this true
@@ -706,7 +706,7 @@
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$id {:enumerable false :get (constantly id)}
     :$file {:enumerable false :get (constantly file-id)}
-    :id {:get (fn [_] (dm/str id))}
+    :id {:get (fn [] (dm/str id))}
 
     :name
     {:this true

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -16,6 +16,7 @@
    [frontend-tests.tokens.logic.token-actions-test]
    [frontend-tests.tokens.logic.token-data-test]
    [frontend-tests.tokens.style-dictionary-test]
+   [frontend-tests.util-object-test]
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]
    [frontend-tests.worker-snap-test]))
@@ -45,6 +46,7 @@
    'frontend-tests.tokens.logic.token-actions-test
    'frontend-tests.tokens.logic.token-data-test
    'frontend-tests.tokens.style-dictionary-test
+   'frontend-tests.util-object-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
    'frontend-tests.worker-snap-test))

--- a/frontend/test/frontend_tests/util_object_test.cljs
+++ b/frontend/test/frontend_tests/util_object_test.cljs
@@ -1,0 +1,113 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util-object-test
+  (:require
+   [app.common.schema :as sm]
+   [app.util.object :as obj]
+   [cljs.pprint :refer [pprint]]
+   [cljs.test :as t]))
+
+(t/deftest getters-and-setters
+  (let [val (volatile! nil)
+        obj (obj/reify {:name "Foo"}
+              :value
+              {:get (fn [] @val)
+               :set (fn [o] (vswap! val (constantly o)))})]
+
+    (t/is (nil? (.-value obj)))
+    (set! (.-value obj) 2)
+    (t/is (= 2 (.-value obj)))
+    (t/is (= 2 @val))))
+
+(t/deftest getters-and-setters-access-this
+  (let [val (volatile! nil)
+        obj (obj/reify {:name "Foo"}
+              :value
+              {:get (fn []
+                      (this-as self
+                               self))
+               :set (fn [o]
+                      (this-as self
+                               (vreset! val self)))})]
+
+    (t/is (identical? obj (.-value obj)))
+    (set! (.-value obj) 1)
+    (t/is (identical? obj @val))))
+
+(t/deftest getters-and-setters-access-explicit-this
+  (let [val1 (volatile! nil)
+        val2 (volatile! nil)
+        obj  (obj/reify {:name "Foo"}
+               :value
+               {:this true
+                :get (fn [this]
+                       (this-as self (vreset! val1 self))
+                       (vreset! val2 this)
+                       this)
+                :set (fn [this o]
+                       (this-as self (vreset! val1 self))
+                       (vreset! val2 this))})]
+
+    (t/is (identical? obj (.-value obj)))
+    (t/is (identical? obj @val1))
+    (t/is (identical? obj @val2))
+
+    (vreset! val1 nil)
+    (vreset! val2 nil)
+    (set! (.-value obj) 1)
+
+    (t/is (identical? obj @val1))
+    (t/is (identical? obj @val2))))
+
+(t/deftest functions-with-map-syntax
+  (let [val (volatile! nil)
+        obj (obj/reify {:name "Foo"}
+              :sum
+              {:fn (fn [a b]
+                     (this-as self (vreset! val self))
+                     (+ a b))})]
+
+    (t/is (= 3 (.sum obj 1 2)))
+    (t/is (identical? obj @val))))
+
+(t/deftest functions-with-short-syntax
+  (let [val (volatile! nil)
+        obj (obj/reify {:name "Foo"}
+              :sum
+              (fn [a b]
+                (this-as self (vreset! val self))
+                (+ a b)))]
+
+    (t/is (= 3 (.sum obj 1 2)))
+    (t/is (identical? obj @val))))
+
+(t/deftest functions-with-schema
+  (let [val (volatile! nil)
+        obj (obj/reify {:name "Foo"}
+              :sum
+              {:schema [:cat ::sm/int ::sm/int]
+               :fn (fn [a b]
+                     (this-as self (vreset! val self))
+                     (+ a b))})]
+    (t/is (= 3 (.sum obj 1 2)))
+    (t/is (= 3 (.sum obj 1 "2")))
+
+    (t/is (true? (.propertyIsEnumerable obj "sum")))
+    (t/is (thrown-with-msg? js/Error
+                            #"check error"
+                            (.sum obj 1 "a")))))
+
+(t/deftest non-enumerable-props
+  (let [val (volatile! nil)
+        obj (obj/reify {:name "Foo"}
+              :sum
+              {:enumerable false
+               :fn (fn [a b]
+                     (this-as self (vreset! val self))
+                     (+ a b))})]
+
+    (t/is (false? (.propertyIsEnumerable obj "sum")))))


### PR DESCRIPTION
### Summary

Add an additional syntax pattern to the `app.util.object/reify` macro (used heavily for defining plugins proxy objects) for validation and coerce operations.

Examples:

```clojure
(defn wrap-error
  "A middleware like function that wraps exception handling."
  [f]
  (fn []
    (try
      (let [args (js-arguments)]
        (.apply f nil args))
      (catch :default cause
        (js/console.log "ERROR" (ex-message cause))
        (throw cause)))))

(defn make-object
  []
  (obj/reify {:name "FooBar" :wrap wrap-error}
    :sayHello
    {:schema [:+ ::sm/text]
     :fn (fn [name1 name2 name3]
           (js/console.log "Hello:" name1)
           (js/console.log "Hello:" name2)
           (js/console.log "Hello:" name3))}

    :sayChao
    {:schema [:+ [:map-of ::sm/text ::sm/boolean]]
     :fn (fn [options]
           (run! (fn [[name say?]]
                   (when say?
                     (js/console.log "Chao:" (pr-str name))))
                 options))}))
```

The `:wrap` is applied only to the `:fn` like properties.

### How to Test

This PR introduces several and important changes to the `obj/reify` macro code. So we need to make several tests on
code where this macro is used (mainly plugins).

Also, several unit tests are added for test the existing features.


