### PR TITLE
:bug: Fix profile not updating after deleting a team member

### DIFF
--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -173,7 +173,8 @@
             params  (assoc params :team-id team-id)]
         (->> (rp/cmd! :delete-team-member params)
              (rx/mapcat (fn [_]
-                          (rx/of (fetch-members team-id)
+                          (rx/of (dp/refresh-profile)
+                                 (fetch-members team-id)
                                  (fetch-teams)
                                  (ptk/data-event ::ev/event
                                                  {::ev/name "delete-team-member"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13037

### Summary
When a team member is deleted, the editors data in the profile/subscription wasn't being refreshed

### Steps to reproduce 
- user needs a Professional subscription
- when adding 9 members to a team (including the owner), the following banner should be shown:
<img width="375" height="253" alt="image" src="https://github.com/user-attachments/assets/e5f0e54e-c9b3-40e5-9cd8-e5e908d02034" />

- after deleting one member, the banner should update like this without needing to refresh the page:
<img width="378" height="266" alt="image" src="https://github.com/user-attachments/assets/1213f22b-1500-4245-b296-19a6a6a35eab" />



### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
