### PR TITLE
:bug: Fix number token applying rotation when line-height attr is specified

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -792,7 +792,8 @@
             unapply-tokens?
             (cfo/shapes-token-applied? token shapes (or attrs all-attributes attributes))
 
-            shape-ids (map :id shapes)]
+            shape-ids
+            (map :id shapes)]
 
         (if unapply-tokens?
           (rx/of

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -741,8 +741,16 @@
                     shapes)
               shapes)
 
-            {:keys [attributes all-attributes on-update-shape]}
+            {:keys [attributes all-attributes on-update-shape on-update-shape-per-attr]}
             (get token-properties (:type token))
+
+            on-update-shape
+            (or (when (seq attrs)
+                  (some (fn [[attr-set update-fn]]
+                          (when (set/subset? attrs attr-set)
+                            update-fn))
+                        on-update-shape-per-attr))
+                on-update-shape)
 
             unapply-tokens?
             (cfo/shapes-token-applied? token shapes (or attrs all-attributes attributes))
@@ -928,6 +936,8 @@
     :attributes ctt/rotation-keys
     :all-attributes ctt/number-keys
     :on-update-shape update-rotation
+    :on-update-shape-per-attr {ctt/rotation-keys  update-rotation
+                               ctt/line-height-keys update-line-height}
     :modal {:key :tokens/number
             :fields [{:label "Number"
                       :key :number}]}}

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -609,6 +609,46 @@
 
 ;; Events to apply / unapply tokens to shapes ------------------------------------------------------------
 
+(def attributes->shape-update
+  "Maps each attribute-set to the update function that applies it to a shape.
+  Used both here (to resolve the correct update fn when explicit attrs are
+  passed to toggle-token) and in propagation.cljs (re-exported from there)."
+  {ctt/border-radius-keys  update-shape-radius-for-corners
+   ctt/color-keys          update-fill-stroke
+   ctt/stroke-width-keys   update-stroke-width
+   ctt/sizing-keys         apply-dimensions-token
+   ctt/opacity-keys        update-opacity
+   ctt/rotation-keys       update-rotation
+
+   ;; Typography
+   ctt/font-family-keys     update-font-family
+   ctt/font-size-keys       update-font-size
+   ctt/font-weight-keys     update-font-weight
+   ctt/letter-spacing-keys  update-letter-spacing
+   ctt/text-case-keys       update-text-case
+   ctt/text-decoration-keys update-text-decoration
+   ctt/typography-token-keys update-typography
+   ctt/shadow-keys          update-shadow
+   ctt/line-height-keys     update-line-height
+
+   ;; Layout
+   #{:x :y}                        update-shape-position
+   #{:p1 :p2 :p3 :p4}              update-layout-padding
+   #{:m1 :m2 :m3 :m4}              update-layout-item-margin
+   #{:column-gap :row-gap}          update-layout-gap
+   #{:width :height}                apply-dimensions-token
+   #{:layout-item-min-w :layout-item-min-h
+     :layout-item-max-w :layout-item-max-h} update-layout-sizing-limits})
+
+;; Flattened per-individual-key version of attributes->shape-update.
+;; Allows O(1) lookup of the update function for any single attribute.
+(def ^:private attr->shape-update
+  (reduce
+   (fn [acc [attr-set update-fn]]
+     (into acc (map (fn [k] [k update-fn]) attr-set)))
+   {}
+   attributes->shape-update))
+
 (defn apply-token
   "Apply `attributes` that match `token` for `shape-ids`.
 
@@ -741,16 +781,13 @@
                     shapes)
               shapes)
 
-            {:keys [attributes all-attributes on-update-shape on-update-shape-per-attr]}
+            {:keys [attributes all-attributes on-update-shape]}
             (get token-properties (:type token))
 
             on-update-shape
-            (or (when (seq attrs)
-                  (some (fn [[attr-set update-fn]]
-                          (when (set/subset? attrs attr-set)
-                            update-fn))
-                        on-update-shape-per-attr))
-                on-update-shape)
+            (if (seq attrs)
+              (or (get attr->shape-update (first attrs)) on-update-shape)
+              on-update-shape)
 
             unapply-tokens?
             (cfo/shapes-token-applied? token shapes (or attrs all-attributes attributes))
@@ -936,8 +973,6 @@
     :attributes ctt/rotation-keys
     :all-attributes ctt/number-keys
     :on-update-shape update-rotation
-    :on-update-shape-per-attr {ctt/rotation-keys  update-rotation
-                               ctt/line-height-keys update-line-height}
     :modal {:key :tokens/number
             :fields [{:label "Number"
                       :key :number}]}}

--- a/frontend/src/app/main/data/workspace/tokens/propagation.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/propagation.cljs
@@ -53,32 +53,7 @@
 
 (def ^:private filter-existing-values? false)
 
