### PR TITLE
:wrench: Await promise correctly to fix tests flakyness

### DIFF
--- a/frontend/playwright/ui/specs/text-editor-v2.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v2.spec.js
@@ -10,7 +10,7 @@ test.beforeEach(async ({ page, context }) => {
 });
 
 test.afterEach(async ({ context }) => {
-  context.clearPermissions();
+  await context.clearPermissions();
 });
 
 test("Create a new text shape", async ({ page }) => {
@@ -27,7 +27,7 @@ test("Create a new text shape", async ({ page }) => {
   await workspace.waitForSelectedShapeName(initialText);
 });
 
-test("Create a new text shape from pasting text", async ({ page, context }) => {
+test("Create a new text shape from pasting text", async ({ page }) => {
   const textToPaste = "Lorem ipsum";
   const workspace = new WasmWorkspacePage(page, {
     textEditor: true,
@@ -49,7 +49,6 @@ test("Create a new text shape from pasting text", async ({ page, context }) => {
 
 test("Create a new text shape from pasting text using context menu", async ({
   page,
-  context,
 }) => {
   const textToPaste = "Lorem ipsum";
   const workspace = new WasmWorkspacePage(page, {
@@ -122,7 +121,6 @@ test.skip("Update an already created text shape by inserting text in between", a
 
 test("Update a new text shape appending text by pasting text", async ({
   page,
-  context,
 }) => {
   const textToPaste = " dolor sit amet";
   const workspace = new WasmWorkspacePage(page, {
@@ -144,7 +142,6 @@ test("Update a new text shape appending text by pasting text", async ({
 
 test.skip("Update a new text shape prepending text by pasting text", async ({
   page,
-  context,
 }) => {
   const textToPaste = "Dolor sit amet ";
   const workspace = new WasmWorkspacePage(page, {

--- a/frontend/playwright/ui/specs/variants.spec.js
+++ b/frontend/playwright/ui/specs/variants.spec.js
@@ -11,7 +11,7 @@ test.beforeEach(async ({ page, context }) => {
 });
 
 test.afterEach(async ({ context }) => {
-  context.clearPermissions();
+  await context.clearPermissions();
 });
 
 const setupVariantsFile = async (workspacePage) => {
@@ -176,7 +176,7 @@ test("User duplicates a variant container", async ({ page }) => {
   await validateVariant(variant_duplicate);
 });
 
-test("User copy paste a variant container", async ({ page, context }) => {
+test("User copy paste a variant container", async ({ page }) => {
   const workspacePage = new WasmWorkspacePage(page);
   // Access to the read/write clipboard necesary for this functionality
   await setupVariantsFileWithVariant(workspacePage);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13283

### Summary

`clearPermissions` async function was never awaited

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

