### PR TITLE
:bug: Fix 'not ISeqable' error when entering float values in layout/opacity inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 - Fix component "broken" after variant switch [Taiga #12984](https://tree.taiga.io/project/penpot/issue/12984)
 - Fix incorrect query for file versions [Github #8463](https://github.com/penpot/penpot/pull/8463)
 - Fix warning when clicking on number token pills [Taiga #13661](https://tree.taiga.io/project/penpot/issue/13661)
+- Fix 'not ISeqable' error when entering float values in layout item and opacity inputs [Github #8569](https://github.com/penpot/penpot/pull/8569)
 
 ## 2.13.3
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layer.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layer.cljs
@@ -140,7 +140,7 @@
         (mf/use-fn
          (mf/deps on-change handle-opacity-change)
          (fn [value]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (handle-opacity-change value)
              (do
                (st/emit! (dwta/toggle-token {:token (first value)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -117,7 +117,7 @@
         (mf/use-fn
          (mf/deps on-change ids)
          (fn [value attr]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (on-change :simple attr value)
              (do
                (st/emit!
@@ -247,7 +247,7 @@
         (mf/use-fn
          (mf/deps on-change ids)
          (fn [value attr]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (on-change :multiple attr value)
              (do
                (st/emit!
@@ -577,7 +577,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
-           (if (or (string? value) (int? value))
+           (if (or (string? value) (number? value))
              (st/emit! (dwsl/update-layout-child ids {attr value}))
              (do
                (st/emit!


### PR DESCRIPTION
### Summary

Replace int? with number? in on-change handlers for layout item margins, min/max sizes, and layer opacity. Using int? caused float values like 8.5 to fall into the design token branch, calling (first 8.5) and crashing.
