### PR TITLE
:wrench: Show label if wasm text editor is enabled

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -53,6 +53,13 @@
    [rumext.v2 :as mf]))
 (def use-dpr? (contains? cf/flags :render-wasm-dpr))
 
+(defn text-editor-wasm?
+  []
+  (let [runtime-features (get @st/state :features-runtime)
+        enabled-features (get @st/state :features)]
+    (or (contains? runtime-features "text-editor-wasm/v1")
+        (contains? enabled-features "text-editor-wasm/v1"))))
+
 (def ^:const UUID-U8-SIZE 16)
 (def ^:const UUID-U32-SIZE (/ UUID-U8-SIZE 4))
 
@@ -149,11 +156,8 @@
         ;; Determine if text-editor-wasm feature is active without requiring
         ;; app.main.features to avoid circular dependency: check runtime and
         ;; persisted feature sets in the store state.
-        (let [runtime-features (get @st/state :features-runtime)
-              enabled-features (get @st/state :features)]
-          (when (or (contains? runtime-features "text-editor-wasm/v1")
-                    (contains? enabled-features "text-editor-wasm/v1"))
-            (text-editor/text-editor-render-overlay)))
+        (when (text-editor-wasm?)
+          (text-editor/text-editor-render-overlay))
         ;; Poll for editor events; if any event occurs, trigger a re-render
         (let [ev (text-editor/text-editor-poll-event)]
           (when (and ev (not= ev 0))
@@ -1395,7 +1399,9 @@
   []
   (cond-> 0
     (dbg/enabled? :wasm-viewbox)
-    (bit-or 2r00000000000000000000000000000001)))
+    (bit-or 2r00000000000000000000000000000001)
+    (text-editor-wasm?)
+    (bit-or 2r00000000000000000000000000001000)))
 
 (defn set-canvas-size
   [canvas]

--- a/frontend/src/app/render_wasm/wasm.cljs
+++ b/frontend/src/app/render_wasm/wasm.cljs
@@ -25,6 +25,7 @@
 (defonce context-initialized? false)
 (defonce context-lost? (atom false))
 
+
 (defonce serializers
   #js {:blur-type shared/RawBlurType
        :blend-mode shared/RawBlendMode

--- a/render-wasm/src/options.rs
+++ b/render-wasm/src/options.rs
@@ -1,3 +1,4 @@
 pub const DEBUG_VISIBLE: u32 = 0x01;
 pub const PROFILE_REBUILD_TILES: u32 = 0x02;
 pub const FAST_MODE: u32 = 0x04;
+pub const INFO_TEXT: u32 = 0x08;

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -46,16 +46,25 @@ pub fn render_wasm_label(render_state: &mut RenderState) {
     let mut paint = skia::Paint::default();
     paint.set_color(skia::Color::GRAY);
 
-    let str = if render_state.options.is_debug_visible() {
+    let mut str = if render_state.options.is_debug_visible() {
         "WASM RENDERER (DEBUG)"
     } else {
         "WASM RENDERER"
     };
     let (scalar, _) = render_state.fonts.debug_font().measure_str(str, None);
-    let p = skia::Point::new(width as f32 - 25.0 - scalar, height as f32 - 25.0);
+    let mut p = skia::Point::new(width as f32 - 25.0 - scalar, height as f32 - 25.0);
 
     let debug_font = render_state.fonts.debug_font();
     canvas.draw_str(str, p, debug_font, &paint);
+
+    if render_state.options.show_info_text() {
+        str = "TEXT EDITOR / V3";
+
+        let (scalar, _) = render_state.fonts.debug_font().measure_str(str, None);
+        p.x = width as f32 - 25.0 - scalar;
+        p.y -= 20.0;
+        canvas.draw_str(str, p, debug_font, &paint);
+    }
 }
 
 #[allow(dead_code)]

--- a/render-wasm/src/render/options.rs
+++ b/render-wasm/src/render/options.rs
@@ -31,4 +31,8 @@ impl RenderOptions {
     pub fn dpr(&self) -> f32 {
         self.dpr.unwrap_or(1.0)
     }
+
+    pub fn show_info_text(&self) -> bool {
+        self.flags & options::INFO_TEXT == options::INFO_TEXT
+    }
 }


### PR DESCRIPTION
### Related Ticket

None

### Summary

This shows a label along the "Wasm renderer" text if the embedded wasm editor is enabled. 

<img width="130" height="52" alt="Screenshot 2026-03-17 at 4 36 37 PM" src="https://github.com/user-attachments/assets/bb8f5182-1538-4d36-ba1b-6655ce2728b1" />

### Steps to reproduce 

Enable / disable the `text-editor-wasm/v1` feature flag and check the viewport. The label should only be displayed when the flag is enabled.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
