### PR TITLE
:bug: Fix broken selection on duplicated shapes on new pages

### DIFF
--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -227,7 +227,7 @@
         :svg-attrs
         (do
           (api/set-shape-svg-attrs v)
-          ;; Always update fills/blur/shadow to clear previous state if filters disappear          
+          ;; Always update fills/blur/shadow to clear previous state if filters disappear
           (api/set-shape-fills id (:fills shape) false)
           (api/set-shape-blur (:blur shape))
           (api/set-shape-shadows (:shadow shape)))
@@ -397,12 +397,18 @@
                    (next es))
             (throw (js/Error. "conj on a map takes map entries or seqables of map entries"))))))))
 
+(def ^:private xf:without-id-and-type
+  (remove (fn [kvpair]
+            (let [k (key kvpair)]
+              (or (= k :id)
+                  (= k :type))))))
+
 (defn create-shape
   "Instanciate a shape from a map"
   [attrs]
   (ShapeProxy. (:id attrs)
                (:type attrs)
-               (dissoc attrs :id :type)))
+               (into {} xf:without-id-and-type attrs)))
 
 (t/add-handlers!
  ;; We only add a write handler, read handler uses the dynamic dispatch

--- a/frontend/src/app/worker/index.cljs
+++ b/frontend/src/app/worker/index.cljs
@@ -58,6 +58,8 @@
 
         (swap! state update ::snap snap/update-page old-page new-page)
         (swap! state update ::selection selection/update-page old-page new-page))
+      (catch :default cause
+        (log/error :hint "error updating page index" :id page-id :cause cause))
       (finally
         (let [elapsed (tpoint)]
           (log/dbg :hint "page index updated" :id page-id :elapsed elapsed ::log/sync? true))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13080

### Summary

This fixes the selection on duplicate shapes on newly created pages.

https://github.com/user-attachments/assets/7bf71c32-86a0-4460-a5e6-42754e4d03b6

### Steps to reproduce

See Taiga ticket .

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
