### PR TITLE
:bug: Fix appendChild/insertChild index logic in plugin shape proxy

### DIFF
--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -961,9 +961,9 @@
 
                  :else
                  (let [child-id     (obj/get child "$id")
-                       is-reversed? (ctl/flex-layout? shape)
+                       is-flex?     (ctl/flex-layout? shape)
                        index
-                       (if (or (not (natural-child-ordering? plugin-id)) is-reversed?)
+                       (if (and (natural-child-ordering? plugin-id) is-flex?)
                          0
                          (count (:shapes shape)))]
                    (st/emit! (dwsh/relocate-shapes #{child-id} id index))))))
@@ -985,10 +985,10 @@
                  (u/display-not-valid :insertChild "Plugin doesn't have 'content:write' permission")
 
                  :else
-                 (let [child-id (obj/get child "$id")
-                       is-reversed? (ctl/flex-layout? shape)
+                 (let [child-id  (obj/get child "$id")
+                       is-flex?  (ctl/flex-layout? shape)
                        index
-                       (if (or (not (natural-child-ordering? plugin-id)) is-reversed?)
+                       (if (and (natural-child-ordering? plugin-id) is-flex?)
                          (- (count (:shapes shape)) index)
                          index)]
                    (st/emit! (dwsh/relocate-shapes #{child-id} id index))))))


### PR DESCRIPTION
## Related issues

Bug 2 from https://github.com/penpot/penpot/issues/8520

###  Summary
#### Symptom

`board.appendChild(shape)` does not reliably insert the child at the visual end of the children list for non-flex boards. The shape ends up at the bottom of the z-stack rather than on top.

#### Background: internal vs. visual child order

Penpot's internal `[:shapes]` vector stores children in **z/stacking order**: index 0 is at the bottom (rendered first, occluded by later entries). For non-flex shapes this is also the "natural" order exposed by the API.

For **flex layout** frames, the API (when `naturalChildOrdering` is enabled) presents children in **visual order**, which is the reverse of the internal vector. Index 0 of `children` is the first visual child, which lives at the *end* of the internal `[:shapes]` vector. 

This reversal is implemented in the `getChildren` getter (`shape.cljs` lines 936–944): it applies `reverse` to the `[:shapes]` vector when `(and (natural-child-ordering? plugin-id) (ctl/flex-layout? shape))`.

#### Root cause — `appendChild`

Old code (`shape.cljs:962–969`):

```clojure
(let [is-reversed? (ctl/flex-layout? shape)
      index
      (if (or (not (natural-child-ordering? plugin-id)) is-reversed?)
        0
        (count (:shapes shape)))]
  ...)
```

The condition `(or (not naturalChildOrdering?) is-reversed?)` is true whenever `naturalChildOrdering` is off **or** the shape is a flex layout. For a non-flex board with the default (`naturalChildOrdering` off), this evaluates to
`(or true false) = true`, so the shape is always inserted at index `0` — the bottom of the z-stack, not the top.

"Append" should always mean "on top" (highest z-index), i.e. `(count :shapes)`. The only exception is a flex layout with `naturalChildOrdering` on, where visual-last corresponds to internal index `0`.

#### Root cause — `insertChild`

Old code (`shape.cljs:987–994`):

```clojure
(let [is-reversed? (ctl/flex-layout? shape)
      index
      (if (or (not (natural-child-ordering? plugin-id)) is-reversed?)
        (- (count (:shapes shape)) index)
        index)]
  ...)
```

The inversion `(- count index)` was applied for all cases where `naturalChildOrdering` was off — including non-flex boards, where logical index and internal index are the same and no inversion is needed. This caused `insertChild(i, shape)` on a non-flex board to place the shape at `count - i` instead of `i`.

Conversely, for a flex layout with `naturalChildOrdering` on (the one case that  actually requires inversion), the old code took the `else` branch and passed `i` directly, which was also wrong.

#### Fix

The correct gating condition for both methods is `(and (natural-child-ordering? plugin-id) (ctl/flex-layout? shape))` — the inversion only applies when the API is presenting children in reversed visual order, which only happens for flex layouts with `naturalChildOrdering` enabled. 

**`appendChild`** — new logic:
- `(and naturalChildOrdering? flex?)` → insert at `0` (visual end = internal front)
- otherwise → insert at `(count :shapes)` (on top of z-stack)

**`insertChild`** — new logic:
- `(and naturalChildOrdering? flex?)` → internal index = `(count :shapes) - i`
- otherwise → internal index = `i` (direct pass-through)

This is consistent with how `getChildren` reverses the array only for
flex+naturalChildOrdering, ensuring `insertChild(i, shape)` places the shape at
the same position that `children[i]` would read it back from.

#### Behaviour matrix after fix

##### `appendChild`

| Shape type   | `naturalChildOrdering` | Index used   | Result              |
|--------------|------------------------|--------------|---------------------|
| non-flex     | OFF (default)          | `count`      | on top of z-stack ✓ |
| non-flex     | ON                     | `count`      | on top of z-stack ✓ |
| flex layout  | OFF                    | `count`      | visual end ✓        |
| flex layout  | ON                     | `0`          | visual end ✓        |

##### `insertChild(i, shape)`

| Shape type   | `naturalChildOrdering` | Internal index | Consistent with `children[i]` |
|--------------|------------------------|----------------|-------------------------------|
| non-flex     | OFF                    | `i`            | ✓                             |
| non-flex     | ON                     | `i`            | ✓                             |
| flex layout  | OFF                    | `i`            | ✓                             |
| flex layout  | ON                     | `count - i`    | ✓                             |

#### Changed file

`frontend/src/app/plugins/shape.cljs` — `:appendChild` and `:insertChild`
handlers (lines 962–994).
