### PR TITLE
:bug: Fix nil values being inserted into TokenTheme :sets field

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -611,7 +611,7 @@
                  is-source
                  external-id
                  (ct/now)
-                 set-names))
+                 (into #{} (filter some?) set-names)))
 
   (enable-set [this set-name]
     (set-sets this (conj sets set-name)))
@@ -632,14 +632,9 @@
 
   (update-set-name [this prev-set-name set-name]
     (if (get sets prev-set-name)
-      (TokenTheme. id
-                   name
-                   group
-                   description
-                   is-source
-                   external-id
-                   (ct/now)
-                   (conj (disj sets prev-set-name) set-name))
+      (let [sets (-> (disj sets prev-set-name)
+                     (conj set-name))]
+        (set-sets this sets))
       this))
 
   (theme-matches-group-name [this group name]
@@ -724,7 +719,7 @@
         (update :is-source d/nilv false)
         (update :external-id #(or % (str new-id)))
         (update :modified-at #(or % (ct/now)))
-        (update :sets set)
+        (update :sets #(into #{} (filter some? %)))
         (check-token-theme-attrs)
         (map->TokenTheme))))
 

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -719,7 +719,7 @@
         (update :is-source d/nilv false)
         (update :external-id #(or % (str new-id)))
         (update :modified-at #(or % (ct/now)))
-        (update :sets #(into #{} (filter some? %)))
+        (update :sets #(into #{} (filter some?) %))
         (check-token-theme-attrs)
         (map->TokenTheme))))
 

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -235,6 +235,19 @@
     (t/is (thrown-with-msg? #?(:cljs js/Error :clj Exception) #"expected valid params for token-theme"
                             (ctob/make-token-theme params)))))
 
+(t/deftest make-token-theme-strips-nil-from-sets
+  (t/testing "make-token-theme strips nil values from :sets"
+    (let [theme (ctob/make-token-theme :name "test" :sets #{"valid-set" nil})]
+      (t/is (= (:sets theme) #{"valid-set"}))))
+  (t/testing "enable-set with nil set-name does not add nil to :sets"
+    (let [theme  (ctob/make-token-theme :name "test" :sets #{"existing-set"})
+          theme' (ctob/enable-set theme nil)]
+      (t/is (= (:sets theme') #{"existing-set"}))))
+  (t/testing "toggle-set with nil set-name does not add nil to :sets"
+    (let [theme  (ctob/make-token-theme :name "test" :sets #{})
+          theme' (ctob/toggle-set theme nil)]
+      (t/is (= (:sets theme') #{})))))
+
 (t/deftest make-tokens-lib
   (let [tokens-lib (ctob/make-tokens-lib)]
     (t/is (= (ctob/set-count tokens-lib) 0))))


### PR DESCRIPTION
### Summary

Fixes the issue related to this report:

```
Context:
--------------------
Hint:     expected valid params for token-theme
Prof ID:  6b3ca3bf-4a83-818b-8007-87047dc77ac5
Team ID:  6b3ca3bf-4a83-818b-8007-87047efdb0f4
File ID:  4b022421-5d94-810c-8007-a71873f0cec1
Version:  2.14.0-RC1-210-gcc2c104e1
URI:      https://hourly.penpot.dev/
HREF:     https://hourly.penpot.dev/#/workspace?team-id=6b3ca3bf-4a83-818b-8007-87047efdb0f4&file-id=4b022421-5d94-810c-8007-a71873f0cec1&page-id=4b022421-5d94-810c-8007-a71873f0cec2

Explain:
--------------------
Errors:
[{:path [:sets 0], :in [:sets nil], :schema :string, :value nil}]

Value:
##object[$app$common$types$tokens_lib$TokenTheme$$]{:id #uuid "25831aef-36c6-8054-8007-a7188b46123e",
                                                    :name "theme2",
                                                    :group "",
                                                    :description "",
                                                    :is-source false,
                                                    :external-id "25831aef-36c6-8054-8007-a7188b46123e",
                                                    :modified-at #inst "2026-03-02T16:11:38.649-00:00",
                                                    :sets #{nil}}



Data:
--------------------
{:type :assertion, :code :data-validation, :hint "expected valid params for token-theme"}

Trace:
--------------------
Error: expected valid params for token-theme
  at new $APP.$cljs$core$ExceptionInfo$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:1385:120)
  at $APP.$cljs$core$ex_info$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:1386:358)
  at $APP.$cljs$core$ex_info$cljs$0core$0IFn$0_invoke$0arity$02$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:1386:131)
  at https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:3100:421
  at $APP.$app$common$types$tokens_lib$make_token_theme$cljs$0core$0IFn$0_invoke$0arity$0variadic$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:6877:338)
  at https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:27028:429
  at $APP.$JSCompiler_prototypeAlias$$.$app$common$types$tokens_lib$ITokenThemes$update_theme$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:26344:1)
  at $app$common$types$tokens_lib$update_theme$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:6889:388)
  at https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:27028:284
  at $APP.$cljs$core$update$$.$cljs$core$IFn$_invoke$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:19310:1)
  at https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:27027:33
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IFn$_invoke$arity$2$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:20112:176)
  at https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:26888:335
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReduce$_reduce$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:19356:34)
  at $APP.$cljs$core$reduce$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:792:320)
  at $app$common$files$changes$process_changes$$.$cljs$core$IFn$_invoke$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:26888:111)
  at $apply_changes$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:9498:45)
  at $APP.$cljs$core$update_in$$.$cljs$core$IFn$_invoke$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:19286:410)
  at $APP.$cljs$core$update_in$$.$cljs$core$IFn$_invoke$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:19285:152)
  at $APP.$cljs$core$update_in$$.$cljs$core$IFn$_invoke$arity$3$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:19285:152)
  at $app$main$data$changes$apply_changes_localy_55588$$.$potok$v2$core$UpdateEvent$update$arity$2$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:9504:343)
  at $potok$v2$core$update$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:4422:338)
  at https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:26435:307
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ISwap$_swap_BANG_$arity$2$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:24805:282)
  at $cljs$core$_swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:18726:204)
  at $cljs$core$_swap_BANG_$$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:18724:471)
  at $APP.$cljs$core$swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://hourly.penpot.dev/js/shared.js?version=2.14.0-RC1-210-gcc2c104e1-1772465324:19169:302)
```

