### PR TITLE
:bug: Fix clipboard getType error when no allowed types found

### DIFF
--- a/frontend/src/app/util/clipboard.js
+++ b/frontend/src/app/util/clipboard.js
@@ -135,7 +135,7 @@ function sortItems(a, b) {
 export async function fromNavigator(options) {
   options = options || {};
   const items = await navigator.clipboard.read();
-  return Promise.all(
+  const result = await Promise.all(
     Array.from(items).map(async (item) => {
       const itemAllowedTypes = Array.from(item.types)
         .filter(filterAllowedTypes(options))
@@ -155,9 +155,15 @@ export async function fromNavigator(options) {
       }
 
       const type = itemAllowedTypes.at(0);
+
+      if (type == null) {
+        return null;
+      }
+
       return item.getType(type);
     }),
   );
+  return result.filter((item) => !!item);
 }
 
 /**


### PR DESCRIPTION
### Summary

When clipboard items have types that don't match the allowed types list, the filtering results in an empty array. Calling getType with undefined throws a NotFoundError. This change adds a check for null/undefined types and filters them from the result.

### Related Report

```
Context:
--------------------
Hint:     Failed to execute 'getType' on 'ClipboardItem': The type was not found
Version:  2.14.0-RC3-2-g31d8b35a2
HREF:     https://design.penpot.app/#/workspace
Trace:
--------------------
NotFoundError: Failed to execute 'getType' on 'ClipboardItem': The type was not found
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:33462:182
  at Array.map (<anonymous>)
  at $module$app$util$clipboard$$.$fromNavigator$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:33460:240)
```