### PR TITLE
:sparkles: Make the virtual clock by profile and not global

### DIFF
--- a/backend/resources/app/templates/debug.tmpl
+++ b/backend/resources/app/templates/debug.tmpl
@@ -12,43 +12,22 @@ Debug Main Page
 </nav>
 <main class="dashboard">
   <section class="widget">
-    <fieldset>
-      <legend>Error reports</legend>
-      <desc><a href="/dbg/error">CLICK HERE TO SEE THE ERROR REPORTS</a> </desc>
-    </fieldset>
 
     <fieldset>
-      <legend>Profile Management</legend>
-      <form method="post" action="/dbg/actions/resend-email-verification">
-        <div class="row">
-          <input type="email" name="email" placeholder="example@example.com" value="" />
-        </div>
-
-        <div class="row">
-          <label for="force-verify">Are you sure?</label>
-          <input id="force-verify" type="checkbox" name="force" />
-          <br />
-          <small>
-            This is a just a security double check for prevent non intentional submits.
-          </small>
-        </div>
-
-        <div class="row">
-          <input type="submit" name="resend" value="Resend Verification" />
-          <input type="submit" name="verify" value="Verify" />
-        </div>
-
-        <div class="row">
-          <input type="submit" class="danger" name="block" value="Block" />
-          <input type="submit" class="danger" name="unblock" value="Unblock" />
-        </div>
-      </form>
+      <legend>CURRENT PROFILE</legend>
+      <desc>
+        <p>
+          Name: <b>{{profile.fullname}}</b> <br />
+          Email: <b>{{profile.email}}</b>
+        </p>
+      </desc>
     </fieldset>
 
     <fieldset>
       <legend>VIRTUAL CLOCK</legend>
 
       <desc>
+        <p><b>IMPORTANT:</b> The virtual clock is profile based and only affects the currently logged-in profile.</p>
         <p>
           CURRENT CLOCK: <b>{{current-clock}}</b>
           <br />
@@ -81,7 +60,92 @@ Debug Main Page
       </form>
     </fieldset>
 
+    <fieldset>
+      <legend>ERROR REPORTS</legend>
+      <desc><a href="/dbg/error">CLICK HERE TO SEE THE ERROR REPORTS</a> </desc>
+    </fieldset>
   </section>
+
+
+  <section class="widget">
+    <fieldset>
+      <legend>Profile Management</legend>
+      <form method="post" action="/dbg/actions/resend-email-verification">
+        <div class="row">
+          <input type="email" name="email" placeholder="example@example.com" value="" />
+        </div>
+
+        <div class="row">
+          <label for="force-verify">Are you sure?</label>
+          <input id="force-verify" type="checkbox" name="force" />
+          <br />
+          <small>
+            This is a just a security double check for prevent non intentional submits.
+          </small>
+        </div>
+
+        <div class="row">
+          <input type="submit" name="resend" value="Resend Verification" />
+          <input type="submit" name="verify" value="Verify" />
+        </div>
+
+        <div class="row">
+          <input type="submit" class="danger" name="block" value="Block" />
+          <input type="submit" class="danger" name="unblock" value="Unblock" />
+        </div>
+      </form>
+    </fieldset>
+    
+
+    <fieldset>
+      <legend>Feature Flags for Team</legend>
+      <desc>Add a feature flag to a team</desc>
+      <form method="post" action="/dbg/actions/handle-team-features">
+        <div class="row">
+          <input type="text" style="width:300px" name="team-id" placeholder="team-id" />
+        </div>
+        <div class="row">
+          <select type="text" style="width:100px" name="feature">
+            {% for feature in supported-features %}
+              <option value="{{feature}}">{{feature}}</option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class="row">
+          <select style="width:100px" name="action">
+            <option value="">Action...</option>
+            <option value="show">Show</option>
+            <option value="enable">Enable</option>
+            <option value="disable">Disable</option>
+          </select>
+        </div>
+
+        <div class="row">
+          <label for="check-feature">Skip feature check</label>
+          <input id="check-feature" type="checkbox" name="skip-check" />
+          <br />
+          <small>
+            Do not check if the feature is supported
+          </small>
+        </div>
+
+        <div class="row">
+          <label for="force-version">Are you sure?</label>
+          <input id="force-version" type="checkbox" name="force" />
+          <br />
+          <small>
+            This is a just a security double check for prevent non intentional submits.
+          </small>
+        </div>
+
+        <div class="row">
+          <input type="submit" value="Submit" />
+        </div>
+      </form>
+    </fieldset>
+  </section>
+
 
   <section class="widget">
 
