### PR TITLE
:bug: Fix blur on page switch

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -70,7 +70,7 @@
 
         on-click
         (mf/use-fn
-         (mf/deps id)
+         (mf/deps id current-page-id)
          (fn []
            ;; For the wasm renderer, apply a blur effect to the viewport canvas
            ;; when we navigate to a different page.

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1240,8 +1240,6 @@ impl RenderState {
         if self.render_in_progress {
             if tree.len() != 0 {
                 self.render_shape_tree_partial(base_object, tree, timestamp, true)?;
-            } else {
-                println!("Empty tree");
             }
             self.flush_and_submit();
 
@@ -1264,8 +1262,6 @@ impl RenderState {
     ) -> Result<(), String> {
         if tree.len() != 0 {
             self.render_shape_tree_partial(base_object, tree, timestamp, false)?;
-        } else {
-            println!("Empty tree");
         }
         self.flush_and_submit();
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13152

### Summary

This fixs 

### Steps to reproduce 

1. Open Foundations file (attached in the ticket
2. Navigate to a few different pages
3. Click on the "Colors" page and wait till it loads
4. Click on the "Colors" page again

Expected behavior: Blur effect should not be applied.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
