### PR TITLE
:sparkles: Add minor improvements to error reporting

### DIFF
--- a/backend/resources/app/templates/error-report.v4.tmpl
+++ b/backend/resources/app/templates/error-report.v4.tmpl
@@ -8,7 +8,6 @@ Report: {{hint|abbreviate:150}} - {{id}} - Penpot Error Report (v4)
 <nav>
   <div>[<a href="/dbg/error?version={{version}}">⮜</a>]</div>
   <div>[<a href="#head">head</a>]</div>
-  <!-- <div>[<a href="#props">props</a>]</div> -->
   <div>[<a href="#context">context</a>]</div>
   {% if report %}
   <div>[<a href="#report">report</a>]</div>
@@ -21,7 +20,8 @@ Report: {{hint|abbreviate:150}} - {{id}} - Penpot Error Report (v4)
       <div class="table-val">
         <h1><span class="not-important">Hint:</span> <br/> {{hint}}</h1>
         <h2><span class="not-important">Reported at:</span> <br/> {{created-at}}</h2>
-        <h2><span class="not-important">Report ID:</span> <br/> {{id}}</h2>
+        <h2><span class="not-important">Origin:</span> <br/> {{origin}}</h2>
+        <h2><span class="not-important">HREF:</span> <br/> {{href}}</h2>
       </div>
     </div>
 

--- a/backend/src/app/loggers/database.clj
+++ b/backend/src/app/loggers/database.clj
@@ -117,7 +117,8 @@
 
     {:context (-> (into (sorted-map) context)
                   (pp/pprint-str :length 50))
-     :props   (pp/pprint-str props :length 50)
+     :origin  (::audit/name record)
+     :href    (get props :href)
      :hint    (get props :hint)
      :report  (get props :report)}))
 

--- a/common/src/app/common/exceptions.cljc
+++ b/common/src/app/common/exceptions.cljc
@@ -299,3 +299,8 @@
          (js/console.log (format-throwable cause))
          (finally
            (js/console.groupEnd))))))
+
+(defn get-hint
+  [cause]
+  (or (some-> (ex-data cause) (get :hint) first-line)
+      (some-> (ex-message cause) first-line)))

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -72,7 +72,6 @@
         (when-let [file-id (or (:file-id data) file-id)]
           (println "File ID: " (str file-id)))
         (println "Version: " (:full cf/version))
-        (println "URI:     " (str cf/public-uri))
         (println "HREF:    " (rt/get-current-href))
         (println)
 
@@ -88,24 +87,36 @@
       (.error js/console "error on generating report" cause)
       nil)))
 
-(defn- show-not-blocking-error
-  "Show a non user blocking error notification"
-  [cause]
-  (let [data (ex-data cause)
-        hint (or (some-> (:hint data) ex/first-line)
-                 (ex-message cause))]
-
+(defn submit-report
+  "Report the error report to the audit log subsystem"
+  [& {:keys [event-name report hint] :or {event-name "unhandled-exception"}}]
+  (when (and (not (str/empty? hint))
+             (string? report)
+             (string? event-name))
     (st/emit!
-     (ev/event {::ev/name "unhandled-exception"
+     (ev/event {::ev/name event-name
                 :hint hint
                 :href (rt/get-current-href)
-                :type (get data :type :unknown)
-                :report (generate-report cause)})
+                :report report}))))
 
-     (ntf/show {:content (tr "errors.unexpected-exception" hint)
-                :type :toast
-                :level :error
-                :timeout 3000}))))
+(defn flash
+  "Show error notification banner and emit error report"
+  [& {:keys [type hint cause] :or {type :handled}}]
+  (when (ex/exception? cause)
+    (when-let [event-name (case type
+                            :handled "handled-exception"
+                            :unhandled "unhandled-exception"
+                            :silent nil)]
+      (let [report (generate-report cause)]
+        (submit-report :event-name event-name
+                       :report report
+                       :hint (ex/get-hint cause)))))
+
+  (st/emit!
+   (ntf/show {:content (or ^boolean hint (tr "errors.generic"))
+              :type :toast
+              :level :error
+              :timeout 5000})))
 
 (defmethod ptk/handle-error :default
   [error]
@@ -114,7 +125,7 @@
     (ptk/handle-error (assoc error :type :assertion))
     (when-let [cause (::instance error)]
       (ex/print-throwable cause :prefix "Unexpected Error")
-      (show-not-blocking-error cause))))
+      (flash :cause cause :type :unhandled))))
 
 ;; We receive a explicit authentication error; If the uri is for
 ;; workspace, dashboard, viewer or settings, then assign the exception
