### PR TITLE
:tada: Enable IPv6 support for docker images

### DIFF
--- a/docker/images/files/nginx-resolvers.conf.template
+++ b/docker/images/files/nginx-resolvers.conf.template
@@ -1,1 +1,1 @@
-resolver $PENPOT_INTERNAL_RESOLVER ipv6=off valid=10s;
+resolver $PENPOT_INTERNAL_RESOLVER valid=10s;

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -73,6 +73,7 @@ http {
 
     server {
         listen 8080 default_server;
+        listen [::]:8080 default_server;
         server_name _;
 
         client_max_body_size $PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE;


### PR DESCRIPTION

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGpkemQ4MHprdjJ0dzJhcDcyMXQza3pzcjRrNGVtcDJva3ZnYzF0NiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1FbU0sArGktaGGDe99/giphy.gif)
- Add IPv6 listener to frontend nginx ([::]:8080)
- Remove ipv6=off from nginx resolver configuration
- Keep full backward compatibility with IPv4

[Issues #8014](https://github.com/penpot/penpot/issues/8014)