### PR TITLE
:bug: Fix penpot.openPage() to navigate in same tab by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 
 - Fix Alt/Option to draw shapes from center point (by @offreal) [Github #8361](https://github.com/penpot/penpot/pull/8361)
 - Add token name on broken token pill on sidebar [Taiga #13527](https://tree.taiga.io/project/penpot/issue/13527)
+- Fix `penpot.openPage()` plugin API not navigating in the same tab; change default to same-tab navigation and allow passing a UUID string instead of a Page object [Github #8520](https://github.com/penpot/penpot/issues/8520)
 
 
 ## 2.14.0 (Unreleased)

--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -542,9 +542,14 @@
 
     :openPage
     (fn [page new-window]
-      (let [id (obj/get page "$id")
-            new-window (if (boolean? new-window) new-window true)]
-        (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window))))
+      (let [id (cond
+                 (page/page-proxy? page) (obj/get page "$id")
+                 (string? page)          (uuid/parse* page)
+                 :else nil)
+            new-window (if (boolean? new-window) new-window false)]
+        (if (nil? id)
+          (u/display-not-valid :openPage "Expected a Page object or a page UUID string")
+          (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
 
     :alignHorizontal
     (fn [shapes direction]

--- a/frontend/src/app/plugins/page.cljs
+++ b/frontend/src/app/plugins/page.cljs
@@ -269,7 +269,7 @@
         (u/display-not-valid :openPage "Plugin doesn't have 'content:read' permission")
 
         :else
-        (let [new-window (if (boolean? new-window) new-window true)]
+        (let [new-window (if (boolean? new-window) new-window false)]
           (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
 
     :createFlow

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -1256,15 +1256,15 @@ export interface Context {
 
   /**
    * Changes the current open page to given page. Requires `content:read` permission.
-   * @param page the page to open
-   * @param newWindow if true opens the page in a new window
+   * @param page the page to open (a Page object or a page UUID string)
+   * @param newWindow if true opens the page in a new window, defaults to false
    *
    * @example
    * ```js
    * context.openPage(page);
    * ```
    */
-  openPage(page: Page, newWindow?: boolean): void;
+  openPage(page: Page | string, newWindow?: boolean): void;
 
   /**
    * Aligning will move all the selected layers to a position relative to one

--- a/plugins/libs/plugins-runtime/src/lib/api/index.ts
+++ b/plugins/libs/plugins-runtime/src/lib/api/index.ts
@@ -323,9 +323,9 @@ export function createApi(
       return plugin.context.createPage();
     },
 
-    openPage(page: Page, newWindow?: boolean): void {
+    openPage(page: Page | string, newWindow?: boolean): void {
       checkPermission('content:read');
-      plugin.context.openPage(page, newWindow ?? true);
+      plugin.context.openPage(page, newWindow ?? false);
     },
 
     alignHorizontal(


### PR DESCRIPTION
### Summary

- Change the default for the newWindow param from true to false, so openPage() navigates in the same tab instead of opening a new one
- Accept a UUID string as the page argument in addition to a Page object, avoiding the need to call penpot.getPage(uuid) first
- Add validation error when an invalid page argument is passed

### Related Ticket

Fixes bug 8 from https://github.com/penpot/penpot/issues/8520

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