@@ -169,56 +233,6 @@ Debug Main Page
 
         <div class="row">
           <input type="submit" name="upload" value="Upload" />
-        </div>
-      </form>
-    </fieldset>
-  </section>
-
-  <section class="widget">
-    <fieldset>
-      <legend>Feature Flags for Team</legend>
-      <desc>Add a feature flag to a team</desc>
-      <form method="post" action="/dbg/actions/handle-team-features">
-        <div class="row">
-          <input type="text" style="width:300px" name="team-id" placeholder="team-id" />
-        </div>
-        <div class="row">
-          <select type="text" style="width:100px" name="feature">
-            {% for feature in supported-features %}
-              <option value="{{feature}}">{{feature}}</option>
-            {% endfor %}
-          </select>
-        </div>
-
-        <div class="row">
-          <select style="width:100px" name="action">
-            <option value="">Action...</option>
-            <option value="show">Show</option>
-            <option value="enable">Enable</option>
-            <option value="disable">Disable</option>
-          </select>
-        </div>
-
-        <div class="row">
-          <label for="check-feature">Skip feature check</label>
-          <input id="check-feature" type="checkbox" name="skip-check" />
-          <br />
-          <small>
-            Do not check if the feature is supported
-          </small>
-        </div>
-
-        <div class="row">
-          <label for="force-version">Are you sure?</label>
-          <input id="force-version" type="checkbox" name="force" />
-          <br />
-          <small>
-            This is a just a security double check for prevent non intentional submits.
-          </small>
-        </div>
-
-        <div class="row">
-          <input type="submit" value="Submit" />
         </div>
       </form>
     </fieldset>

--- a/backend/test/backend_tests/rpc_file_snapshot_test.clj
+++ b/backend/test/backend_tests/rpc_file_snapshot_test.clj
@@ -17,7 +17,6 @@
    [app.db.sql :as sql]
    [app.http :as http]
    [app.rpc :as-alias rpc]
-   [app.setup.clock :as clock]
    [app.storage :as sto]
    [backend-tests.helpers :as th]
    [clojure.test :as t]
@@ -134,7 +133,7 @@
         ;; this will run pending task triggered by deleting user snapshot
         (th/run-pending-tasks!)
 
-        (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+        (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
           (let [res (th/run-task! :objects-gc {})]
             ;; delete 2 snapshots and 2 file data entries
             (t/is (= 4 (:processed res)))))))))

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -19,7 +19,6 @@
    [app.http :as http]
    [app.rpc :as-alias rpc]
    [app.rpc.commands.files :as files]
-   [app.setup.clock :as clock]
    [app.storage :as sto]
    [backend-tests.helpers :as th]
    [clojure.test :as t]
@@ -922,7 +921,7 @@
       (t/is (= 0 (:processed result))))
 
     ;; run permanent deletion
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [result (th/run-task! :objects-gc {})]
         (t/is (= 3 (:processed result)))))
 
@@ -1875,7 +1874,7 @@
         file-id (uuid/next)
         now     (ct/inst "2025-10-31T00:00:00Z")]
 
