### PR TITLE
:bug: Fix blur when clicking on same page 

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -61,7 +61,7 @@
 
 (mf/defc page-item
   {::mf/wrap-props false}
-  [{:keys [page index deletable? selected? editing? hovering?]}]
+  [{:keys [page index deletable? selected? editing? hovering? current-page-id]}]
   (let [input-ref    (mf/use-ref)
         id           (:id page)
         delete-fn    (mf/use-fn (mf/deps id) #(st/emit! (dw/delete-page id)))
@@ -72,8 +72,10 @@
         (mf/use-fn
          (mf/deps id)
          (fn []
-           ;; when using the wasm renderer, apply a blur effect to the viewport canvas
-           (if (features/active-feature? @st/state "render-wasm/v1")
+           ;; For the wasm renderer, apply a blur effect to the viewport canvas
+           ;; when we navigate to a different page.
+           (if (and (features/active-feature? @st/state "render-wasm/v1")
+                    (not= id current-page-id))
              (do
                (wasm.api/capture-canvas-pixels)
                (wasm.api/apply-canvas-blur)
@@ -203,12 +205,13 @@
 
 (mf/defc page-item-wrapper
   {::mf/wrap-props false}
-  [{:keys [page-id index deletable? selected? editing?]}]
+  [{:keys [page-id index deletable? selected? editing? current-page-id]}]
   (let [page-ref (mf/with-memo [page-id]
                    (make-page-ref page-id))
         page     (mf/deref page-ref)]
     [:& page-item {:page page
                    :index index
+                   :current-page-id current-page-id
                    :deletable? deletable?
                    :selected? selected?
                    :editing? editing?}]))
@@ -231,6 +234,7 @@
           :deletable? deletable?
           :editing? (= page-id editing-page-id)
           :selected? (= page-id current-page-id)
+          :current-page-id current-page-id
           :key page-id}])]]))
 
 ;; --- Sitemap Toolbox

--- a/frontend/src/app/main/ui/workspace/viewport/outline.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/outline.cljs
@@ -144,7 +144,7 @@
         modifiers (hooks/use-equal-memo modifiers)
         shapes    (hooks/use-equal-memo shapes)]
 
-    [:g.outlines
+    [:g.outlines.blurrable
      [:& shape-outlines-render {:shapes shapes
                                 :zoom zoom
                                 :modifiers modifiers}]]))

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -252,7 +252,7 @@
         edition        (mf/deref refs/selected-edition)
         grid-edition?  (ctl/grid-layout? objects edition)]
 
-    [:g.frame-titles
+    [:g.frame-titles.blurrable
      (for [{:keys [id parent-id] :as shape} shapes]
        (when (and
               (not= id uuid/zero)

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -424,6 +424,7 @@
        :xmlnsXlink "http://www.w3.org/1999/xlink"
        :preserveAspectRatio "xMidYMid meet"
        :key (str "viewport" page-id)
+       :id "viewport-controls"
        :view-box (utils/format-viewbox vbox)
        :ref on-viewport-ref
        :class (dm/str @cursor (when drawing-tool " drawing") " " (stl/css :viewport-controls))
@@ -473,7 +474,7 @@
               :zoom zoom}]
 
             (when (ctl/any-layout? outlined-frame)
-              [:g.ghost-outline
+              [:g.ghost-outline.blurrable
                [:& outline/shape-outlines
                 {:objects base-objects
                  :selected selected

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -1429,8 +1429,9 @@
 
 (defn apply-canvas-blur
   []
-  (when wasm/canvas
-    (dom/set-style! wasm/canvas "filter" "blur(4px)")))
+  (when wasm/canvas (dom/set-style! wasm/canvas "filter" "blur(4px)"))
+  (let [controls-to-blur (dom/query-all (dom/get-element "viewport-controls") ".blurrable")]
+    (run! #(dom/set-style! % "filter" "blur(4px)") controls-to-blur)))
 
 
 (defn init-wasm-module

--- a/frontend/src/app/render_wasm/api/webgl.cljs
+++ b/frontend/src/app/render_wasm/api/webgl.cljs
@@ -151,6 +151,8 @@ void main() {
       (.clear ^js context (.-DEPTH_BUFFER_BIT ^js context))
       (.clear ^js context (.-STENCIL_BUFFER_BIT ^js context)))
     (dom/set-style! wasm/canvas "filter" "none")
+    (let [controls-to-unblur (dom/query-all (dom/get-element "viewport-controls") ".blurrable")]
+      (run! #(dom/set-style! % "filter" "none") controls-to-unblur))
     (set! wasm/canvas-pixels nil)))
 
 (defn capture-canvas-pixels


### PR DESCRIPTION
- :bug: Fix blur applied when clicking in the active page
- :sparkles: Blur board titles and outlines when switching pages

### Related Ticket

https://tree.taiga.io/project/penpot/issue/13152

### Summary

This PR fixes the bug on the viewport being blurred indefinitely when the user clicks on the active page in the left sidebar.

Also, now board titles and some outlines are blurred as well when switching pages.

### Steps to reproduce 

1. Load a file with multiple pages (like Lucide Icons).
2. In the left sidebar, click on the page that is currently loaded.

Expected result: no blur is applied.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
