### PR TITLE
:globe_with_meridians: Add Canadian French

### DIFF
--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -28,6 +28,7 @@
               ["date-fns/locale/eu$default" :as dfn-eu]
               ["date-fns/locale/fa-IR$default" :as dfn-fa-ir]
               ["date-fns/locale/fr$default" :as dfn-fr]
+              ["date-fns/locale/fr$default" :as dfn-fr-ca]
               ["date-fns/locale/gl$default" :as dfn-gl]
               ["date-fns/locale/he$default" :as dfn-he]
               ["date-fns/locale/hr$default" :as dfn-hr]
@@ -252,6 +253,7 @@
           :fa dfn-fa-ir
           :fa_ir dfn-fa-ir
           :fr dfn-fr
+          :fr dfn-fr-ca
           :he dfn-he
           :pt dfn-pt
           :pt_pt dfn-pt

--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -28,7 +28,7 @@
               ["date-fns/locale/eu$default" :as dfn-eu]
               ["date-fns/locale/fa-IR$default" :as dfn-fa-ir]
               ["date-fns/locale/fr$default" :as dfn-fr]
-              ["date-fns/locale/fr$default" :as dfn-fr-ca]
+              ["date-fns/locale/fr-CA$default" :as dfn-fr-ca]
               ["date-fns/locale/gl$default" :as dfn-gl]
               ["date-fns/locale/he$default" :as dfn-he]
               ["date-fns/locale/hr$default" :as dfn-hr]

--- a/frontend/scripts/_helpers.js
+++ b/frontend/scripts/_helpers.js
@@ -288,6 +288,7 @@ export async function compileTranslations() {
     "es",
     "fa",
     "fr",
+    "fr_CA",
     "he",
     "sr",
     "nb_NO",

--- a/frontend/src/app/util/i18n.cljs
+++ b/frontend/src/app/util/i18n.cljs
@@ -31,6 +31,7 @@
    {:label "Dutch (community)" :value "nl"}
    {:label "Euskera (community)" :value "eu"}
    {:label "Français (community)" :value "fr"}
+   {:label "Français - Canada (community)" :value "fr_CA"}
    {:label "Gallego (Community)" :value "gl"}
    {:label "Hausa (Community)" :value "ha"}
    {:label "Hrvatski (Community)" :value "hr"}


### PR DESCRIPTION
### Related Ticket

N / A

### Summary

Adds Canadian French to the language picker following the formatting of Portuguese.

I've been working on the French (Canada) translation and have reached 91% completion (at the time of writing); enough to start testing. https://hosted.weblate.org/projects/penpot/frontend/fr_CA/

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] ~~Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.~~
- [ ] ~~Include screenshots or videos, if applicable.~~
- [ ] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [ ] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully....pending
- [ ] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->