### PR TITLE
fix: Add error handler to token form validation to prevent crash on naming conflict

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs
@@ -18,6 +18,7 @@
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.tokens.library-edit :as dwtl]
    [app.main.data.workspace.tokens.propagation :as dwtp]
+   [app.main.data.workspace.tokens.errors :as wte]
    [app.main.data.workspace.tokens.remapping :as remap]
    [app.main.refs :as refs]
    [app.main.store :as st]
@@ -224,7 +225,12 @@
                                                 :description description}))
                           (dwtl/toggle-token-path path)
                           (dwtp/propagate-workspace-tokens)
-                          (modal/hide!))))))))))]
+                          (modal/hide!)))))
+                   ;; Error handler: display validation errors in the form instead of crashing
+                   (fn [{:keys [errors]}]
+                     (let [error-messages (wte/humanize-errors errors)
+                           error-message (first error-messages)]
+                       (swap! form assoc-in [:extra-errors :value] {:message error-message})))))))))]
 
     [:> fc/form* {:class (stl/css :form-wrapper)
                   :form form


### PR DESCRIPTION
## Summary

This PR fixes issue #8110 where creating a design token with a name that already exists causes the application to crash.

Fixes #8110

## Changes

- Added error handler to the `rx/subs!` call in `on-submit` function in `generic_form.cljs`
- The handler catches validation errors and displays human-readable error messages in the form's `extra-errors` instead of letting the exception crash the application
- Uses existing `wte/humanize-errors` utility to format error messages

## Testing

1. Open Penpot and go to Design Tokens
2. Create a token named "test"
3. Try to create another token with the same name "test"
4. **Before**: Application crashes with unhandled exception
5. **After**: Error message is displayed in the form field

---
This is a Gittensor contribution
gittensor::146701565