### PR TITLE
:wrench: Improve layout performance

### DIFF
--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -301,11 +301,7 @@ pub extern "C" fn set_view_end() {
         #[cfg(feature = "profile-macros")]
         {
             let total_time = performance::get_time() - unsafe { VIEW_INTERACTION_START };
-            performance::console_log!(
-                "[PERF] view_interaction (zoom_changed={}): {}ms",
-                zoom_changed,
-                total_time
-            );
+            performance::console_log!("[PERF] view_interaction: {}ms", total_time);
         }
     });
 }

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2307,7 +2307,7 @@ impl RenderState {
 
         let mut all_tiles = HashSet::<tiles::Tile>::new();
 
-        let ids = self.touched_ids.clone();
+        let ids = std::mem::take(&mut self.touched_ids);
 
         for shape_id in ids.iter() {
             if let Some(shape) = tree.get(shape_id) {
@@ -2321,8 +2321,6 @@ impl RenderState {
         for tile in all_tiles {
             self.remove_cached_tile(tile);
         }
-
-        self.clean_touched();
 
         performance::end_measure!("rebuild_touched_tiles");
     }

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2195,7 +2195,11 @@ impl RenderState {
      * Given a shape, check the indexes and update it's location in the tile set
      * returns the tiles that have changed in the process.
      */
-    pub fn update_shape_tiles(&mut self, shape: &Shape, tree: ShapesPoolRef) -> HashSet<tiles::Tile> {
+    pub fn update_shape_tiles(
+        &mut self,
+        shape: &Shape,
+        tree: ShapesPoolRef,
+    ) -> HashSet<tiles::Tile> {
         let TileRect(rsx, rsy, rex, rey) = self.get_tiles_for_shape(shape, tree);
 
         // Collect old tiles to avoid borrow conflict with remove_shape_at
@@ -2447,6 +2451,7 @@ impl RenderState {
         self.touched_ids.insert(uuid);
     }
 
+    #[allow(dead_code)]
     pub fn clean_touched(&mut self) {
         self.touched_ids.clear();
     }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1119,6 +1119,25 @@ impl Shape {
         }
     }
 
+    /// Returns children in forward (non-reversed) order - useful for layout calculations
+    pub fn children_ids_iter_forward(&self, include_hidden: bool) -> Box<dyn Iterator<Item = &Uuid> + '_> {
+        if include_hidden {
+            return Box::new(self.children.iter());
+        }
+
+        if let Type::Bool(_) = self.shape_type {
+            Box::new([].iter())
+        } else if let Type::Group(group) = self.shape_type {
+            if group.masked {
+                Box::new(self.children.iter().skip(1))
+            } else {
+                Box::new(self.children.iter())
+            }
+        } else {
+            Box::new(self.children.iter())
+        }
+    }
+
     pub fn all_children(
         &self,
         shapes: ShapesPoolRef,

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1120,7 +1120,10 @@ impl Shape {
     }
 
     /// Returns children in forward (non-reversed) order - useful for layout calculations
-    pub fn children_ids_iter_forward(&self, include_hidden: bool) -> Box<dyn Iterator<Item = &Uuid> + '_> {
+    pub fn children_ids_iter_forward(
+        &self,
+        include_hidden: bool,
+    ) -> Box<dyn Iterator<Item = &Uuid> + '_> {
         if include_hidden {
             return Box::new(self.children.iter());
         }

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -430,34 +430,26 @@ pub fn propagate_modifiers(
                 }
             }
         }
-        // let mut layout_reflows_vec: Vec<Uuid> = layout_reflows.into_iter().collect();
+        // We sort the reflows so they are processed deepest-first in the
+        // tree structure. This way we can be sure that the children layouts
+        // are already reflowed before their parents.
+        let mut layout_reflows_vec: Vec<Uuid> =
+            std::mem::take(&mut layout_reflows).into_iter().collect();
+        layout_reflows_vec.sort_unstable_by(|id_a, id_b| {
+            let da = shapes.get_depth(id_a);
+            let db = shapes.get_depth(id_b);
+            db.cmp(&da)
+        });
 
-        // // We sort the reflows so they are process first the ones that are more
-        // // deep in the tree structure. This way we can be sure that the children layouts
-        // // are already reflowed.
-        // layout_reflows_vec.sort_unstable_by(|id_a, id_b| {
-        //     let da = shapes.get_depth(id_a);
-        //     let db = shapes.get_depth(id_b);
-        //     db.cmp(&da)
-        // });
-
-        // let mut bounds_temp = bounds.clone();
-        // for id in layout_reflows_vec.iter() {
-        //     if reflown.contains(id) {
-        //         continue;
-        //     }
-        //     reflow_shape(id, state, &mut reflown, &mut entries, &mut bounds_temp);
-        // }
-        // layout_reflows = HashSet::new();
-
-        for id in std::mem::take(&mut layout_reflows) {
-            if reflown.contains(&id) {
+        for id in &layout_reflows_vec {
+            if reflown.contains(id) {
                 continue;
             }
-            reflow_shape(&id, state, &mut reflown, &mut entries, &mut bounds);
+            reflow_shape(id, state, &mut reflown, &mut entries, &mut bounds);
         }
     }
 
+    #[allow(dead_code)]
     modifiers
         .iter()
         .map(|(key, val)| TransformEntry::from_input(*key, *val))

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -300,7 +300,20 @@ fn propagate_reflow(
         Type::Frame(Frame {
             layout: Some(_), ..
         }) => {
-            layout_reflows.insert(*id);
+            let mut skip_reflow = false;
+            if shape.is_layout_horizontal_fill() || shape.is_layout_vertical_fill() {
+                if let Some(parent_id) = shape.parent_id {
+                    if parent_id != Uuid::nil() && !reflown.contains(&parent_id) {
+                        // If this is a fill layout but the parent has not been reflown yet
+                        // we wait for the next iteration for reflow
+                        skip_reflow = true;
+                    }
+                }
+            }
+
+            if !skip_reflow {
+                layout_reflows.insert(*id);
+            }
         }
         Type::Group(Group { masked: true }) => {
             let children_ids = shape.children_ids(true);
@@ -417,26 +430,32 @@ pub fn propagate_modifiers(
                 }
             }
         }
+        // let mut layout_reflows_vec: Vec<Uuid> = layout_reflows.into_iter().collect();
 
-        let mut layout_reflows_vec: Vec<Uuid> = layout_reflows.into_iter().collect();
+        // // We sort the reflows so they are process first the ones that are more
+        // // deep in the tree structure. This way we can be sure that the children layouts
+        // // are already reflowed.
+        // layout_reflows_vec.sort_unstable_by(|id_a, id_b| {
+        //     let da = shapes.get_depth(id_a);
+        //     let db = shapes.get_depth(id_b);
+        //     db.cmp(&da)
+        // });
 
-        // We sort the reflows so they are process first the ones that are more
-        // deep in the tree structure. This way we can be sure that the children layouts
-        // are already reflowed.
-        layout_reflows_vec.sort_unstable_by(|id_a, id_b| {
-            let da = shapes.get_depth(id_a);
-            let db = shapes.get_depth(id_b);
-            db.cmp(&da)
-        });
+        // let mut bounds_temp = bounds.clone();
+        // for id in layout_reflows_vec.iter() {
+        //     if reflown.contains(id) {
+        //         continue;
+        //     }
+        //     reflow_shape(id, state, &mut reflown, &mut entries, &mut bounds_temp);
+        // }
+        // layout_reflows = HashSet::new();
 
-        let mut bounds_temp = bounds.clone();
-        for id in layout_reflows_vec.iter() {
-            if reflown.contains(id) {
+        for id in std::mem::take(&mut layout_reflows) {
+            if reflown.contains(&id) {
                 continue;
             }
-            reflow_shape(id, state, &mut reflown, &mut entries, &mut bounds_temp);
+            reflow_shape(&id, state, &mut reflown, &mut entries, &mut bounds);
         }
-        layout_reflows = HashSet::new();
     }
 
     modifiers

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -184,15 +184,18 @@ fn initialize_tracks(
 ) -> Vec<TrackData> {
     let mut tracks = Vec::<TrackData>::new();
     let mut current_track = TrackData::default();
-    let mut children = shape.children_ids(true);
     let mut first = true;
 
-    if flex_data.is_reverse() {
-        children.reverse();
-    }
+    // When is_reverse() is true, we need forward order (children_ids_iter_forward).
+    // When is_reverse() is false, we need reversed order (children_ids_iter).
+    let children_iter: Box<dyn Iterator<Item = Uuid>> = if flex_data.is_reverse() {
+        Box::new(shape.children_ids_iter_forward(true).copied())
+    } else {
+        Box::new(shape.children_ids_iter(true).copied())
+    };
 
-    for child_id in children.iter() {
-        let Some(child) = shapes.get(child_id) else {
+    for child_id in children_iter {
+        let Some(child) = shapes.get(&child_id) else {
             continue;
         };
 

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -296,7 +296,7 @@ fn distribute_fill_main_space(layout_axis: &LayoutAxis, tracks: &mut [TrackData]
                 track.main_size += delta;
 
                 if (child.main_size - child.max_main_size).abs() < MIN_SIZE {
-                    to_resize_children.remove(i);
+                    to_resize_children.swap_remove(i);
                 }
             }
         }
@@ -333,7 +333,7 @@ fn distribute_fill_across_space(layout_axis: &LayoutAxis, tracks: &mut [TrackDat
             left_space -= delta;
 
             if (track.across_size - track.max_across_size).abs() < MIN_SIZE {
-                to_resize_tracks.remove(i);
+                to_resize_tracks.swap_remove(i);
             }
         }
     }

--- a/render-wasm/src/shapes/modifiers/grid_layout.rs
+++ b/render-wasm/src/shapes/modifiers/grid_layout.rs
@@ -6,7 +6,7 @@ use crate::shapes::{
 };
 use crate::state::ShapesPoolRef;
 use crate::uuid::Uuid;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::common::GetBounds;
 
@@ -537,7 +537,7 @@ fn cell_bounds(
 
 pub fn create_cell_data<'a>(
     layout_bounds: &Bounds,
-    children: &[Uuid],
+    children: &HashSet<Uuid>,
     shapes: ShapesPoolRef<'a>,
     cells: &Vec<GridCell>,
     column_tracks: &[TrackData],
@@ -614,7 +614,7 @@ pub fn grid_cell_data<'a>(
 
     let bounds = &mut HashMap::<Uuid, Bounds>::new();
     let layout_bounds = shape.bounds();
-    let children = shape.children_ids(false);
+    let children: HashSet<Uuid> = shape.children_ids_iter(false).copied().collect();
 
     let column_tracks = calculate_tracks(
         true,
@@ -707,7 +707,7 @@ pub fn reflow_grid_layout(
 ) -> VecDeque<Modifier> {
     let mut result = VecDeque::new();
     let layout_bounds = bounds.find(shape);
-    let children = shape.children_ids(true);
+    let children: HashSet<Uuid> = shape.children_ids_iter(true).copied().collect();
 
     let column_tracks = calculate_tracks(
         true,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13242

### Summary

- Use swap_remove instead of remove on vec for better performance
- Do not layout reflow if it's not necessary
- Reduce empty tile slots on pan/zoom 

### Steps to reproduce 

Use a large and complex file to compare

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
