### PR TITLE
:bug: Fix wrong value on property copy on inspect styles

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/rows/color_properties_row.cljs
@@ -84,7 +84,7 @@
                              :else "none")))
         copy-attr
         (mf/use-fn
-         (mf/deps copied formatted-color-value)
+         (mf/deps copied copiable-value)
          (fn []
            (reset! copied* true)
            (clipboard/to-clipboard copiable-value)


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/13645

### Summary

> [!WARNING]
This is a regression in PRO from the latest release

When a property has a token as a value in the inspect tab, when the user copies this value (click on the property value) it does not copy the name of the token, but instead the resolved value.

Surprisingly, when copying it again, the name is the tokens is correctly copied.

Expected: the name of the token is copied, not its resolved value

### Steps to reproduce 

- Create a token and apply it. Let's say `color.primary`
- Select the shape and open the`inspect` tab
- Find the property with the token and copy it
- Expected `color-primary` instead of #13645

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
