### PR TITLE
:sparkles: Add Docker deployment for MCP server

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -40,9 +40,9 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/common/package.json packages/common/
 COPY packages/server/package.json packages/server/
 
-# Plugin is not needed at runtime (static files only)
-# Create a stub so pnpm doesn't complain about missing workspace member
-RUN mkdir -p packages/plugin && echo '{"name":"mcp-plugin","version":"1.0.0"}' > packages/plugin/package.json
+# Copy real plugin package.json to satisfy the lockfile,
+# but --prod will skip its devDependencies (vite, typescript, etc.)
+COPY packages/plugin/package.json packages/plugin/
 
 RUN pnpm install --frozen-lockfile --prod
 

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,65 @@
+# ── Stage 1: Build ──
+FROM node:22-slim AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.31.0 --activate
+
+WORKDIR /app
+
+# Copy workspace manifests first (layer cache)
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/common/package.json packages/common/
+COPY packages/server/package.json packages/server/
+COPY packages/plugin/package.json packages/plugin/
+
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY packages/common/ packages/common/
+COPY packages/server/ packages/server/
+COPY packages/plugin/ packages/plugin/
+
+# Build server (common is a build-time dependency)
+RUN pnpm run build
+
+# Build plugin with the WebSocket URL baked in.
+# In Docker/Traefik, the browser connects to the WS via the public domain.
+# Default works for localhost; override with --build-arg for production.
+ARG WS_URI="ws://localhost:4402"
+RUN cd packages/plugin && WS_URI=${WS_URI} pnpm run build
+
+
+# ── Stage 2: Runtime ──
+FROM node:22-slim
+
+RUN corepack enable && corepack prepare pnpm@10.31.0 --activate
+
+WORKDIR /app
+
+# Install production deps for server only
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/common/package.json packages/common/
+COPY packages/server/package.json packages/server/
+
+# Plugin is not needed at runtime (static files only)
+# Create a stub so pnpm doesn't complain about missing workspace member
+RUN mkdir -p packages/plugin && echo '{"name":"mcp-plugin","version":"1.0.0"}' > packages/plugin/package.json
+
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built server (includes dist/data/ and dist/static/)
+COPY --from=builder /app/packages/server/dist packages/server/dist
+
+# Copy built plugin (static files served by 'serve')
+COPY --from=builder /app/packages/plugin/dist /plugin-dist
+
+# Lightweight static file server for the plugin UI
+RUN npm install -g serve@14
+
+RUN mkdir -p /app/logs
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 4400 4401 4402
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -277,6 +277,214 @@ you may set the following environment variables to configure the two servers
    where the MCP server can be reached. The Penpot MCP Plugin uses this to construct
    the WebSocket URL as `ws://<your-address>:<port>` (default port: `4402`).
 
