### PR TITLE
:bug: Auto-focus search input when shortcuts panel opens

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -483,9 +483,6 @@
            (reset! open-sections [[1]])
            (reset! filter-term "")))]
 
-    (mf/with-effect []
-      (dom/focus! (dom/get-element "shortcut-search")))
-
     [:div {:class (dm/str class " " (stl/css :shortcuts))}
      [:> panel-title* {:class (stl/css :shortcuts-title)
                        :text (tr "shortcuts.title")
@@ -496,7 +493,8 @@
                        :on-clear on-search-clear-click
                        :value @filter-term
                        :placeholder (tr "shortcuts.title")
-                       :icon-id i/search}]]
+                       :icon-id i/search
+                       :auto-focus true}]]
 
      (if match-any?
        [:div {:class (stl/css :shortcuts-list)}


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/8481

### Summary

When the shortcuts panel is opened (via `?` or from the main menu), the search input now automatically receives keyboard focus, allowing users to start typing immediately.

The existing `mf/with-effect` that called `dom/focus!` on element id `"shortcut-search"` was non-functional because the `search-bar*` component was never given that id. Replaced it with the `:auto-focus true` prop already supported by `search-bar*`, which is the standard pattern used across the codebase.

### Steps to reproduce 

1. Open the workspace
2. Press `?` to open the shortcuts panel
3. Verify the search input is focused and you can type immediately without clicking

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->