### PR TITLE
:lipstick: Replace current themes switch with DS switch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - Tokens panel nested path view [Taiga #9966](https://tree.taiga.io/project/penpot/us/9966)
 - Improve usability of lock and hide buttons in the layer panel. [Taiga #12916](https://tree.taiga.io/project/penpot/issue/12916)
 - Optimize sidebar performance for deeply nested shapes [Taiga #13017](https://tree.taiga.io/project/penpot/task/13017)
+- Remove tokens path node and bulk remove tokens [Taiga #13007](https://tree.taiga.io/project/penpot/us/13007)
+- Replace themes management modal radio buttons for switches [Taiga #9215](https://tree.taiga.io/project/penpot/us/9215)
 
 ### :bug: Bugs fixed
 
@@ -22,7 +24,6 @@
 - Fix wrong register image [Taiga #12955](https://tree.taiga.io/project/penpot/task/12955)
 - Fix error message on components doesn't close automatically [Taiga #12012](https://tree.taiga.io/project/penpot/issue/12012)
 - Fix incorrect default option on tokens import dialog [Github #8051](https://github.com/penpot/penpot/pull/8051)
-
 
 ## 2.13.0 (Unreleased)
 
@@ -170,7 +171,6 @@ example. It's still usable as before, we just removed the example.
 
 - Deprecated configuration variables with the prefix `PENPOT_ASSETS_*`, and will be
   removed in future versions:
-
   - The `PENPOT_ASSETS_STORAGE_BACKEND` becomes `PENPOT_OBJECTS_STORAGE_BACKEND` and its
     values passes from (`assets-fs` or `assets-s3`) to (`fs` or `s3`)
   - The `PENPOT_STORAGE_ASSETS_FS_DIRECTORY` becomes `PENPOT_OBJECTS_STORAGE_FS_DIRECTORY`

--- a/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.controls.combobox :refer [combobox*]]
    [app.main.ui.ds.controls.input :refer [input*]]
-   [app.main.ui.ds.controls.radio-buttons :refer [radio-buttons*]]
+   [app.main.ui.ds.controls.switch :refer [switch*]]
    [app.main.ui.ds.controls.utilities.label :refer [label*]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
@@ -85,21 +85,6 @@
                     :on-click create-theme}
         (tr "workspace.tokens.add-new-theme")]]]]))
 
-(mf/defc switch*
-  [{:keys [selected? name on-change]}]
-  (let [selected (if selected? :on :off)]
-    [:> radio-buttons* {:selected selected
-                        :on-change on-change
-                        :name name
-                        :options [{:id "on"
-                                   :icon i/tick
-                                   :label (tr "workspace.tokens.theme.enable")
-                                   :value :on}
-                                  {:id "off"
-                                   :icon i/close
-                                   :label (tr "workspace.tokens.theme.disable")
-                                   :value :off}]}]))
-
 (mf/defc themes-overview
   [{:keys [change-view]}]
   (let [active-theme-paths (mf/deref refs/workspace-active-theme-paths)
@@ -137,6 +122,9 @@
                         (dom/prevent-default e)
                         (dom/stop-propagation e)
                         (st/emit! (dwtl/delete-token-theme id)))
+                      on-switch-theme
+                      (fn []
+                        (st/emit! (dwtl/toggle-token-theme-active id)))
                       on-edit-theme
                       (fn [e]
                         (dom/prevent-default e)
@@ -146,16 +134,10 @@
                   :class (stl/css :theme-row)}
              [:div {:class (stl/css :theme-switch-row)}
 
-              ;; FIXME: FIREEEEEEEEEE THIS
-              [:div {:on-click (fn [e]
-                                 (dom/prevent-default e)
-                                 (dom/stop-propagation e)
-                                 (st/emit! (dwtl/toggle-token-theme-active id)))}
-               [:> switch* {:name (tr "workspace.tokens.theme-name" name)
-                            :on-change (constantly nil)
-                            :selected? selected?}]]]
-             [:div {:class (stl/css :theme-name-row)}
-              [:> text* {:as "span"  :typography "body-medium" :class (stl/css :theme-name) :title name} name]]
+              [:> switch* {:id name
+                           :label name
+                           :on-change on-switch-theme
+                           :default-checked selected?}]]
 
 
              [:div {:class (stl/css :theme-actions-row)}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/9215
<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Replace themes manager modal radio buttons with current DS switch component

### Steps to reproduce 

Current radio buttons
<img width="404" height="276" alt="image" src="https://github.com/user-attachments/assets/55092a01-32b1-4eb6-b2b9-66f1fc2657d9" />

Expected switch
<img width="687" height="484" alt="image" src="https://github.com/user-attachments/assets/1dd9046e-f953-48c0-93f6-d05eeeac2342" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
