### PR TITLE
:whale: Add missing override to Dockerfile.frontend

### DIFF
--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -7,6 +7,7 @@ RUN set -ex; \
     useradd -U -M -u 1001 -s /bin/false -d /opt/penpot penpot; \
     mkdir -p /opt/data/assets; \
     chown -R penpot:penpot /opt/data; \
+    mkdir -p /etc/nginx/overrides/main.d/; \
     mkdir -p /etc/nginx/overrides/http.d/; \
     mkdir -p /etc/nginx/overrides/server.d/; \
     mkdir -p /etc/nginx/overrides/location.d/;


### PR DESCRIPTION
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWNneWs1dXk5eWtrdHpkdWNycG5lYTVncXU5bzQwNGFzMzhvNjA3aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xP4Fk3xFSLTzSn7WKX/giphy.gif)

This PR adds a missing folder for nginx overrides.