### PR TITLE
:bug: Fix pass new icons to radio buttons

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -16,6 +16,7 @@
    [app.main.ui.components.numeric-input :as deprecated-input]
    [app.main.ui.components.radio-buttons :refer [radio-button radio-buttons]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
+   [app.main.ui.ds.foundations.assets.icon :as i]
    [app.main.ui.icons :as deprecated-icon]
    [app.main.ui.workspace.sidebar.options.menus.layout-container :refer [get-layout-flex-icon]]
    [app.util.dom :as dom]
@@ -234,20 +235,20 @@
 
     [:& radio-button
      {:value "fix"
-      :icon  deprecated-icon/fixed-width
+      :icon  i/fixed-width
       :title "Fix width"
       :id    "behaviour-h-fix"}]
 
     (when has-fill
       [:& radio-button
        {:value "fill"
-        :icon  deprecated-icon/fill-content
+        :icon  i/fill-content
         :title "Width 100%"
         :id    "behaviour-h-fill"}])
     (when is-auto
       [:& radio-button
        {:value "auto"
-        :icon  deprecated-icon/hug-content
+        :icon  i/hug-content
         :title "Fit content (Horizontal)"
         :id    "behaviour-h-auto"}])]])
 
@@ -268,7 +269,7 @@
 
     [:& radio-button
      {:value      "fix"
-      :icon       deprecated-icon/fixed-width
+      :icon       i/fixed-width
       :icon-class (stl/css :rotated)
       :title      "Fix height"
       :id         "behaviour-v-fix"}]
@@ -276,14 +277,14 @@
     (when has-fill
       [:& radio-button
        {:value      "fill"
-        :icon       deprecated-icon/fill-content
+        :icon       i/fill-content
         :icon-class (stl/css :rotated)
         :title      "Height 100%"
         :id         "behaviour-v-fill"}])
     (when is-auto
       [:& radio-button
        {:value      "auto"
-        :icon       deprecated-icon/hug-content
+        :icon       i/hug-content
         :icon-class (stl/css :rotated)
         :title      "Fit content (Vertical)"
         :id         "behaviour-v-auto"}])]])


### PR DESCRIPTION
### Related Ticket

This is a follow-up of #7825 

### Summary

The mentioned PR introduced a [change](https://github.com/penpot/penpot/pull/7825/files#diff-5bd08ad78289dd56bda52280774dee29a0ec7cea15730d6469c634845816b829R50) in the radio buttons component that required the icons to be taken from the DS foundations rather than the old ones. This implied updating all instances of this component, but some were not updated, breaking the app when using layout items. This PR addresses this issue.