### PR TITLE
:wrench: Enhance schema validation of token application

### DIFF
--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -175,6 +175,10 @@
 (defn shape-proxy? [p]
   (obj/type-of? p "ShapeProxy"))
 
+;; Cannot use token/token-proxy? here because of circular dependency in applyToShapes in token proxy
+(defn token-proxy? [t]
+  (obj/type-of? t "TokenProxy"))
+
 (defn shape-proxy
   ([plugin-id id]
    (shape-proxy plugin-id (:current-file-id @st/state) (:current-page-id @st/state) id))
@@ -1301,16 +1305,19 @@
                  tokens)))}
 
            :applyToken
-           (fn [token attrs]
-             (let [token (u/locate-token file-id (obj/get token "$set-id") (obj/get token "$id"))
-                   kw-attrs (into #{} (map keyword attrs))]
-               (if (some #(not (cto/token-attr? %)) kw-attrs)
-                 (u/display-not-valid :applyToken attrs)
-                 (st/emit!
-                  (dwta/toggle-token {:token token
-                                      :attrs kw-attrs
-                                      :shape-ids [id]
-                                      :expand-with-children false})))))
+           {:schema [:tuple
+                     [:fn token-proxy?]
+                     [:maybe [:set [:and ::sm/keyword [:fn cto/token-attr?]]]]]
+            :fn (fn [token attrs]
+                  (let [token (u/locate-token file-id (obj/get token "$set-id") (obj/get token "$id"))
+                        kw-attrs (into #{} (map keyword attrs))]
+                    (if (some #(not (cto/token-attr? %)) kw-attrs)
+                      (u/display-not-valid :applyToken attrs)
+                      (st/emit!
+                       (dwta/toggle-token {:token token
+                                           :attrs kw-attrs
+                                           :shape-ids [id]
+                                           :expand-with-children false})))))}
 
            :isVariantHead
            (fn []

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -16,7 +16,6 @@
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.tokens.library-edit :as dwtl]
    [app.main.store :as st]
-   ;; [app.plugins.shape :as shape]
    [app.plugins.utils :as u]
    [app.util.object :as obj]
    [beicon.v2.core :as rx]
@@ -38,10 +37,14 @@
 (defn token-proxy? [p]
   (obj/type-of? p "TokenProxy"))
 
+;; Cannot use shape/shape-proxy? here because of circular dependency in applyToken in shape proxy
+(defn shape-proxy? [s]
+  (obj/type-of? s "ShapeProxy"))
+
 (defn token-proxy
   [plugin-id file-id set-id id]
   (obj/reify {:name "TokenProxy"
-              :wrap u/wrap-errors}
+              :on-error u/handle-error}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$file-id {:enumerable false :get (constantly file-id)}
     :$set-id {:enumerable false :get (constantly set-id)}
@@ -113,14 +116,10 @@
 
     :applyToShapes
     {:schema [:tuple
-              ;; FIXME: the schema decoder is interpreting the array of shape-proxys and converting
-              ;;        them to plain maps. For now we adapt the schema to accept it, but the decoder
-              ;;        should be fixed to keep the original proxy objects coming from the plugin.
-              ;; [:vector [:fn shape/shape-proxy?]]
-              [:vector [:map [:id ::sm/uuid]]]
-              [:maybe [:set [:set [:and ::sm/keyword [:fn cto/token-attr?]]]]]]
+              [:vector [:fn shape-proxy?]]
+              [:maybe [:set [:and ::sm/keyword [:fn cto/token-attr?]]]]]
      :fn (fn [shapes attrs]
-           (apply-token-to-shapes file-id set-id id (map :id shapes) attrs))}
+           (apply-token-to-shapes file-id set-id id (map #(obj/get % "$id") shapes) attrs))}
 
     :applyToSelected
     {:schema [:tuple [:maybe [:set [:and ::sm/keyword [:fn cto/token-attr?]]]]]
@@ -136,7 +135,7 @@
 (defn token-set-proxy
   [plugin-id file-id id]
   (obj/reify {:name "TokenSetProxy"
-              :wrap u/wrap-errors}
+              :on-error u/handle-error}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$file-id {:enumerable false :get (constantly file-id)}
     :$id {:enumerable false :get (constantly id)}
@@ -257,7 +256,7 @@
 (defn token-theme-proxy
   [plugin-id file-id id]
   (obj/reify {:name "TokenThemeProxy"
-              :wrap u/wrap-errors}
+              :on-error u/handle-error}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$file-id {:enumerable false :get (constantly file-id)}
     :$id {:enumerable false :get (constantly id)}
@@ -352,7 +351,7 @@
 (defn tokens-catalog
   [plugin-id file-id]
   (obj/reify {:name "TokensCatalog"
-              :wrap u/wrap-errors}
+              :on-error u/handle-error}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$id {:enumerable false :get (constantly file-id)}
 

--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -223,7 +223,9 @@
 
 (defn display-not-valid
   [code value]
-  (.error js/console (dm/str "[PENPOT PLUGIN] Value not valid: " value ". Code: " code))
+  (if (some? value)
+    (.error js/console (dm/str "[PENPOT PLUGIN] Value not valid: " value ". Code: " code))
+    (.error js/console (dm/str "[PENPOT PLUGIN] Value not valid. Code: " code)))
   nil)
 
 (defn reject-not-valid
@@ -248,19 +250,12 @@
   (let [s (set values)]
     (if (= (count s) 1) (first s) "mixed")))
 
-(defn wrap-errors
-  "Function wrapper to be used in plugin proxies methods to handle errors.
-   When an exception is thrown, a readable error message is output to the console
-   and the exception is captured."
-  [f]
-  (fn []
-    (let [args (js-arguments)]
-      (try
-        (.apply f nil args)
-        (catch :default cause
-          (display-not-valid (ex-message cause) (obj/stringify args))
-          (if-let [explain (-> cause ex-data ::sm/explain)]
-            (println (sm/humanize-explain explain))
-            (js/console.log (ex-data cause)))
-          (js/console.log (.-stack cause))
-          nil)))))
+(defn handle-error
+  "Function to be used in plugin proxies methods to handle errors and print a readable
+   message to the console."
+  [cause]
+  (display-not-valid (ex-message cause) nil)
+  (if-let [explain (-> cause ex-data ::sm/explain)]
+    (println (sm/humanize-explain explain))
+    (js/console.log (ex-data cause)))
+  (js/console.log (.-stack cause)))

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -5226,27 +5226,27 @@ type TokenDimensionProps =
 /**
  * The properties that a FontFamilies token can be applied to.
  */
-type TokenFontFamiliesProps = 'font-families';
+type TokenFontFamiliesProps = 'fontFamilies';
 
 /**
  * The properties that a FontSizes token can be applied to.
  */
-type TokenFontSizesProps = 'font-size';
+type TokenFontSizesProps = 'fontSize';
 
 /**
  * The properties that a FontWeight token can be applied to.
  */
-type TokenFontWeightProps = 'font-weight';
+type TokenFontWeightProps = 'fontWeight';
 
 /**
  * The properties that a LetterSpacing token can be applied to.
  */
-type TokenLetterSpacingProps = 'letter-spacing';
+type TokenLetterSpacingProps = 'letterSpacing';
 
 /**
  * The properties that a Number token can be applied to.
  */
-type TokenNumberProps = 'rotation' | 'line-height';
+type TokenNumberProps = 'rotation';
 
 /**
  * The properties that an Opacity token can be applied to.
@@ -5262,18 +5262,18 @@ type TokenSizingProps =
   | 'height'
 
   // Layout
-  | 'layout-item-min-w'
-  | 'layout-item-max-w'
-  | 'layout-item-min-h'
-  | 'layout-item-max-h';
+  | 'layoutItemMinW'
+  | 'layoutItemMaxW'
+  | 'layoutItemMinH'
+  | 'layoutItemMaxH';
 
 /**
  * The properties that a Spacing token can be applied to.
  */
 type TokenSpacingProps =
   // Spacing / Gap
-  | 'row-gap'
-  | 'column-gap'
+  | 'rowGap'
+  | 'columnGap'
 
   // Spacing / Padding
   | 'p1'
@@ -5290,17 +5290,17 @@ type TokenSpacingProps =
 /**
  * The properties that a BorderWidth token can be applied to.
  */
-type TokenBorderWidthProps = 'stroke-width';
+type TokenBorderWidthProps = 'strokeWidth';
 
 /**
  * The properties that a TextCase token can be applied to.
  */
-type TokenTextCaseProps = 'text-case';
+type TokenTextCaseProps = 'textCase';
 
 /**
  * The properties that a TextDecoration token can be applied to.
  */
-type TokenTextDecorationProps = 'text-decoration';
+type TokenTextDecorationProps = 'textDecoration';
 
 /**
  * The properties that a Typography token can be applied to.


### PR DESCRIPTION
Correctly validate that the parameters given to apply functions are shape and token proxies. Also fixed applied properties names.