### PR TITLE
:bug: Fix collapsible sidebar property titles not toggling on click

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 
 - Fix Alt/Option to draw shapes from center point (by @offreal) [Github #8361](https://github.com/penpot/penpot/pull/8361)
 - Add token name on broken token pill on sidebar [Taiga #13527](https://tree.taiga.io/project/penpot/issue/13527)
+- Fix collapsible sidebar property titles not toggling on click [Github #5168](https://github.com/penpot/penpot/issues/5168)
 
 
 ## 2.14.0 (Unreleased)

--- a/frontend/src/app/main/ui/components/title_bar.cljs
+++ b/frontend/src/app/main/ui/components/title_bar.cljs
@@ -13,30 +13,21 @@
 
 (mf/defc title-bar*
   [{:keys [class collapsable collapsed title children
-           btn-icon btn-title all-clickable add-icon-gap
+           btn-icon btn-title add-icon-gap
            title-class on-collapsed on-btn-click]}]
-  [:div {:class [(stl/css-case :title-bar true
-                               :all-clickable all-clickable)
+  [:div {:class [(stl/css :title-bar)
                  class]}
 
    (if ^boolean collapsable
      [:div {:class [(stl/css :title-wrapper) title-class]}
 
       (let [icon-id (if collapsed "arrow-right" "arrow-down")]
-        (if ^boolean all-clickable
-          [:button {:class (stl/css :icon-text-btn)
-                    :on-click on-collapsed}
-           [:> icon* {:icon-id icon-id
-                      :size "s"
-                      :class (stl/css :icon)}]
-           [:div {:class (stl/css :title)} title]]
-          [:*
-           [:button {:class (stl/css :icon-btn)
-                     :on-click on-collapsed}
-            [:> icon* {:icon-id icon-id
-                       :size "s"
-                       :class (stl/css :icon)}]]
-           [:div {:class (stl/css :title)} title]]))]
+        [:button {:class (stl/css :icon-text-btn)
+                  :on-click on-collapsed}
+         [:> icon* {:icon-id icon-id
+                    :size "s"
+                    :class (stl/css :icon)}]
+         [:div {:class (stl/css :title)} title]])]
 
      [:div {:class [(stl/css-case :title-only true
                                   :title-only-icon-gap add-icon-gap)

--- a/frontend/src/app/main/ui/components/title_bar.scss
+++ b/frontend/src/app/main/ui/components/title_bar.scss
@@ -75,12 +75,3 @@
     --title-color: var(--title-foreground-color-hover);
   }
 }
-
-.icon-btn {
-  @include deprecated.buttonStyle;
-  @include deprecated.flexCenter;
-
-  &:hover {
-    --arrow-icon-color: var(--icon-foreground-hover);
-  }
-}

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -172,7 +172,6 @@
      [:> title-bar*
       {:collapsable   (< 0 assets-count)
        :collapsed     (not is-open)
-       :all-clickable true
        :on-collapsed  on-collapsed
        :add-icon-gap  (= 0 assets-count)
        :title         title}

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.cljs
@@ -101,7 +101,6 @@
                    :open is-open)}
      [:> title-bar* {:collapsable    true
                      :collapsed      (not is-open)
-                     :all-clickable  true
                      :on-collapsed   toggle-open
                      :title          (if is-local
                                        (mf/html [:div {:class (stl/css :special-title)}

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs
@@ -51,7 +51,6 @@
               :on-context-menu on-context-menu}
         [:> title-bar* {:collapsable    true
                         :collapsed      (not is-group-open)
-                        :all-clickable  true
                         :on-collapsed   on-fold-group
                         :title          (mf/html [:* (when-not (empty? other-path)
                                                        [:span {:class (stl/css :pre-path)

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -260,7 +260,6 @@
      [:> title-bar* {:collapsable   true
                      :collapsed     collapsed
                      :on-collapsed  on-toggle-collapsed
-                     :all-clickable true
                      :title         (tr "workspace.sidebar.sitemap")
                      :class         (stl/css :title-spacing-sitemap)}
 


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/5168

### Summary

Collapsible property sections in the right sidebar (fill, stroke, shadows, blur, text, constraints, etc.) could only be toggled by clicking the small arrow icon. Clicking the title text did nothing despite showing a hover state.

The root cause was in the shared `title-bar*` component: when the `all-clickable` prop was not passed (which was the case for all menu sections), the `<button>` element only wrapped the arrow icon, leaving the title text as a non-interactive sibling `<div>`.

Fixed by making the button always wrap both the icon and title text when `collapsable` is true, and removed the now-unnecessary `all-clickable` prop from the component and its 4 call sites that previously needed it.

### Steps to reproduce

1. Draw a rectangle shape
2. Move cursor to any collapsible property (e.g. FILL) in the right sidebar
3. Click on the title text (not the arrow icon)
4. Verify the section now toggles between expanded and collapsed

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->