### PR TITLE
:bug: Fix child layout styles

### DIFF
--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -262,7 +262,7 @@
          :layout-item-min-w
          :layout-item-absolute
          :layout-item-z-index)
-        (api/set-layout-child shape)
+        (api/set-layout-data shape)
 
         :layout-grid-rows
         (api/set-grid-layout-rows v)
@@ -292,7 +292,7 @@
 
             (ctl/flex-layout? shape)
             (api/set-flex-layout shape))
-          (api/set-layout-child shape))
+          (api/set-layout-data shape))
 
         ;; Property not in WASM
         nil))))

--- a/render-wasm/src/wasm/layouts.rs
+++ b/render-wasm/src/wasm/layouts.rs
@@ -40,7 +40,7 @@ pub extern "C" fn clear_shape_layout() {
 }
 
 #[no_mangle]
-pub extern "C" fn set_layout_child_data(
+pub extern "C" fn set_layout_data(
     margin_top: f32,
     margin_right: f32,
     margin_bottom: f32,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12881

### Summary

It seems the issue was that shape properties relative to layout where not being properly set

[screen-recorder-thu-dec-11-2025-11-51-30.webm](https://github.com/user-attachments/assets/5cc93f0b-942c-4b41-9725-6292a41222d0)

### Steps to reproduce 

Follow issue's steps, and also try with other items than variants, like simply copy/pasting a board with a flex layout and absolute elements, for instance.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Check CI passes successfully.
