### PR TITLE
:lipstick: Set import Tokens default option to be Single JSON value

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
@@ -268,8 +268,8 @@
                    :on-click modal/hide!}
        (tr "labels.cancel")]
       [:> import-type-dropdown*
-       {:options [{:label (tr "workspace.tokens.import-menu-zip-option") :value :zip}
-                  {:label (tr "workspace.tokens.import-menu-json-option") :value :file}
+       {:options [{:label (tr "workspace.tokens.import-menu-json-option") :value :file}
+                  {:label (tr "workspace.tokens.import-menu-zip-option") :value :zip}
                   {:label (tr "workspace.tokens.import-menu-folder-option") :value :folder}]
         :on-click handle-import-action
         :text-render render-button-text


### PR DESCRIPTION
This patches makes the default Tokens importing option to match the current default Tokens exporting option (single JSON value). This way it is more obvious and quick to export the tokens from a file and import in new one,

---

While testing our design system we are often re-exporting and re-importing the Tokens to the files using the design system components.

I'm aware that this may be addressed in the future so the Tokens are brought in together with the library. Meanwhile (and even in the future) I think it is sensible to have a symmetry between the export and import defeault options.

### Steps to reproduce

* Add a token to your document.
* Export it (by default it will export a single JSON file).
* Now try to Import it, by default Penpot tries to import a .zip.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable. (I don't think this is worth mentioning on the CHANGE log to be honest :)

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
