### PR TITLE
:globe_with_meridians: Add Canadian French to language selector

### DIFF
--- a/frontend/src/app/util/i18n.cljs
+++ b/frontend/src/app/util/i18n.cljs
@@ -31,6 +31,7 @@
    {:label "Dutch (community)" :value "nl"}
    {:label "Euskera (community)" :value "eu"}
    {:label "Français (community)" :value "fr"}
+   {:label "Français - Canada (community)" :value "fr_ca"}
    {:label "Gallego (Community)" :value "gl"}
    {:label "Hausa (Community)" :value "ha"}
    {:label "Hrvatski (Community)" :value "hr"}


### PR DESCRIPTION
### Related Ticket

 N/A

### Summary

Adds Canadian French to the language picker following the formatting of Portuguese.

I've been working on the French (Canada) translation and have reached 91% completion (at the time of writing); enough to start testing. https://hosted.weblate.org/projects/penpot/frontend/fr_CA/

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] ~~Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.~~
- [ ] ~~Include screenshots or videos, if applicable.~~
- [ ] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [ ] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully....pending
- [ ] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
