### PR TITLE
:sparkles: Add slugify to the filename on assets exportation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ### :bug: Bugs fixed
 
+- Remove whitespaces from asset export filename [Github #8133](https://github.com/penpot/penpot/pull/8133)
 - Fix prototype connections lost when switching between variants [Taiga #12812](https://tree.taiga.io/project/penpot/issue/12812)
 - Fix wrong image in the onboarding invitation block [Taiga #13040](https://tree.taiga.io/project/penpot/issue/13040)
 - Fix wrong register image [Taiga #12955](https://tree.taiga.io/project/penpot/task/12955)

--- a/exporter/src/app/handlers/resources.cljs
+++ b/exporter/src/app/handlers/resources.cljs
@@ -36,7 +36,7 @@
     {:path     path
      :mtype    (mime/get type)
      :name     name
-     :filename (str/concat name (mime/get-extension type))
+     :filename (str/concat (str/slug name) (mime/get-extension type))
      :id       task-id}))
 
 (defn create-zip


### PR DESCRIPTION
### Summary

Fixes https://github.com/penpot/penpot/issues/8017

Mainly removes the strange white-spaces on downloading assets that has white-spaces or are part of a group.

