### PR TITLE
:bug: Fix resize to fit board (wasm)

### DIFF
--- a/frontend/playwright/data/workspace/get-file-13305.json
+++ b/frontend/playwright/data/workspace/get-file-13305.json
@@ -1,0 +1,137 @@
+{
+    "~:features": {
+        "~#set": [
+            "fdata/path-data",
+            "plugins/runtime",
+            "design-tokens/v1",
+            "variants/v1",
+            "layout/grid",
+            "styles/v2",
+            "fdata/objects-map",
+            "render-wasm/v1",
+            "components/v2",
+            "fdata/shape-data-type"
+        ]
+    },
+    "~:team-id": "~u99e49e93-362f-80ef-8007-3450ea52c9a4",
+    "~:permissions": {
+        "~:type": "~:membership",
+        "~:is-owner": true,
+        "~:is-admin": true,
+        "~:can-edit": true,
+        "~:can-read": true,
+        "~:is-logged": true
+    },
+    "~:has-media-trimmed": false,
+    "~:comment-thread-seqn": 0,
+    "~:name": "BUG 13305",
+    "~:revn": 11,
+    "~:modified-at": "~m1770911234124",
+    "~:vern": 0,
+    "~:id": "~u9666e946-78e8-8111-8007-8fe5f0f454bf",
+    "~:is-shared": false,
+    "~:migrations": {
+        "~#ordered-set": [
+            "legacy-2",
+            "legacy-3",
+            "legacy-5",
+            "legacy-6",
+            "legacy-7",
+            "legacy-8",
+            "legacy-9",
+            "legacy-10",
+            "legacy-11",
+            "legacy-12",
+            "legacy-13",
+            "legacy-14",
+            "legacy-16",
+            "legacy-17",
+            "legacy-18",
+            "legacy-19",
+            "legacy-25",
+            "legacy-26",
+            "legacy-27",
+            "legacy-28",
+            "legacy-29",
+            "legacy-31",
+            "legacy-32",
+            "legacy-33",
+            "legacy-34",
+            "legacy-36",
+            "legacy-37",
+            "legacy-38",
+            "legacy-39",
+            "legacy-40",
+            "legacy-41",
+            "legacy-42",
+            "legacy-43",
+            "legacy-44",
+            "legacy-45",
+            "legacy-46",
+            "legacy-47",
+            "legacy-48",
+            "legacy-49",
+            "legacy-50",
+            "legacy-51",
+            "legacy-52",
+            "legacy-53",
+            "legacy-54",
+            "legacy-55",
+            "legacy-56",
+            "legacy-57",
+            "legacy-59",
+            "legacy-62",
+            "legacy-65",
+            "legacy-66",
+            "legacy-67",
+            "0001-remove-tokens-from-groups",
+            "0002-normalize-bool-content-v2",
+            "0002-clean-shape-interactions",
+            "0003-fix-root-shape",
+            "0003-convert-path-content-v2",
+            "0005-deprecate-image-type",
+            "0006-fix-old-texts-fills",
+            "0008-fix-library-colors-v4",
+            "0009-clean-library-colors",
+            "0009-add-partial-text-touched-flags",
+            "0010-fix-swap-slots-pointing-non-existent-shapes",
+            "0011-fix-invalid-text-touched-flags",
+            "0012-fix-position-data",
+            "0013-fix-component-path",
+            "0013-clear-invalid-strokes-and-fills",
+            "0014-fix-tokens-lib-duplicate-ids",
+            "0014-clear-components-nil-objects",
+            "0015-fix-text-attrs-blank-strings",
+            "0015-clean-shadow-color",
+            "0016-copy-fills-from-position-data-to-text-node"
+        ]
+    },
+    "~:version": 67,
+    "~:project-id": "~ucd8f7672-e5d1-810f-8007-87e124eda82a",
+    "~:created-at": "~m1770911129553",
+    "~:backend": "legacy-db",
+    "~:data": {
+        "~:pages": [
+            "~u9666e946-78e8-8111-8007-8fe5f0f49ac6"
+        ],
+        "~:pages-index": {
+            "~u9666e946-78e8-8111-8007-8fe5f0f49ac6": {
+                "~:objects": {
+                    "~#penpot/objects-map/v2": {
+                        "~u00000000-0000-0000-0000-000000000000": "[\"~#shape\",[\"^ \",\"~:y\",0,\"~:hide-fill-on-export\",false,\"~:transform\",[\"~#matrix\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:rotation\",0,\"~:name\",\"Root Frame\",\"~:width\",0.01,\"~:type\",\"~:frame\",\"~:points\",[[\"~#point\",[\"^ \",\"~:x\",0.0,\"~:y\",0.0]],[\"^:\",[\"^ \",\"~:x\",0.01,\"~:y\",0.0]],[\"^:\",[\"^ \",\"~:x\",0.01,\"~:y\",0.01]],[\"^:\",[\"^ \",\"~:x\",0.0,\"~:y\",0.01]]],\"~:r2\",0,\"~:proportion-lock\",false,\"~:transform-inverse\",[\"^3\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:r3\",0,\"~:r1\",0,\"~:id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:parent-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:frame-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:strokes\",[],\"~:x\",0,\"~:proportion\",1.0,\"~:r4\",0,\"~:selrect\",[\"~#rect\",[\"^ \",\"~:x\",0,\"~:y\",0,\"^6\",0.01,\"~:height\",0.01,\"~:x1\",0,\"~:y1\",0,\"~:x2\",0.01,\"~:y2\",0.01]],\"~:fills\",[[\"^ \",\"~:fill-color\",\"#FFFFFF\",\"~:fill-opacity\",1]],\"~:flip-x\",null,\"^H\",0.01,\"~:flip-y\",null,\"~:shapes\",[\"~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a\"]]]",
+                        "~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a": "[\"~#shape\",[\"^ \",\"~:y\",99.99999499320984,\"~:hide-fill-on-export\",false,\"~:transform\",[\"~#matrix\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:rotation\",0,\"~:grow-type\",\"~:fixed\",\"~:hide-in-viewer\",false,\"~:name\",\"Board\",\"~:width\",511.99998180389287,\"~:type\",\"~:frame\",\"~:points\",[[\"~#point\",[\"^ \",\"~:x\",99.9999820137034,\"~:y\",99.99999499320984]],[\"^=\",[\"^ \",\"~:x\",611.9999638175963,\"~:y\",99.99999499320984]],[\"^=\",[\"^ \",\"~:x\",611.9999638175963,\"~:y\",611.9999695949548]],[\"^=\",[\"^ \",\"~:x\",99.9999820137034,\"~:y\",611.9999695949548]]],\"~:r2\",0,\"~:proportion-lock\",false,\"~:transform-inverse\",[\"^3\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:r3\",0,\"~:r1\",0,\"~:id\",\"~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a\",\"~:parent-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:frame-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:strokes\",[],\"~:x\",99.9999820137034,\"~:proportion\",1,\"~:r4\",0,\"~:selrect\",[\"~#rect\",[\"^ \",\"~:x\",99.9999820137034,\"~:y\",99.99999499320984,\"^9\",511.99998180389287,\"~:height\",511.99997460174495,\"~:x1\",99.9999820137034,\"~:y1\",99.99999499320984,\"~:x2\",611.9999638175963,\"~:y2\",611.9999695949548]],\"~:fills\",[[\"^ \",\"~:fill-color\",\"#FFFFFF\",\"~:fill-opacity\",1]],\"~:flip-x\",null,\"^K\",511.99997460174495,\"~:flip-y\",null,\"~:shapes\",[\"~u3edd6127-ced7-80c6-8007-8fe60306baa7\",\"~u3edd6127-ced7-80c6-8007-8fe61479065a\"]]]",
+                        "~u3edd6127-ced7-80c6-8007-8fe60306baa7": "[\"~#shape\",[\"^ \",\"~:y\",109.99999433755875,\"~:transform\",[\"~#matrix\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:rotation\",0,\"~:grow-type\",\"~:fixed\",\"~:hide-in-viewer\",false,\"~:name\",\"Rectangle\",\"~:width\",100.00000357627869,\"~:type\",\"~:rect\",\"~:points\",[[\"~#point\",[\"^ \",\"~:x\",109.99998164176941,\"~:y\",109.99999433755875]],[\"^<\",[\"^ \",\"~:x\",209.9999852180481,\"~:y\",109.99999433755875]],[\"^<\",[\"^ \",\"~:x\",209.9999852180481,\"~:y\",209.9999930858612]],[\"^<\",[\"^ \",\"~:x\",109.99998164176941,\"~:y\",209.9999930858612]]],\"~:r2\",0,\"~:proportion-lock\",false,\"~:transform-inverse\",[\"^2\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:r3\",0,\"~:constraints-v\",\"~:top\",\"~:constraints-h\",\"~:left\",\"~:r1\",0,\"~:id\",\"~u3edd6127-ced7-80c6-8007-8fe60306baa7\",\"~:parent-id\",\"~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a\",\"~:frame-id\",\"~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a\",\"~:strokes\",[],\"~:x\",109.99998164176941,\"~:proportion\",1,\"~:r4\",0,\"~:selrect\",[\"~#rect\",[\"^ \",\"~:x\",109.99998164176941,\"~:y\",109.99999433755875,\"^8\",100.00000357627869,\"~:height\",99.99999874830246,\"~:x1\",109.99998164176941,\"~:y1\",109.99999433755875,\"~:x2\",209.9999852180481,\"~:y2\",209.9999930858612]],\"~:fills\",[[\"^ \",\"~:fill-color\",\"#B1B2B5\",\"~:fill-opacity\",1]],\"~:flip-x\",null,\"^N\",99.99999874830246,\"~:flip-y\",null]]",
+                        "~u3edd6127-ced7-80c6-8007-8fe61479065a": "[\"~#shape\",[\"^ \",\"~:y\",483.9999952316284,\"~:transform\",[\"~#matrix\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:rotation\",0,\"~:grow-type\",\"~:fixed\",\"~:hide-in-viewer\",false,\"~:name\",\"Ellipse\",\"~:width\",256.000000834465,\"~:type\",\"~:circle\",\"~:points\",[[\"~#point\",[\"^ \",\"~:x\",483.99998211860657,\"~:y\",483.9999952316284]],[\"^<\",[\"^ \",\"~:x\",739.9999829530716,\"~:y\",483.9999952316284]],[\"^<\",[\"^ \",\"~:x\",739.9999829530716,\"~:y\",739.9999876022339]],[\"^<\",[\"^ \",\"~:x\",483.99998211860657,\"~:y\",739.9999876022339]]],\"~:proportion-lock\",false,\"~:transform-inverse\",[\"^2\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:constraints-v\",\"~:top\",\"~:constraints-h\",\"~:left\",\"~:id\",\"~u3edd6127-ced7-80c6-8007-8fe61479065a\",\"~:parent-id\",\"~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a\",\"~:frame-id\",\"~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a\",\"~:strokes\",[],\"~:x\",483.99998211860657,\"~:proportion\",1,\"~:selrect\",[\"~#rect\",[\"^ \",\"~:x\",483.99998211860657,\"~:y\",483.9999952316284,\"^8\",256.000000834465,\"~:height\",255.99999237060547,\"~:x1\",483.99998211860657,\"~:y1\",483.9999952316284,\"~:x2\",739.9999829530716,\"~:y2\",739.9999876022339]],\"~:fills\",[[\"^ \",\"~:fill-color\",\"#B1B2B5\",\"~:fill-opacity\",1]],\"~:flip-x\",null,\"^J\",255.99999237060547,\"~:flip-y\",null]]"
+                    }
+                },
+                "~:id": "~u9666e946-78e8-8111-8007-8fe5f0f49ac6",
+                "~:name": "Page 1"
+            }
+        },
+        "~:id": "~u9666e946-78e8-8111-8007-8fe5f0f454bf",
+        "~:options": {
+            "~:components-v2": true,
+            "~:base-font-size": "16px"
+        }
+    }
+}

