### PR TITLE
:books: Adjust MCP presence in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,12 @@
 ### :boom: Breaking changes & Deprecations
 
 ### :rocket: Epics and highlights
+- Add MCP server integration [Taiga #13112](https://tree.taiga.io/project/penpot/us/13112)
 
 ### :sparkles: New features & Enhancements
 
 - Allow duplicating color and typography styles (by @MkDev11) [Github #2912](https://github.com/penpot/penpot/issues/2912)
-- Import Tokens from linked library [Github #8391](https://github.com/penpot/penpot/pull/8391)
+- Import Tokens from linked library (by @dfelinto) [Github #8391](https://github.com/penpot/penpot/pull/8391)
 - Option to download custom fonts (by @dfelinto) [Github #8320](https://github.com/penpot/penpot/issues/8320)
 - Add woff2 support on user uploaded fonts (by @Nivl) [Github #8248](https://github.com/penpot/penpot/pull/8248)
 - Add copy as image to clipboard option to workspace context menu (by @dfelinto) [Github #8313](https://github.com/penpot/penpot/pull/8313)
@@ -27,7 +28,7 @@
 
 ### :sparkles: New features & Enhancements
 
-- Add MCP server integration [Taiga #13112](https://tree.taiga.io/project/penpot/us/13112), [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
+- Access Tokens look & feel refinement [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
 
 ### :bug: Bugs fixed
 


### PR DESCRIPTION
Changelog adjustments
- Moving MCP integrations from 2.15 to 2.16
- Adding Access Tokens Look & Feel line
- Crediting a contributor