### PR TITLE
:tada: Add MCP tools for design tokens (create, list, update)

### DIFF
--- a/.github/workflows/tests-mcp.yml
+++ b/.github/workflows/tests-mcp.yml
@@ -43,3 +43,4 @@ jobs:
           pnpm run fmt:check;
           pnpm -r run build;
           pnpm -r run types:check;
+          pnpm --filter mcp-server run test;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### :sparkles: New features & Enhancements
 
+- Add MCP tools to create, list, and update design tokens (sets, themes, tokens)
 - Allow duplicating color and typography styles (by @MkDev11) [Github #2912](https://github.com/penpot/penpot/issues/2912)
 - Add MCP server integration [Taiga #13112](https://tree.taiga.io/project/penpot/us/13112), [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
 - Add woff2 support on user uploaded fonts (by @Nivl) [Github #8248](https://github.com/penpot/penpot/pull/8248)

--- a/mcp/packages/server/package.json
+++ b/mcp/packages/server/package.json
@@ -14,7 +14,9 @@
     "start:dev": "node --import ts-node/register src/index.ts",
     "start:dev:multi-user": "node --loader ts-node/esm src/index.ts --multi-user",
     "types:check": "tsc --noEmit",
-    "clean": "rm -rf dist/"
+    "clean": "rm -rf dist/",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "mcp",
@@ -46,7 +48,8 @@
     "@types/ws": "^8.5.10",
     "esbuild": "^0.25.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
   },
   "ts-node": {
     "esm": true

--- a/mcp/packages/server/src/PenpotMcpServer.ts
+++ b/mcp/packages/server/src/PenpotMcpServer.ts
@@ -11,6 +11,15 @@ import { HighLevelOverviewTool } from "./tools/HighLevelOverviewTool";
 import { PenpotApiInfoTool } from "./tools/PenpotApiInfoTool";
 import { ExportShapeTool } from "./tools/ExportShapeTool";
 import { ImportImageTool } from "./tools/ImportImageTool";
+import {
+    ListDesignTokensTool,
+    CreateTokenSetTool,
+    CreateTokenThemeTool,
+    CreateTokenTool,
+    UpdateTokenTool,
+    UpdateTokenSetTool,
+    UpdateTokenThemeTool,
+} from "./tools/DesignTokensTools";
 import { ReplServer } from "./ReplServer";
 import { ApiDocs } from "./ApiDocs";
 
@@ -143,6 +152,13 @@ export class PenpotMcpServer {
             new HighLevelOverviewTool(this),
             new PenpotApiInfoTool(this, this.apiDocs),
             new ExportShapeTool(this),
+            new ListDesignTokensTool(this),
+            new CreateTokenSetTool(this),
+            new CreateTokenThemeTool(this),
+            new CreateTokenTool(this),
+            new UpdateTokenTool(this),
+            new UpdateTokenSetTool(this),
+            new UpdateTokenThemeTool(this),
         ];
         if (this.isFileSystemAccessEnabled()) {
             toolInstances.push(new ImportImageTool(this));

--- a/mcp/packages/server/src/tools/DesignTokensTools.spec.ts
+++ b/mcp/packages/server/src/tools/DesignTokensTools.spec.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PenpotMcpServer } from "../PenpotMcpServer";
+import type { ExecuteCodePluginTask } from "../tasks/ExecuteCodePluginTask";
+import {
+    ListDesignTokensTool,
+    CreateTokenSetTool,
+    CreateTokenThemeTool,
+    CreateTokenTool,
+    UpdateTokenTool,
+    UpdateTokenSetTool,
+    UpdateTokenThemeTool,
+} from "./DesignTokensTools";
+
+function createMockServer(taskResult: { data?: { result?: unknown } }) {
+    const executePluginTask = vi.fn().mockResolvedValue(taskResult);
+    return {
+        pluginBridge: { executePluginTask },
+    } as unknown as PenpotMcpServer;
+}
+
+function createRejectingMockServer(errorMessage: string) {
+    const executePluginTask = vi.fn().mockRejectedValue(new Error(errorMessage));
+    return {
+        pluginBridge: { executePluginTask },
+    } as unknown as PenpotMcpServer;
+}
+
+describe("DesignTokensTools", () => {
+    describe("tool names and descriptions", () => {
+        const mockServer = createMockServer({});
+
+        it("ListDesignTokensTool has correct name and description", () => {
+            const tool = new ListDesignTokensTool(mockServer);
+            expect(tool.getToolName()).toBe("list_design_tokens");
+            expect(tool.getToolDescription()).toContain("design tokens");
+            expect(tool.getToolDescription()).toContain("sets");
+            expect(tool.getToolDescription()).toContain("themes");
+        });
+
+        it("CreateTokenSetTool has correct name and description", () => {
+            const tool = new CreateTokenSetTool(mockServer);
+            expect(tool.getToolName()).toBe("create_token_set");
+            expect(tool.getToolDescription()).toContain("token set");
+        });
+
+        it("CreateTokenThemeTool has correct name and description", () => {
+            const tool = new CreateTokenThemeTool(mockServer);
+            expect(tool.getToolName()).toBe("create_token_theme");
+            expect(tool.getToolDescription()).toContain("theme");
+        });
+
+        it("CreateTokenTool has correct name and description", () => {
+            const tool = new CreateTokenTool(mockServer);
+            expect(tool.getToolName()).toBe("create_token");
+            expect(tool.getToolDescription()).toContain("token");
+        });
+
+        it("UpdateTokenTool has correct name and description", () => {
+            const tool = new UpdateTokenTool(mockServer);
+            expect(tool.getToolName()).toBe("update_token");
+            expect(tool.getToolDescription()).toContain("name");
+            expect(tool.getToolDescription()).toContain("value");
+        });
+
+        it("UpdateTokenSetTool has correct name and description", () => {
+            const tool = new UpdateTokenSetTool(mockServer);
+            expect(tool.getToolName()).toBe("update_token_set");
+            expect(tool.getToolDescription()).toContain("Renames");
+        });
+
+        it("UpdateTokenThemeTool has correct name and description", () => {
+            const tool = new UpdateTokenThemeTool(mockServer);
+            expect(tool.getToolName()).toBe("update_token_theme");
+            expect(tool.getToolDescription()).toContain("name");
+            expect(tool.getToolDescription()).toContain("group");
+        });
+    });
+
+    describe("list_design_tokens", () => {
+        it("returns JSON with sets, themes, tokenOverview, tokensBySet when plugin returns data", async () => {
+            const listResult = {
+                sets: [{ id: "set-1", name: "Brand", active: true }],
+                themes: [{ id: "theme-1", group: "scheme", name: "Light", active: true }],
+                tokenOverview: { Brand: { color: ["color.primary"] } },
+                tokensBySet: [
+                    { setId: "set-1", setName: "Brand", tokens: [{ id: "t1", name: "color.primary", type: "color" }] },
+                ],
+            };
+            const mockServer = createMockServer({ data: { result: listResult } });
+            const tool = new ListDesignTokensTool(mockServer);
+
+            const response = await tool.execute({});
+
+            expect(response.content).toHaveLength(1);
+            expect(response.content[0].type).toBe("text");
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.sets).toEqual(listResult.sets);
+            expect(parsed.themes).toEqual(listResult.themes);
+            expect(parsed.tokenOverview).toEqual(listResult.tokenOverview);
+            expect(parsed.tokensBySet).toEqual(listResult.tokensBySet);
+        });
+
+        it("returns failure message when plugin returns no result", async () => {
+            const mockServer = createMockServer({ data: {} });
+            const tool = new ListDesignTokensTool(mockServer);
+
+            const response = await tool.execute({});
+
+            const text = (response.content[0] as { text: string }).text;
+            expect(text).toContain("Failed to list design tokens");
+        });
+
+        it("sends code that uses penpot.library.local.tokens and penpotUtils.tokenOverview", async () => {
+            const executePluginTask = vi.fn().mockResolvedValue({
+                data: { result: { sets: [], themes: [], tokenOverview: {}, tokensBySet: [] } },
+            });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new ListDesignTokensTool(mockServer);
+
+            await tool.execute({});
+
+            expect(executePluginTask).toHaveBeenCalledTimes(1);
+            const task = executePluginTask.mock.calls[0][0] as ExecuteCodePluginTask;
+            const code = (task as { params: { code: string } }).params.code;
+            expect(code).toContain("penpot.library.local.tokens");
+            expect(code).toContain("penpotUtils.tokenOverview");
+            expect(code).toContain("tokensBySet");
+        });
+    });
+
+    describe("create_token_set", () => {
+        it("returns id and name when plugin succeeds", async () => {
+            const mockServer = createMockServer({
+                data: { result: { id: "new-set-id", name: "brand/light" } },
+            });
+            const tool = new CreateTokenSetTool(mockServer);
+
+            const response = await tool.execute({ name: "brand/light" });
+
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("new-set-id");
+            expect(parsed.name).toBe("brand/light");
+        });
+
+        it("sends code that calls addSet with the given name", async () => {
+            const executePluginTask = vi.fn().mockResolvedValue({ data: { result: { id: "x", name: "My Set" } } });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new CreateTokenSetTool(mockServer);
+
+            await tool.execute({ name: "My Set" });
+
+            const task = executePluginTask.mock.calls[0][0] as { params: { code: string } };
+            expect(task.params.code).toContain('addSet({ name: "My Set" })');
+        });
+
+        it("returns failure message when plugin returns no result", async () => {
+            const mockServer = createMockServer({ data: {} });
+            const tool = new CreateTokenSetTool(mockServer);
+
+            const response = await tool.execute({ name: "X" });
+
+            const text = (response.content[0] as { text: string }).text;
+            expect(text).toContain("Failed to create token set");
+        });
+    });
+
+    describe("create_token_theme", () => {
+        it("returns id, group, name when plugin succeeds", async () => {
+            const mockServer = createMockServer({
+                data: { result: { id: "th-1", group: "scheme", name: "Dark" } },
+            });
+            const tool = new CreateTokenThemeTool(mockServer);
+
+            const response = await tool.execute({ group: "scheme", name: "Dark" });
+
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("th-1");
+            expect(parsed.group).toBe("scheme");
+            expect(parsed.name).toBe("Dark");
+        });
+
+        it("sends code that calls addTheme with group and name", async () => {
+            const executePluginTask = vi
+                .fn()
+                .mockResolvedValue({ data: { result: { id: "t", group: "g", name: "N" } } });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new CreateTokenThemeTool(mockServer);
+
+            await tool.execute({ group: "color-scheme", name: "Light" });
+
+            const task = executePluginTask.mock.calls[0][0] as { params: { code: string } };
+            expect(task.params.code).toContain('addTheme({ group: "color-scheme", name: "Light" })');
+        });
+    });
+
+    describe("create_token", () => {
+        it("returns token fields when plugin succeeds", async () => {
+            const mockServer = createMockServer({
+                data: {
+                    result: {
+                        id: "tok-1",
+                        name: "color.primary",
+                        type: "color",
+                        value: "#0066FF",
+                        description: "Brand primary",
+                    },
+                },
+            });
+            const tool = new CreateTokenTool(mockServer);
+
+            const response = await tool.execute({
+                setId: "set-1",
+                type: "color",
+                name: "color.primary",
+                value: "#0066FF",
+                description: "Brand primary",
+            });
+
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("tok-1");
+            expect(parsed.name).toBe("color.primary");
+            expect(parsed.type).toBe("color");
+            expect(parsed.value).toBe("#0066FF");
+            expect(parsed.description).toBe("Brand primary");
+        });
+
+        it("sends code that calls getSetById and addToken with correct args", async () => {
+            const executePluginTask = vi.fn().mockResolvedValue({
+                data: { result: { id: "t", name: "color.primary", type: "color", value: "#0066FF" } },
+            });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new CreateTokenTool(mockServer);
+
+            await tool.execute({ setId: "set-1", type: "color", name: "color.primary", value: "#0066FF" });
+
+            const task = executePluginTask.mock.calls[0][0] as { params: { code: string } };
+            const code = task.params.code;
+            expect(code).toContain('getSetById("set-1")');
+            expect(code).toContain('addToken({ type: "color", name: "color.primary", value: "#0066FF" })');
+        });
+
+        it("returns error message when plugin task throws", async () => {
+            const mockServer = createRejectingMockServer("Token set not found: set-1");
+            const tool = new CreateTokenTool(mockServer);
+
+            const response = await tool.execute({ setId: "set-1", type: "color", name: "c", value: "#000" });
+
+            const text = (response.content[0] as { text: string }).text;
+            expect(text).toContain("Token set not found");
+        });
+    });
+
+    describe("update_token", () => {
+        it("returns success response when plugin returns data", async () => {
+            const mockServer = createMockServer({
+                data: {
+                    result: { id: "tok-1", name: "color.accent", type: "color", value: "#00CC00", description: "" },
+                },
+            });
+            const tool = new UpdateTokenTool(mockServer);
+
+            const response = await tool.execute({ tokenId: "tok-1", name: "color.accent", value: "#00CC00" });
+
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.name).toBe("color.accent");
+            expect(parsed.value).toBe("#00CC00");
+        });
+
+        it("sends code that finds token by id and applies name/value/description updates", async () => {
+            const executePluginTask = vi.fn().mockResolvedValue({
+                data: { result: { id: "t", name: "n", type: "color", value: "#fff" } },
+            });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new UpdateTokenTool(mockServer);
+
+            await tool.execute({ tokenId: "tid-1", name: "new.name", value: "#111" });
+
+            const task = executePluginTask.mock.calls[0][0] as { params: { code: string } };
+            const code = task.params.code;
+            expect(code).toContain('getTokenById("tid-1")');
+            expect(code).toContain('token.name = "new.name"');
+            expect(code).toContain('token.value = "#111"');
+        });
+
+        it("returns message when no updates provided", async () => {
+            const mockServer = createMockServer({});
+            const tool = new UpdateTokenTool(mockServer);
+
+            const response = await tool.execute({ tokenId: "tid-1" });
+
+            const text = (response.content[0] as { text: string }).text;
+            expect(text).toContain("Provide at least one of: name, value, description");
+        });
+    });
+
+    describe("update_token_set", () => {
+        it("returns id and name when plugin succeeds", async () => {
+            const mockServer = createMockServer({
+                data: { result: { id: "set-1", name: "Brand (renamed)" } },
+            });
+            const tool = new UpdateTokenSetTool(mockServer);
+
+            const response = await tool.execute({ setId: "set-1", name: "Brand (renamed)" });
+
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("set-1");
+            expect(parsed.name).toBe("Brand (renamed)");
+        });
+
+        it("sends code that calls getSetById and sets name", async () => {
+            const executePluginTask = vi.fn().mockResolvedValue({ data: { result: { id: "s", name: "New" } } });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new UpdateTokenSetTool(mockServer);
+
+            await tool.execute({ setId: "set-1", name: "New Name" });
+
+            const task = executePluginTask.mock.calls[0][0] as { params: { code: string } };
+            expect(task.params.code).toContain('getSetById("set-1")');
+            expect(task.params.code).toContain('set.name = "New Name"');
+        });
+    });
+
+    describe("update_token_theme", () => {
+        it("returns id, group, name when plugin succeeds", async () => {
+            const mockServer = createMockServer({
+                data: { result: { id: "th-1", group: "new-group", name: "New Name" } },
+            });
+            const tool = new UpdateTokenThemeTool(mockServer);
+
+            const response = await tool.execute({ themeId: "th-1", group: "new-group", name: "New Name" });
+
+            const text = (response.content[0] as { text: string }).text;
+            const parsed = JSON.parse(text);
+            expect(parsed.group).toBe("new-group");
+            expect(parsed.name).toBe("New Name");
+        });
+
+        it("sends code that calls getThemeById and sets name/group", async () => {
+            const executePluginTask = vi
+                .fn()
+                .mockResolvedValue({ data: { result: { id: "t", group: "g", name: "n" } } });
+            const mockServer = { pluginBridge: { executePluginTask } } as unknown as PenpotMcpServer;
+            const tool = new UpdateTokenThemeTool(mockServer);
+
+            await tool.execute({ themeId: "th-1", name: "Renamed" });
+
+            const task = executePluginTask.mock.calls[0][0] as { params: { code: string } };
+            expect(task.params.code).toContain('getThemeById("th-1")');
+            expect(task.params.code).toContain('theme.name = "Renamed"');
+        });
+
+        it("returns message when no updates provided", async () => {
+            const mockServer = createMockServer({});
+            const tool = new UpdateTokenThemeTool(mockServer);
+
+            const response = await tool.execute({ themeId: "th-1" });
+
+            const text = (response.content[0] as { text: string }).text;
+            expect(text).toContain("Provide at least one of: name, group");
+        });
+    });
+});

--- a/mcp/packages/server/src/tools/DesignTokensTools.ts
+++ b/mcp/packages/server/src/tools/DesignTokensTools.ts
@@ -1,0 +1,368 @@
+import { z } from "zod";
+import { Tool } from "../Tool";
+import type { ToolResponse } from "../ToolResponse";
+import { TextResponse } from "../ToolResponse";
+import "reflect-metadata";
+import { PenpotMcpServer } from "../PenpotMcpServer";
+import { ExecuteCodePluginTask } from "../tasks/ExecuteCodePluginTask";
+
+const TOKEN_TYPES = [
+    "borderRadius",
+    "shadow",
+    "color",
+    "dimension",
+    "fontFamilies",
+    "fontSizes",
+    "fontWeights",
+    "letterSpacing",
+    "number",
+    "opacity",
+    "rotation",
+    "sizing",
+    "spacing",
+    "borderWidth",
+    "textCase",
+    "textDecoration",
+    "typography",
+] as const;
+
+/**
+ * List design tokens: returns sets, themes, and token overview.
+ */
+export class ListDesignTokensArgs {
+    static schema = {};
+}
+
+export class ListDesignTokensTool extends Tool<ListDesignTokensArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, ListDesignTokensArgs.schema);
+    }
+
+    getToolName(): string {
+        return "list_design_tokens";
+    }
+
+    getToolDescription(): string {
+        return (
+            "Lists all design tokens in the current file's local library: token sets (with id, name, active), " +
+            "themes (with id, group, name, active), and a token overview per set (set name -> type -> token names). " +
+            "Use the returned ids when creating or updating tokens, sets, or themes."
+        );
+    }
+
+    protected async executeCore(): Promise<ToolResponse> {
+        const code = `
+const catalog = penpot.library.local.tokens;
+const sets = catalog.sets.map(s => ({ id: s.id, name: s.name, active: s.active }));
+const themes = catalog.themes.map(t => ({ id: t.id, group: t.group, name: t.name, active: t.active }));
+const tokenOverview = penpotUtils.tokenOverview();
+const tokensBySet = catalog.sets.map(s => ({ setId: s.id, setName: s.name, tokens: s.tokens.map(t => ({ id: t.id, name: t.name, type: t.type })) }));
+return { sets, themes, tokenOverview, tokensBySet };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to list design tokens.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}
+
+/**
+ * Create a token set.
+ */
+export class CreateTokenSetArgs {
+    static schema = {
+        name: z
+            .string()
+            .min(1, "name cannot be empty")
+            .describe("Name of the token set (may contain group path, e.g. 'brand/light')."),
+    };
+    name!: string;
+}
+
+export class CreateTokenSetTool extends Tool<CreateTokenSetArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, CreateTokenSetArgs.schema);
+    }
+
+    getToolName(): string {
+        return "create_token_set";
+    }
+
+    getToolDescription(): string {
+        return "Creates a new design token set in the local library. Returns the created set's id and name.";
+    }
+
+    protected async executeCore(args: CreateTokenSetArgs): Promise<ToolResponse> {
+        const code = `
+const set = penpot.library.local.tokens.addSet({ name: ${JSON.stringify(args.name)} });
+return { id: set.id, name: set.name };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to create token set.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}
+
+/**
+ * Create a token theme.
+ */
+export class CreateTokenThemeArgs {
+    static schema = {
+        group: z.string().describe("Theme group (e.g. 'color-scheme'). Can be empty string."),
+        name: z.string().min(1, "name cannot be empty").describe("Name of the theme."),
+    };
+    group!: string;
+    name!: string;
+}
+
+export class CreateTokenThemeTool extends Tool<CreateTokenThemeArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, CreateTokenThemeArgs.schema);
+    }
+
+    getToolName(): string {
+        return "create_token_theme";
+    }
+
+    getToolDescription(): string {
+        return "Creates a new design token theme (preset of active sets). Returns the created theme's id, group, and name.";
+    }
+
+    protected async executeCore(args: CreateTokenThemeArgs): Promise<ToolResponse> {
+        const code = `
+const theme = penpot.library.local.tokens.addTheme({ group: ${JSON.stringify(args.group)}, name: ${JSON.stringify(args.name)} });
+return { id: theme.id, group: theme.group, name: theme.name };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to create token theme.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}
+
+/**
+ * Create a design token inside a set.
+ */
+export class CreateTokenArgs {
+    static schema = {
+        setId: z.string().min(1, "setId cannot be empty").describe("Id of the token set (from list_design_tokens)."),
+        type: z.enum(TOKEN_TYPES).describe("Token type (e.g. color, dimension, spacing)."),
+        name: z
+            .string()
+            .min(1, "name cannot be empty")
+            .describe("Token name (e.g. 'color.primary', may contain dots)."),
+        value: z
+            .union([z.string(), z.array(z.string())])
+            .describe(
+                "Token value. For color use hex e.g. '#0066FF'; for dimension e.g. '16px'; references use '{token.name}'."
+            ),
+        description: z.string().optional().describe("Optional description for the token."),
+    };
+    setId!: string;
+    type!: (typeof TOKEN_TYPES)[number];
+    name!: string;
+    value!: string | string[];
+    description?: string;
+}
+
+export class CreateTokenTool extends Tool<CreateTokenArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, CreateTokenArgs.schema);
+    }
+
+    getToolName(): string {
+        return "create_token";
+    }
+
+    getToolDescription(): string {
+        return (
+            "Creates a new design token in the given set. Value format depends on type (e.g. color: '#hex', dimension: '16px'). " +
+            "Returns the created token's id, name, type, and value."
+        );
+    }
+
+    protected async executeCore(args: CreateTokenArgs): Promise<ToolResponse> {
+        const valueJson = JSON.stringify(args.value);
+        const descJson = args.description !== undefined ? JSON.stringify(args.description) : "undefined";
+        const code = `
+const set = penpot.library.local.tokens.getSetById(${JSON.stringify(args.setId)});
+if (!set) throw new Error('Token set not found: ' + ${JSON.stringify(args.setId)});
+const token = set.addToken({ type: ${JSON.stringify(args.type)}, name: ${JSON.stringify(args.name)}, value: ${valueJson} });
+if (${descJson} !== undefined) token.description = ${descJson};
+return { id: token.id, name: token.name, type: token.type, value: token.value, description: token.description };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to create token.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}
+
+/**
+ * Update an existing token (name, value, description).
+ */
+export class UpdateTokenArgs {
+    static schema = {
+        tokenId: z
+            .string()
+            .min(1, "tokenId cannot be empty")
+            .describe("Id of the token to update (from list_design_tokens or create_token)."),
+        name: z.string().optional().describe("New name for the token."),
+        value: z
+            .union([z.string(), z.array(z.string())])
+            .optional()
+            .describe("New value for the token."),
+        description: z.string().optional().describe("New description for the token."),
+    };
+    tokenId!: string;
+    name?: string;
+    value?: string | string[];
+    description?: string;
+}
+
+export class UpdateTokenTool extends Tool<UpdateTokenArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, UpdateTokenArgs.schema);
+    }
+
+    getToolName(): string {
+        return "update_token";
+    }
+
+    getToolDescription(): string {
+        return "Updates an existing design token's name, value, and/or description. Provide only the fields to change.";
+    }
+
+    protected async executeCore(args: UpdateTokenArgs): Promise<ToolResponse> {
+        const updates: string[] = [];
+        if (args.name !== undefined) updates.push(`token.name = ${JSON.stringify(args.name)}`);
+        if (args.value !== undefined) updates.push(`token.value = ${JSON.stringify(args.value)}`);
+        if (args.description !== undefined) updates.push(`token.description = ${JSON.stringify(args.description)}`);
+        if (updates.length === 0) {
+            return new TextResponse("Provide at least one of: name, value, description.");
+        }
+        const code = `
+const catalog = penpot.library.local.tokens;
+let token = null;
+for (const set of catalog.sets) {
+  token = set.getTokenById(${JSON.stringify(args.tokenId)});
+  if (token) break;
+}
+if (!token) throw new Error('Token not found: ' + ${JSON.stringify(args.tokenId)});
+${updates.join("\n")}
+return { id: token.id, name: token.name, type: token.type, value: token.value, description: token.description };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to update token.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}
+
+/**
+ * Update a token set (rename).
+ */
+export class UpdateTokenSetArgs {
+    static schema = {
+        setId: z.string().min(1, "setId cannot be empty").describe("Id of the token set to update."),
+        name: z.string().min(1, "name cannot be empty").describe("New name for the set."),
+    };
+    setId!: string;
+    name!: string;
+}
+
+export class UpdateTokenSetTool extends Tool<UpdateTokenSetArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, UpdateTokenSetArgs.schema);
+    }
+
+    getToolName(): string {
+        return "update_token_set";
+    }
+
+    getToolDescription(): string {
+        return "Renames an existing design token set. Returns the set id and new name.";
+    }
+
+    protected async executeCore(args: UpdateTokenSetArgs): Promise<ToolResponse> {
+        const code = `
+const set = penpot.library.local.tokens.getSetById(${JSON.stringify(args.setId)});
+if (!set) throw new Error('Token set not found: ' + ${JSON.stringify(args.setId)});
+set.name = ${JSON.stringify(args.name)};
+return { id: set.id, name: set.name };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to update token set.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}
+
+/**
+ * Update a token theme (name and/or group).
+ */
+export class UpdateTokenThemeArgs {
+    static schema = {
+        themeId: z.string().min(1, "themeId cannot be empty").describe("Id of the theme to update."),
+        name: z.string().optional().describe("New name for the theme."),
+        group: z.string().optional().describe("New group for the theme."),
+    };
+    themeId!: string;
+    name?: string;
+    group?: string;
+}
+
+export class UpdateTokenThemeTool extends Tool<UpdateTokenThemeArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, UpdateTokenThemeArgs.schema);
+    }
+
+    getToolName(): string {
+        return "update_token_theme";
+    }
+
+    getToolDescription(): string {
+        return "Updates an existing design token theme's name and/or group. Provide only the fields to change.";
+    }
+
+    protected async executeCore(args: UpdateTokenThemeArgs): Promise<ToolResponse> {
+        const updates: string[] = [];
+        if (args.name !== undefined) updates.push(`theme.name = ${JSON.stringify(args.name)}`);
+        if (args.group !== undefined) updates.push(`theme.group = ${JSON.stringify(args.group)}`);
+        if (updates.length === 0) {
+            return new TextResponse("Provide at least one of: name, group.");
+        }
+        const code = `
+const theme = penpot.library.local.tokens.getThemeById(${JSON.stringify(args.themeId)});
+if (!theme) throw new Error('Theme not found: ' + ${JSON.stringify(args.themeId)});
+${updates.join("\n")}
+return { id: theme.id, group: theme.group, name: theme.name };
+`;
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        const data = result.data?.result;
+        if (data === undefined) {
+            return new TextResponse("Failed to update token theme.");
+        }
+        return new TextResponse(JSON.stringify(data, null, 2));
+    }
+}

