### PR TITLE
:bug: Fix null element crash in get-attrs-from-styles

### DIFF
--- a/frontend/src/app/util/text/content/from_dom.cljs
+++ b/frontend/src/app/util/text/content/from_dom.cljs
@@ -38,21 +38,23 @@
 
 (defn get-attrs-from-styles
   [element attrs defaults]
-  (let [attrs (or attrs [])
-        value-empty? (fn [v]
-                       (or (nil? v)
-                           (and (string? v) (empty? v))
-                           (and (coll? v) (empty? v))))]
-    (reduce (fn [acc key]
-              (let [style (.-style element)
-                    value (if (contains? styles/mapping key)
-                            (let [style-name (styles/get-style-name-as-css-variable key)
-                                  [_ style-decode] (get styles/mapping key)]
-                              (style-decode (.getPropertyValue style style-name)))
-                            (let [style-name (styles/get-style-name key)]
-                              (styles/normalize-attr-value key (.getPropertyValue style style-name))))]
-                (assoc acc key (if (value-empty? value) (get defaults key) value))))
-            {} attrs)))
+  (if (nil? element)
+    (or defaults {})
+    (let [attrs (or attrs [])
+          value-empty? (fn [v]
+                         (or (nil? v)
+                             (and (string? v) (empty? v))
+                             (and (coll? v) (empty? v))))]
+      (reduce (fn [acc key]
+                (let [style (.-style element)
+                      value (if (contains? styles/mapping key)
+                              (let [style-name (styles/get-style-name-as-css-variable key)
+                                    [_ style-decode] (get styles/mapping key)]
+                                (style-decode (.getPropertyValue style style-name)))
+                              (let [style-name (styles/get-style-name key)]
+                                (styles/normalize-attr-value key (.getPropertyValue style style-name))))]
+                  (assoc acc key (if (value-empty? value) (get defaults key) value))))
+              {} attrs))))
 
 (defn get-text-span-styles
   [element]

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -21,6 +21,7 @@
    [frontend-tests.util-object-test]
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]
+   [frontend-tests.util-text-from-dom-test]
    [frontend-tests.worker-snap-test]))
 
 (enable-console-print!)
@@ -52,5 +53,6 @@
    'frontend-tests.util-object-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
+   'frontend-tests.util-text-from-dom-test
    'frontend-tests.tokens.workspace-tokens-remap-test
    'frontend-tests.worker-snap-test))

--- a/frontend/test/frontend_tests/util_text_from_dom_test.cljs
+++ b/frontend/test/frontend_tests/util_text_from_dom_test.cljs
@@ -1,0 +1,21 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util-text-from-dom-test
+  (:require
+   [app.common.types.text :as txt]
+   [app.util.text.content.from-dom :as fd]
+   [cljs.test :as t]))
+
+(t/deftest get-attrs-from-styles-with-null-element
+  (t/testing "returns defaults when element is nil"
+    (let [defaults txt/default-root-attrs
+          result   (fd/get-attrs-from-styles nil txt/root-attrs defaults)]
+      (t/is (= defaults result))))
+
+  (t/testing "returns empty map when element and defaults are both nil"
+    (let [result (fd/get-attrs-from-styles nil [] nil)]
+      (t/is (= {} result)))))


### PR DESCRIPTION
### Summary

Guard against null element in get-attrs-from-styles so that when the DOM node is not available the function returns the provided defaults instead of throwing 'Cannot read properties of null (reading style)'.

Report:

```
Trace:
--------------------
TypeError: Cannot read properties of null (reading 'style')
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:9174:22
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReduce$_reduce$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:19274:34)
  at $APP.$cljs$core$reduce$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:793:320)
  at $app$util$text$content$from_dom$get_attrs_from_styles$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:9173:398)
  at $APP.$app$util$text$content$from_dom$create_root$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:9182:111)
  at $app$util$text$content$dom__GT_cljs$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC2-1773136957:189:79)
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC2-1773136957:6621:231
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:15003:414
  at h4e (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:128545)
  at https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:133621
  at h6e (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:15240)
  at ZZ (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:129792)
  at jte (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:43:28735)
  at zer (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:43:28544)
```