### PR TITLE
:sparkles: Allow duplicating color and typography styles from assets panel context menu

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -205,6 +205,21 @@
                            (ctc/check-library-color))]
             (update-color* it state color file-id)))))))
 
+(defn duplicate-color
+  "Create a new color copied from the one with the given id."
+  [file-id color-id]
+  (dm/assert! (uuid? file-id))
+  (dm/assert! (uuid? color-id))
+  (ptk/reify ::duplicate-color
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [data      (dsh/lookup-file-data state)
+            color     (ctl/get-color data color-id)
+            new-color (assoc color :id (uuid/next))
+            changes   (-> (pcb/empty-changes it)
+                          (pcb/add-color new-color))]
+        (rx/of (dch/commit-changes changes))))))
+
 (defn delete-color
   [{:keys [id] :as params}]
   (assert (uuid? id) "expected valid uuid instance for `id`")
@@ -348,6 +363,22 @@
             changes (-> (pcb/empty-changes it)
                         (pcb/with-library-data data)
                         (pcb/delete-typography id))]
+        (rx/of (dch/commit-changes changes))))))
+
+(defn duplicate-typography
+  "Create a new typography copied from the one with the given id."
+  [file-id typography-id]
+  (dm/assert! (uuid? file-id))
+  (dm/assert! (uuid? typography-id))
+  (ptk/reify ::duplicate-typography
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [data           (dsh/lookup-file-data state)
+            typography     (get-in data [:typographies typography-id])
+            new-typography (-> (assoc typography :id (uuid/next))
+                               (ctt/check-typography))
+            changes        (-> (pcb/empty-changes it)
+                               (pcb/add-typography new-typography))]
         (rx/of (dch/commit-changes changes))))))
 
 (defn- add-component2

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
@@ -93,6 +93,17 @@
                          (dwl/sync-file file-id file-id :colors color-id)
                          (dwu/commit-undo-transaction undo-id))))))
 
+        duplicate-color
+        (mf/use-fn
+         (mf/deps file-id color-id multi-colors? multi-assets? selected)
+         (fn []
+           (if (or multi-colors? multi-assets?)
+             (let [undo-id (js/Symbol)]
+               (st/emit! (dwu/start-undo-transaction undo-id))
+               (run! st/emit! (map (partial dwl/duplicate-color file-id) selected))
+               (st/emit! (dwu/commit-undo-transaction undo-id)))
+             (st/emit! (dwl/duplicate-color file-id color-id)))))
+
         rename-color-clicked
         (mf/use-fn
          (mf/deps read-only? local?)
@@ -247,7 +258,10 @@
                      {:name    (tr "workspace.assets.edit")
                       :id      "assets-edit-color"
                       :handler edit-color-clicked})
-
+                   (when-not multi-assets?
+                     {:name    (tr "workspace.assets.duplicate")
+                      :id      "assets-duplicate-color"
+                      :handler duplicate-color})
                    {:name    (tr "workspace.assets.delete")
                     :id      "assets-delete-color"
                     :handler delete-color}

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/typographies.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/typographies.cljs
@@ -377,6 +377,17 @@
                          (dwl/sync-file file-id file-id :typographies (:id @state))
                          (dwu/commit-undo-transaction undo-id))))))
 
+        handle-duplicate-typography
+        (mf/use-fn
+         (mf/deps file-id @state multi-typographies? multi-assets? selected)
+         (fn []
+           (if (or multi-typographies? multi-assets?)
+             (let [undo-id (js/Symbol)]
+               (st/emit! (dwu/start-undo-transaction undo-id))
+               (run! st/emit! (map (partial dwl/duplicate-typography file-id) selected))
+               (st/emit! (dwu/commit-undo-transaction undo-id)))
+             (st/emit! (dwl/duplicate-typography file-id (:id @state))))))
+
         editing-id (:edit-typography local-data)
 
         renaming-id (:rename-typography local-data)
@@ -439,6 +450,11 @@
                        {:name    (tr "workspace.assets.edit")
                         :id      "assets-edit-typography"
                         :handler handle-edit-typography-clicked})
+
+                     (when-not multi-assets?
+                       {:name    (tr "workspace.assets.duplicate")
+                        :id      "assets-duplicate-typography"
+                        :handler handle-duplicate-typography})
 
                      {:name    (tr "workspace.assets.delete")
                       :id      "assets-delete-typography"


### PR DESCRIPTION
### Related Ticket: #2912 

### Summary

Added "Duplicate" option to the right-click context menu for Colors and Typographies in the Assets panel. Previously, only Components supported duplication — this brings feature parity across all asset types.

**Changes:**
- Added `duplicate-color` and `duplicate-typography` events in `libraries.cljs` (data layer)
- Added "Duplicate" menu entry to the color context menu in `colors.cljs`
- Added "Duplicate" menu entry to the typography context menu in `typographies.cljs`
- Supports single and multi-selection duplication with proper undo transactions
- Reuses the existing `workspace.assets.duplicate` translation key

<img width="1311" height="533" alt="2" src="https://github.com/user-attachments/assets/fb73d4a4-97f1-4347-a00d-520fc9924e5a" />

### Steps to reproduce

1. Open a project file in the workspace editor
2. In the left sidebar, open the **Assets** tab

**Test color duplication:**
3. Click the **+** button under Colors to add a color
4. Right-click on the color → verify **Duplicate** appears in the context menu
5. Click **Duplicate** → verify a copy appears with the same name, value, and group
6. Press `Ctrl+Z` → verify the duplicate is removed (undo works)

**Test typography duplication:**
7. Click the **+** button under Typography to add a typography
8. Right-click on the typography → verify **Duplicate** appears in the context menu
9. Click **Duplicate** → verify a copy appears with the same font settings
10. Press `Ctrl+Z` → verify the duplicate is removed

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