--- a/frontend/playwright/data/workspace/update-file-13305.json
+++ b/frontend/playwright/data/workspace/update-file-13305.json
@@ -1,0 +1,98 @@
+{
+    "~:revn": 11,
+    "~:lagged": [
+        {
+            "~:id": "~u9666e946-78e8-8111-8007-8fe7be6223c2",
+            "~:revn": 12,
+            "~:file-id": "~u9666e946-78e8-8111-8007-8fe5f0f454bf",
+            "~:session-id": "~u3966be0d-5f49-807f-8007-8fe68b13fee6",
+            "~:changes": [
+                {
+                    "~:type": "~:mod-obj",
+                    "~:id": "~u3edd6127-ced7-80c6-8007-8fe5f6c52e5a",
+                    "~:page-id": "~u9666e946-78e8-8111-8007-8fe5f0f49ac6",
+                    "~:operations": [
+                        {
+                            "~:type": "~:set",
+                            "~:attr": "~:y",
+                            "~:val": 110.00000528339297,
+                            "~:ignore-geometry": false,
+                            "~:ignore-touched": false
+                        },
+                        {
+                            "~:type": "~:set",
+                            "~:attr": "~:width",
+                            "~:val": 629.9999776102587,
+                            "~:ignore-geometry": false,
+                            "~:ignore-touched": false
+                        },
+                        {
+                            "~:type": "~:set",
+                            "~:attr": "~:points",
+                            "~:val": [
+                                {
+                                    "~#point": {
+                                        "~:x": 109.99999217353886,
+                                        "~:y": 110.00000528339297
+                                    }
+                                },
+                                {
+                                    "~#point": {
+                                        "~:x": 739.9999697837976,
+                                        "~:y": 110.00000528339297
+                                    }
+                                },
+                                {
+                                    "~#point": {
+                                        "~:x": 739.9999697837976,
+                                        "~:y": 739.9999740316338
+                                    }
+                                },
+                                {
+                                    "~#point": {
+                                        "~:x": 109.99999217353886,
+                                        "~:y": 739.9999740316338
+                                    }
+                                }
+                            ],
+                            "~:ignore-geometry": false,
+                            "~:ignore-touched": false
+                        },
+                        {
+                            "~:type": "~:set",
+                            "~:attr": "~:x",
+                            "~:val": 109.99999217353889,
+                            "~:ignore-geometry": false,
+                            "~:ignore-touched": false
+                        },
+                        {
+                            "~:type": "~:set",
+                            "~:attr": "~:selrect",
+                            "~:val": {
+                                "~#rect": {
+                                    "~:x": 109.99999217353889,
+                                    "~:y": 110.00000528339297,
+                                    "~:width": 629.9999776102587,
+                                    "~:height": 629.9999687482408,
+                                    "~:x1": 109.99999217353889,
+                                    "~:y1": 110.00000528339297,
+                                    "~:x2": 739.9999697837976,
+                                    "~:y2": 739.9999740316338
+                                }
+                            },
+                            "~:ignore-geometry": false,
+                            "~:ignore-touched": false
+                        },
+                        {
+                            "~:type": "~:set",
+                            "~:attr": "~:height",
+                            "~:val": 629.9999687482408,
+                            "~:ignore-geometry": false,
+                            "~:ignore-touched": false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/frontend/playwright/ui/specs/workspace-modifers.spec.js
+++ b/frontend/playwright/ui/specs/workspace-modifers.spec.js
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { WasmWorkspacePage } from "../pages/WasmWorkspacePage";
+
+test.beforeEach(async ({ page }) => {
+  await WasmWorkspacePage.init(page);
+});
+
+test("BUG 13305 - Fix resize board to fit content", async ({ page }) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.mockGetFile("workspace/get-file-13305.json");
+  await workspacePage.mockRPC("update-file?id=*", "workspace/update-file-13305.json");
+
+  await workspacePage.goToWorkspace({
+    fileId: "9666e946-78e8-8111-8007-8fe5f0f454bf",
+    pageId: "9666e946-78e8-8111-8007-8fe5f0f49ac6",
+  });
+
+  await workspacePage.clickLeafLayer("Board");
+  await workspacePage.rightSidebar.getByRole("button", { name: "Resize board to fit content" }).click();
+
+  await expect(workspacePage.rightSidebar.getByTitle("Width").getByRole("textbox")).toHaveValue("630");
+  await expect(workspacePage.rightSidebar.getByTitle("Height").getByRole("textbox")).toHaveValue("630");
+  await expect(workspacePage.rightSidebar.getByTitle("X axis").getByRole("textbox")).toHaveValue("110");
+  await expect(workspacePage.rightSidebar.getByTitle("Y axis").getByRole("textbox")).toHaveValue("110");
+});

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -571,11 +571,13 @@
               nil
 
               (ctm/has-geometry? (:modifiers data))
-              (d/vec2 id (ctm/modifiers->transform (:modifiers data)))
+              (let [parent (:geometry-parent (:modifiers data))
+                    kind (if (d/not-empty? parent) :parent :child)]
+                (d/vec2 id {:transform (ctm/modifiers->transform (:modifiers data)) :kind kind}))
 
               ;; Unit matrix is used for reflowing
               :else
-              (d/vec2 id default-transform))))))
+              (d/vec2 id {:transform default-transform :kind :parent}))))))
 
 (defn- parse-geometry-modifiers
   [modif-tree]

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -1247,7 +1247,6 @@
                           (some? new-modif)
                           (assoc (:id frame) {:modifiers new-modif})))))
                   {}))]
