### PR TITLE
:bug: Ignore posthog exceptions in unhandled exception handler

### DIFF
--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -337,9 +337,15 @@
                    (or (str/includes? stack "chrome-extension://")
                        (str/includes? stack "moz-extension://")))))
 
+          (from-posthog? [cause]
+            (let [stack (.-stack cause)]
+              (and (string? stack)
+                   (str/includes? stack "posthog"))))
+
           (is-ignorable-exception? [cause]
             (let [message (ex-message cause)]
               (or (from-extension? cause)
+                  (from-posthog? cause)
                   (= message "Possible side-effect in debug-evaluate")
                   (= message "Unexpected end of input")
                   (str/starts-with? message "invalid props on component")


### PR DESCRIPTION
###Summary 

PostHog recorder throws errors like 'Cannot assign to read only property 'assert' of object' which are unrelated to the application and should be ignored to prevent noise in error reporting.

### Related Report:

```
Context:
--------------------
Hint:     Cannot assign to read only property 'assert' of object '#<Object>'
Version:  2.14.0-RC3-2-g31d8b35a2

Trace:
--------------------
TypeError: Cannot assign to read only property 'assert' of object '#<Object>'
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:202555
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:202299
  at Array.forEach (<anonymous>)
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:202287
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:166167
  at Array.forEach (<anonymous>)
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:166155
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:195821
  at Array.forEach (<anonymous>)
  at _h.et (https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:195809)
  at _h.ae (https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:243205)
  at _h.stop (https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:243263)
  at https://eu-assets.i.posthog.com/static/posthog-recorder.js?v=1.360.0:1:241979
  at As.emit (https://eu-assets.i.posthog.com/static/array.js:1:63403)
  at https://eu-assets.i.posthog.com/static/array.js:1:66782
```