### PR TITLE
:sparkles: Add several redundant checks for library-id on file rpc methods

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -1037,8 +1037,9 @@
    ::webhooks/event? true
    ::sm/params schema:unlink-file-to-library
    ::db/transaction true}
-  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
+  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id file-id library-id] :as params}]
   (check-edition-permissions! conn profile-id file-id)
+  (check-edition-permissions! conn profile-id library-id)
   (unlink-file-from-library conn params)
   nil)
 
@@ -1062,8 +1063,9 @@
   {::doc/added "1.17"
    ::sm/params schema:update-file-library-sync-status
    ::db/transaction true}
-  [{:keys [::db/conn]} {:keys [::rpc/profile-id file-id] :as params}]
+  [{:keys [::db/conn]} {:keys [::rpc/profile-id file-id library-id] :as params}]
   (check-edition-permissions! conn profile-id file-id)
+  (check-edition-permissions! conn profile-id library-id)
   (update-sync conn params))
 
 ;; --- MUTATION COMMAND: ignore-sync

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -1005,19 +1005,19 @@
   "Link a file to a library. Returns the recursive list of libraries used by that library"
   {::doc/added "1.17"
    ::webhooks/event? true
-   ::sm/params schema:link-file-to-library}
-  [cfg {:keys [::rpc/profile-id file-id library-id] :as params}]
+   ::sm/params schema:link-file-to-library
+   ::db/transaction true}
+  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id file-id library-id] :as params}]
+
   (when (= file-id library-id)
     (ex/raise :type :validation
               :code :invalid-library
               :hint "A file cannot be linked to itself"))
 
-  (db/tx-run! cfg
-              (fn [{:keys [::db/conn]}]
-                (check-edition-permissions! conn profile-id file-id)
-                (check-edition-permissions! conn profile-id library-id)
-                (link-file-to-library conn params)
-                (bfc/get-libraries cfg [library-id]))))
+  (check-edition-permissions! conn profile-id file-id)
+  (check-edition-permissions! conn profile-id library-id)
+  (link-file-to-library conn params)
+  (bfc/get-libraries cfg [library-id]))
 
 ;; --- MUTATION COMMAND: unlink-file-from-library
 

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -867,6 +867,52 @@
     (t/is (th/ex-info? error))
     (t/is (th/ex-of-type? error :not-found))))
 
+(t/deftest permissions-checks-unlink-library
+  (let [profile1 (th/create-profile* 1)
+        profile2 (th/create-profile* 2)
+        file1    (th/create-file* 1 {:project-id (:default-project-id profile1)
+                                     :profile-id (:id profile1)
+                                     :is-shared true})
+        file2    (th/create-file* 2 {:project-id (:default-project-id profile1)
+                                     :profile-id (:id profile1)})]
+
+
+    (let [data     {::th/type :unlink-file-from-library
+                    ::rpc/profile-id (:id profile2)
+                    :file-id (:id file2)
+                    :library-id (:id file1)}
+
+          out      (th/command! data)
+          error    (:error out)]
+
+      ;; (th/print-result! out)
+      (t/is (th/ex-info? error))
+      (t/is (th/ex-of-type? error :not-found)))))
+
+
+(t/deftest permissions-checks-update-file-library-status
+  (let [profile1 (th/create-profile* 1)
+        profile2 (th/create-profile* 2)
+        file1    (th/create-file* 1 {:project-id (:default-project-id profile1)
+                                     :profile-id (:id profile1)
+                                     :is-shared true})
+        file2    (th/create-file* 2 {:project-id (:default-project-id profile1)
+                                     :profile-id (:id profile1)})]
+
+
+    (let [data     {::th/type :update-file-library-sync-status
+                    ::rpc/profile-id (:id profile2)
+                    :file-id (:id file2)
+                    :library-id (:id file1)}
+
+          out      (th/command! data)
+          error    (:error out)]
+
+      ;; (th/print-result! out)
+      (t/is (th/ex-info? error))
+      (t/is (th/ex-of-type? error :not-found)))))
+
+
 (t/deftest deletion
   (let [profile1 (th/create-profile* 1)
         file     (th/create-file* 1 {:project-id (:default-project-id profile1)


### PR DESCRIPTION
### Summary

Add redundant checks to several library unlinking and status update operations. This changes are only for code correctness. They are redundant and not strictly necessary.

### Steps to reproduce 

There are no user test required, just code review.

**Merge with REBASE**