### PR TITLE
:sparkles: Finalise MCP package for PROD users

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,6 +1,7 @@
 .idea
 node_modules
 dist
+*.tgz
 *.bak
 *.orig
 temp

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -282,3 +282,5 @@ you may set the following environment variables to configure the two servers
 * The [contribution guidelines for Penpot](../CONTRIBUTING.md) apply
 * Auto-formatting: Use `pnpm run fmt`
 * Generating API type data: See [types-generator/README.md](types-generator/README.md)
+* Packaging and publishing:
+  - Create npm package: `bash scripts/pack` (sets version and then calls `npm pack`)

--- a/mcp/bin/mcp-local.js
+++ b/mcp/bin/mcp-local.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { execSync } = require("child_process");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+
+function run(command) {
+  execSync(command, { cwd: root, stdio: "inherit" });
+}
+
+try {
+  run("corepack pnpm run bootstrap");
+} catch (error) {
+  if (error.code === "ENOENT") {
+    console.error(
+      "corepack is required but was not found. It ships with Node.js >= 16."
+    );
+    process.exit(1);
+  }
+  process.exit(error.status ?? 1);
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penpot/mcp",
-  "version": "1.0.0",
+  "version": "2.13.3",
   "description": "MCP server for Penpot integration",
   "bin": {
     "penpot-mcp": "./bin/mcp-local.js"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "mcp-meta",
+  "name": "@penpot/mcp",
   "version": "1.0.0",
-  "description": "",
+  "description": "MCP server for Penpot integration",
+  "bin": {
+    "penpot-mcp": "./bin/mcp-local.js"
+  },
   "scripts": {
     "build": "pnpm -r run build",
     "build:multi-user": "pnpm -r run build:multi-user",
@@ -18,7 +21,6 @@
     "url": "https://github.com/penpot/penpot.git"
   },
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
-  "private": true,
   "devDependencies": {
     "concurrently": "^9.2.1",
     "prettier": "^3.0.0"

--- a/mcp/packages/plugin/src/task-handlers/ExecuteCodeTaskHandler.ts
+++ b/mcp/packages/plugin/src/task-handlers/ExecuteCodeTaskHandler.ts
@@ -190,6 +190,22 @@ export class ExecuteCodeTaskHandler extends TaskHandler<ExecuteCodeTaskParams> {
             return;
         }
 
+        // This version of the MCP plugin/server is intended for the old PROD version 2.13.3,
+        // in which the `flags` field is not yet present. If it is used with a newer version,
+        // show an informative error version explaining that the user should be using a different
+        // version of the MCP server.
+        // @ts-ignore
+        if (penpot.flags) {
+            throw new Error(
+                "You are using a version of the Penpot MCP server which is incompatible " +
+                    "with the connected Penpot version. " +
+                    "The MCP server version you are using is intended for Penpot 2.13. " +
+                    "Read the documentation for instructions on which version to use: " +
+                    "https://github.com/penpot/penpot/tree/develop/mcp\n" +
+                    "If you are an LLM, tell the user about this!"
+            );
+        }
+
         this.context.console.resetLog();
 
         const context = this.context;

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -132,7 +132,7 @@ Boards can have layout systems that automatically control the positioning and sp
       Check with: `if (board.grid) { ... }`
     - Properties: `rows`, `columns`, `rowGap`, `columnGap`
     - Children are positioned via 1-based row/column indices
-        - Add to grid via `board.flex.appendChild(shape, row, column)`
+        - Add to grid via `board.grid.appendChild(shape, row, column)`
         - Modify grid positioning after the fact via `shape.layoutCell: LayoutCellProperties`
 
   * When working with boards:

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -96,7 +96,7 @@ Use the `export_shape` and `import_image` tools to export and import images.
 Boards can have layout systems that automatically control the positioning and spacing of their children:
 
   * If a board has a layout system, then child positions are controlled by the layout system.
-    For every child, key properties of the child within the layout are stored in `child.layoutChild: LayoutChildProperties`:
+    After adding a shape to the layout as a child, key properties of the child within the layout are controlled in `child.layoutChild: LayoutChildProperties`:
     - `absolute: boolean` - if true, child position is not controlled by layout system. x/y will set *relative* position within parent!
     - margins (`topMargin`, `rightMargin`, `bottomMargin`, `leftMargin` or combined `verticalMargin`, `horizontalMargin`)
     - sizing (`verticalSizing`, `horizontalSizing`: "fill" | "auto" | "fix")

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -85,6 +85,8 @@ Actual low-level shape types are `Rectangle`, `Path`, `Text`, `Ellipse`, `Image`
 
 Cloning: Use `shape.clone(): Shape` to create an exact duplicate (including all properties and children) of a shape; same position as original.
 
+Annotations: Don't add text elements to the design that just repeat a shape's name. In the Penpot UI, the name is displayed anyway.
+
 # Images
 
 The `Image` type is a legacy type. Images are now typically embedded in a `Fill`, with `fillImage` set to an

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -45,6 +45,8 @@ Actual low-level shape types are `Rectangle`, `Path`, `Text`, `Ellipse`, `Image`
   * `name` - Shape name
   * `fills: Fill[]`, `strokes: Stroke[]`, `shadows: Shadow[]` - Styling properties
     - Setting fills: `shape.fills = [{ fillColor: "#FF0000", fillOpacity: 1 }]`; no fill (transparent): `shape.fills = []`; 
+    - Reusing objects in another shape: `targetShape.fills = sourceShape.fills` or more granular `targetShape.fills = [{ fillOpacity: 1, fillImage: sourceShape.fills[0].fillImage }]`
+      The objects are not shared references; you can modify properties of the fills in the target shape without affecting the source shape.
     - Colors: Use hex strings with caps only (e.g. '#FF5533')
     - IMPORTANT: The contents of the arrays are read-only. You cannot modify individual fills/strokes; you need to replace the entire array to change them!  
   * `borderRadius` - Uniform border radius for all corners

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -228,30 +228,75 @@ Each `Library` object has:
   * `colors: LibraryColor[]` - Array of colors
   * `typographies: LibraryTypography[]` - Array of typographies
 
+## Colors and Typographies
+
+Adding a color:
+```
+const newColor: LibraryColor = penpot.library.local.createColor();
+newColor.name = 'Brand Primary';
+newColor.color = '#0066FF';
+```
+
+Adding a typography:
+```
+const newTypo: LibraryTypography = penpot.library.local.createTypography();
+newTypo.name = 'Heading Large';
+// Set typography properties...
+```
+
+## Components
+
 Using library components:
   * find a component in the library by name:
-      const component: LibraryComponent = library.components.find(comp => comp.name.includes('Button'));
+    `const component: LibraryComponent = library.components.find(comp => comp.name.includes('Button'));`
   * create a new instance of the component on the current page:
-      const instance: Shape = component.instance();
+    `const instance: Shape = component.instance();`
     This returns a `Shape` (often a `Board` containing child elements).
     After instantiation, modify the instance's properties as desired.
   * get the reference to the main component shape:
-      const mainShape: Shape = component.mainInstance();
+    `const mainShape: Shape = component.mainInstance();`
 
-Adding assets to a library:
-  * const newColor: LibraryColor = penpot.library.local.createColor();
-    newColor.name = 'Brand Primary';
-    newColor.color = '#0066FF';
-  * const newTypo: LibraryTypography = penpot.library.local.createTypography();
-    newTypo.name = 'Heading Large';
-    // Set typography properties...
-  * const shapes: Shape[] = [shape1, shape2]; // shapes to include
-    const newComponent: LibraryComponent = penpot.library.local.createComponent(shapes);
-    newComponent.name = 'My Button';
+Adding a component to a library:
+```
+const shapes: Shape[] = [shape1, shape2]; // shapes to include
+const newComponent: LibraryComponent = penpot.library.local.createComponent(shapes);
+newComponent.name = 'My Button';
+```
 
 Detaching:
   * When creating new design elements based on a component instance/copy, use `shape.detach()` to break the link to the main component, allowing independent modification.
   * Without detaching, some manipulations will have no effect; e.g. child/descendant removal will not work.
+
+### Variants
+
+Variants are a system for grouping related component versions along named property axes (e.g. Type, Style), powering a structured swap UI for designers using component instances.
+
+* `VariantContainer` (extends `Board`): The board that physically groups all variant components together. 
+  - check with `isVariantContainer()`
+  - property `variants: Variants`.
+* `Variants`: Defines the combinations of property values for which component variants can exist and manages the concrete component variants. 
+  - `properties: string[]` (ordered list of property names); `addProperty()`, `renameProperty(pos, name)`, `currentValues(property)`
+  - `variantComponents(): LibraryVariantComponent[]` 
+* `LibraryVariantComponent` (extends `LibraryComponent`): full library component with metadata, for which `isVariant()` returns true.
+  - `variantProps: { [property: string]: string }` (this component's value for each property)
+  - `variantError` (non-null if e.g. two variants share the same combination of property values)
+  - `setVariantProperty(pos, value)`
+
+Properties are often addressed positionally: `pos` parameter in various methods = index in `Variants.properties`.
+
+**Creating a variant group**:
+- `component.transformInVariant(): null`: Converts a standard component into a variant group, creating a `VariantContainer` and a second duplicate variant. 
+  Both start with a default property `Property 1` with values `Value 1` / `Value 2`; there is no name-based auto-parsing.
+- `board.combineAsVariants(ids: string[]): null`: Combines the board (a main component instance) with other main components (referenced via IDs) into a new variant group. 
+  All components end up inside a single new `VariantContainer` on the canvas.
+- In both cases, look for the created `VariantContainer` on the page, and then edit properties using `variants.renameProperty(pos, name)`, `variants.addProperty()`, and `comp.setVariantProperty(pos, value)`.
+
+**Adding a variant to an existing group**:
+Use `variantContainer.appendChild(mainInstance)` to move a component's main instance into the container, then set its position manually and assign property values via `setVariantProperty`.
+
+**Using Variants**:
+- `compInstance.switchVariant(pos, value)`: On a component instance, switches to the nearest variant that has the given value at property position `pos`, keeping all other property values the same.
+- To instantiate a specific variant, find the right `LibraryVariantComponent` by checking `variantProps`, then call `.instance()`.
 
 # Design Tokens
 

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -43,10 +43,19 @@ Actual low-level shape types are `Rectangle`, `Path`, `Text`, `Ellipse`, `Image`
 
 **Other Writable Properties**:
   * `name` - Shape name
-  * `fills`, `strokes` - Styling properties
-    IMPORTANT: The contents of the arrays are read-only. You cannot modify individual fills/strokes; you need to replace the entire array to change them, e.g.
-    `shape.fills = [{ fillColor: "#FF0000", fillOpacity: 1 }]` to set a single red fill.
-  * `rotation`, `opacity`, `blocked`, `hidden`, `visible`
+  * `fills: Fill[]`, `strokes: Stroke[]`, `shadows: Shadow[]` - Styling properties
+    - Setting fills: `shape.fills = [{ fillColor: "#FF0000", fillOpacity: 1 }]`; no fill (transparent): `shape.fills = []`; 
+    - Colors: Use hex strings with caps only (e.g. '#FF5533')
+    - IMPORTANT: The contents of the arrays are read-only. You cannot modify individual fills/strokes; you need to replace the entire array to change them!  
+  * `borderRadius` - Uniform border radius for all corners
+  * `borderRadiusTopLeft`, `borderRadiusTopRight`, `borderRadiusBottomRight`, `borderRadiusBottomLeft` - Individual corner radii.
+  * `blur: Blur` - Blur properties
+  * `blendMode` - Blend mode (e.g. `"normal"`, `"multiply"`, `"overlay"`, etc.)
+  * `rotation` (deg), `opacity`, `blocked`, `hidden`, `visible`
+  * `proportionLock` - Whether width and height are locked to the same ratio
+  * `constraintsHorizontal` - Horizontal resize constraint (`"left"`, `"right"`, `"center"`, `"leftright"`, `"scale"`)
+  * `constraintsVertical` - Vertical resize constraint (`"top"`, `"bottom"`, `"center"`, `"topbottom"`, `"scale"`)
+  * `flipX`, `flipY` - Horizontal/vertical flip
 
 **Z-Order**:
   * The z-order of shapes is determined by the order in the `children` array of the parent shape.
@@ -358,7 +367,7 @@ Applying tokens:
      - The actual shape properties that the tokens control will reflect the token's resolved value.
 
 Removing tokens:
-  Simply set the respective property directly - token binding is automatically removed, e.g.
+  Simply set the respective property directly - token binding is automatically removed, e.g.  
   shape.fills = [{ fillColor: "#000000", fillOpacity: 1 }]; // Removes fill token
 
 # Visual Inspection of Designs

--- a/mcp/packages/server/package.json
+++ b/mcp/packages/server/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build:server": "esbuild src/index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.js --external:@modelcontextprotocol/* --external:ws --external:express --external:class-transformer --external:class-validator --external:reflect-metadata --external:pino --external:pino-pretty --external:js-yaml --external:sharp",
-    "build": "pnpm run build:server && cp -r src/static dist/static && cp -r data dist/data",
+    "build": "pnpm run build:server && node scripts/copy-resources.js",
     "build:multi-user": "pnpm run build",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "start": "node dist/index.js",

--- a/mcp/packages/server/scripts/copy-resources.js
+++ b/mcp/packages/server/scripts/copy-resources.js
@@ -1,0 +1,5 @@
+import { cpSync } from "fs";
+
+// copy static assets and data to dist
+cpSync("src/static", "dist/static", { recursive: true });
+cpSync("data", "dist/data", { recursive: true });

--- a/mcp/scripts/pack
+++ b/mcp/scripts/pack
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Sets the version from Git tags, then produces the npm tarball.
+# Must be invoked directly (not via npm/pnpm) so that the version
+# is written to package.json before npm reads it.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+bash ./scripts/set-version
+npm pack

--- a/mcp/scripts/set-version
+++ b/mcp/scripts/set-version
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Derives a valid npm semver version from the Git tag produced by
+# `git describe` and writes it into the root package.json.
+#
+# Examples of the conversion:
+#   2.14.0                     ->  2.14.0
+#   2.14.0-RC1                 ->  2.14.0-rc.1
+#   2.14.0-RC1-140-g9f2ca9965  ->  2.14.0-rc.1.140
+#   2.14.0-140-g9f2ca9965      ->  2.14.1-dev.140
+#
+# The last case (commits after a release tag) bumps the patch level so
+# the resulting semver sorts higher than the release.
+
+set -euo pipefail
+
+raw=$(git describe --tags --match "*.*.*")
+
+# Parse: <major>.<minor>.<patch>[-<label><n>][-<commits>-g<hash>]
+if [[ "$raw" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(-([A-Za-z]+)([0-9]*))?(-([0-9]+)-g[0-9a-f]+)?$ ]]; then
+    base="${BASH_REMATCH[1]}"
+    label="${BASH_REMATCH[3]}"        # e.g. RC
+    label_num="${BASH_REMATCH[4]}"    # e.g. 1
+    commits="${BASH_REMATCH[6]}"      # e.g. 140
+
+    # build dot-separated pre-release identifiers
+    pre=""
+    if [[ -n "$label" ]]; then
+        pre="${label,,}"  # use lower-case label
+        [[ -n "$label_num" ]] && pre="${pre}.${label_num}"
+    elif [[ -n "$commits" ]]; then
+        # commits after a release tag: bump patch, mark as dev
+        IFS='.' read -r major minor patch <<< "$base"
+        base="${major}.${minor}.$((patch + 1))"
+        pre="dev"
+    fi
+    [[ -n "$commits" && -n "$pre" ]] && pre="${pre}.${commits}"
+
+    if [[ -n "$pre" ]]; then
+        version="${base}-${pre}"
+    else
+        version="$base"
+    fi
+else
+    echo "ERROR: Cannot parse version from git describe output: $raw" >&2
+    exit 1
+fi
+
+cd "$(dirname "$0")/.."
+npm pkg set "version=${version}"
+echo "$version"


### PR DESCRIPTION
This updates the `mcp-prod` branch for PROD users of the MCP server and prepares the release of the npm package for PROD users.

* Cherry-pick MCP improvements that also apply to PROD users
* Cherry-pick npm build script & set version to `2.13.3` for the release
* Add version check to plugin (checking that `penpot.flags` does not exist) and throw exception if mismatch