### PR TITLE
:sparkles: Enable shadow tokens by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 ### :sparkles: New features & Enhancements
 
+- Add new Box Shadow Tokens [Taiga #10201](https://tree.taiga.io/project/penpot/us/10201)
 - Make i18n translation files load on-demand [Taiga #11474](https://tree.taiga.io/project/penpot/us/11474)
 
 ### :bug: Bugs fixed

--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -169,6 +169,7 @@
    :enable-component-thumbnails
    :enable-render-wasm-dpr
    :enable-token-color
+   :enable-token-shadow
    :enable-inspect-styles
    :enable-feature-fdata-objects-map])
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12896

### Summary

Enable Shadow tokens to be active by default in all deployments.
