### PR TITLE
:bug: Fix spanish translations on import export token modal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Fix typos on download modal [Taiga #12865](https://tree.taiga.io/project/penpot/issue/12865)
 - Fix unhandled exception tokens creation dialog [Github #8110](https://github.com/penpot/penpot/issues/8110)
 - Fix allow negative spread values on shadow token creation [Taiga #13167](https://tree.taiga.io/project/penpot/issue/13167)
+- Fix spanish translations on import export token modal [Taiga #13171](https://tree.taiga.io/project/penpot/issue/13171)
 
 ## 2.12.1
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7594,6 +7594,10 @@ msgstr "Error al importar: No se pudo procesar el JSON."
 msgid "workspace.tokens.export"
 msgstr "Exportar"
 
+#: src/app/main/ui/workspace/tokens/export/modal.cljs:125
+msgid "workspace.tokens.export-tokens"
+msgstr "Exportar tokens"
+
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:118
 msgid "workspace.tokens.export.multiple-files"
 msgstr "Múltiples ficheros"
@@ -7638,9 +7642,25 @@ msgstr "Nombre del grupo"
 msgid "workspace.tokens.grouping-set-alert"
 msgstr "La agrupación de sets aun no está soportada."
 
+#: src/app/main/ui/workspace/tokens/import/modal.cljs:233
+msgid "workspace.tokens.import-button-prefix"
+msgstr "Importar %s"
+
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
 msgid "workspace.tokens.import-error"
 msgstr "Error al importar:"
+
+#: src/app/main/ui/workspace/tokens/import/modal.cljs:273
+msgid "workspace.tokens.import-menu-folder-option"
+msgstr "Carpeta"
+
+#: src/app/main/ui/workspace/tokens/import/modal.cljs:271
+msgid "workspace.tokens.import-menu-json-option"
+msgstr "Archivo JSON único"
+
+#: src/app/main/ui/workspace/tokens/import/modal.cljs:272
+msgid "workspace.tokens.import-menu-zip-option"
+msgstr "Archivo ZIP"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:241
 msgid "workspace.tokens.import-multiple-files"
@@ -7656,7 +7676,7 @@ msgstr ""
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:237
 msgid "workspace.tokens.import-tokens"
-msgstr "Import tokens"
+msgstr "Importar tokens"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:414, src/app/main/ui/workspace/tokens/sidebar.cljs:415
 #, unused


### PR DESCRIPTION
### Related Ticket

This PR solve this issue https://tree.taiga.io/project/penpot/issue/13171

### Summary
on import and export tokens modal there are some texts without spanish tranlations. 

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
