### PR TITLE
:bug: Don't throw exception when picker is closed and image is still uploading

### DIFF
--- a/frontend/src/app/main/data/media.cljs
+++ b/frontend/src/app/main/data/media.cljs
@@ -49,13 +49,14 @@
 (defn notify-start-loading
   []
   (st/emit! (ntf/show {:content (tr "media.loading")
+                       :tag ::media-upload
                        :type :toast
                        :level :info
                        :timeout nil})))
 
 (defn notify-finished-loading
   []
-  (st/emit! (ntf/hide)))
+  (st/emit! (ntf/hide :tag ::media-upload)))
 
 (defn process-error
   [error]

--- a/frontend/src/app/main/data/notifications.cljs
+++ b/frontend/src/app/main/data/notifications.cljs
@@ -76,6 +76,7 @@
               (rx/filter #(not= route-id (:id %)))
               (rx/map hide)
               (rx/take-until stopper)))
+
        (when (:timeout data)
          (let [stopper (rx/filter (ptk/type? ::show) stream)]
            (->> (rx/of (hide))

--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -1016,7 +1016,7 @@
     (update [_ state]
       (update state :colorpicker
               (fn [state]
-                (let [type (:type state)
+                (let [type  (:type state)
                       state (-> state
                                 (update :current-color merge changes)
                                 (update :current-color materialize-color-components)
@@ -1024,6 +1024,7 @@
                                 ;; current color can be a library one
                                 ;; I'm changing via colorpicker
                                 (update :current-color dissoc :ref-id :ref-file))]
+
                   (if-let [stop (:editing-stop state)]
                     (update-in state [:stops stop] (fn [data] (->> changes
                                                                    (merge data)
@@ -1044,7 +1045,9 @@
             (and (= type :color) (nil? (:color state)))]
 
         (when (and add-recent? (not ignore-color?))
-          (let [color (select-keys state [:image :gradient :color :opacity])]
+          (when-let [color (-> state
+                               (select-keys [:image :gradient :color :opacity])
+                               (not-empty))]
             (rx/of (add-recent-color color))))))))
 
 (defn update-colorpicker-gradient

--- a/frontend/src/app/main/data/workspace/media.cljs
+++ b/frontend/src/app/main/data/workspace/media.cljs
@@ -251,9 +251,8 @@
 
 (defn upload-fill-image
   [file on-success]
-  (dm/assert!
-   "expected a valid blob for `file` param"
-   (dmm/blob? file))
+  (assert (dmm/blob? file) "expected a valid blob for `file` param")
+
   (ptk/reify ::upload-fill-image
     ptk/WatchEvent
     (watch [_ state _]


### PR DESCRIPTION
### Summary

Fixes https://github.com/penpot/penpot/issues/8443
