### PR TITLE
:bug: Fix problem when create click

### DIFF
--- a/frontend/src/app/main/data/workspace/drawing/box.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/box.cljs
@@ -43,9 +43,13 @@
       (> dy dx)
       (assoc :x (- (:x point) (* sx (- dy dx)))))))
 
-(defn resize-shape [{:keys [x y width height] :as shape} initial point lock? mod?]
+(defn resize-shape [{:keys [x y width height] :as shape} initial point lock? mod? snap-pixel?]
   (if (and (some? x) (some? y) (some? width) (some? height))
-    (let [draw-rect  (grc/make-rect initial (cond-> point lock? (adjust-ratio initial)))
+    (let [draw-rect (cond-> (grc/make-rect initial (cond-> point lock? (adjust-ratio initial)))
+                      snap-pixel?
+                      (-> (update :width max 1)
+                          (update :height max 1)))
+
           shape-rect (grc/make-rect x y width height)
 
           scalev     (gpt/point (/ (:width draw-rect)
@@ -64,8 +68,8 @@
                                    (ctm/move movev)))))
     shape))
 
-(defn update-drawing [state initial point lock? mod?]
-  (update-in state [:workspace-drawing :object] resize-shape initial point lock? mod?))
+(defn- update-drawing [state initial point lock? mod? snap-pixel?]
+  (update-in state [:workspace-drawing :object] resize-shape initial point lock? mod? snap-pixel?))
 
 (defn move-drawing
   [{:keys [x y]}]
@@ -120,7 +124,7 @@
                     (rx/map move-drawing))
 
                (->> ms/mouse-position
-                    (rx/filter #(> (gpt/distance % initial) (/ 2 zoom)))
+                    (rx/filter #(> (* (gpt/distance % initial) zoom) 10))
                     ;; Take until before the snap calculation otherwise we could cancel the snap in the worker
                     ;; and its a problem for fast moving drawing
                     (rx/take-until stopper)
@@ -131,7 +135,7 @@
                             (rx/map (partial array/conj current)))))
                     (rx/map
                      (fn [[_ shift? mod? point]]
-                       #(update-drawing % initial (cond-> point snap-pixel? (gpt/round-step 1)) shift? mod?))))))
+                       #(update-drawing % initial (cond-> point snap-pixel? (gpt/round-step 1)) shift? mod? snap-pixel?))))))
 
          (->> (rx/of (common/handle-finish-drawing))
               (rx/delay 100)))))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/8340

### Summary

- Create click with zoom wasn't working as expected
- I've restricted the minimum size for newly created shapes to 1 if the snap to pixel is activated

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
