### PR TITLE
:wrench: Make render-wasm visual regression tests use gpu

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -64,6 +64,11 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         viewport: { width: 1920, height: 1080 }, // Add custom viewport size
         deviceScaleFactor: 2,
+        launchOptions: {
+          args: [
+            '--enable-gpu',
+          ],
+        }
       },
       testDir: "./playwright/ui/render-wasm-specs",
       snapshotPathTemplate: "{testDir}/{testFilePath}-snapshots/{arg}.png",


### PR DESCRIPTION
### Related Ticket

### Summary

We need to enable gpu to fix slow blur & shadow tests

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
