### PR TITLE
:sparkles: Add several adjustments for make penpot run on subpath

### DIFF
--- a/frontend/resources/styles/common/dependencies/fonts.scss
+++ b/frontend/resources/styles/common/dependencies/fonts.scss
@@ -13,7 +13,7 @@
   $weight: unquote("normal"),
   $style: string.unquote("normal")
 ) {
-  $filepath: "/fonts/" + $file;
+  $filepath: "../fonts/" + $file;
 
   @font-face {
     font-family: "#{$style-name}";
@@ -29,7 +29,7 @@
 }
 
 @mixin font-face-variable($style-name, $file, $unicode-range) {
-  $filepath: "/fonts/" + $file;
+  $filepath: "../fonts/" + $file;
 
   @font-face {
     font-family: "#{$style-name}";

--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -110,12 +110,9 @@
 
 (defn- normalize-uri
   [uri-str]
-  (let [uri (u/uri uri-str)]
-    ;; Ensure that the path always ends with "/"; this ensures that
-    ;; all path join operations works as expected.
-    (cond-> uri
-      (not (str/ends-with? (:path uri) "/"))
-      (update :path #(str % "/")))))
+  ;; Ensure that the path always ends with "/"; this ensures that
+  ;; all path join operations works as expected.
+  (u/ensure-path-slash uri-str))
 
 (def public-uri
   (normalize-uri (or (obj/get global "penpotPublicURI")

--- a/frontend/src/app/main/fonts.cljs
+++ b/frontend/src/app/main/fonts.cljs
@@ -12,6 +12,7 @@
    [app.common.data.macros :as dm]
    [app.common.logging :as log]
    [app.common.types.text :as txt]
+   [app.common.uri :as u]
    [app.config :as cf]
    [app.util.dom :as dom]
    [app.util.globals :as globals]
@@ -19,7 +20,6 @@
    [app.util.object :as obj]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [lambdaisland.uri :as u]
    [okulary.core :as l]
    [promesa.core :as p]))
 
@@ -138,13 +138,13 @@
                       "&display=block")]
     (dm/str
      (-> cf/public-uri
-         (assoc :path "/internal/gfonts/css")
+         (u/join "internal/gfonts/css")
          (assoc :query query)))))
 
 (defn- process-gfont-css
   [css]
-  (let [base (dm/str (assoc cf/public-uri :path "/internal/gfonts/font"))]
-    (str/replace css "https://fonts.gstatic.com/s" base)))
+  (let [base (u/join cf/public-uri "internal/gfonts/font")]
+    (str/replace css "https://fonts.gstatic.com/s" (dm/str base))))
 
 (defn- fetch-gfont-css
   [url]
@@ -178,7 +178,9 @@
 
 (defn- asset-id->uri
   [asset-id]
-  (str (u/join cf/public-uri "assets/by-id/" asset-id)))
+  (-> cf/public-uri
+      (u/join "assets/by-id/" asset-id)
+      (str)))
 
 (defn generate-custom-font-variant-css
   [family variant]
@@ -370,7 +372,7 @@
       :else
       (let [{:keys [weight style suffix]} (get-variant font font-variant-id)
             suffix (or suffix font-variant-id)
-            params {:uri (dm/str cf/public-uri "fonts/" family "-" suffix ".woff")
+            params {:uri (str (u/join cf/public-uri (str "fonts/" family "-" suffix ".woff")))
                     :family family
                     :style style
                     :weight weight}]

--- a/frontend/src/app/main/rasterizer.cljs
+++ b/frontend/src/app/main/rasterizer.cljs
@@ -14,6 +14,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.logging :as log]
+   [app.common.uri :as u]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.util.dom :as dom]
@@ -26,7 +27,9 @@
 (defonce instance nil)
 (defonce msgbus (rx/subject))
 (defonce origin
-  (dm/str (assoc cf/rasterizer-uri :path "/rasterizer.html")))
+  (-> cf/rasterizer-uri
+      (u/join "rasterizer.html")
+      (dm/str)))
 
 (declare send-message!)
 
@@ -129,7 +132,9 @@
                          (dom/append-child! js/document.body iframe)
                          (set! instance iframe))
 
-                       (let [new-origin (dm/str (assoc cf/public-uri :path "/rasterizer.html"))]
+                       (let [new-origin (-> cf/public-uri
+                                            (u/join "rasterizer.html")
+                                            (dm/str))]
                          (log/warn :hint "fallback to main domain" :origin new-origin)
 
                          (dom/set-attribute! iframe "src" new-origin)


### PR DESCRIPTION
### Summary

Fixes internal issues on penpot for make it work correctly in a subpath, not requiring a  domain to run.

### How to test

Put the `var penpotPublicURI = "https://localhost:3449/penpot"';` under `resources/public/js/config.js`
Make a temporal update on `docker/devenv/files/Caddyfile`:

```caddyfile
localhost:3449 {
	handle_path /penpot* {
		reverse_proxy localhost:4449
	}

	tls /home/selfsigned.crt /home/selfsigned.key
}
```
(replacing the previous entry)

And then reload caddy on the devenv: 

```
sudo caddy reload --config penpot/docker/devenv/files/Caddyfile 
```

Now access to https://localhost:3449/penpot/ and it should work as expected.
