### PR TITLE
:sparkles: Use pseudo-names on release builds of frontend

### DIFF
--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -75,6 +75,7 @@
     {:fn-invoke-direct true
      :optimizations #shadow/env ["PENPOT_BUILD_OPTIMIZATIONS" :as :keyword :default :advanced]
      :source-map true
+     :pseudo-names true
      :elide-asserts true
      :anon-fn-naming-policy :off
      :cross-chunk-method-motion false


### PR DESCRIPTION
### Summary

This enables better stack traces (with more human understandable function names) with the cost to increase js modules size (what is not very relevant when compression is used)