### PR TITLE
:bug: Fix text editor not getting focus back after font variant change

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -270,8 +270,10 @@
                            :font-variant-id new-variant-id
                            :font-weight (:weight variant)
                            :font-style (:style variant)}))
-
-             (dom/blur! (dom/get-target new-variant-id)))))
+             ;; NOTE: the select component we are using does not fire on-blur event
+             ;; so we need to call on-blur manually
+             (when (some? on-blur)
+               (on-blur)))))
 
         on-font-select
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11903

### Summary

This PR fixes the editor not getting focus back after a font variant change. This was caused by our `select` component not triggering / supporting on-blur.

https://github.com/user-attachments/assets/1c172ea1-9a60-4cad-8581-8fbb7cefca48

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
