### PR TITLE
:bug: Fix subscribe to undefined stream error in use-stream hook

### DIFF
--- a/frontend/src/app/main/ui/hooks.cljs
+++ b/frontend/src/app/main/ui/hooks.cljs
@@ -214,10 +214,11 @@
    (mf/use-effect
     deps
     (fn []
-      (let [sub (->> stream (rx/subs! on-subscribe))]
-        #(do
-           (rx/dispose! sub)
-           (when on-dispose (on-dispose))))))))
+      (when stream
+        (let [sub (->> stream (rx/subs! on-subscribe))]
+          #(do
+             (rx/dispose! sub)
+             (when on-dispose (on-dispose)))))))))
 
 ;; https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
 ;; FIXME: replace with rumext


### PR DESCRIPTION
### Summary

Add a nil guard before subscribing to the stream in the use-stream hook. When a nil/undefined stream is passed (e.g., from a conditional expression or timing edge case during React rendering), the subscribe call on undefined causes a TypeError. The guard ensures we only subscribe when the stream is defined.

### Related Report

```
Context:
--------------------
Hint:     Cannot read properties of undefined (reading 'subscribe')
Version:  2.14.0-RC2
HREF:     https://design.penpot.app/#/workspace

Trace:
--------------------
TypeError: Cannot read properties of undefined (reading 'subscribe')
  at $APP.$beicon$v2$core$subscribe$cljs$0core$0IFn$0_invoke$0arity$02$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:4381:177)
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC2-1773136957:300:273
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC2-1773136957:4645:345
  at kR (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:93431)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108737)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109347)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109204)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:109505)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
  at WLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108717)
  at Cf (https://design.penpot.app/js/libs.js?version=2.14.0-RC2-1773136957:42:108619)
```
