### PR TITLE
:bug: Make ct/fomat-inst nil safe

### DIFF
--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -204,40 +204,41 @@
 (defn format-inst
   ([v] (format-inst v :iso))
   ([v fmt]
-   (case fmt
-     (:iso :iso8601)
-     #?(:clj (.format DateTimeFormatter/ISO_INSTANT ^Instant v)
-        :cljs (dfn-format-iso v))
+   (when (some? v)
+     (case fmt
+       (:iso :iso8601)
+       #?(:clj (.format DateTimeFormatter/ISO_INSTANT ^Instant v)
+          :cljs (dfn-format-iso v))
 
-     :iso-date
-     #?(:clj (.format DateTimeFormatter/ISO_LOCAL_DATE
-                      ^ZonedDateTime (ZonedDateTime/ofInstant v (ZoneId/of "UTC")))
-        :cljs (dfn-format-iso v #js {:representation "date"}))
+       :iso-date
+       #?(:clj (.format DateTimeFormatter/ISO_LOCAL_DATE
+                        ^ZonedDateTime (ZonedDateTime/ofInstant v (ZoneId/of "UTC")))
+          :cljs (dfn-format-iso v #js {:representation "date"}))
 
-     (:rfc1123 :http)
-     #?(:clj (.format DateTimeFormatter/RFC_1123_DATE_TIME
-                      ^ZonedDateTime (ZonedDateTime/ofInstant v (ZoneId/of "UTC")))
-        :cljs (dfn-format v "EEE, dd LLL yyyy HH:mm:ss 'GMT'"))
+       (:rfc1123 :http)
+       #?(:clj (.format DateTimeFormatter/RFC_1123_DATE_TIME
+                        ^ZonedDateTime (ZonedDateTime/ofInstant v (ZoneId/of "UTC")))
+          :cljs (dfn-format v "EEE, dd LLL yyyy HH:mm:ss 'GMT'"))
 
-     #?@(:cljs [:time-24-simple
-                (dfn-format v "HH:mm")
+       #?@(:cljs [:time-24-simple
+                  (dfn-format v "HH:mm")
 
-                ;; DEPRECATED
-                :date-full
-                (dfn-format v "PPP")
+                  ;; DEPRECATED
+                  :date-full
+                  (dfn-format v "PPP")
 
-                :localized-date
-                (dfn-format v "PPP")
+                  :localized-date
+                  (dfn-format v "PPP")
 
-                :localized-time
-                (dfn-format v "p")
+                  :localized-time
+                  (dfn-format v "p")
 
-                :localized-date-time
-                (dfn-format v "PPP . p")
+                  :localized-date-time
+                  (dfn-format v "PPP . p")
 
-                (if (string? fmt)
-                  (dfn-format v fmt)
-                  (throw (js/Error. "unpexted format")))]))))
+                  (if (string? fmt)
+                    (dfn-format v fmt)
+                    (throw (js/Error. "unpexted format")))])))))
 
 #?(:cljs
    (def locales

--- a/frontend/src/app/main/data/workspace/versions.cljs
+++ b/frontend/src/app/main/data/workspace/versions.cljs
@@ -137,16 +137,16 @@
   (ptk/reify ::pin-version
     ptk/WatchEvent
     (watch [_ state _]
-      (let [version (->> (dm/get-in state [:workspace-versions :data])
-                         (d/seek #(= (:id %) id)))
-            params  {:id id
-                     :label (ct/format-inst (:created-at version) :localized-date)}]
+      (when-let [version (->> (dm/get-in state [:workspace-versions :data])
+                              (d/seek #(= (:id %) id)))]
+        (let [params {:id id
+                      :label (ct/format-inst (:created-at version) :localized-date)}]
 
-        (->> (rp/cmd! :update-file-snapshot params)
-             (rx/mapcat (fn [_]
-                          (rx/of (update-versions-state {:editing id})
-                                 (fetch-versions)
-                                 (ptk/event ::ev/event {::ev/name "pin-version"})))))))))
+          (->> (rp/cmd! :update-file-snapshot params)
+               (rx/mapcat (fn [_]
+                            (rx/of (update-versions-state {:editing id})
+                                   (fetch-versions)
+                                   (ptk/event ::ev/event {::ev/name "pin-version"}))))))))))
 
 (defn lock-version
   [id]


### PR DESCRIPTION
### Summary

Prevent JS TypeError when date is nil in date formatting.

### Related Report

```
Context:
--------------------
Hint:     Date.prototype.getHours called on incompatible undefined
Version:  2.14.0-RC2
HREF:     https://design.penpot.app/#/workspace

Trace:
--------------------
apply@<anonymous code>:147:76
k@https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:68424
Rwr/<@https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:72327
Rwr@https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:802:72149
$APP.$app$common$time$format_inst$$.$cljs$core$IFn$_invoke$arity$2$@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:23582:52
@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:23661:81
$APP.$JSCompiler_prototypeAlias$$.$cljs$core$IWatchable$_notify_watches$arity$3$@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:19080:460
$APP.$cljs$core$reset_BANG_$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:999:94
$APP.$cljs$core$swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:19087:133
$logfn$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:3367:265
$$jscomp$scope$84173391$15$nextTick$$/<@https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:23635:184
```