### PR TITLE
:bug: Fix changelog to remove MCP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Optimize sidebar performance for deeply nested shapes [Taiga #13017](https://tree.taiga.io/project/penpot/task/13017)
 - Remove tokens path node and bulk remove tokens [Taiga #13007](https://tree.taiga.io/project/penpot/us/13007)
 - Replace themes management modal radio buttons for switches [Taiga #9215](https://tree.taiga.io/project/penpot/us/9215)
+- [Access Tokens] Look & feel refinement [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
 
 ### :bug: Bugs fixed
 


### PR DESCRIPTION
### Related Ticket

Taiga [#13409](https://tree.taiga.io/project/penpot/task/13409)

### Summary

The new access tokens section will be ready for the 2.14 release. We still don't know about the MCP section, which is under a feature flag, so we remove it from the changelog.