### PR TITLE
:sparkles: Add proxypass to caddyfile on devenv

### DIFF
--- a/docker/devenv/files/Caddyfile
+++ b/docker/devenv/files/Caddyfile
@@ -10,3 +10,7 @@ localhost:3449 {
 http://localhost:3450 {
    reverse_proxy localhost:4449
 }
+
+http://penpot-devenv-main:3450 {
+    reverse_proxy localhost:4449
+}


### PR DESCRIPTION
Added an entry on Caddifile to access penpot with `penpot-devenv-main` 