### PR TITLE
:bug: Fix TypeError in get-points when content is not PathData

### DIFF
--- a/common/src/app/common/types/path.cljc
+++ b/common/src/app/common/types/path.cljc
@@ -190,10 +190,14 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn get-points
-  "Returns points for the given segment, faster version of
-  the `content->points`."
+  "Returns points for the given content. Accepts PathData instances or
+  plain segment vectors. Returns nil for nil content."
   [content]
-  (some-> content segment/get-points))
+  (when (some? content)
+    (let [content (if (impl/path-data? content)
+                    content
+                    (impl/path-data content))]
+      (segment/get-points content))))
 
 (defn calc-selrect
   "Calculate selrect from a content. The content can be in a PathData

--- a/common/src/app/common/types/path/impl.cljc
+++ b/common/src/app/common/types/path/impl.cljc
@@ -52,14 +52,15 @@
   [target key & expr]
   (if (:ns &env)
     (let [target (with-meta target {:tag 'js})]
-      `(let [~'cache  (.-cache ~target)
-             ~'result (.get ~'cache ~key)]
-         (if ~'result
-           (do
-             ~'result)
-           (let [~'result (do ~@expr)]
-             (.set ~'cache ~key ~'result)
-             ~'result))))
+      `(let [~'cache (.-cache ~target)]
+         (if (some? ~'cache)
+           (let [~'result (.get ~'cache ~key)]
+             (if ~'result
+               ~'result
+               (let [~'result (do ~@expr)]
+                 (.set ~'cache ~key ~'result)
+                 ~'result)))
+           (do ~@expr))))
     `(do ~@expr)))
 
 (defn- impl-transform-segment

--- a/common/test/common_tests/types/path_data_test.cljc
+++ b/common/test/common_tests/types/path_data_test.cljc
@@ -279,6 +279,12 @@
       (t/is (some? points))
       (t/is (= 3 (count points))))))
 
+(t/deftest path-get-points-plain-vector-safe
+  (t/testing "path/get-points does not throw for plain vector content"
+    (let [points (path/get-points sample-content)]
+      (t/is (some? points))
+      (t/is (= 3 (count points))))))
+
 (defn calculate-extremities
   "Calculate extremities for the provided content.
   A legacy implementation used mainly as reference for testing"

--- a/frontend/src/app/main/data/workspace/path/changes.cljs
+++ b/frontend/src/app/main/data/workspace/path/changes.cljs
@@ -68,7 +68,7 @@
        (let [content (st/get-path state :content)
              content (if (and (not preserve-move-to)
                               (= (-> content last :command) :move-to))
-                       (into [] (take (dec (count content)) content))
+                       (path/content (take (dec (count content)) content))
                        content)]
          (st/set-content state content)))
 

--- a/frontend/src/app/main/data/workspace/path/streams.cljs
+++ b/frontend/src/app/main/data/workspace/path/streams.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.common.data.macros :as dm]
    [app.common.geom.point :as gpt]
-   [app.common.types.path.segment :as path.segm]
+   [app.common.types.path :as path]
    [app.main.data.workspace.path.state :as pst]
    [app.main.snap :as snap]
    [app.main.store :as st]
@@ -167,7 +167,7 @@
         ranges-stream
         (->> content-stream
              (rx/filter some?)
-             (rx/map path.segm/get-points)
+             (rx/map path/get-points)
              (rx/map snap/create-ranges))]
 
     (->> ms/mouse-position


### PR DESCRIPTION
### Summary

Fix:
- path/get-points (app.common.types.path) is now the canonical safe entry point: converts non-PathData content via impl/path-data and handles nil safely before delegating to segment/get-points
- segment/get-points remains a low-level function that expects a PathData instance (no defensive logic at that level)
- streams.cljs: replace direct call to path.segm/get-points with path/get-points so the safe conversion path is always used
- with-cache macro: guards against nil/undefined cache, falling back to direct evaluation for non-PathData targets

### Related Report

```
Context:
--------------------
Hint:     Cannot read properties of undefined (reading 'get')
Version:  2.14.0-RC4
HREF:     https://design.penpot.app/#/workspace

Trace:
--------------------
TypeError: Cannot read properties of undefined (reading 'get')
  at $app$common$types$path$segment$get_points$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:5750:210)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:4354:255
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:14026)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:18696)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1371)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:4372:334
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24733:495
  at $okulary$util$doiter$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:4424:1)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24733:79
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24726:62
  at $okulary$util$doiter$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:4424:1)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IWatchable$_notify_watches$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24725:186)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReset$_reset_BANG_$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24720:241)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ISwap$_swap_BANG_$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24721:129)
  at $cljs$core$_swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:18650:204)
  at $cljs$core$_swap_BANG_$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:18648:471)
  at $APP.$cljs$core$swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:19093:302)
  at $process_update$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:26351:148)
  at Object.next (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:26355:1)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:7168)
  at Object.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:24020)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:25768)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:802:7168)
  at $state_STAR_$$.next (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:26355:549)
  at $potok$v2$core$emit_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:24747:367)
  at $APP.$app$main$store$emit_BANG_$$.$cljs$core$IFn$_invoke$arity$1$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:26365:124)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:35711:552
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC4-1773390091:7773:395
  at u (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:790:76529)
  at t._handleKey (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:790:76811)
  at hS.handleKey (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:790:78751)
  at HTMLDocument.c (https://design.penpot.app/js/libs.js?version=2.14.0-RC4-1773390091:790:77042)
```

