### PR TITLE
:wrench: Change the assets dir to fix deployment with Wrangler

### DIFF
--- a/plugins/apps/colors-to-tokens-plugin/wrangler.toml
+++ b/plugins/apps/colors-to-tokens-plugin/wrangler.toml
@@ -1,7 +1,7 @@
 name = "color-to-tokens-plugin"
 compatibility_date = "2025-01-01"
 
-assets = { directory = "../../dist/apps/colors-to-tokens-plugin/browser" }
+assets = { directory = "../../dist/apps/colors-to-tokens-plugin" }
 
 [[routes]]
 pattern = "WORKER_URI"

--- a/plugins/apps/contrast-plugin/wrangler.toml
+++ b/plugins/apps/contrast-plugin/wrangler.toml
@@ -1,7 +1,7 @@
 name = "contrast-plugin"
 compatibility_date = "2025-01-01"
 
-assets = { directory = "../../dist/apps/contrast-plugin/browser" }
+assets = { directory = "../../dist/apps/contrast-plugin" }
 
 [[routes]]
 pattern = "WORKER_URI"

--- a/plugins/apps/table-plugin/wrangler.toml
+++ b/plugins/apps/table-plugin/wrangler.toml
@@ -1,7 +1,7 @@
 name = "table-plugin"
 compatibility_date = "2025-01-01"
 
-assets = { directory = "../../dist/apps/table-plugin/browser" }
+assets = { directory = "../../dist/apps/table-plugin" }
 
 [[routes]]
 pattern = "WORKER_URI"


### PR DESCRIPTION
<div align="center">

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWU0ZDNhdDF4YTZpMXR1eHRwc2F2ZWkzejM5aDYycWdudDB2dGE3ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZsZmffS4YS5yw/giphy.gif)

</div>

The directory where the plugin bundle is generated has changed. We need to update the configuration so  wrangler can find the assets it have to deploy.
