### PR TITLE
:bug: Fix unhandled AbortError in HTTP fetch requests

### DIFF
--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -343,7 +343,12 @@
                   (= message "Possible side-effect in debug-evaluate")
                   (= message "Unexpected end of input")
                   (str/starts-with? message "invalid props on component")
-                  (str/starts-with? message "Unexpected token "))))
+                  (str/starts-with? message "Unexpected token ")
+                  ;; Abort errors are expected when an in-flight HTTP request is
+                  ;; cancelled (e.g. via RxJS unsubscription / take-until).  They
+                  ;; are handled gracefully inside app.util.http/fetch and must
+                  ;; NOT be surfaced as application errors.
+                  (= (.-name ^js cause) "AbortError"))))
 
           (on-unhandled-error [event]
             (.preventDefault ^js event)

--- a/frontend/src/app/util/http.cljs
+++ b/frontend/src/app/util/http.cljs
@@ -123,10 +123,15 @@
                                 (/ current-time (inc count)))
                      count (inc count)]
                  (swap! network-averages assoc (:path uri) {:count count :average average})))))
+
        (fn []
          (vreset! unsubscribed? true)
          (when @abortable?
-           (.abort ^js controller)))))))
+           ;; Provide an explicit reason so that the resulting AbortError carries
+           ;; a meaningful message instead of the browser default
+           ;; "signal is aborted without reason".
+           (.abort ^js controller (ex-info (str "fetch to '" uri "' is aborted")
+                                           {:uri uri}))))))))
 
 (defn response->map
   [response]


### PR DESCRIPTION
### Summary

- Providing an explicit reason to AbortController when subscriptions are disposed.
- Updating the global error handler to ignore AbortError exceptions.
- Ensuring unhandled rejections use the ignorable exception filter.

The root cause was RxJS disposal calling .abort() without a reason, combined with the on-unhandled-rejection handler missing the ignorable error filter.


There are now way to reproduce, fix based on the following report: 

```
AbortError: signal is aborted without reason
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC3-1773151343:4701:107
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:796)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at $Qe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:802)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:416)
  at e.unsubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1585)
  at e._complete (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1780)
  at e.complete (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1520)
  at e._complete (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1756)
  at e.complete (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1520)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:25412)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:18696)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:18696)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:7168)
  at Object.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:24020)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-1773151343:802:25768)
```