+## Docker Deployment
+
+You can run the Penpot MCP server as a Docker container alongside your existing
+Penpot docker-compose stack. The container includes both the MCP server and
+the plugin UI server.
+
+### How It Works
+
+```
+MCP Client (e.g. Claude Code) ──(HTTPS/SSE)──► MCP Server (:4401)
+                                                    ▲
+                                                    │ WebSocket (:4402)
+                                                    ▼
+Browser (Penpot) ◄──────────────────────────── Plugin UI (:4400)
+```
+
+The MCP server acts as a bridge between your AI client and Penpot.
+The Penpot MCP Plugin runs inside your browser within Penpot's UI and must
+remain open while using the MCP server. The plugin communicates with the
+MCP server via WebSocket to execute design operations.
+
+### Prerequisites
+
+- A running Penpot instance (docker-compose based)
+- A reverse proxy (e.g. Traefik) for TLS termination (recommended for remote access)
+- A DNS record for the MCP server (e.g. `mcp.yourdomain.com`)
+
+### Files
+
+The Docker setup requires two files in the `mcp/` directory, alongside the
+existing source code:
+
+- `Dockerfile` — multi-stage build (build + runtime)
+- `entrypoint.sh` — starts the MCP server and plugin UI server
+
+### Building
+
+The plugin's WebSocket URL is baked in at build time. Set the `WS_URI` build
+argument to match how your browser will reach the WebSocket endpoint:
+
+```shell
+# For localhost development
+docker compose build penpot-mcp
+
+# For production behind a reverse proxy
+docker compose build --build-arg WS_URI="wss://mcp.yourdomain.com/ws" penpot-mcp
+```
+
+### docker-compose Service Definition
+
+Add the following service to your `docker-compose.yml`:
+
+```yaml
+  penpot-mcp:
+    build:
+      context: ./mcp
+      dockerfile: Dockerfile
+      args:
+        WS_URI: "wss://${PENPOT_MCP_DOMAIN_NAME}/ws"
+    restart: always
+    expose:
+      - 4400
+      - 4401
+      - 4402
+    networks:
+      - penpot
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+
+      # MCP SSE + HTTP endpoint (AI clients connect here)
+      - "traefik.http.routers.penpot-mcp.rule=Host(`${PENPOT_MCP_DOMAIN_NAME}`)"
+      - "traefik.http.routers.penpot-mcp.entrypoints=websecure"
+      - "traefik.http.routers.penpot-mcp.tls=true"
+      - "traefik.http.routers.penpot-mcp.tls.certresolver=tls_resolver"
+      - "traefik.http.routers.penpot-mcp.service=penpot-mcp"
+      - "traefik.http.routers.penpot-mcp.priority=1"
+      - "traefik.http.services.penpot-mcp.loadbalancer.server.port=4401"
+
+      # WebSocket (plugin in browser connects here)
+      - "traefik.http.routers.penpot-mcp-ws.rule=Host(`${PENPOT_MCP_DOMAIN_NAME}`) && PathPrefix(`/ws`)"
+      - "traefik.http.routers.penpot-mcp-ws.entrypoints=websecure"
+      - "traefik.http.routers.penpot-mcp-ws.tls=true"
+      - "traefik.http.routers.penpot-mcp-ws.tls.certresolver=tls_resolver"
+      - "traefik.http.routers.penpot-mcp-ws.service=penpot-mcp-ws"
+      - "traefik.http.routers.penpot-mcp-ws.priority=2"
+      - "traefik.http.services.penpot-mcp-ws.loadbalancer.server.port=4402"
+
+      # Plugin UI (load into Penpot's plugin manager)
+      - "traefik.http.routers.penpot-mcp-plugin.rule=Host(`${PENPOT_MCP_DOMAIN_NAME}`) && PathPrefix(`/plugin`)"
+      - "traefik.http.routers.penpot-mcp-plugin.entrypoints=websecure"
+      - "traefik.http.routers.penpot-mcp-plugin.tls=true"
+      - "traefik.http.routers.penpot-mcp-plugin.tls.certresolver=tls_resolver"
+      - "traefik.http.routers.penpot-mcp-plugin.service=penpot-mcp-plugin"
+      - "traefik.http.routers.penpot-mcp-plugin.priority=3"
+      - "traefik.http.middlewares.mcp-plugin-strip.stripprefix.prefixes=/plugin"
+      - "traefik.http.routers.penpot-mcp-plugin.middlewares=mcp-plugin-strip"
+      - "traefik.http.services.penpot-mcp-plugin.loadbalancer.server.port=4400"
+
+    environment:
+      PENPOT_MCP_SERVER_HOST: "0.0.0.0"
+      PENPOT_MCP_SERVER_PORT: "4401"
+      PENPOT_MCP_WEBSOCKET_PORT: "4402"
+      PENPOT_MCP_LOG_LEVEL: "info"
+      PENPOT_MCP_REMOTE_MODE: "true"
+```
+
+Add to your `.env` file:
+
+```
+PENPOT_MCP_DOMAIN_NAME=mcp.yourdomain.com
+```
+
+### Connecting MCP Clients
+
+#### Claude Code
+
+Claude Code supports HTTP transport natively:
+
+```shell
+claude mcp add penpot -t http https://mcp.yourdomain.com/mcp
+```
+
+Or add to `~/.claude/settings.json` (or project `.claude/settings.json`):
+
+```json
+{
+    "mcpServers": {
+        "penpot": {
+            "type": "sse",
+            "url": "https://mcp.yourdomain.com/sse"
+        }
+    }
+}
+```
+
+#### Claude Desktop
+
+Since Claude Desktop only supports stdio transport, use `mcp-remote` as a proxy:
+
+```json
+{
+    "mcpServers": {
+        "penpot": {
+            "command": "npx",
+            "args": ["-y", "mcp-remote", "https://mcp.yourdomain.com/sse"]
+        }
+    }
+}
+```
+
+### Loading the Plugin in Penpot
+
+1. Open Penpot in your browser and navigate to a design file
+2. Open the Plugins menu
+3. Add the plugin URL: `https://mcp.yourdomain.com/plugin/manifest.json`
+4. Open the plugin UI and click "Connect to MCP server"
+5. The connection status should change to "Connected to MCP server"
+
+> [!IMPORTANT]
+> Do not close the plugin's UI while using the MCP server, as this will
+> disconnect the WebSocket and the AI client will lose access to your designs.
+
+### Without a Reverse Proxy
+
+If you are running Penpot without a reverse proxy (e.g. for local development
+with Docker), you can expose the ports directly instead:
+
+```yaml
+  penpot-mcp:
+    build:
+      context: ./mcp
+      dockerfile: Dockerfile
+      # Default WS_URI (ws://localhost:4402) works for localhost
+    restart: always
+    ports:
+      - "4400:4400"
+      - "4401:4401"
+      - "4402:4402"
+    networks:
+      - penpot
+    environment:
+      PENPOT_MCP_SERVER_HOST: "0.0.0.0"
+      PENPOT_MCP_SERVER_PORT: "4401"
+      PENPOT_MCP_WEBSOCKET_PORT: "4402"
+      PENPOT_MCP_LOG_LEVEL: "info"
+      PENPOT_MCP_REMOTE_MODE: "true"
+```
+
+Then connect Claude Code with:
+
+```shell
+claude mcp add penpot -t http http://localhost:4401/mcp --allow-http
+```
+
+And load the plugin in Penpot using `http://localhost:4400/manifest.json`.
+
+### Without the Plugin UI Server (Port 4400)
+
+If you prefer to serve the plugin UI separately (e.g. from another web server
+or CDN), you can skip port 4400 in the container. In that case:
+
+1. Build the plugin locally: `cd packages/plugin && WS_URI="wss://mcp.yourdomain.com/ws" pnpm run build`
+2. Deploy the contents of `packages/plugin/dist/` to any static file host
+3. Point Penpot's plugin manager to that host's `manifest.json`
+4. The Docker container only needs to expose ports 4401 and 4402
+
 ## Development
 
 * The [contribution guidelines for Penpot](../CONTRIBUTING.md) apply

