### PR TITLE
:bug: Fix WebGL context lost error

### DIFF
--- a/frontend/playwright/ui/specs/render-wasm.spec.js
+++ b/frontend/playwright/ui/specs/render-wasm.spec.js
@@ -16,6 +16,29 @@ test.skip("BUG 10867 - Crash when loading comments", async ({ page }) => {
   ).toBeVisible();
 });
 
+test("BUG 13541 - Shows error page when WebGL context is lost", async ({
+  page,
+}) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.goToWorkspace();
+  await workspacePage.waitForFirstRender();
+
+  // Simulate a WebGL context loss by dispatching the event on the canvas
+  await workspacePage.canvas.evaluate((canvas) => {
+    const event = new Event("webglcontextlost", { cancelable: true });
+    canvas.dispatchEvent(event);
+  });
+
+  await expect(
+    page.getByText("Oops! The canvas context was lost"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("WebGL has stopped working"),
+  ).toBeVisible();
+  await expect(page.getByText("Reload page")).toBeVisible();
+});
+
 test.skip("BUG 12164 - Crash when trying to fetch a missing font", async ({
   page,
 }) => {

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -127,6 +127,13 @@
     (ex/print-throwable cause :prefix "WASM critical error"))
   (st/emit! (rt/assign-exception error)))
 
+(defmethod ptk/handle-error :wasm-exception
+  [error]
+  (when-let [cause (::instance error)]
+    (let [prefix (or (:prefix error) "Exception")]
+      (ex/print-throwable cause :prefix prefix)))
+  (st/emit! (rt/assign-exception error)))
+
 ;; We receive a explicit authentication error; If the uri is for
 ;; workspace, dashboard, viewer or settings, then assign the exception
 ;; for show the error page. Otherwise this explicitly clears all
@@ -343,7 +350,7 @@
               (set! last-exception cause)
               (let [data (ex-data cause)
                     type (get data :type)]
-                (if (#{:wasm-critical :wasm-non-blocking} type)
+                (if (#{:wasm-critical :wasm-non-blocking :wasm-exception} type)
                   (on-error cause)
                   (when-not (is-ignorable-exception? cause)
                     (ex/print-throwable cause :prefix "Uncaught Exception")

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -478,8 +478,12 @@
       :service-unavailable
       [:> service-unavailable*]
 
-      :webgl-context-lost
-      [:> webgl-context-lost*]
+      :wasm-exception
+      (case (get data :exception-type)
+        :webgl-context-lost
+        [:> webgl-context-lost*]
+
+        [:> internal-error* props])
 
       [:> internal-error* props])))
 

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -1421,7 +1421,9 @@
   (dom/prevent-default event)
   (reset! wasm/context-lost? true)
   (log/warn :hint "WebGL context lost")
-  (ex/raise :type :webgl-context-lost
+  (ex/raise :type :wasm-exception
+            :exception-type :webgl-context-lost
+            :prefix "WebGL context lost"
             :hint "WebGL context lost"))
 
 (defn init-canvas-context


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13541

### Summary

Raise an exception and show the exception page on the webgl context lost situation

[screen-recorder-mon-mar-09-2026-16-44-27.webm](https://github.com/user-attachments/assets/b635f9dd-9e99-481f-9db5-78b4b23b2512)

### Steps to reproduce 

1. Open a file
2. Open the console
3. Paste this code to force the exception:

```js
const canvas = document.querySelector('canvas');
const gl = canvas.getContext('webgl2');
const ext = gl.getExtension('WEBGL_lose_context');
ext.loseContext()
```

4. Check the exception is shown and it's possible to reload the page

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
