### PR TITLE
:bug: Fix problem with createText in plugins

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -27,6 +27,7 @@
    [app.main.data.workspace.media :as dwm]
    [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.wasm-text :as dwwt]
+   [app.main.features :as features]
    [app.main.fonts :refer [fetch-font-css]]
    [app.main.router :as rt]
    [app.main.store :as st]
@@ -365,8 +366,10 @@
                   (cb/add-object shape))]
 
           (st/emit! (ch/commit-changes changes)
-                    (se/event plugin-id "create-shape" :type :text)
-                    (dwwt/resize-wasm-text-debounce (:id shape)))
+                    (se/event plugin-id "create-shape" :type :text))
+
+          (when (features/active-feature? @st/state "render-wasm/v1")
+            (st/emit! (dwwt/resize-wasm-text-debounce (:id shape))))
 
           (shape/shape-proxy plugin-id (:id shape)))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13429

### Summary

We forgot to check the flag and was giving error on createText.


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
