### PR TITLE
:bug: Fix empty state message in trash page

### DIFF
--- a/frontend/playwright/ui/specs/dashboard-deleted.spec.js
+++ b/frontend/playwright/ui/specs/dashboard-deleted.spec.js
@@ -20,12 +20,7 @@ test.describe("Dashboard Deleted Page", () => {
     // Navigate directly to deleted page
     await dashboardPage.goToDeleted();
 
-    // Check for the restore all and clear trash buttons
-    await expect(
-      page.getByRole("button", { name: "Restore All" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Clear trash" }),
-    ).toBeVisible();
+    // Check for the delete-page-section element
+    await expect(page.getByTestId("deleted-page-section")).toBeVisible();
   });
 });

--- a/frontend/src/app/main/ui/dashboard/deleted.cljs
+++ b/frontend/src/app/main/ui/dashboard/deleted.cljs
@@ -284,37 +284,44 @@
 
     [:*
      [:> header* {:team team}]
-     [:section {:class (stl/css :dashboard-container :no-bg)}
+     [:section {:class (stl/css :dashboard-container :no-bg)
+                :data-testid "deleted-page-section"}
       [:*
        [:div {:class (stl/css :no-bg)}
 
         [:> menu* {:team-id team-id :section :dashboard-deleted}]
 
-        [:div {:class (stl/css :deleted-info-content)}
-         [:p {:class (stl/css :deleted-info)}
-          (tr "dashboard.trash-info-text-part1")
-          [:span {:class (stl/css :info-text-highlight)}
-           (tr "dashboard.trash-info-text-part2" deletion-days)]
-          (tr "dashboard.trash-info-text-part3")
-          [:br]
-          (tr "dashboard.trash-info-text-part4")]
-         [:div {:class (stl/css :deleted-options)}
-          [:> button* {:variant "ghost"
-                       :type "button"
-                       :on-click on-restore-all}
-           (tr "dashboard.restore-all-deleted-button")]
-          [:> button* {:variant "destructive"
-                       :type "button"
-                       :icon "delete"
-                       :on-click on-delete-all}
-           (tr "dashboard.clear-trash-button")]]]
+        (if (seq projects)
+          [:*
+           [:div {:class (stl/css :deleted-info-content)}
+            [:p {:class (stl/css :deleted-info)}
+             (tr "dashboard.trash-info-text-part1")
+             [:span {:class (stl/css :info-text-highlight)}
+              (tr "dashboard.trash-info-text-part2" deletion-days)]
+             (tr "dashboard.trash-info-text-part3")
+             [:br]
+             (tr "dashboard.trash-info-text-part4")]
+            [:div {:class (stl/css :deleted-options)}
+             [:> button* {:variant "ghost"
+                          :type "button"
+                          :on-click on-restore-all}
+              (tr "dashboard.restore-all-deleted-button")]
+             [:> button* {:variant "destructive"
+                          :type "button"
+                          :icon "delete"
+                          :on-click on-delete-all}
+              (tr "dashboard.clear-trash-button")]]]
 
-        (when projects
-          (for [{:keys [id] :as project} projects]
-            (let [files (when deleted-map
-                          (->> (vals deleted-map)
-                               (filterv #(= id (:project-id %)))
-                               (sort-by :modified-at #(compare %2 %1))))]
-              [:> deleted-project-item* {:project project
-                                         :files files
-                                         :key id}])))]]]]))
+           (for [{:keys [id] :as project} projects]
+             (let [files (when deleted-map
+                           (->> (vals deleted-map)
+                                (filterv #(= id (:project-id %)))
+                                (sort-by :modified-at #(compare %2 %1))))]
+               [:> deleted-project-item* {:project project
+                                          :files files
+                                          :key id}]))]
+
+          ;; when no deleted projects
+          [:div {:class (stl/css :deleted-info-content)}
+           [:p {:class (stl/css :deleted-info)}
+            (tr "dashboard.deleted.empty-state-description")]])]]]]))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -8572,3 +8572,6 @@ msgstr "Restore unexpectedly slow"
 
 msgid "dashboard.progress-notification.slow-delete"
 msgstr "Deletion unexpectedly slow"
+
+msgid "dashboard.deleted.empty-state-description"
+msgstr "Your trash is empty. Deleted files and projects will appear here."

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -8419,3 +8419,6 @@ msgstr "Restauración inesperadamente lenta"
 
 msgid "dashboard.progress-notification.slow-delete"
 msgstr "Eliminación inesperadamente lenta"
+
+msgid "dashboard.deleted.empty-state-description"
+msgstr "Tu papelera está vacía. Los archivos y proyectos eliminados aparecerán aquí."


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13004

### Summary

State message should be different when the trash is empty.

### Steps to reproduce 

Compare empty trash vs full.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.