### PR TITLE
:sparkles: Add several improvements to frontend error reporting

### DIFF
--- a/backend/resources/app/templates/base.tmpl
+++ b/backend/resources/app/templates/base.tmpl
@@ -5,7 +5,6 @@
     <meta name="robots" content="noindex,nofollow">
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>{% block title %}{% endblock %}</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono">
     <style>
       {% include "app/templates/styles.css"  %}
     </style>

--- a/backend/resources/app/templates/error-list.tmpl
+++ b/backend/resources/app/templates/error-list.tmpl
@@ -8,7 +8,7 @@ penpot - error list
   <nav>
     <div class="title">
       <a href="/dbg"> [BACK]</a>
-      <h1>Error reports (last 200)</h1>
+      <h1>Error reports (last 300)</h1>
 
       <a class="{% if version = 3 %}strong{% endif %}" href="?version=3">[BACKEND ERRORS]</a>
       <a class="{% if version = 4 %}strong{% endif %}" href="?version=4">[FRONTEND ERRORS]</a>

--- a/backend/resources/app/templates/error-list.tmpl
+++ b/backend/resources/app/templates/error-list.tmpl
@@ -5,23 +5,25 @@ penpot - error list
 {% endblock %}
 
 {% block content %}
-<nav>
-  <div class="title">
-    <h1>Error reports (last 200)
-      <a href="/dbg">[GO BACK]</a>
-    </h1>
-  </div>
-</nav>
-<main class="horizontal-list">
-  <ul>
-    {% for item in items %}
-      <li>
-        <a class="date" href="/dbg/error/{{item.id}}">{{item.created-at}}</a>
-        <a class="hint" href="/dbg/error/{{item.id}}">
-          <span class="title">{{item.hint|abbreviate:150}}</span>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
-</main>
+  <nav>
+    <div class="title">
+      <a href="/dbg"> [BACK]</a>
+      <h1>Error reports (last 200)</h1>
+
+      <a class="{% if version = 3 %}strong{% endif %}" href="?version=3">[BACKEND ERRORS]</a>
+      <a class="{% if version = 4 %}strong{% endif %}" href="?version=4">[FRONTEND ERRORS]</a>
+    </div>
+  </nav>
+  <main class="horizontal-list">
+    <ul>
+      {% for item in items %}
+        <li>
+          <a class="date" href="/dbg/error/{{item.id}}">{{item.created-at}}</a>
+          <a class="hint" href="/dbg/error/{{item.id}}">
+            <span class="title">{{item.hint|abbreviate:150}}</span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </main>
 {% endblock %}

--- a/backend/resources/app/templates/error-report.v3.tmpl
+++ b/backend/resources/app/templates/error-report.v3.tmpl
@@ -6,7 +6,7 @@ Report: {{hint|abbreviate:150}} - {{id}} - Penpot Error Report (v3)
 
 {% block content %}
 <nav>
-  <div>[<a href="/dbg/error">⮜</a>]</div>
+  <div>[<a href="/dbg/error?version={{version}}">⮜</a>]</div>
   <div>[<a href="#head">head</a>]</div>
   <div>[<a href="#props">props</a>]</div>
   <div>[<a href="#context">context</a>]</div>

--- a/backend/resources/app/templates/error-report.v4.tmpl
+++ b/backend/resources/app/templates/error-report.v4.tmpl
@@ -1,7 +1,7 @@
  {% extends "app/templates/base.tmpl" %}
 
 {% block title %}
-Report: {{hint|abbreviate:150}} - {{id}} - Penpot Error Report (v3)
+Report: {{hint|abbreviate:150}} - {{id}} - Penpot Error Report (v4)
 {% endblock %}
 
 {% block content %}

