### PR TITLE
:ambulance: Hot fix for text editor internal error

### DIFF
--- a/frontend/text-editor/src/editor/TextEditor.js
+++ b/frontend/text-editor/src/editor/TextEditor.js
@@ -702,7 +702,8 @@ export function isEmpty(instance) {
   if (isTextEditor(instance)) {
     return instance.isEmpty;
   }
-  throw new TypeError('Instance is not a TextEditor');
+  return null;
+  // throw new TypeError('Instance is not a TextEditor');
 }
 
 /**
@@ -716,7 +717,8 @@ export function getRoot(instance) {
   if (isTextEditor(instance)) {
     return instance.root;
   }
-  throw new TypeError("Instance is not a TextEditor");
+  return null;
+  // throw new TypeError("Instance is not a TextEditor");
 }
 
 /**
@@ -729,9 +731,10 @@ export function getRoot(instance) {
 export function setRoot(instance, root) {
   if (isTextEditor(instance)) {
     instance.root = root;
-    return instance;
+    // return instance;
   }
-  throw new TypeError("Instance is not a TextEditor");
+  return instance;
+  // throw new TypeError("Instance is not a TextEditor");
 }
 
 /**
@@ -756,7 +759,8 @@ export function getCurrentStyle(instance) {
   if (isTextEditor(instance)) {
     return instance.currentStyle;
   }
-  throw new TypeError("Instance is not a TextEditor");
+  // throw new TypeError("Instance is not a TextEditor");
+  return null;
 }
 
 /**
@@ -771,7 +775,8 @@ export function applyStylesToSelection(instance, styles) {
   if (isTextEditor(instance)) {
     return instance.applyStylesToSelection(styles);
   }
-  throw new TypeError("Instance is not a TextEditor");
+  // throw new TypeError("Instance is not a TextEditor");
+  return null;
 }
 
 /**
@@ -785,7 +790,8 @@ export function dispose(instance) {
   if (isTextEditor(instance)) {
     return instance.dispose();
   }
-  throw new TypeError("Instance is not a TextEditor");
+  // throw new TypeError("Instance is not a TextEditor");
+  return null;
 }
 
 export default TextEditor;


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #13308](https://tree.taiga.io/project/penpot/issue/13308)

### Summary

On tests.penpot.dev, adding a fill to a text layer triggers an internal server error. This prevents users from applying background fills or color fills directly to text layers.

### Steps to reproduce 

1. Open a file on tests.penpot.dev.
2. Create or select a text layer on the canvas.
3. In the Design sidebar, go to the Fill section.
4. Add a new fill to the selected text layer (e.g. click the + button to add a fill).

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