-    (binding [ct/*clock* (clock/fixed now)]
+    (binding [ct/*clock* (ct/fixed-clock now)]
       (let [data {::th/type :create-file
                   ::rpc/profile-id (:id prof)
                   :project-id proj-id
@@ -1937,7 +1936,7 @@
         file-id (uuid/next)
         now     (ct/inst "2025-10-31T00:00:00Z")]
 
-    (binding [ct/*clock* (clock/fixed now)]
+    (binding [ct/*clock* (ct/fixed-clock now)]
       (let [data {::th/type :create-file
                   ::rpc/profile-id (:id prof)
                   :project-id proj-id
@@ -2000,7 +1999,7 @@
         team-id (:default-team-id profile)
         now     (ct/inst "2025-10-31T00:00:00Z")]
 
-    (binding [ct/*clock* (clock/fixed now)]
+    (binding [ct/*clock* (ct/fixed-clock now)]
       (let [project (th/create-project* 1 {:profile-id (:id profile)
                                            :team-id team-id})
             file    (th/create-file* 1 {:profile-id (:id profile)

--- a/backend/test/backend_tests/rpc_file_thumbnails_test.clj
+++ b/backend/test/backend_tests/rpc_file_thumbnails_test.clj
@@ -85,7 +85,7 @@
       (t/is (map? (:result out))))
 
     ;; run the task again
-    (let [res (binding [ct/*clock* (clock/fixed (ct/in-future {:minutes 31}))]
+    (let [res (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:minutes 31}))]
                 (th/run-task! "storage-gc-touched" {}))]
       (t/is (= 2 (:freeze res))))
 
@@ -136,7 +136,7 @@
       (t/is (some? (sto/get-object storage (:media-id row2))))
 
       ;; run the task again
-      (let [res (binding [ct/*clock* (clock/fixed (ct/in-future {:minutes 31}))]
+      (let [res (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:minutes 31}))]
                   (th/run-task! :storage-gc-touched {}))]
         (t/is (= 1 (:delete res)))
         (t/is (= 0 (:freeze res))))
@@ -147,7 +147,7 @@
 
       ;; Run the storage gc deleted task, it should permanently delete
       ;; all storage objects related to the deleted thumbnails
-      (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+      (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
         (let [res (th/run-task! :storage-gc-deleted {})]
           (t/is (= 1 (:deleted res)))))
 
@@ -247,7 +247,7 @@
 
       ;; Run the storage gc deleted task, it should permanently delete
       ;; all storage objects related to the deleted thumbnails
-      (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+      (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
         (let [result (th/run-task! :storage-gc-deleted {})]
           (t/is (= 1 (:deleted result)))))
 

--- a/backend/test/backend_tests/rpc_font_test.clj
+++ b/backend/test/backend_tests/rpc_font_test.clj
@@ -12,7 +12,6 @@
    [app.db :as db]
    [app.http :as http]
    [app.rpc :as-alias rpc]
-   [app.setup.clock :as clock]
    [app.storage :as sto]
    [backend-tests.helpers :as th]
    [clojure.test :as t]
@@ -147,7 +146,7 @@
       (t/is (= 0 (:freeze res)))
       (t/is (= 0 (:delete res))))
 
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [res (th/run-task! :objects-gc {})]
         (t/is (= 2 (:processed res))))
 
@@ -208,7 +207,7 @@
       (t/is (= 0 (:freeze res)))
       (t/is (= 0 (:delete res))))
 
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [res (th/run-task! :objects-gc {})]
         (t/is (= 1 (:processed res))))
 
@@ -268,7 +267,7 @@
       (t/is (= 0 (:freeze res)))
       (t/is (= 0 (:delete res))))
 
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [res (th/run-task! :objects-gc {})]
         (t/is (= 1 (:processed res))))
 

--- a/backend/test/backend_tests/rpc_project_test.clj
+++ b/backend/test/backend_tests/rpc_project_test.clj
@@ -12,7 +12,6 @@
    [app.db :as db]
    [app.http :as http]
    [app.rpc :as-alias rpc]
-   [app.setup.clock :as clock]
    [backend-tests.helpers :as th]
    [clojure.test :as t]))
 
@@ -228,7 +227,7 @@
         (t/is (= 0 (count result)))))
 
     ;; run permanent deletion
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [result (th/run-task! :objects-gc {})]
         (t/is (= 1 (:processed result)))))
 

--- a/backend/test/backend_tests/rpc_team_test.clj
+++ b/backend/test/backend_tests/rpc_team_test.clj
@@ -13,7 +13,6 @@
    [app.db :as db]
    [app.http :as http]
    [app.rpc :as-alias rpc]
-   [app.setup.clock :as clock]
    [app.storage :as sto]
    [app.tokens :as tokens]
    [backend-tests.helpers :as th]
@@ -526,7 +525,7 @@
         (t/is (= :not-found (:type edata)))))
 
     ;; run permanent deletion
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [result (th/run-task! :objects-gc {})]
         (t/is (= 2 (:processed result)))))
 
@@ -583,7 +582,7 @@
       (t/is (= 1 (count rows)))
       (t/is (ct/inst? (:deleted-at (first rows)))))
 
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:days 8}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:days 8}))]
       (let [result (th/run-task! :objects-gc {})]
         (t/is (= 7 (:processed result)))))))
 

--- a/backend/test/backend_tests/storage_test.clj
+++ b/backend/test/backend_tests/storage_test.clj
@@ -11,7 +11,6 @@
    [app.common.uuid :as uuid]
    [app.db :as db]
    [app.rpc :as-alias rpc]
-   [app.setup.clock :as clock]
    [app.storage :as sto]
    [backend-tests.helpers :as th]
    [clojure.test :as t]
@@ -99,14 +98,14 @@
                                            ::sto/expired-at (ct/in-future {:hours 1})
                                            :content-type "text/plain"})]
 
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:minutes 0}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:minutes 0}))]
       (let [res (th/run-task! :storage-gc-deleted {})]
         (t/is (= 1 (:deleted res)))))
 
     (let [res (th/db-exec-one! ["select count(*) from storage_object;"])]
       (t/is (= 2 (:count res))))
 
-    (binding [ct/*clock* (clock/fixed (ct/in-future {:minutes 61}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/in-future {:minutes 61}))]
       (let [res (th/run-task! :storage-gc-deleted {})]
         (t/is (= 1 (:deleted res)))))
 
@@ -331,22 +330,22 @@
                                            :content-type "text/plain"})]
 
 
-    (binding [ct/*clock* (clock/fixed now)]
+    (binding [ct/*clock* (ct/fixed-clock now)]
       (let [res (th/run-task! :storage-gc-touched {})]
         (t/is (= 0 (:freeze res)))
         (t/is (= 0 (:delete res)))))
 
 
-    (binding [ct/*clock* (clock/fixed (ct/plus now {:minutes 1}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/plus now {:minutes 1}))]
       (let [res (th/run-task! :storage-gc-touched {})]
         (t/is (= 0 (:freeze res)))
         (t/is (= 1 (:delete res)))))
 
 
-    (binding [ct/*clock* (clock/fixed (ct/plus now {:hours 1}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/plus now {:hours 1}))]
       (let [res (th/run-task! :storage-gc-deleted {})]
         (t/is (= 0 (:deleted res)))))
 
-    (binding [ct/*clock* (clock/fixed (ct/plus now {:hours 2}))]
+    (binding [ct/*clock* (ct/fixed-clock (ct/plus now {:hours 2}))]
       (let [res (th/run-task! :storage-gc-deleted {})]
         (t/is (= 0 (:deleted res)))))))

--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -64,7 +64,32 @@
       java.time.temporal.TemporalAmount
       java.time.temporal.TemporalUnit)))
 
+(declare inst)
+
 #?(:clj (def ^:dynamic *clock* (Clock/systemDefaultZone)))
+
+#?(:clj
+   (defn clock?
+     [o]
+     (instance? Clock o)))
+
+#?(:clj
+   (defn get-system-clock
+     []
+     (Clock/systemDefaultZone)))
+
+#?(:clj
+   (defn offset-clock
+     [offset]
+     (Clock/offset ^Clock (Clock/systemDefaultZone) ^Duration offset)))
+
+#?(:clj
+   (defn fixed-clock
+     [instant]
+     (Clock/fixed ^Instant (inst instant)
+                  ^ZoneId (ZoneId/of "Z"))))
+
+
 
 (defn now
   []


### PR DESCRIPTION

### Summary

Make the virtual clock (testing only feature) assign by profile instead of globally. 
Now the virtual cock only affects RPC/HTTP requests and not worker tasks.

### Steps to reproduce 

Use the dbg panel to assign offsets and check that the offset is only affecting the currently logged profile.
