### PR TITLE
:bug: Fix TypeError when path content is nil in get-points calls

### DIFF
--- a/common/test/common_tests/types/path_data_test.cljc
+++ b/common/test/common_tests/types/path_data_test.cljc
@@ -270,6 +270,15 @@
     (t/is (= result1 result2))
     (t/is (= result2 result3))))
 
+(t/deftest path-get-points-nil-safe
+  (t/testing "path/get-points returns nil for nil content without throwing"
+    (t/is (nil? (path/get-points nil))))
+  (t/testing "path/get-points returns correct points for valid content"
+    (let [content (path/content sample-content)
+          points  (path/get-points content)]
+      (t/is (some? points))
+      (t/is (= 3 (count points))))))
+
 (defn calculate-extremities
   "Calculate extremities for the provided content.
   A legacy implementation used mainly as reference for testing"

--- a/frontend/src/app/main/data/workspace/path/edition.cljs
+++ b/frontend/src/app/main/data/workspace/path/edition.cljs
@@ -59,8 +59,8 @@
                 content      (get shape :content)
                 new-content  (path/apply-content-modifiers content content-modifiers)
 
-                old-points   (path.segment/get-points content)
-                new-points   (path.segment/get-points new-content)
+                old-points   (path/get-points content)
+                new-points   (path/get-points new-content)
                 point-change (->> (map hash-map old-points new-points) (reduce merge))]
 
             (when (and (some? new-content) (some? shape))
@@ -162,7 +162,7 @@
             start-position (apply min-key #(gpt/distance start-position %) selected-points)
 
             content (st/get-path state :content)
-            points  (path.segment/get-points content)]
+            points  (path/get-points content)]
 
         (rx/concat
          ;; This stream checks the consecutive mouse positions to do the dragging
@@ -255,7 +255,7 @@
             start-delta-y (dm/get-in modifiers [index cy] 0)
 
             content (st/get-path state :content)
-            points  (path.segment/get-points content)
+            points  (path/get-points content)
 
             point (-> content (nth (if (= prefix :c1) (dec index) index)) (path.helpers/segment->point))
             handler (-> content (nth index) (path.segment/get-handler prefix))


### PR DESCRIPTION
### Summary

Use nil-safe path/get-points wrapper (some-> based) instead of direct path.segment/get-points calls in edition.cljs to prevent 'Cannot read properties of undefined (reading get)' crash.

Add nil-safety test to verify path/get-points returns nil without throwing when content is nil.


Report:

```
Trace:
--------------------
TypeError: Cannot read properties of undefined (reading 'get')
  at $APP.$app$common$types$path$segment$get_points$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:5748:215)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:4353:255
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:14026)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:18696)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1371)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:4371:334
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24727:495
  at $okulary$util$doiter$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:4423:1)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24727:79
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24720:62
  at $okulary$util$doiter$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:4423:1)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IWatchable$_notify_watches$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24719:186)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReset$_reset_BANG_$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24714:241)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ISwap$_swap_BANG_$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24715:129)
  at $cljs$core$_swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:18644:204)
  at $cljs$core$_swap_BANG_$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:18642:471)
  at $APP.$cljs$core$swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:19087:302)
  at $process_update$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:26345:148)
  at Object.next (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:26349:1)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:7168)
  at Object.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:24020)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:25768)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:7168)
  at $state_STAR_$$.next (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:26349:549)
  at $potok$v2$core$emit_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:24741:367)
  at $APP.$app$main$store$emit_BANG_$$.$cljs$core$IFn$_invoke$arity$1$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:26359:124)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:35703:552
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:7771:395
  at u (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:790:76219)
  at t._handleKey (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:790:76501)
  at hS.handleKey (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:790:78441)
  at HTMLDocument.c (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:790:76732)
```

### How to reproduce

Unable to reproduce, just safety check added to code that already fails.