### PR TITLE
:wrench: Show / Hide wasm info label via config flag

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -136,6 +136,8 @@
     :webhooks
     ;; TODO: deprecate this flag and consolidate the code
     :render-wasm-dpr
+    ;; Show WASM renderer info label (hidden by default).
+    :render-wasm-info
     :hide-release-modal
     :subscriptions
     :subscriptions-old

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -1401,7 +1401,9 @@
     (dbg/enabled? :wasm-viewbox)
     (bit-or 2r00000000000000000000000000000001)
     (text-editor-wasm?)
-    (bit-or 2r00000000000000000000000000001000)))
+    (bit-or 2r00000000000000000000000000001000)
+    (contains? cf/flags :render-wasm-info)
+    (bit-or 2r00000000000000000000000000010000)))
 
 (defn set-canvas-size
   [canvas]

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -1401,9 +1401,9 @@
     (dbg/enabled? :wasm-viewbox)
     (bit-or 2r00000000000000000000000000000001)
     (text-editor-wasm?)
-    (bit-or 2r00000000000000000000000000001000)
+    (bit-or 2r00000000000000000000000000000100)
     (contains? cf/flags :render-wasm-info)
-    (bit-or 2r00000000000000000000000000010000)))
+    (bit-or 2r00000000000000000000000000001000)))
 
 (defn set-canvas-size
   [canvas]

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -55,10 +55,11 @@
 
 (defn text-editor-wasm?
   []
-  (let [runtime-features (get @st/state :features-runtime)
-        enabled-features (get @st/state :features)]
-    (or (contains? runtime-features "text-editor-wasm/v1")
-        (contains? enabled-features "text-editor-wasm/v1"))))
+  (or (contains? cf/flags :feature-text-editor-wasm)
+      (let [runtime-features (get @st/state :features-runtime)
+            enabled-features (get @st/state :features)]
+        (or (contains? runtime-features "text-editor-wasm/v1")
+            (contains? enabled-features "text-editor-wasm/v1")))))
 
 (def ^:const UUID-U8-SIZE 16)
 (def ^:const UUID-U32-SIZE (/ UUID-U8-SIZE 4))

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -3,7 +3,6 @@ mod emscripten;
 mod error;
 mod math;
 mod mem;
-mod options;
 mod performance;
 mod render;
 mod shapes;

--- a/render-wasm/src/options.rs
+++ b/render-wasm/src/options.rs
@@ -1,5 +1,0 @@
-pub const DEBUG_VISIBLE: u32 = 0x01;
-pub const PROFILE_REBUILD_TILES: u32 = 0x02;
-pub const FAST_MODE: u32 = 0x04;
-pub const TEXT_EDITOR_V3: u32 = 0x08;
-pub const SHOW_WASM_INFO: u32 = 0x10;

--- a/render-wasm/src/options.rs
+++ b/render-wasm/src/options.rs
@@ -1,4 +1,5 @@
 pub const DEBUG_VISIBLE: u32 = 0x01;
 pub const PROFILE_REBUILD_TILES: u32 = 0x02;
 pub const FAST_MODE: u32 = 0x04;
-pub const INFO_TEXT: u32 = 0x08;
+pub const TEXT_EDITOR_V3: u32 = 0x08;
+pub const SHOW_WASM_INFO: u32 = 0x10;

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -61,7 +61,7 @@ pub fn render_wasm_label(render_state: &mut RenderState) {
     let debug_font = render_state.fonts.debug_font();
     canvas.draw_str(str, p, debug_font, &paint);
 
-    if render_state.options.show_info_text() {
+    if render_state.options.is_text_editor_v3() {
         str = "TEXT EDITOR / V3";
 
         let (scalar, _) = render_state.fonts.debug_font().measure_str(str, None);

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -41,6 +41,10 @@ pub fn render_debug_cache_surface(render_state: &mut RenderState) {
 }
 
 pub fn render_wasm_label(render_state: &mut RenderState) {
+    if !render_state.options.show_wasm_info() {
+        return;
+    }
+
     let canvas = render_state.surfaces.canvas(SurfaceId::Target);
     let skia::ISize { width, height } = canvas.base_layer_size();
     let mut paint = skia::Paint::default();

--- a/render-wasm/src/render/options.rs
+++ b/render-wasm/src/render/options.rs
@@ -1,42 +1,43 @@
-use crate::options;
+// Render options flags
+const DEBUG_VISIBLE: u32 = 0x01;
+const PROFILE_REBUILD_TILES: u32 = 0x02;
+const TEXT_EDITOR_V3: u32 = 0x04;
+const SHOW_WASM_INFO: u32 = 0x08;
 
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct RenderOptions {
     pub flags: u32,
     pub dpr: Option<f32>,
+    fast_mode: bool,
 }
 
 impl RenderOptions {
     pub fn is_debug_visible(&self) -> bool {
-        self.flags & options::DEBUG_VISIBLE == options::DEBUG_VISIBLE
+        self.flags & DEBUG_VISIBLE == DEBUG_VISIBLE
     }
 
     pub fn is_profile_rebuild_tiles(&self) -> bool {
-        self.flags & options::PROFILE_REBUILD_TILES == options::PROFILE_REBUILD_TILES
+        self.flags & PROFILE_REBUILD_TILES == PROFILE_REBUILD_TILES
     }
 
     /// Use fast mode to enable / disable expensive operations
     pub fn is_fast_mode(&self) -> bool {
-        self.flags & options::FAST_MODE == options::FAST_MODE
+        self.fast_mode
     }
 
     pub fn set_fast_mode(&mut self, enabled: bool) {
-        if enabled {
-            self.flags |= options::FAST_MODE;
-        } else {
-            self.flags &= !options::FAST_MODE;
-        }
+        self.fast_mode = enabled;
     }
 
     pub fn dpr(&self) -> f32 {
         self.dpr.unwrap_or(1.0)
     }
 
-    pub fn show_info_text(&self) -> bool {
-        self.flags & options::TEXT_EDITOR_V3 == options::TEXT_EDITOR_V3
+    pub fn is_text_editor_v3(&self) -> bool {
+        self.flags & TEXT_EDITOR_V3 == TEXT_EDITOR_V3
     }
 
     pub fn show_wasm_info(&self) -> bool {
-        self.flags & options::SHOW_WASM_INFO == options::SHOW_WASM_INFO
+        self.flags & SHOW_WASM_INFO == SHOW_WASM_INFO
     }
 }

--- a/render-wasm/src/render/options.rs
+++ b/render-wasm/src/render/options.rs
@@ -33,6 +33,10 @@ impl RenderOptions {
     }
 
     pub fn show_info_text(&self) -> bool {
-        self.flags & options::INFO_TEXT == options::INFO_TEXT
+        self.flags & options::TEXT_EDITOR_V3 == options::TEXT_EDITOR_V3
+    }
+
+    pub fn show_wasm_info(&self) -> bool {
+        self.flags & options::SHOW_WASM_INFO == options::SHOW_WASM_INFO
     }
 }


### PR DESCRIPTION
> ⚠️ QA has told us to hold this for now. If we merge it we should update config.js from PRE immediately to enable the flag, unless they have given us green light on this.

### Related Ticket

https://tree.taiga.io/project/penpot/task/13720

### Summary

- Adds `render-wasm-info` config flag to show/hide the `WASM RENDERER` label at the bottom right (default: text is hidden)
- Fixes not being able to enable the embedded editor via a config flag.

### Steps to reproduce 

Edit your `config.js` and add/remove `enable-render-wasm-info` to your `penpotFlags` array.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
