### PR TITLE
:bug: Display missing selected tokens set info

### DIFF
--- a/frontend/playwright/ui/specs/tokens/sets.spec.js
+++ b/frontend/playwright/ui/specs/tokens/sets.spec.js
@@ -216,4 +216,32 @@ test.describe("Tokens: Sets Tab", () => {
     await expect(tokenSetItems.nth(1)).toHaveAttribute("aria-checked", "false");
     await expect(tokenSetItems.nth(2)).toHaveAttribute("aria-checked", "true");
   });
+
+  test("Display active set and verify if is enabled", async ({ page }) => {
+    const { tokenThemesSetsSidebar, tokensSidebar, tokenSetItems } =
+      await setupTokensFile(page);
+
+    // Create set
+    await tokenThemesSetsSidebar
+      .getByRole("button", { name: "Add set" })
+      .click();
+    await changeSetInput(tokenThemesSetsSidebar, "Inactive set");
+    await tokenThemesSetsSidebar
+      .getByRole("button", { name: "Inactive set" })
+      .click();
+    let activeSetTitle = await tokensSidebar.getByTestId(
+      "active-token-set-title",
+    );
+    await expect(activeSetTitle).toHaveText("TOKENS - Inactive set");
+    const inactiveSetInfo = await tokensSidebar.getByTitle(
+      "This set is not active.",
+    );
+    await expect(inactiveSetInfo).toBeVisible();
+
+    // Switch active set
+
+    await tokenThemesSetsSidebar.getByRole("button", { name: "theme" }).click();
+    await expect(activeSetTitle).toHaveText("TOKENS - theme");
+    await expect(inactiveSetInfo).not.toBeVisible();
+  });
 });

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -60,18 +60,20 @@
     [:div {:class (stl/css :sets-header-container)}
      [:> text* {:as "span"
                 :typography "headline-small"
-                :class (stl/css :sets-header)}
+                :class (stl/css :sets-header)
+                :data-testid "active-token-set-title"}
       (tr "workspace.tokens.tokens-section-title" (ctob/get-name selected-token-set))]
-     [:div {:class (stl/css :sets-header-status) :title (tr "workspace.tokens.inactive-set-description")}
+     (when (and (some? selected-token-set-id)
+                (not (token-set-active? (ctob/get-name selected-token-set))))
+       [:div {:class (stl/css :sets-header-status) :title (tr "workspace.tokens.inactive-set-description")}
         ;; NOTE: when no set in tokens-lib, the selected-token-set-id
         ;; will be `nil`, so for properly hide the inactive message we
         ;; check that at least `selected-token-set-id` has a value
-      (when (and (some? selected-token-set-id)
-                 (not (token-set-active? (ctob/get-name selected-token-set))))
+
         [:*
          [:> icon* {:class (stl/css :sets-header-status-icon) :icon-id i/eye-off}]
          [:> text* {:as "span" :typography "body-small" :class (stl/css :sets-header-status-text)}
-          (tr "workspace.tokens.inactive-set")]])]]))
+          (tr "workspace.tokens.inactive-set")]]])]))
 
 (mf/defc tokens-section*
   {::mf/private true}

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -44,7 +44,7 @@
   {::mf/private true}
   [{:keys [tokens-lib selected-token-set-id]}]
   (let [selected-token-set
-        (mf/with-memo [tokens-lib]
+        (mf/with-memo [tokens-lib selected-token-set-id]
           (when selected-token-set-id
             (some-> tokens-lib (ctob/get-set selected-token-set-id))))
 
@@ -135,7 +135,7 @@
     [:*
      [:& token-context-menu]
 
-     [:& selected-set-info* {:tokens-lib tokens-lib
+     [:> selected-set-info* {:tokens-lib tokens-lib
                              :selected-token-set-id selected-token-set-id}]
 
      (for [type filled-group]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13034
<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Active set info is not being displayed correctly

### Steps to reproduce 

https://github.com/penpot/penpot/pull/7775#issuecomment-3732744674

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
