### PR TITLE
:wrench: Update tmux to build render-wasm on start up

### DIFF
--- a/docker/devenv/files/start-tmux.sh
+++ b/docker/devenv/files/start-tmux.sh
@@ -41,4 +41,9 @@ tmux select-window -t penpot:3
 tmux send-keys -t penpot 'cd penpot/backend' enter C-l
 tmux send-keys -t penpot './scripts/start-dev' enter
 
+tmux new-window -t penpot:4 -n 'rust-wasm'
+tmux select-window -t penpot:4
+tmux send-keys -t penpot 'cd penpot/render-wasm' enter C-l
+tmux send-keys -t penpot './build' enter
+
 tmux -2 attach-session -t penpot


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13257

### Summary

This adds a new tab in the tmux to build the `render-wasm` wasm module. It is `./build` and not `./watch` because atm sometimes `./watch` does not pick up some changes. 

### Steps to reproduce 

`./manage.sh build-devenv --local`

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