--- a/backend/resources/app/templates/error-report.v4.tmpl
+++ b/backend/resources/app/templates/error-report.v4.tmpl
@@ -1,0 +1,46 @@
+ {% extends "app/templates/base.tmpl" %}
+
+{% block title %}
+Report: {{hint|abbreviate:150}} - {{id}} - Penpot Error Report (v3)
+{% endblock %}
+
+{% block content %}
+<nav>
+  <div>[<a href="/dbg/error?version={{version}}">⮜</a>]</div>
+  <div>[<a href="#head">head</a>]</div>
+  <!-- <div>[<a href="#props">props</a>]</div> -->
+  <div>[<a href="#context">context</a>]</div>
+  {% if report %}
+  <div>[<a href="#report">report</a>]</div>
+  {% endif %}
+</nav>
+<main>
+  <div class="table">
+    <div class="table-row multiline">
+      <div id="head" class="table-key">HEAD</div>
+      <div class="table-val">
+        <h1><span class="not-important">Hint:</span> <br/> {{hint}}</h1>
+        <h2><span class="not-important">Reported at:</span> <br/> {{created-at}}</h2>
+        <h2><span class="not-important">Report ID:</span> <br/> {{id}}</h2>
+      </div>
+    </div>
+
+    <div class="table-row multiline">
+      <div id="context" class="table-key">CONTEXT: </div>
+
+      <div class="table-val">
+        <pre>{{context}}</pre>
+      </div>
+    </div>
+
+    {% if report %}
+    <div class="table-row multiline">
+      <div id="report" class="table-key">REPORT:</div>
+      <div class="table-val">
+        <pre>{{report}}</pre>
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</main>
+{% endblock %}

--- a/backend/resources/app/templates/styles.css
+++ b/backend/resources/app/templates/styles.css
@@ -1,5 +1,5 @@
 * {
-  font-family: "JetBrains Mono", monospace;
+  font-family: monospace;
   font-size: 12px;
 }
 
@@ -36,6 +36,10 @@ small {
   color: #888;
 }
 
