### PR TITLE
:sparkles: Add background blur type support to common schema

### DIFF
--- a/common/src/app/common/geom/shapes/bounds.cljc
+++ b/common/src/app/common/geom/shapes/bounds.cljc
@@ -92,10 +92,15 @@
                 (not= :svg (dm/get-in shape [:content :tag])))
            ;; If no shadows or blur, we return the selrect as is
            (and (empty? (-> shape :shadow))
-                (zero? (-> shape :blur :value (or 0)))))
+                (or (nil? (:blur shape))
+                    (not= :layer-blur (-> shape :blur :type))
+                    (zero? (-> shape :blur :value (or 0))))))
      (dm/get-prop shape :selrect)
      (let [filters    (shape->filters shape)
-           blur-value (or (-> shape :blur :value) 0)
+           blur-value (case (-> shape :blur :type)
+                        :layer-blur (or (-> shape :blur :value) 0)
+                        :background-blur 0
+                        0)
            srect      (-> (dm/get-prop shape :points)
                           (grc/points->rect))]
        (get-rect-filter-bounds srect filters blur-value ignore-shadow-margin?)))))
@@ -209,7 +214,10 @@
            (not (cfh/frame-shape? shape)) (or (:children-bounds shape)))
 
          filters (shape->filters shape)
-         blur-value (or (-> shape :blur :value) 0)]
+         blur-value (case (-> shape :blur :type)
+                      :layer-blur (or (-> shape :blur :value) 0)
+                      :background-blur 0
+                      0)]
 
      (get-rect-filter-bounds children-bounds filters blur-value ignore-shadow-margin?))))
 

--- a/common/src/app/common/types/shape/blur.cljc
+++ b/common/src/app/common/types/shape/blur.cljc
@@ -8,9 +8,12 @@
   (:require
    [app.common.schema :as sm]))
 
+(def schema:blur-type
+  [:enum :layer-blur :background-blur])
+
 (def schema:blur
   [:map {:title "Blur"}
    [:id ::sm/uuid]
-   [:type [:= :layer-blur]]
+   [:type schema:blur-type]
    [:value ::sm/safe-number]
    [:hidden :boolean]])


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/13436

### Summary

First step for having background-blur feature

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
