### PR TITLE
:sparkles: Make mcp env vars to use the same convention as penpot

### DIFF
--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -121,7 +121,7 @@ http {
             proxy_http_version 1.1;
         }
 
-        location /mcp {
+        location /plugins/mcp {
             alias /home/penpot/penpot/mcp/packages/plugin/dist;
             proxy_http_version 1.1;
         }

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -129,6 +129,11 @@ http {
             proxy_buffering off;
         }
 
+        location /plugins {
+            alias /var/www/app/plugins;
+            proxy_http_version 1.1;
+        }
+
         location /readyz {
             access_log off;
             proxy_pass $PENPOT_BACKEND_URI$request_uri;

--- a/frontend/scripts/build
+++ b/frontend/scripts/build
@@ -4,8 +4,6 @@
 
 set -ex
 
-export INCLUDE_STORYBOOK=${BUILD_STORYBOOK:-no};
-export INCLUDE_WASM=${BUILD_WASM:-yes};
 export EXTRA_PARAMS=$SHADOWCLJS_EXTRA_PARAMS;
 
 export BUILD_DATE=$(date -R);
@@ -18,6 +16,8 @@ export VERSION_TAG="${VERSION}-${BUILD_TS}";
 # performant code on macros (example: rumext)
 export NODE_ENV=production;
 
+rm -rf node_modules;
+
 corepack enable;
 corepack install;
 pnpm install;
@@ -28,9 +28,16 @@ rm -rf resources/public;
 mkdir -p resources/public;
 mkdir -p target/dist;
 
+# Build render wasm binary
 pushd ../render-wasm;
 ./build
 popd
+
+pushd ../mcp;
+rm -rf node_modules;
+./scripts/setup
+WS_URI="/mcp/ws" pnpm run --filter "mcp-plugin" build:multi-user
+popd;
 
 pnpm run build:app:main $EXTRA_PARAMS;
 pnpm run build:app:libs;
@@ -40,8 +47,6 @@ sed -i "s/\.\/render.js/.\/render.js?version=$VERSION_TAG/g" resources/public/js
 
 rsync -avr resources/public/ target/dist/
 
-if [ "$INCLUDE_STORYBOOK" = "yes" ];  then
-    # build storybook
-    pnpm run build:storybook || exit 1;
-    rsync -avr storybook-static/ target/dist/storybook-static;
-fi
+# Include the MCP plugin on the bundle
+mkdir -p target/dist/plugins/mcp/;
+rsync -avr ../mcp/packages/plugin/dist/ target/dist/plugins/mcp/

--- a/frontend/scripts/build-storybook
+++ b/frontend/scripts/build-storybook
@@ -13,7 +13,7 @@ export VERSION_TAG="${VERSION}-${BUILD_TS}";
 export NODE_ENV=production;
 
 corepack enable;
-corepack install || exit 1;
-pnpm install || exit 1;
+corepack install;
+pnpm install;
 
-pnpm run build:storybook || exit 1;
+pnpm run build:storybook;

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -255,14 +255,14 @@
       :data-testid "text-editor-container"
       :style {:width "var(--editor-container-width)"
               :height "var(--editor-container-height)"}}
-      ;; We hide the editor when is blurred because otherwise the
-      ;; selection won't let us see the underlying text. Use opacity
-      ;; because display or visibility won't allow to recover focus
-      ;; afterwards.
+     ;; We hide the editor when is blurred because otherwise the
+     ;; selection won't let us see the underlying text. Use opacity
+     ;; because display or visibility won't allow to recover focus
+     ;; afterwards.
 
-      ;; IMPORTANT! This is now done through DOM mutations (see
-      ;; on-blur and on-focus) but I keep this for future references.
-      ;; :opacity (when @blurred 0)}}
+     ;; IMPORTANT! This is now done through DOM mutations (see
+     ;; on-blur and on-focus) but I keep this for future references.
+     ;; :opacity (when @blurred 0)}}
 
      [:div
       {:class (dm/str

--- a/mcp/packages/plugin/vite.config.ts
+++ b/mcp/packages/plugin/vite.config.ts
@@ -1,14 +1,14 @@
 import { defineConfig } from "vite";
 import livePreview from "vite-live-preview";
 
-// Debug: Log the environment variables
-console.log("MULTI_USER_MODE env:", process.env.MULTI_USER_MODE);
-console.log("Will define IS_MULTI_USER_MODE as:", JSON.stringify(process.env.MULTI_USER_MODE === "true"));
+let WS_URI = process.env.WS_URI || "http://localhost:4402";
+let MULTI_USER_MODE = process.env.MULTI_USER_MODE === "true";
 
-let WS_URI = "http://localhost:4402";
+console.log("Will define IS_MULTI_USER_MODE as:", JSON.stringify(MULTI_USER_MODE));
 console.log("Will define PENPOT_MCP_WEBSOCKET_URL as:", JSON.stringify(WS_URI));
 
 export default defineConfig({
+    base: "./",
     plugins: [
         livePreview({
             reload: true,

--- a/mcp/packages/server/src/PenpotMcpServer.ts
+++ b/mcp/packages/server/src/PenpotMcpServer.ts
@@ -41,22 +41,17 @@ export class PenpotMcpServer {
         sse: {} as Record<string, { transport: SSEServerTransport; userToken?: string }>,
     };
 
-    private readonly port: number;
-    private readonly webSocketPort: number;
-    private readonly replPort: number;
-    private readonly listenAddress: string;
-    /**
-     * the address (domain name or IP address) via which clients can reach the MCP server
-     */
-    public readonly serverAddress: string;
+    public readonly host: string;
+    public readonly port: number;
+    public readonly webSocketPort: number;
+    public readonly replPort: number;
 
     constructor(private isMultiUser: boolean = false) {
         // read port configuration from environment variables
+        this.host = process.env.PENPOT_MCP_SERVER_HOST ?? "0.0.0.0";
         this.port = parseInt(process.env.PENPOT_MCP_SERVER_PORT ?? "4401", 10);
         this.webSocketPort = parseInt(process.env.PENPOT_MCP_WEBSOCKET_PORT ?? "4402", 10);
         this.replPort = parseInt(process.env.PENPOT_MCP_REPL_PORT ?? "4403", 10);
-        this.listenAddress = process.env.PENPOT_MCP_SERVER_LISTEN_ADDRESS ?? "0.0.0.0";
-        this.serverAddress = process.env.PENPOT_MCP_SERVER_ADDRESS ?? "0.0.0.0";
 
         this.configLoader = new ConfigurationLoader(process.cwd());
         this.apiDocs = new ApiDocs();
@@ -234,12 +229,12 @@ export class PenpotMcpServer {
         this.setupHttpEndpoints();
 
         return new Promise((resolve) => {
-            this.app.listen(this.port, this.listenAddress, async () => {
+            this.app.listen(this.port, this.host, async () => {
                 this.logger.info(`Multi-user mode: ${this.isMultiUserMode()}`);
                 this.logger.info(`Remote mode: ${this.isRemoteMode()}`);
-                this.logger.info(`Modern Streamable HTTP endpoint: http://${this.serverAddress}:${this.port}/mcp`);
-                this.logger.info(`Legacy SSE endpoint: http://${this.serverAddress}:${this.port}/sse`);
-                this.logger.info(`WebSocket server URL: ws://${this.serverAddress}:${this.webSocketPort}`);
+                this.logger.info(`Modern Streamable HTTP endpoint: http://${this.host}:${this.port}/mcp`);
+                this.logger.info(`Legacy SSE endpoint: http://${this.host}:${this.port}/sse`);
+                this.logger.info(`WebSocket server URL: ws://${this.host}:${this.webSocketPort}`);
 
                 // start the REPL server
                 await this.replServer.start();

--- a/mcp/packages/server/src/ReplServer.ts
+++ b/mcp/packages/server/src/ReplServer.ts
@@ -88,9 +88,7 @@ export class ReplServer {
         return new Promise((resolve) => {
             this.server = this.app.listen(this.port, () => {
                 this.logger.info(`REPL server started on port ${this.port}`);
-                this.logger.info(
-                    `REPL interface URL: http://${this.pluginBridge.mcpServer.serverAddress}:${this.port}`
-                );
+                this.logger.info(`REPL interface URL: http://${this.pluginBridge.mcpServer.host}:${this.port}`);
                 resolve();
             });
         });


### PR DESCRIPTION
### Summary

Simplify the environment variables related to listen host on MCP server and use the same naming as other penpot services.