### PR TITLE
:tada: Text Editor v3 theme conf

### DIFF
--- a/render-wasm/src/render/text_editor.rs
+++ b/render-wasm/src/render/text_editor.rs
@@ -66,7 +66,7 @@ fn render_selection(
     }
 
     let mut paint = Paint::default();
-    paint.set_blend_mode(BlendMode::Multiply);
+    paint.set_blend_mode(BlendMode::default());
     paint.set_color(editor_state.theme.selection_color);
     paint.set_anti_alias(true);
 

--- a/render-wasm/src/state/text_editor.rs
+++ b/render-wasm/src/state/text_editor.rs
@@ -91,7 +91,7 @@ pub enum TextEditorEvent {
 }
 
 /// FIXME: It should be better to get these constants from the frontend through the API.
-const SELECTION_COLOR: Color = Color::from_argb(255, 0, 209, 184);
+const SELECTION_COLOR: Color = Color::from_argb(127, 0, 209, 184);
 const CURSOR_WIDTH: f32 = 1.5;
 const CURSOR_COLOR: Color = Color::BLACK;
 const CURSOR_BLINK_INTERVAL_MS: f64 = 530.0;

--- a/render-wasm/src/wasm/text_editor.rs
+++ b/render-wasm/src/wasm/text_editor.rs
@@ -6,6 +6,7 @@ use crate::utils::uuid_from_u32_quartet;
 use crate::utils::uuid_to_u32_quartet;
 use crate::{with_state, with_state_mut, STATE};
 use macros::ToJs;
+use skia_safe::Color;
 
 #[derive(PartialEq, ToJs)]
 #[repr(u8)]
@@ -22,6 +23,21 @@ pub enum CursorDirection {
 // ============================================================================
 // STATE MANAGEMENT
 // ============================================================================
+
+#[no_mangle]
+pub extern "C" fn text_editor_apply_theme(
+    selection_color: u32,
+    cursor_width: f32,
+    cursor_color: u32,
+) {
+    with_state_mut!(state, {
+        // NOTE: In the future could be interesting to fill al this data from
+        // a structure pointer.
+        state.text_editor_state.theme.selection_color = Color::new(selection_color);
+        state.text_editor_state.theme.cursor_width = cursor_width;
+        state.text_editor_state.theme.cursor_color = Color::new(cursor_color);
+    })
+}
 
 #[no_mangle]
 pub extern "C" fn text_editor_start(a: u32, b: u32, c: u32, d: u32) -> bool {


### PR DESCRIPTION
### Related Ticket

[Taiga Task #12885](https://tree.taiga.io/project/penpot/task/12885)
[Taiga Task #13495](https://tree.taiga.io/project/penpot/task/13495)

### Summary

- Adds a function to customize TextEditor theme.
- Changes how selection rects are rendered.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
