### PR TITLE
:bug: Fix problem with dragging handlers

### DIFF
--- a/common/src/app/common/types/path.cljc
+++ b/common/src/app/common/types/path.cljc
@@ -112,8 +112,10 @@
                 (:c2y params) (update-in [index :params :c2y] + (:c2y params)))
               content))]
 
-    (impl/path-data
-     (reduce apply-to-index (vec content) modifiers))))
+    (if (some? modifiers)
+      (impl/path-data
+       (reduce apply-to-index (vec content) modifiers))
+      content)))
 
 (defn transform-content
   "Applies a transformation matrix over content and returns a new

--- a/frontend/src/app/main/ui/workspace/shapes/path/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/path/editor.cljs
@@ -148,11 +148,12 @@
         (mf/use-fn
          (mf/deps index prefix is-move)
          (fn [event]
-           (dom/stop-propagation event)
-           (dom/prevent-default event)
+           (when (dom/left-mouse? event)
+             (dom/stop-propagation event)
+             (dom/prevent-default event)
 
-           (when ^boolean is-move
-             (st/emit! (drp/start-move-handler index prefix)))))]
+             (when ^boolean is-move
+               (st/emit! (drp/start-move-handler index prefix))))))]
 
     [:g.handler {:pointer-events (if ^boolean is-draw "none" "visible")}
      [:line


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12985

### Steps to reproduce 

- drag a path handler and without releasing, press the escape key.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
