### PR TITLE
:bug: Fix line-height units and resolved value

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/typography.cljs
@@ -93,9 +93,9 @@
         line-height-sub-token
         (mf/with-memo [token]
           (if-let [value (get token :value)]
-            {:type :number
+            {:type :dimensions
              :value (get value :line-height)}
-            {:type :number}))
+            {:type :dimensions}))
 
         text-case-sub-token
         (mf/with-memo [token]


### PR DESCRIPTION
### Related Ticket

This PR fixes this PR https://tree.taiga.io/project/penpot/issue/13019

### Summary

In this PR we have fixed the line-height on typography token. 
Now you can use:
- plain number, e.g. 2. Resolved-value should not be visible because is the same value (2)
- number with units, e.g. 4px, Resolved value in reference with font-size
- percetage value, e.g. 2%, resolved value will be 0.02
- basic maths with plain numbers, e.g. 2*2 (resolved value 4) or 4+3 (resolved value 7)

### Steps to reproduce 
See issue for detailed step by step

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
