### PR TITLE
:sparkles: Add better error report on wrong input on logging helpers

### DIFF
--- a/common/src/app/common/logging.cljc
+++ b/common/src/app/common/logging.cljc
@@ -128,7 +128,9 @@
     :warn  "#f5871f"
     :info  "#4271ae"
     :debug "#969896"
-    :trace "#8e908c"))
+    :trace "#8e908c"
+    (let [hint (str "invalid level provided to `level->color` function: " (pr-str level))]
+      (throw (ex-info hint {:level level})))))
 
 (defn- level->name
   [level]
@@ -137,7 +139,9 @@
     :trace "TRC"
     :info  "INF"
     :warn   "WRN"
-    :error "ERR"))
+    :error "ERR"
+    (let [hint (str "invalid level provided to `level->name` function: " (pr-str level))]
+      (throw (ex-info hint {:level level})))))
 
 (defn level->int
   [level]
@@ -146,7 +150,9 @@
     :debug 20
     :info 30
     :warn 40
-    :error 50))
+    :error 50
+    (let [hint (str "invalid level provided to `level->int` function: " (pr-str level))]
+      (throw (ex-info hint {:level level})))))
 
 (defn build-message
   [props]


### PR DESCRIPTION
### Summary

We have several reports like this:

<img width="1272" height="176" alt="image" src="https://github.com/user-attachments/assets/4d4ea27e-9bb3-459b-bd00-010d00b2bdae" />

We have no way to reproduce this. 
This PR add better error reporting for properly understand what comes on level next time it happens.
