### PR TITLE
:bug: Set correct defaults for storage configuration on compose

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -130,12 +130,6 @@ services:
     environment:
       << : [*penpot-flags, *penpot-public-uri, *penpot-http-body-size, *penpot-secret-key]
 
-      ## The PREPL host. Mainly used for external programatic access to penpot backend
-      ## (example: admin). By default it will listen on `localhost` but if you are going to use
-      ## the `admin`, you will need to uncomment this and set the host to `0.0.0.0`.
-
-      # PENPOT_PREPL_HOST: 0.0.0.0
-
       ## Database connection parameters. Don't touch them unless you are using custom
       ## postgresql connection parameters.
 

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -145,8 +145,8 @@ services:
       ## Default configuration for assets storage: using filesystem based with all files
       ## stored in a docker volume.
 
-      PENPOT_ASSETS_STORAGE_BACKEND: assets-fs
-      PENPOT_STORAGE_ASSETS_FS_DIRECTORY: /opt/data/assets
+      PENPOT_OBJECTS_STORAGE_BACKEND: fs
+      PENPOT_OBJECTS_STORAGE_FS_DIRECTORY: /opt/data/assets
 
       ## Also can be configured to to use a S3 compatible storage.
 


### PR DESCRIPTION
https://github.com/penpot/penpot/issues/7974

### Summary

Fixes the default compose template adding missing storage configuration. We assumed it was a default but that not the case. This PR add proper defaults to the default compose template.
