### PR TITLE
:bug: Fix unhandled exception on using decimals on stroke row

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
@@ -94,12 +94,12 @@
         (mf/use-fn
          (mf/deps index on-stroke-width-change)
          (fn [value]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (on-stroke-width-change index value)
-             (do
-               (st/emit! (dwta/toggle-token {:token (first value)
-                                             :attrs #{:stroke-width}
-                                             :shape-ids ids}))))))
+
+             (st/emit! (dwta/toggle-token {:token (first value)
+                                           :attrs #{:stroke-width}
+                                           :shape-ids ids})))))
 
         stroke-alignment (or (:stroke-alignment stroke) :center)
 


### PR DESCRIPTION
### Summary

Unhandled exception when using decimals on stroke row. Is a regression and it does not happens on production

### Steps to reproduce 

- Create rect
- Add stroke
- Change width to 1.2