--- a/mcp/packages/server/vitest.config.ts
+++ b/mcp/packages/server/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        include: ["src/**/*.spec.ts"],
+        globals: false,
+    },
+    resolve: {
+        extensions: [".ts"],
+    },
+});

--- a/mcp/pnpm-lock.yaml
+++ b/mcp/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.30)
 
 packages:
 
@@ -121,6 +124,12 @@ packages:
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -133,6 +142,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -143,6 +158,12 @@ packages:
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -157,6 +178,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -169,6 +196,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -179,6 +212,12 @@ packages:
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -193,6 +232,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -203,6 +248,12 @@ packages:
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -217,6 +268,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -227,6 +284,12 @@ packages:
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -241,6 +304,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -251,6 +320,12 @@ packages:
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -265,6 +340,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -275,6 +356,12 @@ packages:
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -289,6 +376,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -301,6 +394,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -311,6 +410,12 @@ packages:
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -337,6 +442,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -359,6 +470,12 @@ packages:
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -385,6 +502,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -396,6 +519,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -409,6 +538,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -419,6 +554,12 @@ packages:
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -828,6 +969,35 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -871,6 +1041,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -883,6 +1057,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -891,6 +1069,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -898,6 +1080,10 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   class-transformer@0.5.1:
     resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
@@ -972,6 +1158,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1009,9 +1199,17 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1034,6 +1232,9 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1045,6 +1246,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -1177,6 +1382,12 @@ packages:
   libphonenumber-js@1.12.35:
     resolution: {integrity: sha512-T/Cz6iLcsZdb5jDncDcUNhSAJ0VlSC9TnsqtBNdpkaAmy24/R1RhErtNWVWBrcUZKs9hSgaVsBkc7HxYnazIfw==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -1251,6 +1462,13 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1399,6 +1617,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
@@ -1410,9 +1631,15 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1437,9 +1664,27 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1499,6 +1744,42 @@ packages:
     peerDependencies:
       vite: '>=5.2.13'
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1539,9 +1820,39 @@ packages:
       yaml:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -1602,10 +1913,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -1614,10 +1931,16 @@ snapshots:
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -1626,10 +1949,16 @@ snapshots:
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -1638,10 +1967,16 @@ snapshots:
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -1650,10 +1985,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -1662,10 +2003,16 @@ snapshots:
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -1674,10 +2021,16 @@ snapshots:
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -1686,16 +2039,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1710,6 +2072,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -1720,6 +2085,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1734,10 +2102,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -1746,10 +2120,16 @@ snapshots:
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -2046,6 +2426,46 @@ snapshots:
     dependencies:
       '@types/node': 20.19.30
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.30))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.30)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2080,6 +2500,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   atomic-sleep@1.0.0: {}
 
   body-parser@2.2.2:
