### PR TITLE
:bug: Add resolved value to tokens in plugins API

### DIFF
--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -13,6 +13,7 @@
    [app.common.types.tokens-lib :as ctob]
    [app.common.uuid :as uuid]
    [app.main.data.style-dictionary :as sd]
+   [app.main.data.tokenscript :as ts]
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.tokens.library-edit :as dwtl]
    [app.main.store :as st]
@@ -33,6 +34,14 @@
                            :attrs attrs
                            :shape-ids shape-ids
                            :expand-with-children false})))))
+
+(defn- get-resolved-value
+  [token tokens-tree]
+  (let [resolved-tokens (ts/resolve-tokens tokens-tree)
+        resolved-value  (-> resolved-tokens
+                            (dm/get-in [(:name token) :resolved-value])
+                            (ts/tokenscript-symbols->penpot-unit))]
+    resolved-value))
 
 (defn token-proxy? [p]
   (obj/type-of? p "TokenProxy"))
@@ -84,6 +93,26 @@
      :set
      (fn [_ value]
        (st/emit! (dwtl/update-token set-id id {:value value})))}
+
+    :resolvedValue
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [token           (u/locate-token file-id set-id id)
+             tokens-lib      (u/locate-tokens-lib file-id)
+             tokens-tree     (ctob/get-tokens-in-active-sets tokens-lib)]
+         (get-resolved-value token tokens-tree)))}
+
+    :resolvedValueString
+    {:this true
+     :enumerable false
+     :get
+     (fn [_]
+       (let [token           (u/locate-token file-id set-id id)
+             tokens-lib      (u/locate-tokens-lib file-id)
+             tokens-tree     (ctob/get-tokens-in-active-sets tokens-lib)]
+         (str (get-resolved-value token tokens-tree))))}
 
     :description
     {:this true

--- a/plugins/apps/poc-tokens-plugin/src/app/app.component.html
+++ b/plugins/apps/poc-tokens-plugin/src/app/app.component.html
@@ -113,7 +113,9 @@
                 class="body-m panel-item token-item"
                 (click)="applyToken(token.id)"
               >
-                <span>{{ token.name }}</span>
+                <span title="{{ token.resolvedValueString }}">
+                  {{ token.name }}
+                </span>
                 <button
                   type="button"
                   data-appearance="secondary"

--- a/plugins/apps/poc-tokens-plugin/src/app/app.component.ts
+++ b/plugins/apps/poc-tokens-plugin/src/app/app.component.ts
@@ -23,6 +23,7 @@ type Token = {
   id: string;
   name: string;
   description: string;
+  resolvedValueString: string;
 };
 
 type TokensGroup = [string, Token[]];

--- a/plugins/apps/poc-tokens-plugin/src/plugin.ts
+++ b/plugins/apps/poc-tokens-plugin/src/plugin.ts
@@ -109,6 +109,7 @@ function loadTokens(setId: string) {
             id: token.id,
             name: token.name,
             description: token.description,
+            resolvedValueString: token.resolvedValueString,
           };
         }),
       ]);

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -4346,6 +4346,15 @@ export interface TokenBase {
   remove(): void;
 
   /**
+   * The value calculated by finding all tokens with the same name in active sets
+   * and resolving the references.
+   *
+   * It's converted to string, regardless of the data type of the value depending
+   * on the token type. It can be undefined if no value has been found in active sets.
+   */
+  readonly resolvedValueString: string | undefined;
+
+  /**
    * Applies this token to one or more properties of the given shapes.
    * @param shapes is an array of shapes to apply it.
    * @param properties an optional list of property names. If omitted, the


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/8341

### Summary

Add resolved values to tokens. Now each token type has a `resolvedValue` property, with a type depending on the token. Also the `TokenBase` class has a `resolvedValueString` property, where the value is converted to a string.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
