### PR TITLE
:wrench: Remove deleting node_modules on watch

### DIFF
--- a/frontend/scripts/watch
+++ b/frontend/scripts/watch
@@ -4,8 +4,6 @@ TARGET=${1:-app};
 
 set -ex
 
-rm -rf node_modules;
-
 corepack enable;
 corepack install;
 pnpm install;


### PR DESCRIPTION
Note: This is on `staging-render` because it gets merged regularly to `develop`, but not the other way around (and it's not urgent).