@@ -2098,6 +2520,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2108,12 +2532,22 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  check-error@2.1.3: {}
 
   class-transformer@0.5.1: {}
 
@@ -2179,6 +2613,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   depd@2.0.0: {}
 
   detect-libc@2.1.2: {}
@@ -2205,9 +2641,37 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2273,6 +2737,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventsource-parser@3.0.6: {}
@@ -2280,6 +2748,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@7.5.1(express@5.2.1):
     dependencies:
@@ -2420,6 +2890,12 @@ snapshots:
 
   libphonenumber-js@1.12.35: {}
 
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-error@1.3.6: {}
 
   math-intrinsics@1.1.0: {}
@@ -2465,6 +2941,10 @@ snapshots:
   path-key@3.1.1: {}
 
   path-to-regexp@8.3.0: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2702,6 +3182,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   sonic-boom@4.2.0:
     dependencies:
       atomic-sleep: 1.0.0
@@ -2710,7 +3192,11 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2736,10 +3222,20 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   toidentifier@1.0.1: {}
 
@@ -2802,6 +3298,33 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  vite-node@2.1.9(@types/node@20.19.30):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.30):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.57.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+      fsevents: 2.3.3
+
   vite@7.3.1(@types/node@20.19.30):
     dependencies:
       esbuild: 0.27.2
