### PR TITLE
:sparkles: Add the ability to log using logging subsystem the audit events

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -62,6 +62,7 @@
   #{:audit-log
     :audit-log-archive
     :audit-log-gc
+    :audit-log-logger
     :auto-file-snapshot
     ;; enables the `/api/doc` endpoint that lists all the rpc methods available.
     :backend-api-doc


### PR DESCRIPTION
### Summary

Add the ability to log using logging subsystem the audit events

### How to test

- Add `enable-audit-log-logger` config flag
- Just navigate on dashboard and look backend log to see the log entries
