### PR TITLE
:bug: Fix incorrect handling of numeric values layout padding and gap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - Fix wrong image in the onboarding invitation block [Taiga #13040](https://tree.taiga.io/project/penpot/issue/13040)
 - Fix wrong register image [Taiga #12955](https://tree.taiga.io/project/penpot/task/12955)
 - Fix error message on components doesn't close automatically [Taiga #12012](https://tree.taiga.io/project/penpot/issue/12012)
+- Fix incorrect handling of input values on layout gap and padding inputs [Github #8113](https://github.com/penpot/penpot/issues/8113)
 - Fix incorrect default option on tokens import dialog [Github #8051](https://github.com/penpot/penpot/pull/8051)
 - Fix unhandled exception tokens creation dialog [Github #8110](https://github.com/penpot/penpot/issues/8110)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
@@ -366,7 +366,7 @@
         (mf/use-fn
          (mf/deps on-change ids)
          (fn [value attr event]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (on-change :simple attr value event)
              (do
                (let [resolved-value (:resolved-value (first value))
@@ -480,7 +480,7 @@
         (mf/use-fn
          (mf/deps on-change ids)
          (fn [value attr event]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (on-change :multiple attr value event)
              (do
                (let [resolved-value (:resolved-value (first value))]
@@ -713,7 +713,7 @@
         (mf/use-fn
          (mf/deps on-change wrap-type ids)
          (fn [value event attr]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (on-change (= "nowrap" wrap-type) attr value event)
              (do
                (let [resolved-value (:resolved-value (first value))]


### PR DESCRIPTION
### Summary

Fixes https://github.com/penpot/penpot/issues/8113

### How to reproduce

- Create a board
- Add flex layout
- Update column gap with 0.5
- Press UP on keyboard