### PR TITLE
:bug: Fix incorrect version visibility on workspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.13.4
+
+### :bug: Bugs fixed
+
+- Fix incorrect query for file versions [Github #8463](https://github.com/penpot/penpot/pull/8463)
+
+
 ## 2.13.3
 
 ### :bug: Bugs fixed

--- a/backend/src/app/features/file_snapshots.clj
+++ b/backend/src/app/features/file_snapshots.clj
@@ -138,6 +138,7 @@
                  c.deleted_at
             FROM snapshots1 AS c
            WHERE c.file_id = ?
+           ORDER BY c.created_at DESC
        ), snapshots3 AS (
           (SELECT * FROM snapshots2
             WHERE created_by = 'system'
@@ -150,8 +151,7 @@
               AND deleted_at IS NULL
             LIMIT 500)
        )
-       SELECT * FROM snapshots3
-        ORDER BY created_at DESC"))
+       SELECT * FROM snapshots3;"))
 
 (defn get-visible-snapshots
   "Return a list of snapshots fecheable from the API, it has a limited

--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -208,7 +208,7 @@
                 (dfn-format v "p")
 
                 :localized-date-time
-                (dfn-format v "PPPp")
+                (dfn-format v "PPP . p")
 
                 (if (string? fmt)
                   (dfn-format v fmt)

--- a/frontend/src/app/main/ui/ds/layout/tab_switcher.scss
+++ b/frontend/src/app/main/ui/ds/layout/tab_switcher.scss
@@ -114,4 +114,5 @@
   width: 100%;
   height: 100%;
   outline: $b-1 solid var(--tab-panel-outline-color);
+  overflow-y: auto;
 }

--- a/frontend/src/app/main/ui/ds/product/milestone_group.cljs
+++ b/frontend/src/app/main/ui/ds/product/milestone_group.cljs
@@ -39,7 +39,6 @@
         (mf/spread-props props
                          {:class [class class']
                           :data-testid "milestone"})
-
         open*
         (mf/use-state false)
 
@@ -57,7 +56,13 @@
                            (dom/get-data "index")
                            (d/parse-integer))]
              (when (fn? on-menu-click)
-               (on-menu-click index event)))))]
+               (on-menu-click index event)))))
+
+        snapshots
+        (mf/with-memo [snapshots]
+          (map-indexed (fn [index date]
+                         (d/vec2 date index))
+                       snapshots))]
 
     [:> :div props
      [:> text*  {:as "span" :typography t/body-small :class (stl/css :name)} label]
@@ -76,14 +81,14 @@
                                        :icon-arrow-toggled open?)}]]
 
       (when ^boolean open?
-        (for [[idx d] (d/enumerate snapshots)]
-          [:div {:key (dm/str "entry-" idx)
+        (for [[date index] snapshots]
+          [:div {:key (dm/str "entry-" index)
                  :class (stl/css :version-entry)}
-           [:> date* {:date d :class (stl/css :date) :typography t/body-small}]
+           [:> date* {:date date :class (stl/css :date) :typography t/body-small}]
            [:> icon-button* {:class (stl/css :entry-button)
                              :variant "ghost"
                              :icon i/menu
                              :aria-label (tr "workspace.versions.version-menu")
-                             :data-index idx
+                             :data-index index
                              :on-click on-menu-click}]]))]]))
 

--- a/frontend/src/app/main/ui/ds/utilities/date.cljs
+++ b/frontend/src/app/main/ui/ds/utilities/date.cljs
@@ -6,10 +6,8 @@
 
 (ns app.main.ui.ds.utilities.date
   (:require-macros
-   [app.common.data.macros :as dm]
    [app.main.style :as stl])
   (:require
-   [app.common.data :as d]
    [app.common.time :as ct]
    [app.main.ui.ds.foundations.typography :as t]
    [app.main.ui.ds.foundations.typography.text :refer [text*]]
@@ -30,15 +28,10 @@
 (mf/defc date*
   {::mf/schema schema:date}
   [{:keys [class date selected typography] :rest props}]
-  (let [class (d/append-class class (stl/css-case :date true :is-selected selected))
-        date  (cond-> date (not (ct/inst? date)) ct/inst)
+  (let [date       (cond-> date (not (ct/inst? date)) ct/inst)
         typography (or typography t/body-medium)]
     [:> text* {:as "time"
                :typography typography
-               :class class
+               :class [class (stl/css-case :date true :is-selected selected)]
                :date-time (ct/format-inst date :iso)}
-     (dm/str
-      (ct/format-inst date :localized-date)
-      " . "
-      (ct/format-inst date :localized-time)
-      "h")]))
+     (ct/format-inst date :localized-date-time)]))

--- a/frontend/src/app/main/ui/workspace/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar.scss
@@ -159,3 +159,7 @@
   overflow: hidden;
   height: calc(100vh - deprecated.$s-88);
 }
+
+.history-tab {
+  overflow-y: auto;
+}


### PR DESCRIPTION
### Summary

When a file has a lot of versions, the current query for retrieve versions, select the first 500 but without applying the ordering, this means that database can return a random set of 500 elements. The main fix comes adding explicit ordering before limit ensuring to return the latest versions.

This also makes a small change on how the date is formatted removing the inconsistent `h` suffix.

Previously: 
<img width="280" height="53" alt="image" src="https://github.com/user-attachments/assets/0c2d7466-7f49-4a46-b863-3548283b2e98" />
Current:
<img width="226" height="33" alt="image" src="https://github.com/user-attachments/assets/7c339151-73ed-4572-aaba-39f1ed386cab" />


Also add minimal efficiency improvements reducing allocation on milestone-group* component.

### How to test

You need to open a file with a lot of auto-saved versions, you will see that the returned result are not consistent and maybe showing older versions. This PR fixes that.

If you don't have access to that file, ensure at least you can see versions as you see them previously and nothing evident is broken.

**MERGE WITH SQUASH**