+.strong {
+  font-weight: 900;
+}
+
 .not-important {
   color: #888;
   font-weight: 200;
@@ -57,14 +61,26 @@ nav {
 
 nav > .title {
   display: flex;
-  justify-content: center;
   width: 100%;
 }
 
+nav > .title > a {
+  color: black;
+  text-decoration: none;
+}
+
+nav > .title > a.strong {
+  text-decoration: underline;
+}
+
 nav > .title > h1 {
-  padding: 0px;
   margin: 0px;
   font-size: 11px;
+  display: block;
+}
+
+nav > .title > * {
+  padding: 0px 6px;
 }
 
 nav > div {

--- a/backend/src/app/http/errors.clj
+++ b/backend/src/app/http/errors.clj
@@ -32,7 +32,7 @@
         (assoc :request/ip-addr (inet/parse-request request))
         (assoc :request/profile-id (get claims :uid))
         (assoc :request/auth-data auth)
-        (assoc :version/frontend (or (yreq/get-header request "x-frontend-version") "unknown")))))
+        (assoc :frontend/version (or (yreq/get-header request "x-frontend-version") "unknown")))))
 
 (defmulti handle-error
   (fn [cause _ _]

--- a/backend/src/app/loggers/database.clj
+++ b/backend/src/app/loggers/database.clj
@@ -14,6 +14,7 @@
    [app.common.schema :as sm]
    [app.config :as cf]
    [app.db :as db]
+   [app.loggers.audit :as audit]
    [clojure.spec.alpha :as s]
    [integrant.core :as ig]
    [promesa.exec :as px]
@@ -28,69 +29,108 @@
 (defonce enabled (atom true))
 
 (defn- persist-on-database!
-  [pool id report]
+  [pool id version report]
   (when-not (db/read-only? pool)
     (db/insert! pool :server-error-report
                 {:id id
-                 :version 3
+                 :version version
                  :content (db/tjson report)})))
+
+(defn- concurrent-exception?
+  [cause]
+  (or (instance? java.util.concurrent.CompletionException cause)
+      (instance? java.util.concurrent.ExecutionException cause)))
 
 (defn record->report
   [{:keys [::l/context ::l/message ::l/props ::l/logger ::l/level ::l/cause] :as record}]
   (assert (l/valid-record? record) "expectd valid log record")
-  (if (or (instance? java.util.concurrent.CompletionException cause)
-          (instance? java.util.concurrent.ExecutionException cause))
-    (-> record
-        (assoc ::trace (ex/format-throwable cause :data? true :explain? false :header? false :summary? false))
-        (assoc ::l/cause (ex-cause cause))
-        (record->report))
+  (let [data (if (concurrent-exception? cause)
+               (ex-data (ex-cause cause))
+               (ex-data cause))
 
-    (let [data (ex-data cause)
-          ctx  (-> context
-                   (assoc :tenant (cf/get :tenant))
-                   (assoc :host (cf/get :host))
-                   (assoc :public-uri (str (cf/get :public-uri)))
-                   (assoc :logger/name logger)
-                   (assoc :logger/level level)
-                   (dissoc :request/params :value :params :data))]
+        ctx  (-> context
+                 (assoc :service/tenant (cf/get :tenant))
+                 (assoc :service/host (cf/get :host))
+                 (assoc :service/public-uri (str (cf/get :public-uri)))
+                 (assoc :backend/version (:full cf/version))
+                 (assoc :logger/name logger)
+                 (assoc :logger/level level)
+                 (dissoc :request/params :value :params :data))]
 
-      (merge
-       {:context (-> (into (sorted-map) ctx)
-                     (pp/pprint-str :length 50))
-        :props   (pp/pprint-str props :length 50)
-        :hint    (or (when-let [message (ex-message cause)]
-                       (if-let [props-hint (:hint props)]
-                         (str props-hint ": " message)
-                         message))
-                     @message)
-        :trace   (or (::trace record)
-                     (some-> cause (ex/format-throwable :data? true :explain? false :header? false :summary? false)))}
+    (merge
+     {:context (-> (into (sorted-map) ctx)
+                   (pp/pprint-str :length 50))
+      :props   (pp/pprint-str props :length 50)
+      :hint    (or (when-let [message (ex-message cause)]
+                     (if-let [props-hint (:hint props)]
+                       (str props-hint ": " message)
+                       message))
+                   @message)
+      :trace   (or (::trace record)
+                   (some-> cause (ex/format-throwable :data? true :explain? false :header? false :summary? false)))}
 
-       (when-let [params (or (:request/params context) (:params context))]
-         {:params (pp/pprint-str params :length 20 :level 20)})
+     (when-let [params (or (:request/params context) (:params context))]
+       {:params (pp/pprint-str params :length 20 :level 20)})
 
-       (when-let [value (:value context)]
-         {:value (pp/pprint-str value :length 30 :level 13)})
+     (when-let [value (:value context)]
+       {:value (pp/pprint-str value :length 30 :level 13)})
 
-       (when-let [data (some-> data (dissoc ::s/problems ::s/value ::s/spec ::sm/explain :hint))]
-         {:data (pp/pprint-str data :length 30 :level 13)})
+     (when-let [data (some-> data (dissoc ::s/problems ::s/value ::s/spec ::sm/explain :hint))]
+       {:data (pp/pprint-str data :length 30 :level 13)})
 
-       (when-let [explain (ex/explain data :length 30 :level 13)]
-         {:explain explain})))))
+     (when-let [explain (ex/explain data :length 30 :level 13)]
+       {:explain explain}))))
 
-(defn error-record?
-  [{:keys [::l/level]}]
-  (= :error level))
-
-(defn- handle-event
+(defn- handle-log-record
+  "Convert the log record into a report object and persist it on the database"
   [{:keys [::db/pool]} {:keys [::l/id] :as record}]
   (try
     (let [uri    (cf/get :public-uri)
           report (-> record record->report d/without-nils)]
-      (l/debug :hint "registering error on database" :id id
-               :uri (str uri "/dbg/error/" id))
+      (l/dbg :hint "registering error on database"
+             :id id
+             :src "logging"
+             :uri (str uri "/dbg/error/" id))
+      (persist-on-database! pool id 3 report))
+    (catch Throwable cause
+      (l/warn :hint "unexpected exception on database error logger" :cause cause))))
 
-      (persist-on-database! pool id report))
+(defn- event->report
+  [{:keys [::audit/context ::audit/props ::audit/ip-addr] :as record}]
+  (let [context
+        (reduce-kv (fn [context k v]
+                     (let [k' (keyword "frontend" (name k))]
+                       (-> context
+                           (dissoc k)
+                           (assoc k' v))))
+                   context
+                   context)
+
+        context
+        (-> context
+            (assoc :backend/tenant (cf/get :tenant))
+            (assoc :backend/host (cf/get :host))
+            (assoc :backend/public-uri (str (cf/get :public-uri)))
+            (assoc :backend/version (:full cf/version))
+            (assoc :frontend/ip-addr ip-addr))]
+
+    {:context (-> (into (sorted-map) context)
+                  (pp/pprint-str :length 50))
+     :props   (pp/pprint-str props :length 50)
+     :hint    (get props :hint)
+     :report  (get props :report)}))
+
+(defn- handle-audit-event
+  "Convert the log record into a report object and persist it on the database"
+  [{:keys [::db/pool]} {:keys [::audit/id] :as event}]
+  (try
+    (let [uri    (cf/get :public-uri)
+          report (-> event event->report d/without-nils)]
+      (l/dbg :hint "registering error on database"
+             :id id
+             :src "audit-log"
+             :uri (str uri "/dbg/error/" id))
+      (persist-on-database! pool id 4 report))
     (catch Throwable cause
       (l/warn :hint "unexpected exception on database error logger" :cause cause))))
 
@@ -100,26 +140,49 @@
 
 (defmethod ig/init-key ::reporter
   [_ cfg]
-  (let [input (sp/chan :buf (sp/sliding-buffer 64)
-                       :xf  (filter error-record?))]
-    (add-watch l/log-record ::reporter #(sp/put! input %4))
+  (let [input  (sp/chan :buf (sp/sliding-buffer 256))
+        thread (px/thread
+                 {:name "penpot/reporter/database"}
+                 (l/info :hint "initializing database error persistence")
+                 (try
+                   (loop []
+                     (when-let [item (sp/take! input)]
+                       (cond
+                         (::l/id item)
+                         (handle-log-record cfg item)
 
-    (px/thread {:name "penpot/database-reporter"}
-      (l/info :hint "initializing database error persistence")
-      (try
-        (loop []
-          (when-let [record (sp/take! input)]
-            (handle-event cfg record)
-            (recur)))
-        (catch InterruptedException _
-          (l/debug :hint "reporter interrupted"))
-        (catch Throwable cause
-          (l/error :hint "unexpected error" :cause cause))
-        (finally
-          (sp/close! input)
-          (remove-watch l/log-record ::reporter)
-          (l/info :hint "reporter terminated"))))))
+                         (::audit/id item)
+                         (handle-audit-event cfg item)
+
+                         :else
+                         (l/warn :hint "received unexpected item" :item item))
+
+                       (recur)))
+
+                   (catch InterruptedException _
+                     (l/debug :hint "reporter interrupted"))
+                   (catch Throwable cause
+                     (l/error :hint "unexpected error" :cause cause))
+                   (finally
+                     (l/info :hint "reporter terminated"))))]
+
+    (add-watch l/log-record ::reporter
+               (fn [_ _ _ record]
+                 (when (= :error (::l/level record))
+                   (sp/put! input record))))
+
+    {::input input
+     ::thread thread}))
 
 (defmethod ig/halt-key! ::reporter
-  [_ thread]
-  (some-> thread px/interrupt!))
+  [_ {:keys [::input ::thread]}]
+  (remove-watch l/log-record ::reporter)
+  (sp/close! input)
+  (px/interrupt! thread))
+
+(defn emit
+  "Emit an event/report into the database reporter"
+  [cfg event]
+  (when-let [{:keys [::input]} (get cfg ::reporter)]
+    (sp/put! input event)))
+

--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -337,7 +337,13 @@
     ::setup/props        (ig/ref ::setup/props)
 
     ::email/blacklist    (ig/ref ::email/blacklist)
-    ::email/whitelist    (ig/ref ::email/whitelist)}
+    ::email/whitelist    (ig/ref ::email/whitelist)
+
+    :app.loggers.database/reporter
+    (ig/ref :app.loggers.database/reporter)
+
+    :app.loggers.mattermost/reporter
+    (ig/ref :app.loggers.mattermost/reporter)}
 
    :app.nitrate/client
    {::http.client/client (ig/ref ::http.client/client)

--- a/backend/src/app/migrations.clj
+++ b/backend/src/app/migrations.clj
@@ -456,7 +456,10 @@
     :fn (mg/resource "app/migrations/sql/0142-add-sso-provider-table.sql")}
 
    {:name "0143-http-session-v2-table"
-    :fn (mg/resource "app/migrations/sql/0143-add-http-session-v2-table.sql")}])
+    :fn (mg/resource "app/migrations/sql/0143-add-http-session-v2-table.sql")}
+
+   {:name "0144-mod-server-error-report-table"
+    :fn (mg/resource "app/migrations/sql/0144-mod-server-error-report-table.sql")}])
 
 (defn apply-migrations!
   [pool name migrations]

--- a/backend/src/app/migrations/sql/0144-mod-server-error-report-table.sql
+++ b/backend/src/app/migrations/sql/0144-mod-server-error-report-table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE server_error_report DROP CONSTRAINT server_error_report_pkey;
+ALTER TABLE server_error_report ADD PRIMARY KEY (id);
+CREATE INDEX server_error_report__version__idx
+    ON server_error_report ( version );

--- a/backend/test/backend_tests/helpers.clj
+++ b/backend/test/backend_tests/helpers.clj
@@ -103,6 +103,14 @@
                      (assoc-in [::db/pool ::db/username] (:database-username config))
                      (assoc-in [::db/pool ::db/password] (:database-password config))
                      (assoc-in [:app.rpc/methods :app.setup/templates] templates)
+                     (assoc-in [:app.rpc/methods :app.setup/templates] templates)
+                     (update :app.rpc/methods
+                             (fn [state]
+                               (-> state
+                                   (assoc :app.setup/templates templates)
+                                   (assoc :app.loggers.mattermost/reporter nil)
+                                   (assoc :app.loggers.database/reporter nil))))
+
                      (dissoc :app.srepl/server
                              :app.http/server
                              :app.http/route

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -7,10 +7,8 @@
 (ns app.main.errors
   "Generic error handling"
   (:require
-   [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.pprint :as pp]
-   [app.common.schema :as sm]
    [app.config :as cf]
    [app.main.data.auth :as da]
    [app.main.data.event :as ev]
@@ -35,7 +33,7 @@
 ;; Will contain last uncaught exception
 (def last-exception nil)
 
-(defn- exception->error-data
+(defn exception->error-data
   [cause]
   (let [data (ex-data cause)]
     (-> data
@@ -74,8 +72,8 @@
         (when-let [file-id (or (:file-id data) file-id)]
           (println "File ID: " (str file-id)))
         (println "Version: " (:full cf/version))
-        (println "URI:     " cf/public-uri)
-        (println "HREF:    " (.-href g/location))
+        (println "URI:     " (str cf/public-uri))
+        (println "HREF:    " (rt/get-current-href))
         (println)
 
         (println
@@ -100,6 +98,7 @@
     (st/emit!
      (ev/event {::ev/name "unhandled-exception"
                 :hint hint
+                :href (rt/get-current-href)
                 :type (get data :type :unknown)
                 :report (generate-report cause)})
 

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -7,17 +7,20 @@
 (ns app.main.errors
   "Generic error handling"
   (:require
+   [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.pprint :as pp]
    [app.common.schema :as sm]
+   [app.config :as cf]
    [app.main.data.auth :as da]
+   [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.data.notifications :as ntf]
    [app.main.data.workspace :as-alias dw]
    [app.main.router :as rt]
    [app.main.store :as st]
    [app.main.worker]
-   [app.util.globals :as glob]
+   [app.util.globals :as g]
    [app.util.i18n :refer [tr]]
    [app.util.timers :as ts]
    [cuerdas.core :as str]
@@ -32,63 +35,13 @@
 ;; Will contain last uncaught exception
 (def last-exception nil)
 
-(defn- print-data!
-  [data]
-  (-> data
-      (dissoc ::sm/explain)
-      (dissoc :explain)
-      (dissoc ::trace)
-      (dissoc ::instance)
-      (pp/pprint {:width 70})))
-
-(defn- print-explain!
-  [data]
-  (when-let [{:keys [errors] :as explain} (::sm/explain data)]
-    (let [errors (mapv #(update % :schema sm/form) errors)]
-      (pp/pprint errors {:width 100 :level 15 :length 20})))
-
-  (when-let [explain (:explain data)]
-    (js/console.log explain)))
-
-(defn- print-trace!
-  [data]
-  (some-> data ::trace js/console.log))
-
-(defn- print-group!
-  [message f]
-  (try
-    (js/console.group message)
-    (f)
-    (catch :default _ nil)
-    (finally
-      (js/console.groupEnd message))))
-
-(defn print-cause!
-  [message cause]
-  (print-group! message (fn []
-                          (print-data! cause)
-                          (print-explain! cause)
-                          (print-trace! cause))))
-
-(defn exception->error-data
+(defn- exception->error-data
   [cause]
   (let [data (ex-data cause)]
     (-> data
         (assoc :hint (or (:hint data) (ex-message cause)))
         (assoc ::instance cause)
         (assoc ::trace (.-stack cause)))))
-
-(defn print-error!
-  [cause]
-  (cond
-    (map? cause)
-    (print-cause! (:hint cause "Unexpected Error") cause)
-
-    (ex/error? cause)
-    (print-cause! (ex-message cause) (ex-data cause))
-
-    :else
-    (print-cause! (ex-message cause) (exception->error-data cause))))
 
 (defn on-error
   "A general purpose error handler."
@@ -104,13 +57,65 @@
 ;; Set the main potok error handler
 (reset! st/on-error on-error)
 
+(defn generate-report
+  [cause]
+  (try
+    (let [team-id    (:current-team-id @st/state)
+          file-id    (:current-file-id @st/state)
+          profile-id (:profile-id @st/state)
+          data       (ex-data cause)]
+
+      (with-out-str
+        (println "Context:")
+        (println "--------------------")
+        (println "Hint:    " (or (:hint data) (ex-message cause) "--"))
+        (println "Prof ID: " (str (or profile-id "--")))
+        (println "Team ID: " (str (or team-id "--")))
+        (when-let [file-id (or (:file-id data) file-id)]
+          (println "File ID: " (str file-id)))
+        (println "Version: " (:full cf/version))
+        (println "URI:     " cf/public-uri)
+        (println "HREF:    " (.-href g/location))
+        (println)
+
+        (println
+         (ex/format-throwable cause))
+        (println)
+
+        (println "Last events:")
+        (println "--------------------")
+        (pp/pprint @st/last-events {:length 200})
+        (println)))
+    (catch :default cause
+      (.error js/console "error on generating report" cause)
+      nil)))
+
+(defn- show-not-blocking-error
+  "Show a non user blocking error notification"
+  [cause]
+  (let [data (ex-data cause)
+        hint (or (some-> (:hint data) ex/first-line)
+                 (ex-message cause))]
+
+    (st/emit!
+     (ev/event {::ev/name "unhandled-exception"
+                :hint hint
+                :type (get data :type :unknown)
+                :report (generate-report cause)})
+
+     (ntf/show {:content (tr "errors.unexpected-exception" hint)
+                :type :toast
+                :level :error
+                :timeout 3000}))))
+
 (defmethod ptk/handle-error :default
   [error]
-  (st/async-emit! (rt/assign-exception error))
-  (print-group! "Unhandled Error"
-                (fn []
-                  (print-trace! error)
-                  (print-data! error))))
+  (if (and (string? (:hint error))
+           (str/starts-with? (:hint error) "Assert failed:"))
+    (ptk/handle-error (assoc error :type :assertion))
+    (when-let [cause (::instance error)]
+      (ex/print-throwable cause :prefix "Unexpected Error")
+      (show-not-blocking-error cause))))
 
 ;; We receive a explicit authentication error; If the uri is for
 ;; workspace, dashboard, viewer or settings, then assign the exception
@@ -141,11 +146,9 @@
 ;; and frontend.
 
 (defmethod ptk/handle-error :validation
-  [{:keys [code] :as error}]
-  (print-group! "Validation Error"
-                (fn []
-                  (print-data! error)
-                  (print-explain! error)))
+  [{:keys [code ::instance] :as error}]
+  (ex/print-throwable instance :prefix "Validation Error")
+
   (cond
     (= code :invalid-paste-data)
     (let [message (tr "errors.paste-data-validation")]
@@ -193,23 +196,14 @@
     :else
     (st/async-emit! (rt/assign-exception error))))
 
-
 ;; This is a pure frontend error that can be caused by an active
 ;; assertion (assertion that is preserved on production builds). From
 ;; the user perspective this should be treated as internal error.
 (defmethod ptk/handle-error :assertion
   [error]
-  (ts/schedule
-   #(st/emit! (ntf/show {:content (tr "errors.internal-assertion-error")
-                         :type :toast
-                         :level :error
-                         :timeout 3000})))
-
-  (print-group! "Internal Assertion Error"
-                (fn []
-                  (print-trace! error)
-                  (print-data! error)
-                  (print-explain! error))))
+  (when-let [cause (::instance error)]
+    (show-not-blocking-error cause)
+    (ex/print-throwable cause :prefix "Assertion Error")))
 
 ;; ;; All the errors that happens on worker are handled here.
 (defmethod ptk/handle-error :worker-error
@@ -221,9 +215,8 @@
                 :level :error
                 :timeout 3000})))
 
-  (print-group! "Internal Worker Error"
-                (fn []
-                  (print-data! error))))
+  (some-> (::instance error)
+          (ex/print-throwable :prefix "Web Worker Error")))
 
 ;; Error on parsing an SVG
 (defmethod ptk/handle-error :svg-parser
@@ -251,12 +244,9 @@
 (derive :service-unavailable ::exceptional-state)
 
 (defmethod ptk/handle-error ::exceptional-state
-  [error]
-  (when-let [cause (::instance error)]
-    (js/console.log (.-stack cause)))
-
-  (ts/schedule
-   #(st/emit! (rt/assign-exception error))))
+  [{:keys [::instance] :as error}]
+  (ex/print-throwable instance :prefix "Exceptional State")
+  (ts/schedule #(st/emit! (rt/assign-exception error))))
 
 (defn- redirect-to-dashboard
   []
@@ -264,7 +254,7 @@
         project-id (:current-project-id @st/state)]
     (if (and project-id team-id)
       (st/emit! (rt/nav :dashboard-files {:team-id team-id :project-id project-id}))
-      (set! (.-href glob/location) ""))))
+      (set! (.-href g/location) ""))))
 
 (defmethod ptk/handle-error :restriction
   [{:keys [code] :as error}]
@@ -312,34 +302,19 @@
                                           :text (tr "errors.deprecated.contact.text")
                                           :after (tr "errors.deprecated.contact.after")
                                           :on-click #(st/emit! (rt/nav :settings-feedback))}}))
-
     :else
-    (print-cause! "Restriction Error" error)))
+    (when-let [cause (::instance error)]
+      (ex/print-throwable cause :prefix "Restriction Error")
+      (show-not-blocking-error cause))))
 
 ;; This happens when the backed server fails to process the
 ;; request. This can be caused by an internal assertion or any other
 ;; uncontrolled error.
 
 (defmethod ptk/handle-error :server-error
-  [error]
-  (st/async-emit! (rt/assign-exception error))
-  (print-group! "Server Error"
-                (fn []
-                  (print-data! (dissoc error :data))
-
-                  (when-let [werror (:data error)]
-                    (cond
-                      (= :assertion (:type werror))
-                      (print-group! "Assertion Error"
-                                    (fn []
-                                      (print-data! werror)
-                                      (print-explain! werror)))
-
-                      :else
-                      (print-group! "Unexpected"
-                                    (fn []
-                                      (print-data! werror)
-                                      (print-explain! werror))))))))
+  [{:keys [::instance] :as error}]
+  (ex/print-throwable instance :prefix "Server Error")
+  (st/async-emit! (rt/assign-exception error)))
 
 (defonce uncaught-error-handler
   (letfn [(is-ignorable-exception? [cause]
@@ -354,28 +329,19 @@
             (when-let [cause (unchecked-get event "error")]
               (set! last-exception cause)
               (when-not (is-ignorable-exception? cause)
-                (ex/print-throwable cause :prefix "uncaught exception")
-                (st/async-emit!
-                 (ntf/show {:content (tr "errors.unexpected-exception" (ex-message cause))
-                            :type :toast
-                            :level :error
-                            :timeout 3000})))))
-
+                (ex/print-throwable cause :prefix "Uncaught Exception")
+                (ts/schedule #(show-not-blocking-error cause)))))
 
           (on-unhandled-rejection [event]
             (.preventDefault ^js event)
             (when-let [cause (unchecked-get event "reason")]
               (set! last-exception cause)
-              (ex/print-throwable cause :prefix "uncaught rejection")
-              (st/async-emit!
-               (ntf/show {:content (tr "errors.unexpected-exception" (ex-message cause))
-                          :type :toast
-                          :level :error
-                          :timeout 3000}))))]
+              (ex/print-throwable cause :prefix "Uncaught Rejection")
+              (ts/schedule #(show-not-blocking-error cause))))]
 
-    (.addEventListener glob/window "error" on-unhandled-error)
-    (.addEventListener glob/window "unhandledrejection" on-unhandled-rejection)
+    (.addEventListener g/window "error" on-unhandled-error)
+    (.addEventListener g/window "unhandledrejection" on-unhandled-rejection)
     (fn []
-      (.removeEventListener glob/window "error" on-unhandled-error)
-      (.removeEventListener glob/window "unhandledrejection" on-unhandled-rejection))))
+      (.removeEventListener g/window "error" on-unhandled-error)
+      (.removeEventListener g/window "unhandledrejection" on-unhandled-rejection))))
 

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -145,8 +145,10 @@
 ;; and frontend.
 
 (defmethod ptk/handle-error :validation
-  [{:keys [code ::instance] :as error}]
-  (ex/print-throwable instance :prefix "Validation Error")
+  [{:keys [code] :as error}]
+
+  (when-let [instance (get error ::instance)]
+    (ex/print-throwable instance :prefix "Validation Error"))
 
   (cond
     (= code :invalid-paste-data)
@@ -243,8 +245,9 @@
 (derive :service-unavailable ::exceptional-state)
 
 (defmethod ptk/handle-error ::exceptional-state
-  [{:keys [::instance] :as error}]
-  (ex/print-throwable instance :prefix "Exceptional State")
+  [error]
+  (when-let [instance (get error ::instance)]
+    (ex/print-throwable instance :prefix "Exceptional State"))
   (ts/schedule #(st/emit! (rt/assign-exception error))))
 
 (defn- redirect-to-dashboard
@@ -311,8 +314,9 @@
 ;; uncontrolled error.
 
 (defmethod ptk/handle-error :server-error
-  [{:keys [::instance] :as error}]
-  (ex/print-throwable instance :prefix "Server Error")
+  [error]
+  (when-let [instance (get error ::instance)]
+    (ex/print-throwable instance :prefix "Server Error"))
   (st/async-emit! (rt/assign-exception error)))
 
 (defonce uncaught-error-handler

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.exceptions :as ex]
    [app.common.logging :as log]
    [app.main.data.dashboard :as dd]
    [app.main.data.event :as ev]
@@ -360,7 +361,7 @@
                  on-error
                  (fn [cause]
                    (reset! status* :error)
-                   (errors/print-error! cause)
+                   (ex/print-throwable cause)
                    (rx/of (modal/hide)
                           (ntf/error (tr "dashboard.libraries-and-templates.import-error"))))
 

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -15,7 +15,6 @@
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.data.notifications :as ntf]
-   [app.main.errors :as errors]
    [app.main.store :as st]
    [app.main.ui.components.file-uploader :refer [file-uploader*]]
    [app.main.ui.ds.product.loader :refer [loader*]]

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -453,7 +453,7 @@
   [{:keys [data route] :as props}]
   (let [type   (get data :type)
         report (mf/with-memo [data]
-                 (generate-report data))
+                 (some-> data ::errors/instance errors/generate-report))
         props  (mf/spread-props props {:report report})]
 
     (mf/with-effect [data route report]

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -36,7 +36,6 @@
    [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 ;; FIXME: this is a workaround until we export this class on beicon library
@@ -447,7 +446,6 @@
                        (rx/of default)
                        (rx/throw cause)))))))
 
-
 (mf/defc exception-section*
   {::mf/private true}
   [{:keys [data route] :as props}]
@@ -459,13 +457,13 @@
     (mf/with-effect [data route report]
       (let [params (:query-params route)
             params (u/map->query-string params)]
-        (st/emit! (ptk/data-event ::ev/event
-                                  {::ev/name "exception-page"
-                                   :type (get data :type :unknown)
-                                   :hint (get data :hint)
-                                   :path (get route :path)
-                                   :report report
-                                   :params params}))))
+        (st/emit! (ev/event {::ev/name "exception-page"
+                             :type (get data :type :unknown)
+                             :href (rt/get-current-href)
+                             :hint (get data :hint)
+                             :path (get route :path)
+                             :report report
+                             :params params}))))
 
     (case type
       :not-found

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -391,7 +391,7 @@
             (group-by :code)
             (clj->js))
        (catch :default cause
-         (errors/print-error! cause))))))
+         (ex/print-throwable cause))))))
 
 (defn ^:export validate-schema
   []
@@ -399,7 +399,7 @@
     (let [file (dsh/lookup-file @st/state)]
       (cfv/validate-file-schema! file))
     (catch :default cause
-      (errors/print-error! cause))))
+      (ex/print-throwable cause))))
 
 (defn ^:export repair
   [reload?]
@@ -431,7 +431,7 @@
                           (when reload?
                             (dom/reload-current-window)))
                         (fn [cause]
-                          (errors/print-error! cause)))))))))
+                          (ex/print-throwable cause)))))))))
 
 (defn ^:export fix-orphan-shapes
   []

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1467,7 +1467,7 @@ msgid "errors.generic"
 msgstr "Something wrong has happened."
 
 msgid "errors.unexpected-exception"
-msgstr "Unexpected exception: %s"
+msgstr "Unexpected error: %s"
 
 #: src/app/main/errors.cljs:200
 msgid "errors.internal-assertion-error"


### PR DESCRIPTION
### Summary

Add the ability to capture frontend error reports on the dbg pannel.

How to test:
- open the https://localhost:3449/dbg
- Go to error reports, you should be able to filter by the origin.
- In order to capture error reports, audit log should be enabled.

For example you can put `(assert (= 1 2) "foo")` on line 184 in the frontend/src/app/main/ui/dashboard/projects.cljs file and the try to create file in a project, this will simulate an exception.

**Merge with SQUASH**
