### PR TITLE
:books: Move Design Tokens > Spacing image to the Spacing section

### DIFF
--- a/docs/user-guide/design-systems/design-tokens.njk
+++ b/docs/user-guide/design-systems/design-tokens.njk
@@ -219,9 +219,6 @@ desc: Learn how to create, manage and apply Penpot Design Tokens using W3C DTCG 
 
 <h3 id="design-tokens-sizing">Sizing</h3>
 <p>Sizing tokens can define various size-related design properties, namely the height and width of design elements.The sizing token supports numeric values, which include negative values.</p>
-<figure>
-  <img src="/img/design-tokens/11-tokens-spacing.webp" alt="Tokens spacing" />
-</figure>
 <h4>Applying Sizing Tokens</h4>
 <p>To apply the sizing token to an element, select the element and choose the token from the list:</p>
 <ul>
@@ -245,6 +242,9 @@ desc: Learn how to create, manage and apply Penpot Design Tokens using W3C DTCG 
 
 <h3 id="design-tokens-spacing">Spacing</h3>
 <p>The spacing token defines the distance between design elements and supports numeric values, which include negative values. Spacing tokens must be applied to Flex Layout boards. </p>
+<figure>
+  <img src="/img/design-tokens/11-tokens-spacing.webp" alt="Tokens spacing" />
+</figure>
 <p class="advice">If you apply the token to a board before flex-layout is applied to it, you may have to remove and re-apply the token for it to take effect.</p>
 <h4>Applying Spacing Tokens</h4>
 <p>To apply the spacing token to an element, select the element and choose the token from the list:</p>


### PR DESCRIPTION
### Related Ticket

N/A

### Summary

Right now, when one goes to [Docs > Design Systems > Design Tokens > Available tokens > Sizing](https://help.penpot.app/user-guide/design-systems/design-tokens/#design-tokens-sizing), there's this following image, but representing the use of a "Spacing" token named `spacing.xl`:

![11-tokens-spacing](https://github.com/user-attachments/assets/68b6ff0b-53a4-438a-b206-557942500ea9)

This PR moves the use  of the Spacing image (`/img/design-tokens/11-tokens-spacing.webp`) to the right "Spacing" section in the "Design Tokens" documentation.

The image's name is already the right one, using the word "spacing", so there's no need to rename it.

> [!NOTE]
> Maybe the need was rather to change the image content. If that's the case, feel free to close this PR as I suppose there's a dedicated process to create these images uniformly.

After this fix, the "Spacing" documentation looks like this:

<img width="701" height="1012" alt="Screenshot 2026-02-27 at 08 26 20" src="https://github.com/user-attachments/assets/b48e14a7-929f-4534-93eb-e1a000845560" />

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- (N/A) Add or modify existing integration tests in case of bugs or new features, if applicable.
- (N/A) Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- (N/A) Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.