--- a/mcp/entrypoint.sh
+++ b/mcp/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+PLUGIN_PORT=${PLUGIN_PORT:-4400}
+
+cleanup() {
+    echo "Shutting down..."
+    kill "$MCP_PID" "$PLUGIN_PID" 2>/dev/null || true
+    wait "$MCP_PID" "$PLUGIN_PID" 2>/dev/null || true
+    exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+# Start MCP server (ports 4401 + 4402 via env vars)
+cd /app
+node packages/server/dist/index.js &
+MCP_PID=$!
+
+# Serve plugin static files (manifest.json, plugin.js, index.html)
+serve -s /plugin-dist -l "$PLUGIN_PORT" --no-clipboard &
+PLUGIN_PID=$!
+
+echo "MCP server started (SSE: ${PENPOT_MCP_SERVER_PORT:-4401}, WS: ${PENPOT_MCP_WEBSOCKET_PORT:-4402})"
+echo "Plugin UI: http://0.0.0.0:${PLUGIN_PORT}"
+
+wait $MCP_PID $PLUGIN_PID

--- a/mcp/entrypoint.sh
+++ b/mcp/entrypoint.sh
@@ -12,8 +12,9 @@ cleanup() {
 trap cleanup 15 2
 
 # Start MCP server (ports 4401 + 4402 via env vars)
-cd /app
-node packages/server/dist/index.js &
+# CWD must be the server dist dir — ConfigurationLoader resolves data/ relative to process.cwd()
+cd /app/packages/server/dist
+node index.js &
 MCP_PID=$!
 
 # Serve plugin static files (manifest.json, plugin.js, index.html)

--- a/mcp/entrypoint.sh
+++ b/mcp/entrypoint.sh
@@ -9,7 +9,7 @@ cleanup() {
     wait "$MCP_PID" "$PLUGIN_PID" 2>/dev/null || true
     exit 0
 }
-trap cleanup SIGTERM SIGINT
+trap cleanup 15 2
 
 # Start MCP server (ports 4401 + 4402 via env vars)
 cd /app


### PR DESCRIPTION
Add Dockerfile (multi-stage build) and entrypoint.sh to run the MCP server and plugin UI server in a dockerized environment. Add Docker Deployment section to README.md with Traefik reverse proxy configuration, Claude Code/Desktop client setup, and localhost fallback instructions.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
