### PR TITLE
:bug: Fix paragraph height across paragraphs with different line sizes

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -333,7 +333,7 @@
                     (case valign
                       "bottom" (- y (- height selrect-height))
                       "center" (- y (/ (- height selrect-height) 2))
-                      "top"    y)
+                      y)
                     y)]
             [(assoc selrect :y y :width max-width :height max-height) transform])
 

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -253,11 +253,12 @@ fn draw_text(
 
     let layer_rec = SaveLayerRec::default();
     canvas.save_layer(&layer_rec);
-    let mut normalized_line_height = text_content.normalized_line_height();
+    let mut previous_line_height = text_content.normalized_line_height();
 
     for paragraph_builder_group in paragraph_builder_groups {
-        let mut group_offset_y = global_offset_y;
+        let group_offset_y = global_offset_y;
         let group_len = paragraph_builder_group.len();
+        let mut paragraph_offset_y = previous_line_height;
 
         for (paragraph_index, paragraph_builder) in paragraph_builder_group.iter_mut().enumerate() {
             let mut paragraph = paragraph_builder.build();
@@ -266,12 +267,13 @@ fn draw_text(
             paragraph.paint(canvas, xy);
 
             let line_metrics = paragraph.get_line_metrics();
+
             if paragraph_index == group_len - 1 {
                 if line_metrics.is_empty() {
-                    group_offset_y += normalized_line_height;
+                    paragraph_offset_y = paragraph.ideographic_baseline();
                 } else {
-                    normalized_line_height = paragraph.ideographic_baseline();
-                    group_offset_y += paragraph.ideographic_baseline() * line_metrics.len() as f32;
+                    paragraph_offset_y = paragraph.height();
+                    previous_line_height = paragraph.ideographic_baseline();
                 }
             }
 
@@ -280,7 +282,7 @@ fn draw_text(
             }
         }
 
-        global_offset_y = group_offset_y;
+        global_offset_y += paragraph_offset_y;
     }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12849

### Summary

Use paragraph height and paragraph ideographic baseline accordingly

### Steps to reproduce 

<img width="1527" height="1129" alt="image" src="https://github.com/user-attachments/assets/f1ffb968-9840-4f4f-b5c3-c109554ba57d" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
