### PR TITLE
:paperclip: Revert show version notes when navigate from cc

### DIFF
--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -10,7 +10,6 @@
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.common :as dcm]
-   [app.main.data.modal :as modal]
    [app.main.data.team :as dtm]
    [app.main.errors :as errors]
    [app.main.refs :as refs]
@@ -154,8 +153,6 @@
         props   (get profile :props)
         section (get data :name)
         team    (mf/deref refs/team)
-        params-release-notes
-        (-> route :params :query :release-notes)
 
 
         show-question-modal?
@@ -181,13 +178,6 @@
              (:onboarding-viewed props)
              (not= (:release-notes-viewed props) (:main cf/version))
              (not= "0.0" (:main cf/version)))]
-
-    (mf/with-effect [section params-release-notes]
-      (when (= params-release-notes "show")
-        (let [query-params  (-> route :params :query)
-              updated-params (dissoc query-params :release-notes)]
-          (st/emit! (modal/show {:type :release-notes :version (:main cf/version)}))
-          (st/emit! (rt/nav section updated-params {::rt/replace true})))))
 
     [:& (mf/provider ctx/current-route) {:value route}
      (case section


### PR DESCRIPTION
### Summary
Since we no longer need this approach, we will revert the changes from this PR https://github.com/penpot/penpot/pull/8546

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
