### PR TITLE
:bug: Fix shape operations on sidebar when using interaction observer

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -422,7 +422,8 @@
           (reset! observer-var nil))))
 
     ;; Re-observe sentinel whenever children-count changes (sentinel moves)
-    (mf/with-effect [children-count expanded?]
+    ;; and (shapes item) to reconnect observer after shape changes
+    (mf/with-effect [children-count expanded? (:shapes item)]
       (let [total (count (:shapes item))
             node (mf/ref-val ref)
             scroll-node (dom/get-parent-with-data node "scroll-container")


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13192
https://tree.taiga.io/project/penpot/issue/13194

### Summary

We needed to listen to the shape item too to refresh the observer. This should fix both issues.

[screen-recorder-mon-jan-26-2026-16-02-34.webm](https://github.com/user-attachments/assets/6ff0fd09-89d9-4db6-98ad-9930f8cdfd61)

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
