### PR TITLE
:bug: Fix unpublish library modal not scrolling file list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,7 @@ example. It's still usable as before, we just removed the example.
 - Fix copy/pasting application/transit+json [Taiga #12721](https://tree.taiga.io/project/penpot/issue/12721)
 - Fix problem with plugins content attribute [Plugins #209](https://github.com/penpot/penpot-plugins/issues/209)
 - Fix U and E icon displayed in project list [Taiga #12806](https://tree.taiga.io/project/penpot/issue/12806)
+- Fix unpublish library modal not scrolling a long file list [Taiga #12285](https://tree.taiga.io/project/penpot/issue/12285)
 
 ## 2.11.1
 

--- a/frontend/src/app/main/ui/delete_shared.cljs
+++ b/frontend/src/app/main/ui/delete_shared.cljs
@@ -106,14 +106,14 @@
        (when (not= 0 count-libraries)
          (if (pos? (count references))
            [:*
-            [:div
-             (when (and (string? scd-msg) (not= scd-msg ""))
-               [:h3 {:class (stl/css :modal-scd-msg)} scd-msg])
-             [:ul {:class (stl/css :element-list)}
-              (for [[file-id file-name] references]
-                [:li {:class (stl/css :list-item)
-                      :key (dm/str file-id)}
-                 [:span "- " file-name]])]]
+            (when (and (string? scd-msg) (not= scd-msg ""))
+              [:p {:class (stl/css :modal-scd-msg)} scd-msg])
+
+            [:ul {:class (stl/css :element-list)}
+             (for [[file-id file-name] references]
+               [:li {:class (stl/css :list-item)
+                     :key (dm/str file-id)}
+                [:span "- " file-name]])]
             (when (and (string? hint) (not= hint ""))
               [:> context-notification* {:level :info
                                          :appearance :ghost}

--- a/frontend/src/app/main/ui/delete_shared.scss
+++ b/frontend/src/app/main/ui/delete_shared.scss
@@ -4,7 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "refactor/common-refactor.scss" as deprecated;
+@use "refactor/basic-rules.scss" as *;
+@use "ds/typography.scss" as t;
 
 .modal-overlay {
   @extend .modal-overlay-base;
@@ -16,7 +17,7 @@
 .modal-container {
   @extend .modal-container-base;
   display: grid;
-  gap: deprecated.$s-24;
+  gap: var(--sp-xxl);
   grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
@@ -27,7 +28,7 @@
 }
 
 .modal-title {
-  @include deprecated.headlineMediumTypography;
+  @include t.use-typography("headline-medium");
   color: var(--modal-title-foreground-color);
 }
 
@@ -36,14 +37,13 @@
 }
 
 .modal-content {
-  @include deprecated.bodySmallTypography;
+  @include t.use-typography("body-small");
   display: grid;
-  grid-template-rows: auto 1fr auto;
-  gap: deprecated.$s-24;
+  gap: var(--sp-s);
 }
 
 .element-list {
-  @include deprecated.bodyLargeTypography;
+  @include t.use-typography("body-large");
   color: var(--modal-text-foreground-color);
   overflow-y: scroll;
   margin-block: 0;
@@ -71,7 +71,7 @@
 .modal-scd-msg,
 .modal-subtitle,
 .modal-msg {
-  @include deprecated.bodyLargeTypography;
+  @include t.use-typography("body-large");
   color: var(--modal-text-foreground-color);
   line-height: 1.5;
 }

--- a/frontend/src/app/main/ui/delete_shared.scss
+++ b/frontend/src/app/main/ui/delete_shared.scss
@@ -15,10 +15,15 @@
 
 .modal-container {
   @extend .modal-container-base;
+  display: grid;
+  gap: deprecated.$s-24;
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
-.modal-header {
-  margin-bottom: deprecated.$s-24;
+.list-wrapper {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  max-height: 100%;
 }
 
 .modal-title {
@@ -32,12 +37,16 @@
 
 .modal-content {
   @include deprecated.bodySmallTypography;
-  margin-bottom: deprecated.$s-24;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: deprecated.$s-24;
 }
 
 .element-list {
   @include deprecated.bodyLargeTypography;
   color: var(--modal-text-foreground-color);
+  overflow-y: scroll;
+  margin-block: 0;
 }
 
 .action-buttons {
@@ -53,6 +62,10 @@
   &.danger {
     @extend .modal-danger-btn;
   }
+}
+
+.modal-scd-msg {
+  margin-block: 0;
 }
 
 .modal-scd-msg,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12285

### Summary

This adds a scroll to the file list (when it's too long) in the Unpublish Library modal.

<img width="545" height="541" alt="Unpublish library modal" src="https://github.com/user-attachments/assets/06cf4545-2714-4497-9db9-9c9329102823" />

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
