### PR TITLE
:wrench: Hide text color from selected text

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
@@ -29,6 +29,23 @@
 
   color: transparent;
 
+  // Match Skia's text layout precision: prevent browser text-size
+  // adjustments and ensure consistent kerning across browsers.
+  text-size-adjust: none;
+  -webkit-text-size-adjust: none;
+  font-kerning: normal;
+
+  &::selection,
+  *::selection {
+    color: transparent;
+    -webkit-text-fill-color: transparent; // WebKit/Safari
+  }
+
+  &::-moz-selection,
+  *::-moz-selection {
+    color: transparent;
+  }
+
   [data-itype="paragraph"] {
     line-height: inherit;
     user-select: text;


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13256

### Summary

While we work on the embedded text editor, we're disabling the text color highlight on selected text to reduce the visual friction

<img width="405" height="406" alt="image" src="https://github.com/user-attachments/assets/431c072e-d7fb-4133-8854-3d9d88001a18" />
<img width="216" height="486" alt="image" src="https://github.com/user-attachments/assets/b7e485cd-f732-4a9c-86ae-67aa43fafe45" />



### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