-(def ^:private attributes->shape-update
-  {ctt/border-radius-keys dwta/update-shape-radius-for-corners
-   ctt/color-keys dwta/update-fill-stroke
-   ctt/stroke-width-keys dwta/update-stroke-width
-   ctt/sizing-keys dwta/apply-dimensions-token
-   ctt/opacity-keys dwta/update-opacity
-   ctt/rotation-keys dwta/update-rotation
-
-   ;; Typography
-   ctt/font-family-keys dwta/update-font-family
-   ctt/font-size-keys dwta/update-font-size
-   ctt/font-weight-keys dwta/update-font-weight
-   ctt/letter-spacing-keys dwta/update-letter-spacing
-   ctt/text-case-keys dwta/update-text-case
-   ctt/text-decoration-keys dwta/update-text-decoration
-   ctt/typography-token-keys dwta/update-typography
-   ctt/shadow-keys dwta/update-shadow
-   #{:line-height} dwta/update-line-height
-
-   ;; Layout
-   #{:x :y} dwta/update-shape-position
-   #{:p1 :p2 :p3 :p4} dwta/update-layout-padding
-   #{:m1 :m2 :m3 :m4} dwta/update-layout-item-margin
-   #{:column-gap :row-gap} dwta/update-layout-gap
-   #{:width :height} dwta/apply-dimensions-token
-   #{:layout-item-min-w :layout-item-min-h :layout-item-max-w :layout-item-max-h} dwta/update-layout-sizing-limits})
+(def ^:private attributes->shape-update dwta/attributes->shape-update)
 
 (def ^:private attribute-actions-map
   (flatten-set-keyed-map attributes->shape-update {}))

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -189,7 +189,6 @@
              (clear-schedule schedule-ref)
              (add-schedule schedule-ref (d/nilv delay 300)
                            (fn []
-                             (prn tooltip-id)
                              (when-let [active @active-tooltip]
                                (when (not= (:id active) tooltip-id)
                                  (when-let [tooltip-el (dom/get-element (:id active))]

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -192,7 +192,7 @@
    (assert (uuid? id))
 
    (let [data (u/locate-shape file-id page-id id)]
-     (-> (obj/reify {:name "ShapeProxy"}
+     (-> (obj/reify {:name "ShapeProxy" :on-error u/handle-error}
            :$plugin {:enumerable false :get (fn [] plugin-id)}
            :$id {:enumerable false :get (fn [] id)}
            :$file {:enumerable false :get (fn [] file-id)}

--- a/frontend/src/app/util/object.cljc
+++ b/frontend/src/app/util/object.cljc
@@ -464,6 +464,13 @@
      (let [o (get o type-symbol)]
        (= o t))))
 
+#?(:cljs
+   (def Proxy
+     (app.util.object/class
+      :name "Proxy"
+      :extends js/Object
+      :constructor (constantly nil))))
+
 (defmacro reify
   "A domain specific variation of reify that creates anonymous objects
   on demand with the ability to assign protocol implementations and
@@ -481,7 +488,7 @@
         obj-sym
         (gensym "obj-")]
 
-    `(let [~obj-sym (cljs.core/js-obj)
+    `(let [~obj-sym (new Proxy)
            ~f-sym   (fn [] ~type-name)]
        (add-properties! ~obj-sym
                         {:name ~'js/Symbol.toStringTag


### PR DESCRIPTION
### Related Ticket

Fixes bug 5 from https://github.com/penpot/penpot/issues/8520

### Summary

Calling `applyToken(token, ["line-height"])` on a `:number`-type token would correctly update the text's line-height, but would **also rotate the shape** by the token's numeric value (e.g. 1.6°). The setter accepted the call without
error and the getter read back the correct value — a classic silent failure.

**Root cause:** `toggle-token` resolved `on-update-shape` exclusively from `token-properties` keyed by token *type*. For `:number` tokens that function is unconditionally `update-rotation`, regardless of which `attrs` were explicitly passed by the caller. The `attrs` parameter is forwarded to `on-update-shape` but `update-rotation` declares it `_attributes` and ignores it entirely.

### Fix (two commits)

**`e4024ca`** — Direct bug fix in `toggle-token`: when explicit `attrs` are provided, look up the correct update function from a flattened `attr → update-fn` map before falling back to the `token-properties` default. This
stops `update-rotation` from being called when the requested attribute is `line-height`.

**`5eb437b`** — Refactor to make the fix generic and eliminate duplication: the `attributes->shape-update` map (which was private to `propagation.cljs`) is moved to `application.cljs` — where all the update functions it references are defined — and made public. `propagation.cljs` now simply aliases it. A private
flattened `attr->shape-update` map is derived from it at load time and used by `toggle-token` for O(1) lookup.

The result: any token type whose explicit `attrs` require a different update function than the type default will now dispatch correctly, with no per-type special casing needed in `token-properties`.

### Files changed

- `frontend/src/app/main/data/workspace/tokens/application.cljs`
- `frontend/src/app/main/data/workspace/tokens/propagation.cljs`

### How to reproduce

```js
penpot = ɵcontext
shape = penpot.getSelectedShapes()[0]
token = penpot.library.local.tokens.sets[0].tokens.find(t => t.type === "number")
shape.applyToken(token, ["line-height"])
```
NOTE: you will be unable to reproduce this on staging because of other error related to missing fixes on obj/reify included in the separated commit
