### PR TITLE
:wrench: Improve pan rendering

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -883,6 +883,9 @@
 
 (defn set-view-box
   [prev-zoom zoom vbox]
+  ;; Enable fast mode at the start of pan/zoom interaction
+  ;; This will be disabled when render-finish fires (after debounce delay)
+  (h/call wasm/internal-module "_set_view_start")
   (h/call wasm/internal-module "_set_view" zoom (- (:x vbox)) (- (:y vbox)))
 
   (if (mth/close? prev-zoom zoom)

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -874,25 +874,37 @@
 
 (def render-finish
   (letfn [(do-render [ts]
+            (perf/begin-measure "render-finish")
             (h/call wasm/internal-module "_set_view_end")
-            (render ts))]
+            (render ts)
+            (perf/end-measure "render-finish"))]
     (fns/debounce do-render DEBOUNCE_DELAY_MS)))
 
 (def render-pan
-  (fns/throttle render THROTTLE_DELAY_MS))
+  (letfn [(do-render-pan [ts]
+            (perf/begin-measure "render-pan")
+            (render ts)
+            (perf/end-measure "render-pan"))]
+    (fns/throttle do-render-pan THROTTLE_DELAY_MS)))
 
 (defn set-view-box
   [prev-zoom zoom vbox]
-  ;; Enable fast mode at the start of pan/zoom interaction
-  ;; This will be disabled when render-finish fires (after debounce delay)
-  (h/call wasm/internal-module "_set_view_start")
-  (h/call wasm/internal-module "_set_view" zoom (- (:x vbox)) (- (:y vbox)))
+  (let [is-pan (mth/close? prev-zoom zoom)]
+    (perf/begin-measure "set-view-box")
+    (h/call wasm/internal-module "_set_view_start")
+    (h/call wasm/internal-module "_set_view" zoom (- (:x vbox)) (- (:y vbox)))
 
-  (if (mth/close? prev-zoom zoom)
-    (do (render-pan)
-        (render-finish))
-    (do (h/call wasm/internal-module "_render_from_cache" 0)
-        (render-finish))))
+    (if is-pan
+      (do (perf/end-measure "set-view-box")
+          (perf/begin-measure "set-view-box::pan")
+          (render-pan)
+          (render-finish)
+          (perf/end-measure "set-view-box::pan"))
+      (do (perf/end-measure "set-view-box")
+          (perf/begin-measure "set-view-box::zoom")
+          (h/call wasm/internal-module "_render_from_cache" 0)
+          (render-finish)
+          (perf/end-measure "set-view-box::zoom")))))
 
 (defn set-object
   [objects shape]

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -251,10 +251,15 @@ pub extern "C" fn set_view_end() {
         state.render_state.options.set_fast_mode(false);
         // We can have renders in progress
         state.render_state.cancel_animation_frame();
-        if state.render_state.options.is_profile_rebuild_tiles() {
-            state.rebuild_tiles();
-        } else {
-            state.rebuild_tiles_shallow();
+        // Only rebuild tile indices when zoom has changed.
+        // During pan-only operations, shapes stay in the same tiles
+        // because tile_size = 1/scale * TILE_SIZE (depends only on zoom).
+        if state.render_state.zoom_changed() {
+            if state.render_state.options.is_profile_rebuild_tiles() {
+                state.rebuild_tiles();
+            } else {
+                state.rebuild_tiles_shallow();
+            }
         }
     });
 }

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -235,9 +235,20 @@ pub extern "C" fn set_view(zoom: f32, x: f32, y: f32) {
     });
 }
 
