### PR TITLE
:bug: Fix removeChild crash on portal-on-document* unmount 

### DIFF
--- a/frontend/src/app/main/ui/components/portal.cljs
+++ b/frontend/src/app/main/ui/components/portal.cljs
@@ -11,6 +11,11 @@
 
 (mf/defc portal-on-document*
   [{:keys [children]}]
-  (mf/portal
-   (mf/html [:* children])
-   (dom/get-body)))
+  (let [container (mf/use-memo #(dom/create-element "div"))]
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
+    (mf/portal
+     (mf/html [:* children])
+     container)))

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -328,7 +328,11 @@
                ;; it right afterwards, in the next render cycle.
                (dom/append-child! item-el counter-el)
                (dnd/set-drag-image! event item-el (:x offset) (:y offset))
-               (ts/raf #(dom/remove-child! item-el counter-el))))))
+               ;; Guard against race condition: if the user navigates away
+               ;; before the RAF fires, item-el may have been unmounted and
+               ;; counter-el is no longer a child — removeChild would throw.
+               (ts/raf #(when (dom/child? counter-el item-el)
+                          (dom/remove-child! item-el counter-el)))))))
 
         on-menu-click
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -104,13 +104,13 @@
          (fn [event]
            (when (kbd/enter? event)
              (st/emit!
-              (dcm/go-to-dashboard-files :project-id project-id)
-              (ts/schedule-on-idle
-               (fn []
-                 (when-let [title (dom/get-element (str project-id))]
-                   (dom/set-attribute! title "tabindex" "0")
-                   (dom/focus! title)
-                   (dom/set-attribute! title "tabindex" "-1"))))))))
+              (dcm/go-to-dashboard-files :project-id project-id))
+             (ts/schedule
+              (fn []
+                (when-let [title (dom/get-element (str project-id))]
+                  (dom/set-attribute! title "tabindex" "0")
+                  (dom/focus! title)
+                  (dom/set-attribute! title "tabindex" "-1")))))))
 
         on-menu-click
         (mf/use-fn
@@ -234,7 +234,7 @@
         (mf/use-fn
          (fn [e]
            (when (kbd/enter? e)
-             (ts/schedule-on-idle
+             (ts/schedule
               (fn []
                 (let [search-title (dom/get-element (str "dashboard-search-title"))]
                   (when search-title
@@ -713,13 +713,13 @@
          (mf/deps team-id)
          (fn []
            (st/emit!
-            (dcm/go-to-dashboard-recent :team-id team-id)
-            (ts/schedule-on-idle
-             (fn []
-               (when-let [projects-title (dom/get-element "dashboard-projects-title")]
-                 (dom/set-attribute! projects-title "tabindex" "0")
-                 (dom/focus! projects-title)
-                 (dom/set-attribute! projects-title "tabindex" "-1")))))))
+            (dcm/go-to-dashboard-recent :team-id team-id))
+           (ts/schedule
+            (fn []
+              (when-let [projects-title (dom/get-element "dashboard-projects-title")]
+                (dom/set-attribute! projects-title "tabindex" "0")
+                (dom/focus! projects-title)
+                (dom/set-attribute! projects-title "tabindex" "-1"))))))
 
         go-fonts
         (mf/use-fn
@@ -731,14 +731,14 @@
          (mf/deps team)
          (fn []
            (st/emit!
-            (dcm/go-to-dashboard-fonts :team-id team-id)
-            (ts/schedule-on-idle
-             (fn []
-               (let [font-title (dom/get-element "dashboard-fonts-title")]
-                 (when font-title
-                   (dom/set-attribute! font-title "tabindex" "0")
-                   (dom/focus! font-title)
-                   (dom/set-attribute! font-title "tabindex" "-1"))))))))
+            (dcm/go-to-dashboard-fonts :team-id team-id))
+           (ts/schedule
+            (fn []
+              (let [font-title (dom/get-element "dashboard-fonts-title")]
+                (when font-title
+                  (dom/set-attribute! font-title "tabindex" "0")
+                  (dom/focus! font-title)
+                  (dom/set-attribute! font-title "tabindex" "-1")))))))
 
         go-drafts
         (mf/use-fn
@@ -751,7 +751,7 @@
          (mf/deps team-id default-project-id)
          (fn []
            (st/emit! (dcm/go-to-dashboard-files :team-id team-id :project-id default-project-id))
-           (ts/schedule-on-idle
+           (ts/schedule
             (fn []
               (when-let [title (dom/get-element "dashboard-drafts-title")]
                 (dom/set-attribute! title "tabindex" "0")
@@ -768,14 +768,14 @@
          (mf/deps team-id)
          (fn []
            (st/emit!
-            (dcm/go-to-dashboard-libraries :team-id team-id)
-            (ts/schedule-on-idle
-             (fn []
-               (let [libs-title (dom/get-element "dashboard-libraries-title")]
-                 (when libs-title
-                   (dom/set-attribute! libs-title "tabindex" "0")
-                   (dom/focus! libs-title)
-                   (dom/set-attribute! libs-title "tabindex" "-1"))))))))
+            (dcm/go-to-dashboard-libraries :team-id team-id))
+           (ts/schedule
+            (fn []
+              (let [libs-title (dom/get-element "dashboard-libraries-title")]
+                (when libs-title
+                  (dom/set-attribute! libs-title "tabindex" "0")
+                  (dom/focus! libs-title)
+                  (dom/set-attribute! libs-title "tabindex" "-1")))))))
 
         pinned-projects
         (mf/with-memo [projects]


### PR DESCRIPTION
## Related issues:

- https://github.com/penpot/penpot/issues/8540

## Summary

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
  at zLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:99950)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101498)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:104543)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:104967)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:104694)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101825)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:101625)
```

### Fix `removeChild` crash on dashboard navigation

**Root cause** (`portal.cljs`)

`portal-on-document*` passed `document.body` directly as the React portal `containerInfo`. When navigating away while a file-menu portal was open, concurrent React commit phases both called `document.body.removeChild(node)` for the same node — the second call throwing:

```
NotFoundError: Failed to execute 'removeChild' on 'Node':
The node to be removed is not a child of this node.
```

**Fix:** allocate a dedicated `<div>` container per `portal-on-document*` instance. The container is appended to `body` on mount and removed on unmount, giving React an exclusive `containerInfo` that never races with other portals (including `modal-container*`, which also targets `document.body`).

---

### Fix stale deferred DOM ops in dashboard navigation (`grid.cljs`, `sidebar.cljs`)

Two secondary issues found during investigation:

- **`grid.cljs`** — on drag-start, a temporary ghost element is scheduled for removal via `requestAnimationFrame`. If the user navigates away before the RAF fires, React has already unmounted the card node, making `removeChild` throw. Fixed by guarding the call with `dom/child?`.

- **`sidebar.cljs`** — keyboard navigation handlers used `ts/schedule-on-idle`  (`requestIdleCallback` with a **30s timeout**) to focus section titles after navigation, leaving a large window for the callback to operate on stale DOM.
  The calls were also incorrectly passed as arguments to `st/emit!`, which silently ignores non-event values. Fixed by replacing all occurrences with `ts/schedule` (`setTimeout 0`) and moving them outside `st/emit!`.
