### PR TITLE
:bug: Fix translation on rename token

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7551,6 +7551,10 @@ msgstr "Remap Token References"
 msgid "workspace.tokens.renaming-token-from-to"
 msgstr "Renaming token from '%s' to '%s'"
 
+#: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs
+msgid "workspace.tokens.warning-name-change"
+msgstr "Renaming this token will break any reference to its old name"
+
 #: src/app/main/ui/workspace/tokens/remapping_modal.cljs
 msgid "workspace.tokens.references-found"
 msgstr "%s references found in your design"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -4428,6 +4428,10 @@ msgstr "Actualizar referencias de token"
 msgid "workspace.tokens.renaming-token-from-to"
 msgstr "Renombrando el token de '%s' a '%s'"
 
+#: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs
+msgid "workspace.tokens.warning-name-change"
+msgstr "Cambiar el nombre de este token romperá cualquier referencia a su nombre anterior."
+
 #: src/app/main/ui/workspace/tokens/remapping_modal.cljs
 msgid "workspace.tokens.references-found"
 msgstr "%s referencias encontradas en tu diseño"


### PR DESCRIPTION
### Related Ticket

This PR fixes this issue https://tree.taiga.io/project/penpot/issue/13031

### Summary
There is a lost translation on token edition modal text
<img width="1367" height="1300" alt="Screenshot from 2026-01-13 15-56-21" src="https://github.com/user-attachments/assets/4399f159-4027-4280-8cbd-ae7dbd42e65c" />
<img width="1367" height="1300" alt="Screenshot from 2026-01-13 15-55-53" src="https://github.com/user-attachments/assets/c18e073f-367c-4766-9e29-4cfccaf04408" />

### Steps to reproduce 
See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
