### PR TITLE
:bug: Fix ordering of absolute shapes with no z-index

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2180,13 +2180,13 @@ impl RenderState {
                         ids.reverse();
                     }
                     // Sort by z_index descending (higher z renders on top).
-                    // When z_index is equal, absolute children go behind
-                    // non-absolute children (false < true).
+                    // When z_index is equal, absolute children go above
+                    // non-absolute children
                     ids.sort_by_key(|id| {
                         let s = tree.get(id);
                         let z = s.map(|s| s.z_index()).unwrap_or(0);
                         let abs = s.map(|s| s.is_absolute()).unwrap_or(false);
-                        (std::cmp::Reverse(z), abs)
+                        (std::cmp::Reverse(z), !abs)
                     });
                     ids
                 } else {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13536

### Summary

Fixes display order on absolute-positioned elements with no z-index (see the bell notifications icon in here).

<img width="857" height="218" alt="z-index bug" src="https://github.com/user-attachments/assets/954e3a0f-5fd4-418f-ace7-7c236b031777" />

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
