### PR TITLE
:bug: Fix problems about applying tokens to shapes with plugins

### DIFF
--- a/common/src/app/common/files/tokens.cljc
+++ b/common/src/app/common/files/tokens.cljc
@@ -35,7 +35,7 @@
   [::sm/text {:error/fn token-value-empty-fn}])
 
 (def schema:token-value-font-family
-  [:vector :string])
+  [:vector ::sm/text])
 
 (def schema:token-value-typography-map
   [:map

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -11,6 +11,7 @@
    [app.common.files.helpers :as cfh]
    [app.common.geom.rect :as grc]
    [app.common.geom.shapes :as gsh]
+   [app.common.json :as json]
    [app.common.path-names :as cpn]
    [app.common.record :as crc]
    [app.common.schema :as sm]
@@ -1295,7 +1296,7 @@
                         (get :applied-tokens))]
                 (reduce
                  (fn [acc [prop name]]
-                   (obj/set! acc (d/name prop) name))
+                   (obj/set! acc (json/write-camel-key prop) name))
                  #js {}
                  tokens)))}
 

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -16,7 +16,7 @@
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.tokens.library-edit :as dwtl]
    [app.main.store :as st]
-  ;;  [app.plugins.shape :as shape]
+   ;; [app.plugins.shape :as shape]
    [app.plugins.utils :as u]
    [app.util.object :as obj]
    [beicon.v2.core :as rx]
@@ -118,12 +118,12 @@
               ;;        should be fixed to keep the original proxy objects coming from the plugin.
               ;; [:vector [:fn shape/shape-proxy?]]
               [:vector [:map [:id ::sm/uuid]]]
-              [:maybe [:set ::sm/keyword]]]
+              [:maybe [:set [:set [:and ::sm/keyword [:fn cto/token-attr?]]]]]]
      :fn (fn [shapes attrs]
            (apply-token-to-shapes file-id set-id id (map :id shapes) attrs))}
 
     :applyToSelected
-    {:schema [:tuple [:maybe [:set ::sm/keyword]]]
+    {:schema [:tuple [:maybe [:set [:and ::sm/keyword [:fn cto/token-attr?]]]]]
      :fn (fn [attrs]
            (let [selected (get-in @st/state [:workspace-local :selected])]
              (apply-token-to-shapes file-id set-id id selected attrs)))}))

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -16,7 +16,7 @@
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.tokens.library-edit :as dwtl]
    [app.main.store :as st]
-   [app.plugins.shape :as shape]
+  ;;  [app.plugins.shape :as shape]
    [app.plugins.utils :as u]
    [app.util.object :as obj]
    [beicon.v2.core :as rx]
@@ -113,7 +113,11 @@
 
     :applyToShapes
     {:schema [:tuple
-              [:vector [:fn shape/shape-proxy?]]
+              ;; FIXME: the schema decoder is interpreting the array of shape-proxys and converting
+              ;;        them to plain maps. For now we adapt the schema to accept it, but the decoder
+              ;;        should be fixed to keep the original proxy objects coming from the plugin.
+              ;; [:vector [:fn shape/shape-proxy?]]
+              [:vector [:map [:id ::sm/uuid]]]
               [:maybe [:set ::sm/keyword]]]
      :fn (fn [shapes attrs]
            (apply-token-to-shapes file-id set-id id (map :id shapes) attrs))}

--- a/plugins/apps/poc-tokens-plugin/src/plugin.ts
+++ b/plugins/apps/poc-tokens-plugin/src/plugin.ts
@@ -251,7 +251,14 @@ function applyToken(
     token.applyToSelected(properties);
   }
 
-  // Alternatve way
+  // Alternative way
+  //
+  // const selection = penpot.selection;
+  // if (token && selection) {
+  //   token.applyToShapes(selection, properties);
+  // }
+
+  // Other alternative way
   //
   // const selection = penpot.selection;
   // if (token && selection) {

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -3744,7 +3744,7 @@ export interface ShapeBase extends PluginData {
    * and the value set to the attributes will depend on which sets are active
    * (and will change if different sets or themes are activated later).
    */
-  readonly tokens: { [property: string]: string };
+  readonly tokens: { [property in TokenProperty]: string };
 
   /**
    * @return Returns true if the current shape is inside a component instance
@@ -5221,7 +5221,7 @@ type TokenDimensionProps =
   | 'y'
 
   // Stroke width
-  | 'stroke-width';
+  | 'strokeWidth';
 
 /**
  * The properties that a FontFamilies token can be applied to.


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot-mcp/issues/38

### Summary

Several enhancements in the `tokens` attribute of shapes in the API. Also temporarily fixed `applyToShapes` method in shape object.

### Steps to reproduce 

For first one, see the issue.
For the second one, try the following code in a plugin:
```javascript
  const tokensCatalog = penpot.library.local.tokens;
  const set = tokensCatalog?.getSetById(<someSetId>);
  const token = set?.getTokenById(<someTokenId>);

  const selection = penpot.selection;
  if (token && selection) {
    token.applyToShapes(selection, <someProperties>);
  }
```

Currently this triggers a validation error. With this PR it should be fixed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
