### PR TITLE
:sparkles: Improve unhandled exception handling

### DIFF
--- a/common/src/app/common/exceptions.cljc
+++ b/common/src/app/common/exceptions.cljc
@@ -241,7 +241,20 @@
        (with-out-str
          (print-all cause)))))
 
-#?(:clj
-   (defn print-throwable
-     [cause & {:as opts}]
-     (println (format-throwable cause opts))))
+(defn print-throwable
+  [cause & {:as opts}]
+  #?(:clj
+     (println (format-throwable cause opts))
+     :cljs
+     (let [prefix (get opts :prefix "exception")
+           title  (str prefix ": " (ex-message cause))
+           exdata (ex-data cause)]
+       (js/console.group title)
+       (when-let [explain (get exdata ::sm/explain)]
+         (println (sm/humanize-explain explain)))
+
+       (js/console.log "\nData:")
+       (pp/pprint (dissoc exdata ::sm/explain))
+
+       (js/console.log "\nTrace:")
+       (js/console.error (.-stack cause)))))

--- a/frontend/src/app/main/ui/error_boundary.cljs
+++ b/frontend/src/app/main/ui/error_boundary.cljs
@@ -8,6 +8,7 @@
   "React error boundary components"
   (:require
    ["react-error-boundary" :as reb]
+   [app.common.exceptions :as ex]
    [app.main.errors :as errors]
    [app.main.refs :as refs]
    [goog.functions :as gfn]
@@ -34,7 +35,8 @@
           ;; very small amount of time, so we debounce for 100ms for
           ;; avoid duplicate and redundant reports
           (gfn/debounce (fn [error info]
-                          (js/console.log "Cause stack: \n" (.-stack error))
+                          (set! errors/last-exception error)
+                          (ex/print-throwable error)
                           (js/console.error
                            "Component trace: \n"
                            (unchecked-get info "componentStack")

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -8,6 +8,7 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.exceptions :as ex]
    [app.common.files.repair :as cfr]
    [app.common.files.validate :as cfv]
    [app.common.json :as json]
@@ -456,3 +457,8 @@
 (defn ^:export network-averages
   []
   (.log js/console (clj->js @http/network-averages)))
+
+
+(defn print-last-exception
+  []
+  (some-> errors/last-exception ex/print-throwable))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1466,6 +1466,9 @@ msgstr ""
 msgid "errors.generic"
 msgstr "Something wrong has happened."
 
+msgid "errors.unexpected-exception"
+msgstr "Unexpected exception: %s"
+
 #: src/app/main/errors.cljs:200
 msgid "errors.internal-assertion-error"
 msgstr "Internal Assertion Error"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1462,6 +1462,9 @@ msgstr ""
 msgid "errors.generic"
 msgstr "Ha ocurrido algún error."
 
+msgid "errors.unexpected-exception"
+msgstr "Error inesperado: %s"
+
 #: src/app/main/errors.cljs:200
 msgid "errors.internal-assertion-error"
 msgstr "Error interno de aserción"


### PR DESCRIPTION
### Summary

This PR add several improvements on how unhandled exceptions are managed by penpot.

Relevant changes:

- No longer show internal error page because the application should recover correctly. So we instead show small toast.
- Add `debug.print_last_exception()` that prints the latest exception with several ad-dons (print explain on schema errors, print stack trace and the error data)
- Properly catch unhandled rejection on promises in the same way as unhandled exceptions.

<img width="1078" height="304" alt="image" src="https://github.com/user-attachments/assets/8c126966-1d93-4ea1-bc70-f98a163c1fae" />