@@ -2814,9 +3337,49 @@ snapshots:
       '@types/node': 20.19.30
       fsevents: 2.3.3
 
+  vitest@2.1.9(@types/node@20.19.30):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.30))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.30)
+      vite-node: 2.1.9(@types/node@20.19.30)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
### Related Ticket

<!-- New feature; a discussion issue can be opened if maintainers request it. -->

### Summary

Adds MCP server tools to create, list, and update design tokens so that design tokens can be managed from the Penpot MCP integration (e.g. from Cursor or other MCP clients).

**New tools:**
- `list_design_tokens` – list sets, themes, token overview, and tokens by set (with ids for updates)
- `create_token_set` – create a token set by name
- `create_token_theme` – create a theme (group + name)
- `create_token` – create a token in a set (type, name, value, optional description)
- `update_token` – update a token's name, value, and/or description
- `update_token_set` – rename a token set
- `update_token_theme` – update a theme's name and/or group

**Other dd Vitest and 26 unit tests for the design tokens tools (mocked plugin bridge).
- Run `pnpm --filter mcp-server run test` in MCP CI (tests-mcp.yml) as part of the existing Check step.
- CHANGES.md updated for 2.15.0.

### Steps to reproduce

1. Connect Penpot MCP (plugin) to the MCP server.
2. From an MCP client (e.g. Cursor), call `list_design_tokens` to see current sets/themes/tokens.
3. Call `create_token_set` with e.g. `name: "brand/light"`, then `create_token` with `setId`, `type: "color"`, `name: "color.primary"`, `value: "#0066FF"`.
4. Call `update_token` with the token id and new `name` or `value` to verify updates.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~Include screenshots or videos, if applicable.~ *(N/A – no UI changes)*
- [x] Add or modify existing integration tests in case of bugs or new feures, if applicable.
- [x] ~Refactor any modified SCSS files following the refactor guide.~ *(N/A – no SCSS changes)*
- [x] Check CI passes successfully. *(Verified locally: fmt:check, build, types:check, test all pass)*
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.