### PR TITLE
:bug: Sort tokens by name

### DIFF
--- a/common/src/app/common/path_names.cljc
+++ b/common/src/app/common/path_names.cljc
@@ -188,7 +188,7 @@ Some naming conventions:
   [segments separator]
   (let [sorted  (sort-by-children segments separator)
         grouped (group-by-first-segment sorted separator)]
-    grouped))
+    (into (sorted-map) grouped)))
 
 (defn- build-tree-node
   "Builds a single tree node with lazy children."


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13535

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Tokens are not sorted by name (but should)
<img width="306" height="205" alt="image" src="https://github.com/user-attachments/assets/8541435f-6c1d-4e93-a286-ee7c94c64e21" />

### Steps to reproduce 

Create or import tokens with different names

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
