### PR TITLE
:paperclip: Use generic error when failing to download font

### DIFF
--- a/frontend/src/app/main/ui/dashboard/fonts.cljs
+++ b/frontend/src/app/main/ui/dashboard/fonts.cljs
@@ -369,7 +369,7 @@
                               (dom/trigger-download filename blob))
                             (fn [error]
                               (js/console.error "error downloading font" error)
-                              (st/emit! (ntf/error (tr "errors.download-font")))))))))
+                              (st/emit! (ntf/error (tr "errors.generic")))))))))
 
         on-delete-variant
         (mf/use-fn


### PR DESCRIPTION
The font specific error string was never added to en.po (my own mistake).

Looking further into it, there is no need to add more work to translators when a generic error goes a long way. Specially since this is not expected to happen.

### Related Ticket

Missing translation introduced on own commit: c55c23c6dd3a77ee4718086e04f71e75d211b3a8


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
