### PR TITLE
:bug: Fix lazy load intersection on dragging at the beginning

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -299,7 +299,7 @@
 
         on-drop
         (mf/use-fn
-         (mf/deps id index objects expanded? selected)
+         (mf/deps id objects expanded? selected)
          (fn [side _data]
            (let [single? (= (count selected) 1)
                  same?   (and single? (= (first selected) id))]
@@ -320,14 +320,18 @@
 
                      [parent-id _] (ctn/find-valid-parent-and-frame-ids parent-id objects (map #(get objects %) selected) false files)
 
-                     parent    (get objects parent-id)
+                     parent        (get objects parent-id)
+                     current-index (d/index-of (:shapes parent) id)
 
                      to-index  (cond
                                  (= side :center) 0
                                  (and expanded? (= side :bot) (d/not-empty? (:shapes shape))) (count (:shapes parent))
-                                 (= side :top) (inc index)
-                                 :else index)]
-                 (st/emit! (dw/relocate-selected-shapes parent-id to-index)))))))
+                                 ;; target not found in parent (while lazy loading)
+                                 (neg? current-index) nil
+                                 (= side :top) (inc current-index)
+                                 :else current-index)]
+                 (when (some? to-index)
+                   (st/emit! (dw/relocate-selected-shapes parent-id to-index))))))))
 
         on-hold
         (mf/use-fn
@@ -416,11 +420,7 @@
                 current @children-count*
                 new-count (min total (max current chunk-size min-count))]
             (reset! children-count* new-count))
-          (reset! children-count* 0)))
-      (fn []
-        (when-let [obs ^js @observer-var]
-          (.disconnect obs)
-          (reset! observer-var nil))))
+          (reset! children-count* 0))))
 
     ;; Re-observe sentinel whenever children-count changes (sentinel moves)
     ;; and (shapes item) to reconnect observer after shape changes
@@ -501,4 +501,4 @@
                 :component-child? component-tree?}])))
         (when (< children-count (count (:shapes item)))
           [:div {:ref lazy-ref
-                 :style {:min-height 1}}])])]))
+                 :class (stl/css :lazy-load-sentinel)}])])]))

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.scss
@@ -270,3 +270,7 @@
 .filtered {
   min-width: deprecated.$s-12;
 }
+.lazy-load-sentinel {
+  min-height: 1px;
+  pointer-events: none;
+}

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -522,8 +522,7 @@
          [:& filters-tree {:objects filtered-objects
                            :key (dm/str (:id page))
                            :parent-size size-parent}]
-         [:div {:ref lazy-load-ref
-                :style {:min-height 16}}]]
+         [:div {:ref lazy-load-ref}]]
         [:div {:on-scroll on-scroll
                :class (stl/css :tool-window-content)
                :data-scroll-container true


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13194

### Summary

It seems that the observer (based on children-count)  was being disconnected when start dragging after a cleanup, and it was not re-run. It also checks the current-index, so it is not dropped to the bottom

### Steps to reproduce 

check the video attached to the issue

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
