### PR TITLE
:bug: Fix setting a portion of text as bold or underline messes thing…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.12.1
+
+### :bug: Bugs fixed
+
+- Fix setting a portion of text as bold or underline messes things up [Github #7980](https://github.com/penpot/penpot/issues/7980)
+
 ## 2.12.0
 
 ### :boom: Breaking changes & Deprecations

--- a/frontend/src/app/main/ui/shapes/text/styles.cljs
+++ b/frontend/src/app/main/ui/shapes/text/styles.cljs
@@ -106,9 +106,11 @@
                               :overflowWrap "initial"
                               :lineBreak "auto"
                               :whiteSpace "break-spaces"
-                              :textRendering "geometricPrecision"
-                              :display "inline-block"
-                              :verticalAlign "top"}
+                              :textRendering "geometricPrecision"}
+         base            (cond-> base
+                           (= (:line-height data) "0")
+                           (-> (obj/set! "display" "inline-block")
+                               (obj/set! "verticalAlign" "top")))
          fills
          (cond
            ;; DEPRECATED: still here for backward compatibility with


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12982 in github https://github.com/penpot/penpot/issues/7980

### Summary

Introduced trying to solve https://tree.taiga.io/project/penpot/issue/12252 (with these solution both situations should work ok)

