### PR TITLE
:bug: Break long token names in remapping modal

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/remapping_modal.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/remapping_modal.scss
@@ -50,7 +50,7 @@
 .modal-title {
   @include t.use-typography("headline-medium");
   color: var(--modal-title-foreground-color);
-  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .modal-content {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13221
<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Break long token names in remapping modal title

### Steps to reproduce 

<img width="1236" height="537" alt="image" src="https://github.com/user-attachments/assets/d32d7bd3-e9b3-4a1f-b142-c8ba83f94f48" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
