### PR TITLE
:bug: Fix negative border radius token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 ### :bug: Bugs fixed
 
 - Fix security issue (Path Traversal Vulnerability) on fonts related RPC method
+- Fix allow creating negative border radius tokens [Taiga #13317](https://tree.taiga.io/project/penpot/issue/13317)
 
 
 ## 2.13.1

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/border_radius.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/border_radius.cljs
@@ -1,0 +1,48 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.main.ui.workspace.tokens.management.forms.border-radius
+  (:require
+   [app.common.data :as d]
+   [app.common.files.tokens :as cft]
+   [app.common.schema :as sm]
+   [app.common.types.token :as cto]
+   [app.main.ui.workspace.tokens.management.forms.generic-form :as generic]
+   [app.util.i18n :refer [tr]]
+   [rumext.v2 :as mf]))
+
+(defn- make-schema
+  [tokens-tree]
+  (sm/schema
+   [:and
+    [:map
+     [:name
+      [:and
+       [:string {:min 1 :max 255
+                 :error/fn #(str (:value %) (tr "workspace.tokens.token-name-length-validation-error"))}]
+       (sm/update-properties cto/token-name-ref assoc
+                             :error/fn #(str (:value %) (tr "workspace.tokens.token-name-validation-error")))
+       [:fn {:error/fn #(tr "workspace.tokens.token-name-duplication-validation-error" (:value %))}
+        #(not (cft/token-name-path-exists? % tokens-tree))]]]
+
+     [:value
+      [:and
+       [::sm/text]
+       [:fn {:error/fn #(tr "workspace.tokens.border-radius-token-value-error")}
+        (fn [value]
+          (let [n (d/parse-double value)]
+            (or (nil? n) (not (< n 0)))))]]]
+
+     [:description {:optional true}
+      [:string {:max 2048 :error/fn #(tr "errors.field-max-length" 2048)}]]]]))
+
+
+(mf/defc form*
+  [{:keys [token token-type] :rest props}]
+  (let [props (mf/spread-props props {:token token
+                                      :make-schema make-schema
+                                      :token-type token-type})]
+    [:> generic/form* props]))

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/input.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/input.cljs
@@ -160,7 +160,8 @@
          (sd/resolve-tokens-interactive)
          (rx/mapcat
           (fn [resolved-tokens]
-            (let [{:keys [errors resolved-value] :as resolved-token} (get resolved-tokens (:name token))]
+            (let [{:keys [errors resolved-value] :as resolved-token} (get resolved-tokens (:name token))
+                  _ (prn "token" token)]
               (if resolved-value
                 (rx/of {:value resolved-value})
                 (rx/of {:error (first errors)}))))))))
@@ -230,9 +231,16 @@
                                         (do
                                           (swap! form assoc-in [:extra-errors input-name] {:message error})
                                           (reset! hint* {:message error :type "error"}))
-                                        (let [message (tr "workspace.tokens.resolved-value" value)]
-                                          (swap! form update :extra-errors dissoc input-name)
-                                          (reset! hint* {:message message :type "hint"}))))))))]
+                                        ;; This is needed because, SD allows to create br token with negative values
+                                        (if (and
+                                             (< value 0)
+                                             (= :border-radius (:type token)))
+                                          (do
+                                            (swap! form assoc-in [:extra-errors input-name] {:message (tr "workspace.tokens.border-radius-token-value-error")})
+                                            (reset! hint* {:message (tr "workspace.tokens.border-radius-token-value-error") :type "error"}))
+                                          (let [message (tr "workspace.tokens.resolved-value" value)]
+                                            (swap! form update :extra-errors dissoc input-name)
+                                            (reset! hint* {:message message :type "hint"})))))))))]
 
         (fn []
           (rx/dispose! subs))))

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/form_container.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/form_container.cljs
@@ -10,6 +10,7 @@
    [app.common.files.tokens :as cft]
    [app.common.types.tokens-lib :as ctob]
    [app.main.refs :as refs]
+   [app.main.ui.workspace.tokens.management.forms.border-radius :as border-radius]
    [app.main.ui.workspace.tokens.management.forms.color :as color]
    [app.main.ui.workspace.tokens.management.forms.font-family :as font-family]
    [app.main.ui.workspace.tokens.management.forms.generic-form :as generic]
@@ -50,4 +51,5 @@
       :text-case [:> generic/form* text-case-props]
       :text-decoration [:> generic/form* text-decoration-props]
       :font-weight [:> generic/form* font-weight-props]
+      :border-radius [:> border-radius/form* props]
       [:> generic/form* props])))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -8080,6 +8080,10 @@ msgstr "Blur value cannot be negative"
 msgid "workspace.tokens.shadow-token-spread-value-error"
 msgstr "Spread value cannot be negative"
 
+#: src/app/main/ui/workspace/tokens/management/forms/border_radius.cljs
+msgid "workspace.tokens.border-radius-token-value-error"
+msgstr "Border-radius value cannot be negative"
+
 #: src/app/main/ui/workspace/tokens/management/create/border_radius.cljs:42, src/app/main/ui/workspace/tokens/management/create/form.cljs:68
 msgid "workspace.tokens.token-name-length-validation-error"
 msgstr "Name should be at least 1 character"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7976,6 +7976,10 @@ msgstr "El valor de blur no puede ser negativo"
 msgid "workspace.tokens.shadow-token-spread-value-error"
 msgstr "El valor de spread no puede ser negativo"
 
+#: src/app/main/ui/workspace/tokens/management/forms/border_radius.cljs
+msgid "workspace.tokens.border-radius-token-value-error"
+msgstr "El valor de Border radius no puede ser negativo"
+
 #: src/app/main/ui/workspace/tokens/management/create/border_radius.cljs:42, src/app/main/ui/workspace/tokens/management/create/form.cljs:68
 msgid "workspace.tokens.token-name-length-validation-error"
 msgstr "El nombre debería ser de al menos 1 caracter"


### PR DESCRIPTION
### Related Ticket

This PR solves this issue https://tree.taiga.io/project/penpot/issue/13317

### Summary

Do not allow create negative border radius tokens.

### Steps to reproduce 

- Open border radius token modal
- Enter a negative value (e.g. -2) 

An error should show up and submit button whould be disabled

- Enter a negative math operation (e.g 1 - 3)

The same error should show up.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