-
         (if (features/active-feature? state "render-wasm/v1")
           (rx/of (dwm/apply-wasm-modifiers modifiers {:undo-group undo-group}))
           (rx/of (dwm/apply-modifiers {:modifiers modifiers :undo-group undo-group})))))))

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -51,15 +51,18 @@
    [cuerdas.core :as str]
    [promesa.core :as p]
    [rumext.v2 :as mf]))
-
 (def use-dpr? (contains? cf/flags :render-wasm-dpr))
 
 (def ^:const UUID-U8-SIZE 16)
 (def ^:const UUID-U32-SIZE (/ UUID-U8-SIZE 4))
 
+;; FIXME: Migrate this as we adjust the DTO structure in wasm
 (def ^:const MODIFIER-U8-SIZE 40)
 (def ^:const MODIFIER-U32-SIZE (/ MODIFIER-U8-SIZE 4))
 (def ^:const MODIFIER-TRANSFORM-U8-OFFSET-SIZE 16)
+(def ^:const INPUT-MODIFIER-U8-SIZE 44)
+(def ^:const INPUT-MODIFIER-U32-SIZE (/ INPUT-MODIFIER-U8-SIZE 4))
+
 
 (def ^:const GRID-LAYOUT-ROW-U8-SIZE 8)
 (def ^:const GRID-LAYOUT-COLUMN-U8-SIZE 8)
