### PR TITLE
:bug: Fix import Tokens default option

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
@@ -273,4 +273,4 @@
                   {:label (tr "workspace.tokens.import-menu-folder-option") :value :folder}]
         :on-click handle-import-action
         :text-render render-button-text
-        :default :zip}]]]))
+        :default :file}]]]))


### PR DESCRIPTION
This was intended to be changed on 13fcf3a9bb25. However only the menu order changed, not the default option.

### Summary

I introduced this change on #7918 however I had some issues testing it (as mentioned [here](https://github.com/penpot/penpot/pull/7918#issuecomment-3628364732)). As it turned out the issue wasn't caching (only), but that I missed a bit.

### Steps to reproduce

* Go to Tokens > Tools > Import
* See that `Import Single Json File` is the default option.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
