### PR TITLE
:bug: Fix add/remove fills to text node

### DIFF
--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -214,8 +214,8 @@
        ptk/WatchEvent
        (watch [_ state _]
          (let [change-fn
-               (fn [shape attrs]
-                 (update shape :fills types.fills/prepend attrs))
+               (fn [node attrs]
+                 (update node :fills types.fills/prepend attrs))
                undo-id
                (js/Symbol)]
            (rx/concat

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -238,7 +238,8 @@ export class SelectionController extends EventTarget {
   #applyStylesFromElementToCurrentStyle(element) {
     for (let index = 0; index < element.style.length; index++) {
       const styleName = element.style.item(index);
-      if (styleName === "--fills") {
+      // Only merge fill styles from text spans.
+      if (!isTextSpan(element) && styleName === "--fills") {
         continue;
       }
       let styleValue = element.style.getPropertyValue(styleName);


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #13106](https://tree.taiga.io/project/penpot/issue/13106)

### Summary

When selecting text content directly (not the text box container), the fill color controls become unavailable. You cannot remove an existing fill color from selected text, nor can you add a fill color to text that doesn't have one. This prevents users from applying or removing text fill colors when working with text selections.

### Steps to reproduce 

1. Create or select a text box with some text content
2. Select the text content itself (not the text box container)
3. Attempt to remove the fill color using the "Remove color" button in the FILL section

OR

1. Create or select a text box with text content that doesn't have a fill color
2. Select the text content itself (not the text box container)
3. Attempt to add a fill color

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
