### PR TITLE
:bug: Update switch checked state on change prop

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/switch.cljs
+++ b/frontend/src/app/main/ui/ds/controls/switch.cljs
@@ -67,6 +67,11 @@
                                 :on-key-down handle-keydown
                                 :disabled disabled?})]
 
+    (mf/use-effect
+     (mf/deps default-checked)
+     (fn []
+       (reset! checked* default-checked)))
+
     [:> :div props
      [:div {:id id
             :class (stl/css :switch-track)}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13230
<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Logic in the component does only provide a single valid value for the switch, but it was not being updated internally when the property changed.

### Steps to reproduce 

Try to have more than one active theme 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
