### PR TITLE
:bug: Fix DataCloneError in plugin postMessage communication

### DIFF
--- a/plugins/libs/plugins-runtime/src/lib/api/index.ts
+++ b/plugins/libs/plugins-runtime/src/lib/api/index.ts
@@ -68,8 +68,21 @@ export function createApi(
       },
 
       sendMessage(message: unknown) {
+        let cloneableMessage: unknown;
+
+        try {
+          cloneableMessage = structuredClone(message);
+        } catch (err) {
+          console.error(
+            'plugin sendMessage: the message could not be cloned. ' +
+              'Ensure the message does not contain functions, DOM nodes, or other non-serializable values.',
+            err,
+          );
+          return;
+        }
+
         const event = new CustomEvent('message', {
-          detail: message,
+          detail: cloneableMessage,
         });
 
         plugin.getModal()?.dispatchEvent(event);

--- a/plugins/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
+++ b/plugins/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
@@ -129,7 +129,14 @@ export class PluginModalElement extends HTMLElement {
         return;
       }
 
-      iframe.contentWindow.postMessage((e as CustomEvent).detail, '*');
+      try {
+        iframe.contentWindow.postMessage((e as CustomEvent).detail, '*');
+      } catch (err) {
+        console.error(
+          'plugin modal: failed to send message to iframe via postMessage.',
+          err,
+        );
+      }
     });
 
     this.shadowRoot.appendChild(this.wrapper);


### PR DESCRIPTION
### Summary 

Fixes a crash where plugins sending messages via 'penpot.ui.sendMessage()' could fail if their message payload contained non-serializable values like functions or closures.

The fix adds validation using 'structuredClone()' to catch these messages early with a helpful error message, and adds a defensive try/catch in the modal's message handler as a safety net.

Fixes the error: 'Failed to execute postMessage on Window: ... could not be cloned.'

### Related Report

```
Context:
--------------------
Hint:     Failed to execute 'postMessage' on 'Window': l=>{let u=this.createInterpreterConfig({input:l}),c=new ym(o,u).interpret();if(!(c instanceof bc)){let d=this.g...<omitted>...c} could not be cloned.
Version:  2.14.0-RC3-2-g31d8b35a2
HREF:     https://design.penpot.app/

Trace:
--------------------
DataCloneError: Failed to execute 'postMessage' on 'Window': l=>{let u=this.createInterpreterConfig({input:l}),c=new ym(o,u).interpret();if(!(c instanceof bc)){let d=this.g...<omitted>...c} could not be cloned.
  at MJ.<anonymous> (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:790:2347)
  at Object.sendMessage (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:790:60263)
  at y.sendResponse (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:1:1)), <anonymous>:1:317)
  at y.sendSuccess (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:1:1)), <anonymous>:1:419)
  at w.handle (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:1:1)), <anonymous>:3:304)
  at async x (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC3-2-g31d8b35a2-1773165299:1:1)), <anonymous>:3:1051)
```