+/// Called at the start of pan/zoom interaction to enable fast rendering mode.
+/// In fast mode, expensive operations like shadows are skipped for better performance.
+#[no_mangle]
+pub extern "C" fn set_view_start() {
+    with_state_mut!(state, {
+        state.render_state.options.set_fast_mode(true);
+    });
+}
+
 #[no_mangle]
 pub extern "C" fn set_view_end() {
     with_state_mut!(state, {
+        // Disable fast mode when interaction ends
+        state.render_state.options.set_fast_mode(false);
         // We can have renders in progress
         state.render_state.cancel_animation_frame();
         if state.render_state.options.is_profile_rebuild_tiles() {

--- a/render-wasm/src/options.rs
+++ b/render-wasm/src/options.rs
@@ -1,2 +1,3 @@
 pub const DEBUG_VISIBLE: u32 = 0x01;
 pub const PROFILE_REBUILD_TILES: u32 = 0x02;
+pub const FAST_MODE: u32 = 0x04;

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1479,8 +1479,11 @@ impl RenderState {
                     .surfaces
                     .get_render_context_translation(self.render_area, scale);
 
+                // Skip expensive drop shadow rendering in fast mode (during pan/zoom)
+                let skip_shadows = self.options.is_fast_mode();
+
                 // For text shapes, render drop shadow using text rendering logic
-                if !matches!(element.shape_type, Type::Text(_)) {
+                if !skip_shadows && !matches!(element.shape_type, Type::Text(_)) {
                     // Shadow rendering technique: Two-pass approach for proper opacity handling
                     //
                     // The shadow rendering uses a two-pass technique to ensure that overlapping

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2057,6 +2057,12 @@ impl RenderState {
         self.cached_viewbox.zoom() * self.options.dpr()
     }
 
+    /// Returns true if the zoom level has changed since the last cached viewbox.
+    /// Used to optimize pan-only operations where tile indices don't need to be rebuilt.
+    pub fn zoom_changed(&self) -> bool {
+        (self.viewbox.zoom - self.cached_viewbox.zoom).abs() > f32::EPSILON
+    }
+
     pub fn mark_touched(&mut self, uuid: Uuid) {
         self.touched_ids.insert(uuid);
     }

--- a/render-wasm/src/render/options.rs
+++ b/render-wasm/src/render/options.rs
@@ -15,6 +15,20 @@ impl RenderOptions {
         self.flags & options::PROFILE_REBUILD_TILES == options::PROFILE_REBUILD_TILES
     }
 
+    /// Fast mode is enabled during interactive pan/zoom operations.
+    /// When active, expensive operations like shadows are skipped for better performance.
+    pub fn is_fast_mode(&self) -> bool {
+        self.flags & options::FAST_MODE == options::FAST_MODE
+    }
+
+    pub fn set_fast_mode(&mut self, enabled: bool) {
+        if enabled {
+            self.flags |= options::FAST_MODE;
+        } else {
+            self.flags &= !options::FAST_MODE;
+        }
+    }
+
     pub fn dpr(&self) -> f32 {
         self.dpr.unwrap_or(1.0)
     }

--- a/render-wasm/src/render/options.rs
+++ b/render-wasm/src/render/options.rs
@@ -15,8 +15,7 @@ impl RenderOptions {
         self.flags & options::PROFILE_REBUILD_TILES == options::PROFILE_REBUILD_TILES
     }
 
-    /// Fast mode is enabled during interactive pan/zoom operations.
-    /// When active, expensive operations like shadows are skipped for better performance.
+    /// Use fast mode to enable / disable expensive operations
     pub fn is_fast_mode(&self) -> bool {
         self.flags & options::FAST_MODE == options::FAST_MODE
     }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12855

### Summary

This PR avoids rebuilding tiles when panning and not zooming if it's not necessary, and includes some performance logs that can be useful to compare changes when building in mode debug:

```
./build debug --features profile-macros
```

### Steps to reproduce 

Compare panning against large files

**Current**

[screen-recorder-tue-dec-09-2025-12-42-44.webm](https://github.com/user-attachments/assets/0c2f617e-52f6-4fd3-a46b-392a9e5aaf6a)


**New**

[screen-recorder-tue-dec-09-2025-12-43-53.webm](https://github.com/user-attachments/assets/2d32c18c-7cd6-44c1-8411-17105de3a48d)


### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
