### PR TITLE
:sparkles: Add version property to plugins API

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -18,6 +18,7 @@
    [app.common.types.shape :as cts]
    [app.common.types.text :as txt]
    [app.common.uuid :as uuid]
+   [app.config :as cf]
    [app.main.data.changes :as ch]
    [app.main.data.common :as dcm]
    [app.main.data.helpers :as dsh]
@@ -84,6 +85,10 @@
     :$plugin {:enumerable false :get (fn [] plugin-id)}
 
     ;; Public properties
+    :version
+    {:this true
+     :get (constantly (:base cf/version))}
+
     :root
     {:this true
      :get #(.getRoot ^js %)}

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 1.5.0 (Unreleased)
 
 - **plugin-types**: Added a flags subcontexts with the flag `naturalChildrenOrdering`
+- **plugins-runtime**: Added `version` field that returns the current version
+- **plugin-types**: Fix penpot.openPage() to navigate in same tab by default
+- **plugin-types**: Added `createVariantFromComponents`
+- **plugin-types**: Change return type of `combineAsVariants`
+- **plugin-types**: Added `textBounds` property for text shapes
 
 ## 1.4.2 (2026-01-21)
 

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -769,6 +769,11 @@ export interface CommonLayout {
  */
 export interface Context {
   /**
+   * Returns the current penpot version.
+   */
+  readonly version: string;
+
+  /**
    * The root shape in the current Penpot context. Requires `content:read` permission.
    *
    * @example

--- a/plugins/libs/plugins-runtime/src/lib/api/index.ts
+++ b/plugins/libs/plugins-runtime/src/lib/api/index.ts
@@ -165,6 +165,10 @@ export function createApi(
 
     // Penpot State API
 
+    get version(): string {
+      return plugin.context.version;
+    },
+
     get root(): Shape | null {
       checkPermission('content:read');
       return plugin.context.root;


### PR DESCRIPTION
### Related Ticket
https://github.com/penpot/penpot-mcp/issues/46

### Summary

Adds version property into the plugins API

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
