### PR TITLE
:sparkles: Add navigation to nitrate from the sidebar

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -304,7 +304,12 @@
          (fn []
            (if (dm/get-in profile [:props :nitrate-license :valid])
              (dnt/go-to-nitrate-cc)
-             (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))]
+             (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
+
+        on-go-to-cc-click
+        (mf/use-fn
+         (fn []
+           (dnt/go-to-nitrate-cc)))]
 
     [:> dropdown-menu* props
 
@@ -349,7 +354,15 @@
        [:> dropdown-menu-item* {:on-click    on-create-org-click
                                 :class       (stl/css :team-dropdown-item :action)}
         [:span {:class (stl/css :icon-wrapper)} add-icon]
-        [:span {:class (stl/css :team-text)} (tr "dashboard.create-new-org")]])]))
+        [:span {:class (stl/css :team-text)} (tr "dashboard.create-new-org-menu")]])
+
+     (when allow-create-org
+       [:hr {:role "separator" :class (stl/css :team-separator)}]
+       [:> dropdown-menu-item* {:on-click    on-go-to-cc-click
+                                :class       (stl/css :team-dropdown-item :action)}
+
+        [:span {:class (stl/css :icon-wrapper)} [:> icon* {:icon-id i/open-link}]]
+        [:span {:class (stl/css :team-text)} (tr "dashboard.go-to-control-center")]])]))
 
 (mf/defc team-options-dropdown*
   {::mf/private true}
@@ -560,9 +573,9 @@
                     :class (stl/css :nitrate-create-org)
                     :on-click on-create-org-click} (tr "dashboard.create-new-org")]]
 
-      [:div {:class (stl/css :sidebar-team-switch)}
-       [:div {:class (stl/css :switch-content)}
-        [:button {:class (stl/css :current-team)
+      [:div {:class (stl/css :sidebar-team-switch :sidebar-org-switch)}
+       [:div {:class (stl/css :switch-content :org-switch-content)}
+        [:button {:class (stl/css :current-team :current-org)
                   :on-click on-show-teams-click
                   :on-key-down on-show-teams-keydown}
 

--- a/frontend/src/app/main/ui/dashboard/sidebar.scss
+++ b/frontend/src/app/main/ui/dashboard/sidebar.scss
@@ -111,6 +111,22 @@
   overflow: hidden;
 }
 
+// SIDEBAR ORG SWITCH
+.sidebar-org-switch {
+  width: 100%;
+  margin: 0;
+}
+
+.org-switch-content {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.current-org {
+  padding: 0 var(--sp-s) 0 var(--sp-l);
+}
+
 // This icon still use the old svg
 .penpot-icon {
   @include deprecated.flexCenter;
@@ -527,7 +543,6 @@
   max-height: calc(2 * var(--sp-xxxl));
   justify-content: space-between;
   padding: var(--sp-xs) var(--sp-l) var(--sp-xs) var(--sp-s);
-  // border-block-end: $b-1 solid var(--color-background-quaternary);
 }
 
 .nitrate-orgs-empty {

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -8840,3 +8840,9 @@ msgstr "Autosaved versions will be kept for %s days."
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Click to close the path"
+
+msgid "dashboard.create-new-org-menu"
+msgstr "Create org"
+
+msgid "dashboard.go-to-control-center"
+msgstr "Go to control center"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -8692,3 +8692,9 @@ msgstr "Los autoguardados duran %s días."
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Pulsar para cerrar la ruta"
+
+msgid "dashboard.create-new-org-menu"
+msgstr "Crear org"
+
+msgid "dashboard.go-to-control-center"
+msgstr "Ir al control center"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13538

### Summary

Navigate to control center from the orgs dropdown.

### Steps to reproduce 

You need to have a Nitrate subscription and some orgs created.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.