@@ -203,7 +214,7 @@
 (defmethod ptk/handle-error :assertion
   [error]
   (when-let [cause (::instance error)]
-    (show-not-blocking-error cause)
+    (flash :cause cause :type :handled)
     (ex/print-throwable cause :prefix "Assertion Error")))
 
 ;; ;; All the errors that happens on worker are handled here.
@@ -307,7 +318,7 @@
     :else
     (when-let [cause (::instance error)]
       (ex/print-throwable cause :prefix "Restriction Error")
-      (show-not-blocking-error cause))))
+      (flash :cause cause :type :unhandled))))
 
 ;; This happens when the backed server fails to process the
 ;; request. This can be caused by an internal assertion or any other
@@ -333,14 +344,14 @@
               (set! last-exception cause)
               (when-not (is-ignorable-exception? cause)
                 (ex/print-throwable cause :prefix "Uncaught Exception")
-                (ts/schedule #(show-not-blocking-error cause)))))
+                (ts/schedule #(flash :cause cause :type :unhandled)))))
 
           (on-unhandled-rejection [event]
             (.preventDefault ^js event)
             (when-let [cause (unchecked-get event "reason")]
               (set! last-exception cause)
               (ex/print-throwable cause :prefix "Uncaught Rejection")
-              (ts/schedule #(show-not-blocking-error cause))))]
+              (ts/schedule #(flash :cause cause :type :unhandled))))]
 
     (.addEventListener g/window "error" on-unhandled-error)
     (.addEventListener g/window "unhandledrejection" on-unhandled-rejection)

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -9,13 +9,12 @@
   (:require
    ["rxjs" :as rxjs]
    [app.common.data :as d]
+   [app.common.exceptions :as ex]
    [app.common.pprint :as pp]
-   [app.common.uri :as u]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.auth :refer [is-authenticated?]]
    [app.main.data.common :as dcm]
-   [app.main.data.event :as ev]
    [app.main.errors :as errors]
    [app.main.refs :as refs]
    [app.main.repo :as rp]
@@ -448,22 +447,22 @@
 
 (mf/defc exception-section*
   {::mf/private true}
-  [{:keys [data route] :as props}]
+  [{:keys [data] :as props}]
   (let [type   (get data :type)
-        report (mf/with-memo [data]
-                 (some-> data ::errors/instance errors/generate-report))
+        cause  (get data ::errors/instance)
+
+        report (mf/with-memo [cause]
+                 (when (ex/exception? cause)
+                   (errors/generate-report cause)))
+
         props  (mf/spread-props props {:report report})]
 
-    (mf/with-effect [data route report]
-      (let [params (:query-params route)
-            params (u/map->query-string params)]
-        (st/emit! (ev/event {::ev/name "exception-page"
-                             :type (get data :type :unknown)
-                             :href (rt/get-current-href)
-                             :hint (get data :hint)
-                             :path (get route :path)
-                             :report report
-                             :params params}))))
+    (mf/with-effect [report type cause]
+      (when (and (ex/exception? cause)
+                 (not (contains? #{:not-found :authentication} type)))
+        (errors/submit-report :event-name "exception-page"
+                              :report report
+                              :hint (ex/get-hint cause))))
 
     (case type
       :not-found


### PR DESCRIPTION
### Summary

Improves frontend error reporting mechanism.

Relevant changes:
- The error banner now shows generic message instead of exception message
- Add additional relevant info to report
- Add minor changes on report template
- Do not report `:not-found` and `:authentication` errors
- Expose helpers for proper error reporting on other parts of application

There are no explicit user tests, just code review.