### PR TITLE
:bug: Fix crash in select* when options vector is empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
 - Fix incorrect query for file versions [Github #8463](https://github.com/penpot/penpot/pull/8463)
 - Fix warning when clicking on number token pills [Taiga #13661](https://tree.taiga.io/project/penpot/issue/13661)
 - Fix 'not ISeqable' error when entering float values in layout item and opacity inputs [Github #8569](https://github.com/penpot/penpot/pull/8569)
+- Fix crash in select component when options vector is empty [Github #8578](https://github.com/penpot/penpot/pull/8578)
 
 ## 2.13.3
 

--- a/frontend/src/app/main/ui/ds/controls/select.cljs
+++ b/frontend/src/app/main/ui/ds/controls/select.cljs
@@ -22,7 +22,8 @@
   [options id]
   (let [options (if (delay? options) @options options)]
     (or (d/seek #(= id (get % :id)) options)
-        (nth options 0))))
+        (when (seq options)
+          (nth options 0)))))
 
 (defn- get-selected-option-id
   [options default]
@@ -178,7 +179,8 @@
 
         selected-option
         (mf/with-memo [options selected-id]
-          (get-option options selected-id))
+          (when (d/not-empty? options)
+            (get-option options selected-id)))
 
         label
         (get selected-option :label)


### PR DESCRIPTION
### Summary

Guard get-option fallback with (when (seq options) ...) to avoid "No item 0 in vector of length 0" when options is an empty vector. Also guard the selected-option memo in select* to mirror the same pattern already present in combobox*.

Trace:

```
Error: No item 0 in vector of length 0
  at $cljs$core$vector_index_out_of_bounds$$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:1065:89)
  at $cljs$core$array_for$$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:1067:278)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IIndexed$_nth$arity$2$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:19200:121)
  at $APP.$cljs$core$nth$cljs$0core$0IFn$0_invoke$0arity$02$$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:730:562)
  at $APP.$app$main$ui$ds$controls$select$get_option$$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:17084:247)
  at https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:17091:6
  at FJ (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:39227)
  at Object.useState (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:46942)
  at Zn.useState (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:12:94568)
  at $APP.$rumext$v2$use_state$cljs$0core$0IFn$0_invoke$0arity$01$$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:4594:170)
  at $APP.$app$main$ui$ds$controls$select$select_STAR_$$ (https://design.penpot.app/js/shared.js?version=2.13.3-1771248791:17090:461)
  at AQ (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:34374)
  at zJ (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:62512)
  at TPe (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:73053)
  at YPe (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:107276)
  at qqt (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:106323)
  at iJ (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:106150)
  at jPe (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:103227)
  at yIe (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:114949)
  at AR (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:113500)
  at tFe (https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:113777)
  at https://design.penpot.app/js/libs.js?version=2.13.3-1771248791:42:115014
```

## Root cause

`get-option` in `select.cljs` uses `d/seek` to find an option matching the requested id, and falls back to the first item in the list if none is found:

```clojure
(defn get-option [options id]
  (let [options (if (delay? options) @options options)]
    (or (d/seek #(= id (get % :id)) options)
        (nth options 0))))   ;; <-- throws when options is []
```

When `options` is an empty vector, `d/seek` returns `nil`, so `(or nil ...)` evaluates the fallback — and `(nth [] 0)` throws `"No item 0 in vector of length 0"`. 

The Malli schema for `select*` declares `[:vector {:min 1} ...]`, but schema validation is only enforced in development mode and does not prevent the crash in production.

## How an empty `options` is produced

The variant component panel builds option lists via `get-variant-options`:

```clojure
(defn- get-variant-options [prop-name prop-vals]
  (->> (filter #(= (:name %) prop-name) prop-vals)
       first       ;; nil when prop-name not found
       :value      ;; nil
       (mapv ...)));; (mapv f nil) → []
```

If `prop-name` is missing from `prop-vals` (e.g. during a stale re-render while a component is being updated), this produces `[]`, which is passed directly to `[:> select* {:options [] ...}]`.

## Fix

Two changes in `frontend/src/app/main/ui/ds/controls/select.cljs`:

**1. Guard the fallback in `get-option`:**

```clojure
(defn get-option [options id]
  (let [options (if (delay? options) @options options)]
    (or (d/seek #(= id (get % :id)) options)
        (when (seq options)
          (nth options 0)))))
```

`get-option` now returns `nil` instead of throwing when `options` is empty.

**2. Guard the `selected-option` memo in `select*`:**

```clojure
selected-option
(mf/with-memo [options selected-id]
  (when (d/not-empty? options)
    (get-option options selected-id)))
```

This mirrors the identical pattern that was already present in `combobox*`. When `options` is empty, `selected-option` is `nil`, `label` and `icon` are `nil`, `empty-selected-id?` is `true`, and the button renders `"--"` as a placeholder — a graceful degraded state rather than a crash.
