### PR TITLE
:recycle: Minor naming changes and event handling

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -40,6 +40,7 @@
    ;; FIXME: rename; confunsing name
    [app.render-wasm.wasm :as wasm]
    [app.util.debug :as dbg]
+   [app.util.dom :as dom]
    [app.util.functions :as fns]
    [app.util.globals :as ug]
    [app.util.text.content :as tc]
@@ -1229,6 +1230,13 @@
           (re-find #"(?i)edge" user-agent) :edge
           :else :unknown)))))
 
+(defn- on-webgl-context-lost
+  [event]
+  (dom/prevent-default event)
+  (reset! wasm/context-lost? true)
+  (log/warn :hint "WebGL context lost")
+  (st/emit! (drw/context-lost)))
+
 (defn init-canvas-context
   [canvas]
   (let [gl      (unchecked-get wasm/internal-module "GL")
@@ -1256,14 +1264,8 @@
         (set-canvas-size canvas)
 
         ;; Add event listeners for WebGL context lost
-        (let [handler (fn [event]
-                        (.preventDefault event)
-                        (reset! wasm/context-lost? true)
-                        (log/warn :hint "WebGL context lost")
-                        (st/emit! (drw/context-lost)))]
-          (set! wasm/context-lost-handler handler)
-          (set! wasm/context-lost-canvas canvas)
-          (.addEventListener canvas "webglcontextlost" handler))
+        (set! wasm/canvas canvas)
+        (.addEventListener canvas "webglcontextlost" on-webgl-context-lost)
         (set! wasm/context-initialized? true)))
 
     context-init?))
@@ -1277,10 +1279,9 @@
       (h/call wasm/internal-module "_clean_up")
 
       ;; Remove event listener for WebGL context lost
-      (when (and wasm/context-lost-handler wasm/context-lost-canvas)
-        (.removeEventListener wasm/context-lost-canvas "webglcontextlost" wasm/context-lost-handler)
-        (set! wasm/context-lost-canvas nil)
-        (set! wasm/context-lost-handler nil))
+      (when wasm/canvas
+        (.removeEventListener wasm/canvas "webglcontextlost" on-webgl-context-lost)
+        (set! wasm/canvas nil))
 
       ;; Ensure the WebGL context is properly disposed so browsers do not keep
       ;; accumulating active contexts between page switches.

--- a/frontend/src/app/render_wasm/wasm.cljs
+++ b/frontend/src/app/render_wasm/wasm.cljs
@@ -9,8 +9,20 @@
 
 (defonce internal-frame-id nil)
 (defonce internal-module #js {})
+
+;; Reference to the HTML canvas element.
+(defonce canvas nil)
+
+;; Reference to the Emscripten GL context wrapper.
 (defonce gl-context-handle nil)
+
+;; Reference to the actual WebGL Context returned
+;; by the `.getContext` method of the canvas.
 (defonce gl-context nil)
+
+(defonce context-initialized? false)
+(defonce context-lost? (atom false))
+
 (defonce serializers
   #js {:blur-type shared/RawBlurType
        :blend-mode shared/RawBlendMode
@@ -44,8 +56,3 @@
        :stroke-linecap shared/RawStrokeLineCap
        :stroke-linejoin shared/RawStrokeLineJoin
        :fill-rule shared/RawFillRule})
-
-(defonce context-initialized? false)
-(defonce context-lost? (atom false))
-(defonce context-lost-handler nil)
-(defonce context-lost-canvas nil)


### PR DESCRIPTION
### Summary

- Changes some names like `context-lost-canvas` for `canvas`.
- Creates a new private function for handling the contextlost event.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
