### PR TITLE
:bug: Fix plain vector leaking into shape :content from shape-to-path

### DIFF
--- a/common/src/app/common/types/path/segment.cljc
+++ b/common/src/app/common/types/path/segment.cljc
@@ -777,7 +777,7 @@
   content as PathData instance."
   [content transform]
   (if (some? transform)
-    (impl/-transform content transform)
+    (impl/-transform (impl/path-data content) transform)
     content))
 
 (defn move-content

--- a/common/src/app/common/types/path/shape_to_path.cljc
+++ b/common/src/app/common/types/path/shape_to_path.cljc
@@ -168,7 +168,7 @@
                       child-as-paths)]
     (-> group
         (assoc :type :path)
-        (assoc :content content)
+        (assoc :content (path.impl/path-data content))
         (merge head-data)
         (d/without-keys dissoc-attrs))))
 
@@ -184,7 +184,8 @@
         (:bool-type shape)
 
         content
-        (bool/calculate-content bool-type (map :content children))]
+        (-> (bool/calculate-content bool-type (map :content children))
+            (path.impl/path-data))]
 
     (-> shape
         (assoc :type :path)


### PR DESCRIPTION
### Summary

Fix incorrect plain/binary path data handling on several path conversion helpers.

### Context

```
Context:
--------------------
Hint:     No protocol method ITransformable.-transform defined for type object: [{:command :move-to, :params {:x 272, :y 443}} {:command :line-to, :params {:x 338, :y 403}} ... {:command :line-to, :params {:x 435, :y 435}} {:command :line-to, :params {:x 432, :y 447}}]
Version:  2.14.0-RC3

Trace:
--------------------
$APP.$cljs$core$missing_protocol$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:431:392
$app$common$types$path$impl$_transform$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:5677:317
$app$common$types$path$segment$transform_content$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:5853:382
$app$common$types$path$move_content$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:6081:315
$APP.$cljs$core$update$$.$cljs$core$IFn$_invoke$arity$4$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:19230:133
$app$common$geom$shapes$transforms$move$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:6104:432
$APP.$app$common$geom$shapes$translate_to_frame$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:6369:107
$APP.$cljs$core$map$$.$cljs$core$IFn$_invoke$arity$3$/<@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:19111:263
$JSCompiler_StaticMethods_sval$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:842:357
$APP.$JSCompiler_prototypeAlias$$.$cljs$core$ISeqable$_seq$arity$1$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:18960:112
$APP.$JSCompiler_prototypeAlias$$.$cljs$core$ISeq$_first$arity$1$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:18959:83
$APP.$cljs$core$first$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:666:353
$app$main$ui$workspace$sidebar$options$menus$constraints$constraints_menu$$/$values__$1$jscomp$4$$<@https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC3-1773151343:6143:270
$app$main$ui$workspace$sidebar$options$menus$constraints$constraints_menu$$@https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC3-1773151343:6145:389
bte@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:48310
kee@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:71389
ILe@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:81793
i4e@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:117786
rer@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:116813
QZ@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:116637
ZLe@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:113390
EBe@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:125512
PR@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:124035
p4e@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:124322
R4e</cer/<@https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:42:125575
```