@@ -1278,13 +1281,16 @@
   (when-not ^boolean (empty? entries)
     (let [heapf32 (mem/get-heap-f32)
           heapu32 (mem/get-heap-u32)
-          size    (mem/get-alloc-size entries MODIFIER-U8-SIZE)
+          size    (mem/get-alloc-size entries INPUT-MODIFIER-U8-SIZE)
           offset  (mem/alloc->offset-32 size)]
 
-      (reduce (fn [offset [id transform]]
-                (-> offset
-                    (mem.h32/write-uuid heapu32 id)
-                    (mem.h32/write-matrix heapf32 transform)))
+      (reduce (fn [offset [id data]]
+                (let [transform (:transform data)
+                      kind (:kind data)]
+                  (-> offset
+                      (mem.h32/write-uuid heapu32 id)
+                      (mem.h32/write-matrix heapf32 transform)
+                      (mem.h32/write-u32 heapu32 (sr/translate-transform-entry-kind kind)))))
               offset
               entries)
 

--- a/frontend/src/app/render_wasm/api/shared.js
+++ b/frontend/src/app/render_wasm/api/shared.js
@@ -249,3 +249,8 @@ export const CursorDirection = {
   "line-end": 5,
 };
 
+export const RawTransformEntryKind = {
+  "parent": 0,
+  "child": 1,
+};
+

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -274,3 +274,8 @@
     :edge 3
     :unknown 4
     4))
+
+(defn translate-transform-entry-kind [kind]
+  (let [values (unchecked-get wasm/serializers "transform-entry-kind")
+        default (unchecked-get values "parent")]
+    (d/nilv (unchecked-get values (d/name kind)) default)))

--- a/frontend/src/app/render_wasm/wasm.cljs
+++ b/frontend/src/app/render_wasm/wasm.cljs
@@ -54,6 +54,7 @@
        :text-direction shared/RawTextDirection
        :text-decoration shared/RawTextDecoration
        :text-transform shared/RawTextTransform
+       :transform-entry-kind shared/RawTransformEntryKind
        :segment-data shared/RawSegmentData
        :stroke-linecap shared/RawStrokeLineCap
        :stroke-linejoin shared/RawStrokeLineJoin

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -698,21 +698,6 @@ pub extern "C" fn clean_modifiers() {
 }
 
 #[no_mangle]
-pub extern "C" fn propagate_modifiers(pixel_precision: bool) -> *mut u8 {
-    let bytes = mem::bytes();
-
-    let entries: Vec<_> = bytes
-        .chunks(size_of::<<TransformEntry as SerializableResult>::BytesType>())
-        .map(|data| TransformEntry::try_from(data).unwrap())
-        .collect();
-
-    with_state!(state, {
-        let result = shapes::propagate_modifiers(state, &entries, pixel_precision);
-        mem::write_vec(result)
-    })
-}
-
-#[no_mangle]
 pub extern "C" fn set_modifiers() {
     let bytes = mem::bytes();
 

--- a/render-wasm/src/shapes/transform.rs
+++ b/render-wasm/src/shapes/transform.rs
@@ -39,6 +39,7 @@ pub struct TransformEntry {
 }
 
 impl TransformEntry {
+    // FIXME: We should be able to refactor code so we don't need these from_* methods
     pub fn from_input(id: Uuid, transform: Matrix) -> Self {
         TransformEntry {
             id,
@@ -47,6 +48,8 @@ impl TransformEntry {
             propagate: true,
         }
     }
+
+    // FIXME: We should be able to refactor code so we don't need these from_* methods
     pub fn from_propagate(id: Uuid, transform: Matrix) -> Self {
         TransformEntry {
             id,
@@ -119,6 +122,7 @@ impl From<TransformEntry> for [u8; 40] {
     }
 }
 
+// FIXME: Use a DTO for this
 impl SerializableResult for TransformEntry {
     type BytesType = [u8; 40];
 

--- a/render-wasm/src/wasm.rs
+++ b/render-wasm/src/wasm.rs
@@ -10,3 +10,4 @@ pub mod strokes;
 pub mod svg_attrs;
 pub mod text;
 pub mod text_editor;
+pub mod transforms;

--- a/render-wasm/src/wasm/transforms.rs
+++ b/render-wasm/src/wasm/transforms.rs
@@ -1,0 +1,88 @@
+use macros::ToJs;
+
+use skia_safe as skia;
+
+use crate::mem;
+use crate::shapes::{self, TransformEntry, TransformEntrySource};
+use crate::utils::uuid_from_u32_quartet;
+use crate::{with_state, STATE};
+
+#[derive(Debug, PartialEq, Clone, Copy, ToJs)]
+#[repr(u8)]
+enum RawTransformEntryKind {
+    #[allow(dead_code)]
+    Parent = 0,
+    Child = 1,
+}
+
+impl From<u8> for RawTransformEntryKind {
+    fn from(value: u8) -> Self {
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(C)]
+#[repr(align(4))]
+pub struct RawTransformEntry {
+    id: [u32; 4],
+    transform: [f32; 6],
+    kind: RawTransformEntryKind,
+}
+
+const RAW_TRANSFORM_ENTRY_SIZE: usize = size_of::<RawTransformEntry>();
+
+impl From<[u8; RAW_TRANSFORM_ENTRY_SIZE]> for RawTransformEntry {
+    fn from(bytes: [u8; RAW_TRANSFORM_ENTRY_SIZE]) -> Self {
+        unsafe { std::mem::transmute(bytes) }
+    }
+}
+
+impl TryFrom<&[u8]> for RawTransformEntry {
+    type Error = String;
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; RAW_TRANSFORM_ENTRY_SIZE] = bytes
+            .try_into()
+            .map_err(|_| "Invalid transform entry bytes".to_string())?;
+        Ok(RawTransformEntry::from(bytes))
+    }
+}
+
+impl From<RawTransformEntry> for TransformEntry {
+    fn from(value: RawTransformEntry) -> Self {
+        let [a, b, c, d] = value.id;
+        let transform = skia::Matrix::new_all(
+            value.transform[0],
+            value.transform[2],
+            value.transform[4],
+            value.transform[1],
+            value.transform[3],
+            value.transform[5],
+            0.0,
+            0.0,
+            1.0,
+        );
+
+        TransformEntry {
+            id: uuid_from_u32_quartet(a, b, c, d),
+            transform,
+            source: TransformEntrySource::Input,
+            propagate: value.kind == RawTransformEntryKind::Child,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn propagate_modifiers(pixel_precision: bool) -> *mut u8 {
+    let bytes = mem::bytes();
+
+    let entries: Vec<TransformEntry> = bytes
+        .chunks(RAW_TRANSFORM_ENTRY_SIZE)
+        .map(|data| RawTransformEntry::try_from(data).unwrap().into())
+        .collect();
+
+    with_state!(state, {
+        let result = shapes::propagate_modifiers(state, &entries, pixel_precision);
+        mem::write_vec(result)
+    })
+}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13305

### Summary

This fixes "Resize to fit" in boards not being applied correctly when the new canvas renderer is active.

https://github.com/user-attachments/assets/742d7928-c61b-44f4-b53e-87f6be77b0af

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
