### PR TITLE
:bug: Fix validation of shadow token with missing keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Fix viewer can update library [Taiga #13186](https://tree.taiga.io/project/penpot/issue/13186)
 - Fix remove fill affects different element than selected [Taiga #13128](https://tree.taiga.io/project/penpot/issue/13128)
 - Fix cannot apply second token after creation while shape is selected [Taiga #13513](https://tree.taiga.io/project/penpot/issue/13513)
+- Fix error activating a set with invalid shadow token applied [Taiga #13528](https://tree.taiga.io/project/penpot/issue/13528)
 
 ## 2.13.3
 

--- a/frontend/src/app/main/data/style_dictionary.cljs
+++ b/frontend/src/app/main/data/style_dictionary.cljs
@@ -377,7 +377,15 @@
 (defn- parse-single-shadow
   "Parses a single shadow map with properties: x, y, blur, spread, color, type."
   [shadow-map shadow-index]
-  (let [add-keyed-errors (fn [shadow-result k errors]
+  (let [shadow-map (merge {:offset-x nil   ;; Ensure that all keys are processed, even if missing in the original token
+                           :offset-y nil
+                           :blur nil
+                           :spread nil
+                           :color nil
+                           :inset false}
+                          shadow-map)
+
+        add-keyed-errors (fn [shadow-result k errors]
                            (update shadow-result :errors concat
                                    (map #(assoc % :shadow-key k :shadow-index shadow-index) errors)))
         parsers {:offset-x parse-sd-token-general-value


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13528

### Summary

The error in the issue is caused by a shadow token with missing keys (offset-x and offset-y) that has been applied to some shapes. This is an invalid value, but the checks were not detecting the case. So when the themes are enabled and the corresponding sets activated, the value was being copied to the shadow of the shapes, generating a schema validation error on save.

### Steps to reproduce 

See issue. The fourth step (click on active sets button next to the theme name) is not necessary. Just wait for the changes being sent to backend.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
