### PR TITLE
:bug: Add token name in broken token tooltip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 ### :bug: Bugs fixed
 
 - Fix Alt/Option to draw shapes from center point (by @offreal) [Github #8361](https://github.com/penpot/penpot/pull/8361)
+- Add token name on broken token pill on sidebar [Taiga #13527](https://tree.taiga.io/project/penpot/issue/13527)
 
 
 ## 2.14.0 (Unreleased)

--- a/frontend/playwright/ui/specs/tokens/apply.spec.js
+++ b/frontend/playwright/ui/specs/tokens/apply.spec.js
@@ -910,7 +910,7 @@ test.describe("Tokens: Detach token", () => {
     await expect(page.getByText("Don't remap")).toBeVisible();
     await page.getByText("Don't remap").click();
     const brokenPill = borderRadiusSection.getByRole("button", {
-      name: "This token is not in any",
+      name: "is not in any active set",
     });
     await expect(brokenPill).toBeVisible();
 

--- a/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
@@ -658,7 +658,7 @@
         (when (and token-applied (not= :multiple token-applied))
           (let [token       (get-option-by-name dropdown-options token-applied)
                 id          (get token :id)
-                label       (get token :name)
+                label       (or (get token :name) applied-token)
                 token-value (or (get token :resolved-value)
                                 (or (mf/ref-val last-value*)
                                     (fmt/format-number value)))

--- a/frontend/src/app/main/ui/ds/controls/utilities/token_field.cljs
+++ b/frontend/src/app/main/ui/ds/controls/utilities/token_field.cljs
@@ -40,7 +40,7 @@
   (let [set-active? (some? id)
         content     (if set-active?
                       label
-                      (tr "ds.inputs.token-field.no-active-token-option"))
+                      (tr "ds.inputs.token-field.no-active-token-option" label))
         default-id  (mf/use-id)
         id          (d/nilv id default-id)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -96,14 +96,14 @@
         id (dm/str (:id token) "-name")
         swatch-tooltip-content (cond
                                  not-active
-                                 (tr "ds.inputs.token-field.no-active-token-option")
+                                 (tr "ds.inputs.token-field.no-active-token-option" token-name)
                                  has-errors
                                  (tr "color-row.token-color-row.deleted-token")
                                  :else
                                  (tr "workspace.tokens.resolved-value" resolved))
         name-tooltip-content (cond
                                not-active
-                               (tr "ds.inputs.token-field.no-active-token-option")
+                               (tr "ds.inputs.token-field.no-active-token-option" token-name)
                                has-errors
                                (tr "color-row.token-color-row.deleted-token")
                                :else

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -1362,7 +1362,7 @@ msgstr "Token trennen"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Dieser Token ist nicht Teil eines aktiven Sets oder ungültig."
+msgstr "%s ist nicht Teil eines aktiven Sets oder ungültig."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1270,7 +1270,7 @@ msgstr "Detach token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "This token is not in any active set or has an invalid value."
+msgstr "%s is not in any active set or has an invalid value."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1274,7 +1274,7 @@ msgstr "Desvincular token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Este token no está disponible en ningún set o tiene un valor inválido."
+msgstr "%s no está disponible en ningún set o tiene un valor inválido."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -1369,7 +1369,7 @@ msgstr "Détacher le token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Ce token n'est pas disponible dans la collection ou le thème actif."
+msgstr "%s n'est pas disponible dans la collection ou le thème actif."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/fr_CA.po
+++ b/frontend/translations/fr_CA.po
@@ -1360,7 +1360,7 @@ msgstr "Détacher du token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Ce token n'est disponible dans aucune collection ou est invalide."
+msgstr "%s n'est disponible dans aucune collection ou est invalide."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -1185,10 +1185,6 @@ msgstr "פתיחת רשימת אסימונים"
 msgid "ds.inputs.token-field.detach-token"
 msgstr "ניתוק אסימון"
 
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "האסימון הזה לא זמין באף ערכה או שהערך שלו שגוי."
-
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"
 msgstr "ספק האימות לא מורשה לפרופיל הזה"

--- a/frontend/translations/hi.po
+++ b/frontend/translations/hi.po
@@ -1256,10 +1256,6 @@ msgstr "token सूची खोलें"
 msgid "ds.inputs.token-field.detach-token"
 msgstr "token अलग करें"
 
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "यह token किसी भी सक्रिय सेट में नहीं है या इसका मान अमान्य है।"
-
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"
 msgstr "इस प्रोफाइल के लिए ऑथ प्रोवाइडर अनुमति नहीं है"

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -1355,7 +1355,7 @@ msgstr "Scollega token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Questo token non è disponibile in nessun set o tema attivo."
+msgstr "%s non è disponibile in nessun set o tema attivo."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -1214,10 +1214,6 @@ msgstr "Atvērt tekstvienību sarakstu"
 msgid "ds.inputs.token-field.detach-token"
 msgstr "Atdalīt tekstvienību"
 
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Šī tekstvienība nav nevienā aktīvajā kopā vai tai ir nederīga vērtība."
-
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"
 msgstr "Autentificēšanās nodrošinātājs nav atļauts šim profilam"

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -1358,7 +1358,7 @@ msgstr "Token loskoppelen"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Dit token is niet beschikbaar in een actieve verzameling of thema."
+msgstr "%s is niet beschikbaar in een actieve verzameling of thema."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/pt_BR.po
+++ b/frontend/translations/pt_BR.po
@@ -1187,7 +1187,7 @@ msgstr "Desvincular token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Este token não está em nenhum conjunto ativo ou possui um valor inválido."
+msgstr "%s não está em nenhum conjunto ativo ou possui um valor inválido."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -1204,7 +1204,7 @@ msgstr "Detașează tokenul"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Acest token nu este în nici un set activ sau are o valoare invalidă."
+msgstr "%s nu este în nici un set activ sau are o valoare invalidă."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/ru.po
+++ b/frontend/translations/ru.po
@@ -1184,12 +1184,6 @@ msgstr "Открыть список токенов"
 msgid "ds.inputs.token-field.detach-token"
 msgstr "Отсоединить токен"
 
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr ""
-"Этот токен не входит ни в один активный набор или имеет недопустимое "
-"значение."
-
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"
 msgstr "Поставщик аутентификации не разрешён для этого профиля"

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -1188,7 +1188,7 @@ msgstr "Lösgör token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Denna token är inte i någon aktiv uppsättning eller har ett ogiltigt värde."
+msgstr "%s är inte i någon aktiv uppsättning eller har ett ogiltigt värde."
 
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -1355,12 +1355,6 @@ msgstr "Token listesini aç"
 msgid "ds.inputs.token-field.detach-token"
 msgstr "Tokeni ayır"
 
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr ""
-"Bu token herhangi bir etkin kümede bulunmuyor veya geçersiz bir değere "
-"sahip."
-
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"
 msgstr "Kimlik doğrulama sağlayıcısına bu profil için izin verilmiyor"

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -1116,10 +1116,6 @@ msgstr "打开token列表"
 msgid "ds.inputs.token-field.detach-token"
 msgstr "分离token"
 
-#: src/app/main/ui/ds/controls/utilities/token_field.cljs:43, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:99, src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs:106
-msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "该token于任意活动集合或主题皆不可用。"
-
 #: src/app/main/data/auth.cljs:339
 msgid "errors.auth-provider-not-allowed"
 msgstr "认证提供者不允许访问此个人设定"


### PR DESCRIPTION
### Related Ticket

[Add token name in broken token tooltip](https://tree.taiga.io/project/penpot/issue/13527)

### Summary
On a broken pill show the name of the broken token

To test this bug you need to activate "enable-feature-token-input"

### Steps to reproduce 
1. Create a token set
2. Create a token on that set
3. apply token to a shape
4. de-active set so pill looks broken on numeric input.
<img width="776" height="281" alt="Screenshot from 2026-02-26 11-39-07" src="https://github.com/user-attachments/assets/ccc65906-e390-4ecc-beb2-d6cc1b01205d" />


### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
