### PR TITLE
:wrench: Show message and button to reload the page when WebGL context is lost

### DIFF
--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -308,6 +308,16 @@
      [:div {:class (stl/css :sign-info)}
       [:button {:on-click on-click} (tr "labels.retry")]]]))
 
+(mf/defc webgl-context-lost*
+  []
+  (let [on-reload (mf/use-fn #(js/location.reload))]
+    [:> error-container* {}
+     [:div {:class (stl/css :main-message)} (tr "labels.webgl-context-lost.main-message")]
+     [:div {:class (stl/css :desc-message)} (tr "labels.webgl-context-lost.desc-message")]
+     [:div {:class (stl/css :buttons-container)}
+      [:> button* {:variant "primary" :on-click on-reload}
+       (tr "labels.reload-page")]]]))
+
 (defn- generate-report
   [data]
   (try
@@ -437,6 +447,7 @@
                        (rx/of default)
                        (rx/throw cause)))))))
 
+
 (mf/defc exception-section*
   {::mf/private true}
   [{:keys [data route] :as props}]
@@ -468,6 +479,9 @@
 
       :service-unavailable
       [:> service-unavailable*]
+
+      :webgl-context-lost
+      [:> webgl-context-lost*]
 
       [:> internal-error* props])))
 

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -10,6 +10,7 @@
    ["react-dom/server" :as rds]
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.exceptions :as ex]
    [app.common.files.helpers :as cfh]
    [app.common.logging :as log]
    [app.common.math :as mth]
@@ -21,7 +22,6 @@
    [app.common.types.text :as txt]
    [app.common.uuid :as uuid]
    [app.config :as cf]
-   [app.main.data.render-wasm :as drw]
    [app.main.refs :as refs]
    [app.main.render :as render]
    [app.main.store :as st]
@@ -1236,7 +1236,8 @@
   (dom/prevent-default event)
   (reset! wasm/context-lost? true)
   (log/warn :hint "WebGL context lost")
-  (st/emit! (drw/context-lost)))
+  (ex/raise :type :webgl-context-lost
+            :hint "WebGL context lost"))
 
 (defn init-canvas-context
   [canvas]

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2521,6 +2521,9 @@ msgstr "Release notes"
 msgid "labels.reload-file"
 msgstr "Reload file"
 
+msgid "labels.reload-page"
+msgstr "Reload page"
+
 #: src/app/main/ui/workspace/libraries.cljs, src/app/main/ui/dashboard/team.cljs
 #, unused
 msgid "labels.remove"
@@ -8438,6 +8441,12 @@ msgstr "Recent"
 
 msgid "labels.deleted"
 msgstr "Deleted"
+
+msgid "labels.webgl-context-lost.main-message"
+msgstr "Oops! The canvas context was lost"
+
+msgid "labels.webgl-context-lost.desc-message"
+msgstr "WebGL has stopped working. Please reload the page to reset it"
 
 msgid "dashboard.restore-all-deleted-button"
 msgstr "Restore All"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2502,6 +2502,9 @@ msgstr "Notas de versión"
 msgid "labels.reload-file"
 msgstr "Recargar archivo"
 
+msgid "labels.reload-page"
+msgstr "Recargar página"
+
 #: src/app/main/ui/workspace/libraries.cljs, src/app/main/ui/dashboard/team.cljs
 #, unused
 msgid "labels.remove"
@@ -8291,6 +8294,12 @@ msgstr "Recientes"
 
 msgid "labels.deleted"
 msgstr "Eliminados"
+
+msgid "labels.webgl-context-lost.main-message"
+msgstr "Ups! Se ha perdido el contexto del canvas"
+
+msgid "labels.webgl-context-lost.desc-message"
+msgstr "WebGL ha dejado de funcionar. Por favor, recarga la página para restaurarlo"
 
 msgid "dashboard.restore-all-deleted-button"
 msgstr "Restaurar todo"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13018

### Summary

Instead of trying to _automagically_ reset the canvas when the WebGL context is lost, show a message and ask the user to reload the page.

<img width="1203" height="1053" alt="Screenshot 2026-01-09 at 12-56-20 New File 1 - Penpot" src="https://github.com/user-attachments/assets/e9cfdc1d-c9d0-49f6-93c7-bbe2bd2127e3" />

### Steps to reproduce 

1. Open any file
2. Open the console and execute the following code to force the context lost event:

```js
const canvas = document.querySelector('canvas');
const gl = canvas.getContext('webgl2');
const ext = gl.getExtension('WEBGL_lose_context');
ext.loseContext()
```

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
