### PR TITLE
:bug: Fix grow options not verifying text-editor/v2

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -137,12 +137,13 @@
          (fn [value]
            (on-blur)
            (let [uid (js/Symbol)
-                 grow-type (keyword value)
-                 content (when editor-instance
-                           (content/dom->cljs (dwt/get-editor-root editor-instance)))]
+                 grow-type (keyword value)]
              (st/emit! (dwu/start-undo-transaction uid))
-             (when (some? content)
-               (st/emit! (dwt/v2-update-text-shape-content (first ids) content :finalize? true)))
+             (when (features/active-feature? @st/state "text-editor/v2")
+               (let [content (when editor-instance
+                               (content/dom->cljs (dwt/get-editor-root editor-instance)))]
+                 (when (some? content)
+                   (st/emit! (dwt/v2-update-text-shape-content (first ids) content :finalize? true)))))
              (st/emit! (dwsh/update-shapes ids #(assoc % :grow-type grow-type)))
 
              (when (features/active-feature? @st/state "render-wasm/v1")


### PR DESCRIPTION
### Summary

Guard against null element in get-attrs-from-styles so that when the DOM node is not available the function returns the provided defaults instead of throwing 'Cannot read properties of null (reading style)'.

Report:

```
Trace:
--------------------
TypeError: Cannot read properties of null (reading 'style')
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:9174:22
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReduce$_reduce$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:19274:34)
  at $APP.$cljs$core$reduce$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:793:320)
  at $app$util$text$content$from_dom$get_attrs_from_styles$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:9173:398)
  at $APP.$app$util$text$content$from_dom$create_root$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:9182:111)
  at $app$util$text$content$dom__GT_cljs$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC2-1773136957:189:79)
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC2-1773136957:6621:231
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:15003:414
  at h4e (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:128545)
  at https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:133621
  at h6e (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:15240)
  at ZZ (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:129792)
  at jte (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:43:28735)
  at zer (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:43:28544)
```

> Copied from https://github.com/penpot/penpot/pull/8567