### PR TITLE
:sparkles: Add the concept of version to plugins

### DIFF
--- a/frontend/src/app/main/ui/workspace/plugins.cljs
+++ b/frontend/src/app/main/ui/workspace/plugins.cljs
@@ -95,10 +95,10 @@
   []
 
   (let [plugins-state* (mf/use-state #(preg/plugins-list))
-        plugins-state @plugins-state*
+        plugins-state  (deref plugins-state*)
 
-        plugin-url* (mf/use-state "")
-        plugin-url  @plugin-url*
+        plugin-url*    (mf/use-state "")
+        plugin-url     (deref plugin-url*)
 
         fetching-manifest? (mf/use-state false)
 

--- a/frontend/src/app/plugins/register.cljs
+++ b/frontend/src/app/plugins/register.cljs
@@ -38,6 +38,7 @@
         desc (obj/get manifest "description")
         code (obj/get manifest "code")
         icon (obj/get manifest "icon")
+        vers (d/nilv (obj/get manifest "version") 1)
 
         permissions (into #{} (obj/get manifest "permissions" []))
         permissions
@@ -55,9 +56,13 @@
         (u/uri plugin-url)
 
         origin
-        (-> plugin-url
-            (u/join ".")
-            (str))
+        (if (= vers 1)
+          (-> plugin-url
+              (assoc :path "/")
+              (str))
+          (-> plugin-url
+              (u/join ".")
+              (str)))
 
         prev-plugin
         (->> (:data @registry)

--- a/mcp/packages/plugin/public/manifest.json
+++ b/mcp/packages/plugin/public/manifest.json
@@ -1,6 +1,7 @@
 {
     "name": "Penpot MCP Plugin",
     "code": "plugin.js",
+    "version": 2,
     "description": "This plugin enables interaction with the Penpot MCP server",
     "permissions": ["content:read", "content:write", "library:read", "library:write", "comment:read", "comment:write"]
 }


### PR DESCRIPTION
### Summary

- Make mcp plugin version 2

For the moment, the manifest with version 2 has strong requirement that manifest.json is located on the base/root path. This makes possible to run plugins on a subpath. For now is a convention until we standarize it.

This is backward compatible change and fixes regression introduced with MCP integration PR that breaks old plugins.

