### PR TITLE
:bug: Close other open context menus on open a context menu

### DIFF
--- a/frontend/src/app/util/globals.js
+++ b/frontend/src/app/util/globals.js
@@ -35,13 +35,25 @@ goog.scope(function () {
     };
   }
 
-  self.event = function(...args) {
-    return new CustomEvent(...args);
+  self.event = function(name, detail) {
+    const options = {};
+    if (detail !== undefined) {
+      options.detail = detail;
+    }
+    return new CustomEvent(name, options);
   };
 
   self.dispatch_BANG_ = function(...args) {
     self.document.dispatchEvent(...args);
   };
+
+  self.listen = function(...args) {
+    self.document.addEventListener(...args);
+  };
+
+  self.unlisten = function(...args) {
+    self.document.removeEventListener(...args);
+  }
 
   self.window = (function () {
     if (typeof goog.global.window !== "undefined") {


### PR DESCRIPTION
### Summary

You can open multiple context menus on assets panel, this PR fixes that.

<img width="432" height="831" alt="image" src="https://github.com/user-attachments/assets/a1fd5040-053a-4d61-9943-276f9be8535f" />


