### PR TITLE
:sparkles: Add `throwValidationErrors` flag for plugins

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -117,7 +117,7 @@
      (fn [_ shapes]
        (cond
          (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-         (u/display-not-valid :selection shapes)
+         (u/not-valid plugin-id :selection shapes)
 
          :else
          (let [ids (into (d/ordered-set) (map #(obj/get % "$id")) shapes)]
@@ -182,7 +182,7 @@
     (fn [shapes]
       (cond
         (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-        (u/display-not-valid :shapesColors-shapes shapes)
+        (u/not-valid plugin-id :shapesColors-shapes shapes)
 
         :else
         (let [objects (u/locate-objects)
@@ -202,13 +202,13 @@
             new-color (parser/parse-color-data new-color)]
         (cond
           (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-          (u/display-not-valid :replaceColor-shapes shapes)
+          (u/not-valid plugin-id :replaceColor-shapes shapes)
 
           (not (sm/validate ctc/schema:color old-color))
-          (u/display-not-valid :replaceColor-oldColor old-color)
+          (u/not-valid plugin-id :replaceColor-oldColor old-color)
 
           (not (sm/validate ctc/schema:color new-color))
-          (u/display-not-valid :replaceColor-newColor new-color)
+          (u/not-valid plugin-id :replaceColor-newColor new-color)
 
           :else
           (let [file-id (:current-file-id @st/state)
@@ -261,10 +261,10 @@
     (fn  [name url]
       (cond
         (not (string? name))
-        (u/display-not-valid :uploadMedia-name name)
+        (u/not-valid plugin-id :uploadMedia-name name)
 
         (not (string? url))
-        (u/display-not-valid :uploadMedia-url url)
+        (u/not-valid plugin-id :uploadMedia-url url)
 
         :else
         (let [file-id (:current-file-id @st/state)]
@@ -295,7 +295,7 @@
     (fn [shapes]
       (cond
         (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-        (u/display-not-valid :group-shapes shapes)
+        (u/not-valid plugin-id :group-shapes shapes)
 
         :else
         (let [file-id (:current-file-id @st/state)
@@ -310,10 +310,10 @@
     (fn [group & rest]
       (cond
         (not (shape/shape-proxy? group))
-        (u/display-not-valid :ungroup group)
+        (u/not-valid plugin-id :ungroup group)
 
         (and (some? rest) (not (every? shape/shape-proxy? rest)))
-        (u/display-not-valid :ungroup rest)
+        (u/not-valid plugin-id :ungroup rest)
 
         :else
         (let [shapes (concat [group] rest)
@@ -353,7 +353,7 @@
     (fn [text]
       (cond
         (or (not (string? text)) (empty? text))
-        (u/display-not-valid :createText text)
+        (u/not-valid plugin-id :createText text)
 
         :else
         (let [page  (dsh/lookup-page @st/state)
@@ -384,7 +384,7 @@
     (fn [svg-string]
       (cond
         (or (not (string? svg-string)) (empty? svg-string))
-        (u/display-not-valid :createShapeFromSvg svg-string)
+        (u/not-valid plugin-id :createShapeFromSvg svg-string)
 
         :else
         (let [id (uuid/next)
@@ -401,7 +401,7 @@
          (cond
            (or (not (string? svg-string)) (empty? svg-string))
            (do
-             (u/display-not-valid :createShapeFromSvg "Svg not valid")
+             (u/not-valid plugin-id :createShapeFromSvg "Svg not valid")
              (reject "Svg not valid"))
 
            :else
@@ -419,10 +419,10 @@
       (let [bool-type (keyword bool-type)]
         (cond
           (not (contains? cts/bool-types bool-type))
-          (u/display-not-valid :createBoolean-boolType bool-type)
+          (u/not-valid plugin-id :createBoolean-boolType bool-type)
 
           (or (not (array? shapes)) (empty? shapes) (not (every? shape/shape-proxy? shapes)))
-          (u/display-not-valid :createBoolean-shapes shapes)
+          (u/not-valid plugin-id :createBoolean-shapes shapes)
 
           :else
           (let [ids      (into #{} (map #(obj/get % "$id")) shapes)
@@ -436,10 +436,10 @@
       (let [type (d/nilv (obj/get options "type") "html")]
         (cond
           (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-          (u/display-not-valid :generateMarkup-shapes shapes)
+          (u/not-valid plugin-id :generateMarkup-shapes shapes)
 
           (and (some? type) (not (contains? #{"html" "svg"} type)))
-          (u/display-not-valid :generateMarkup-type type)
+          (u/not-valid plugin-id :generateMarkup-type type)
 
           :else
           (let [resolved-code
@@ -471,16 +471,16 @@
             children? (d/nilv (obj/get options "includeChildren") true)]
         (cond
           (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-          (u/display-not-valid :generateStyle-shapes shapes)
+          (u/not-valid plugin-id :generateStyle-shapes shapes)
 
           (and (some? type) (not (contains? #{"css"} type)))
-          (u/display-not-valid :generateStyle-type type)
+          (u/not-valid plugin-id :generateStyle-type type)
 
           (and (some? prelude?) (not (boolean? prelude?)))
-          (u/display-not-valid :generateStyle-withPrelude prelude?)
+          (u/not-valid plugin-id :generateStyle-withPrelude prelude?)
 
           (and (some? children?) (not (boolean? children?)))
-          (u/display-not-valid :generateStyle-includeChildren children?)
+          (u/not-valid plugin-id :generateStyle-includeChildren children?)
 
           :else
           (let [resolved-styles
@@ -553,7 +553,7 @@
                  :else nil)
             new-window (if (boolean? new-window) new-window false)]
         (if (nil? id)
-          (u/display-not-valid :openPage "Expected a Page object or a page UUID string")
+          (u/not-valid plugin-id :openPage "Expected a Page object or a page UUID string")
           (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
 
     :alignHorizontal
@@ -565,10 +565,10 @@
                   nil)]
         (cond
           (nil? dir)
-          (u/display-not-valid :alignHorizontal-direction "Direction not valid")
+          (u/not-valid plugin-id :alignHorizontal-direction "Direction not valid")
 
           (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-          (u/display-not-valid :alignHorizontal-shapes "Not valid shapes")
+          (u/not-valid plugin-id :alignHorizontal-shapes "Not valid shapes")
 
           :else
           (let [ids (into #{} (map #(obj/get % "$id")) shapes)]
@@ -583,10 +583,10 @@
                   nil)]
         (cond
           (nil? dir)
-          (u/display-not-valid :alignVertical-direction "Direction not valid")
+          (u/not-valid plugin-id :alignVertical-direction "Direction not valid")
 
           (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-          (u/display-not-valid :alignVertical-shapes "Not valid shapes")
+          (u/not-valid plugin-id :alignVertical-shapes "Not valid shapes")
 
           :else
           (let [ids (into #{} (map #(obj/get % "$id")) shapes)]
@@ -596,7 +596,7 @@
     (fn [shapes]
       (cond
         (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-        (u/display-not-valid :distributeHorizontal-shapes "Not valid shapes")
+        (u/not-valid plugin-id :distributeHorizontal-shapes "Not valid shapes")
 
         :else
         (let [ids (into #{} (map #(obj/get % "$id")) shapes)]
@@ -606,7 +606,7 @@
     (fn [shapes]
       (cond
         (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-        (u/display-not-valid :distributeVertical-shapes "Not valid shapes")
+        (u/not-valid plugin-id :distributeVertical-shapes "Not valid shapes")
 
         :else
         (let [ids (into #{} (map #(obj/get % "$id")) shapes)]
@@ -616,7 +616,7 @@
     (fn [shapes]
       (cond
         (or (not (array? shapes)) (not (every? shape/shape-proxy? shapes)))
-        (u/display-not-valid :flatten-shapes "Not valid shapes")
+        (u/not-valid plugin-id :flatten-shapes "Not valid shapes")
 
         :else
         (let [ids (into #{} (map #(obj/get % "$id")) shapes)]
@@ -627,7 +627,7 @@
       (cond
         (or (not (seq shapes))
             (not (every? u/is-main-component-proxy? shapes)))
-        (u/display-not-valid :shapes shapes)
+        (u/not-valid plugin-id :shapes shapes)
 
         :else
         (let [file-id (obj/get (first shapes) "$file")

--- a/frontend/src/app/plugins/comments.cljs
+++ b/frontend/src/app/plugins/comments.cljs
@@ -60,13 +60,13 @@
          (let [profile (:profile @st/state)]
            (cond
              (or (not (string? content)) (empty? content))
-             (u/display-not-valid :content "Not valid")
+             (u/not-valid plugin-id :content "Not valid")
 
              (not= (:id profile) (:owner-id data))
-             (u/display-not-valid :content "Cannot change content from another user's comments")
+             (u/not-valid plugin-id :content "Cannot change content from another user's comments")
 
              (not (r/check-permission plugin-id "comment:write"))
-             (u/display-not-valid :content "Plugin doesn't have 'comment:write' permission")
+             (u/not-valid plugin-id :content "Plugin doesn't have 'comment:write' permission")
 
              :else
              (->> (rp/cmd! :update-comment {:id (:id data) :content content})
@@ -81,7 +81,7 @@
            (cond
              (not (r/check-permission plugin-id "comment:write"))
              (do
-               (u/display-not-valid :remove "Plugin doesn't have 'comment:write' permission")
+               (u/not-valid plugin-id :remove "Plugin doesn't have 'comment:write' permission")
                (reject "Plugin doesn't have 'comment:write' permission"))
 
              :else
@@ -120,10 +120,10 @@
            (cond
              (or (not (sm/valid-safe-number? (:x position)))
                  (not (sm/valid-safe-number? (:y position))))
-             (u/display-not-valid :position "Not valid point")
+             (u/not-valid plugin-id :position "Not valid point")
 
              (not (r/check-permission plugin-id "comment:write"))
-             (u/display-not-valid :position "Plugin doesn't have 'comment:write' permission")
+             (u/not-valid plugin-id :position "Plugin doesn't have 'comment:write' permission")
 
              :else
              (do (st/emit! (dwc/update-comment-thread-position @data* [(:x position) (:y position)]))
@@ -137,10 +137,10 @@
        (fn [is-resolved]
          (cond
            (not (boolean? is-resolved))
-           (u/display-not-valid :resolved "Not a boolean type")
+           (u/not-valid plugin-id :resolved "Not a boolean type")
 
            (not (r/check-permission plugin-id "comment:write"))
-           (u/display-not-valid :resolved "Plugin doesn't have 'comment:write' permission")
+           (u/not-valid plugin-id :resolved "Plugin doesn't have 'comment:write' permission")
 
            :else
            (do (st/emit! (dc/update-comment-thread (assoc @data* :is-resolved is-resolved)))
@@ -153,7 +153,7 @@
            (cond
              (not (r/check-permission plugin-id "comment:read"))
              (do
-               (u/display-not-valid :findComments "Plugin doesn't have 'comment:read' permission")
+               (u/not-valid plugin-id :findComments "Plugin doesn't have 'comment:read' permission")
                (reject "Plugin doesn't have 'comment:read' permission"))
 
              :else
@@ -169,10 +169,10 @@
       (fn [content]
         (cond
           (not (r/check-permission plugin-id "comment:write"))
-          (u/display-not-valid :reply "Plugin doesn't have 'comment:write' permission")
+          (u/not-valid plugin-id :reply "Plugin doesn't have 'comment:write' permission")
 
           (or (not (string? content)) (empty? content))
-          (u/display-not-valid :reply "Not valid")
+          (u/not-valid plugin-id :reply "Not valid")
 
           :else
           (js/Promise.
@@ -186,10 +186,10 @@
               owner   (dsh/lookup-profile @st/state (:owner-id data))]
           (cond
             (not (r/check-permission plugin-id "comment:write"))
-            (u/display-not-valid :remove "Plugin doesn't have 'comment:write' permission")
+            (u/not-valid plugin-id :remove "Plugin doesn't have 'comment:write' permission")
 
             (not= (:id profile) owner)
-            (u/display-not-valid :remove "Cannot change content from another user's comments")
+            (u/not-valid plugin-id :remove "Cannot change content from another user's comments")
 
             :else
             (js/Promise.

--- a/frontend/src/app/plugins/file.cljs
+++ b/frontend/src/app/plugins/file.cljs
@@ -45,10 +45,10 @@
        (fn [value]
          (cond
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :label "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :label "Plugin doesn't have 'content:write' permission")
 
            (or (not (string? value)) (empty? value))
-           (u/display-not-valid :label value)
+           (u/not-valid plugin-id :label value)
 
            :else
            (do (swap! data assoc :label value :created-by "user")
@@ -145,7 +145,7 @@
     (fn [key]
       (cond
         (not (string? key))
-        (u/display-not-valid :getPluginData-key key)
+        (u/not-valid plugin-id :getPluginData-key key)
 
         :else
         (let [file (u/locate-file id)]
@@ -155,13 +155,13 @@
     (fn [key value]
       (cond
         (or (not (string? key)) (empty? key))
-        (u/display-not-valid :setPluginData-key key)
+        (u/not-valid plugin-id :setPluginData-key key)
 
         (not (string? value))
-        (u/display-not-valid :setPluginData-value value)
+        (u/not-valid plugin-id :setPluginData-value value)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :setPluginData "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data id :file (keyword "plugin" (str plugin-id)) key value))))
@@ -175,10 +175,10 @@
     (fn [namespace key]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :getSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :getSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :getSharedPluginData-key key)
+        (u/not-valid plugin-id :getSharedPluginData-key key)
 
         :else
         (let [file (u/locate-file id)]
@@ -188,16 +188,16 @@
     (fn [namespace key value]
       (cond
         (or (not (string? namespace)) (empty? namespace))
-        (u/display-not-valid :setSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
         (or (not (string? key)) (empty? key))
-        (u/display-not-valid :setSharedPluginData-key key)
+        (u/not-valid plugin-id :setSharedPluginData-key key)
 
         (not (string? value))
-        (u/display-not-valid :setSharedPluginData-value value)
+        (u/not-valid plugin-id :setSharedPluginData-value value)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data id :file (keyword "shared" namespace) key value))))
@@ -206,7 +206,7 @@
     (fn [namespace]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :getSharedPluginDataKeys namespace)
+        (u/not-valid plugin-id :getSharedPluginDataKeys namespace)
 
         :else
         (let [file (u/locate-file id)]
@@ -216,7 +216,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :createPage "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :createPage "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [page-id (uuid/next)]

--- a/frontend/src/app/plugins/flags.cljs
+++ b/frontend/src/app/plugins/flags.cljs
@@ -6,16 +6,10 @@
 
 (ns app.plugins.flags
   (:require
-   [app.common.data.macros :as dm]
    [app.main.store :as st]
    [app.plugins.utils :as u]
    [app.util.object :as obj]
    [potok.v2.core :as ptk]))
-
-(defn natural-child-ordering?
-  [plugin-id]
-  (boolean
-   (dm/get-in @st/state [:plugins :flags plugin-id :natural-child-ordering])))
 
 (defn clear
   [id]
@@ -37,13 +31,27 @@
     :naturalChildOrdering
     {:this false
      :get
-     (fn [] (natural-child-ordering? plugin-id))
+     (fn [] (u/natural-child-ordering? plugin-id))
 
      :set
      (fn [value]
        (cond
          (not (boolean? value))
-         (u/display-not-valid :naturalChildOrdering value)
+         (u/not-valid plugin-id :naturalChildOrdering value)
 
          :else
-         (st/emit! (set-flag plugin-id :natural-child-ordering value))))}))
+         (st/emit! (set-flag plugin-id :natural-child-ordering value))))}
+
+    :throwValidationErrors
+    {:this false
+     :get
+     (fn [] (u/throw-validation-errors? plugin-id))
+
+     :set
+     (fn [value]
+       (cond
+         (not (boolean? value))
+         (u/not-valid plugin-id :throwValidationErrors value)
+
+         :else
+         (st/emit! (set-flag plugin-id :throw-validation-errors value))))}))

--- a/frontend/src/app/plugins/flex.cljs
+++ b/frontend/src/app/plugins/flex.cljs
@@ -12,7 +12,6 @@
    [app.main.data.workspace.shape-layout :as dwsl]
    [app.main.data.workspace.shapes :as dwsh]
    [app.main.store :as st]
-   [app.plugins.flags :refer [natural-child-ordering?]]
    [app.plugins.register :as r]
    [app.plugins.utils :as u]
    [app.util.object :as obj]))
@@ -39,10 +38,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/flex-direction-types value))
-           (u/display-not-valid :dir value)
+           (u/not-valid plugin-id :dir value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :dir "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :dir "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-flex-dir value})))))}
@@ -55,10 +54,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/wrap-types value))
-           (u/display-not-valid :wrap value)
+           (u/not-valid plugin-id :wrap value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :wrap "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :wrap "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-wrap-type value})))))}
@@ -71,10 +70,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/align-items-types value))
-           (u/display-not-valid :alignItems value)
+           (u/not-valid plugin-id :alignItems value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :alignItems "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :alignItems "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-align-items value})))))}
@@ -87,10 +86,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/align-content-types value))
-           (u/display-not-valid :alignContent value)
+           (u/not-valid plugin-id :alignContent value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :alignContent "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :alignContent "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-align-content value})))))}
@@ -103,10 +102,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/justify-items-types value))
-           (u/display-not-valid :justifyItems value)
+           (u/not-valid plugin-id :justifyItems value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :justifyItems "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :justifyItems "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-justify-items value})))))}
@@ -119,10 +118,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/justify-content-types value))
-           (u/display-not-valid :justifyContent value)
+           (u/not-valid plugin-id :justifyContent value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :justifyContent "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :justifyContent "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-justify-content value})))))}
@@ -134,10 +133,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :rowGap value)
+         (u/not-valid plugin-id :rowGap value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :rowGap "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :rowGap "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-gap {:row-gap value}}))))}
@@ -149,10 +148,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :columnGap value)
+         (u/not-valid plugin-id :columnGap value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :columnGap "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :columnGap "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-gap {:column-gap value}}))))}
@@ -164,10 +163,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :verticalPadding value)
+         (u/not-valid plugin-id :verticalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :verticalPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :verticalPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p1 value :p3 value}}))))}
@@ -179,10 +178,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :horizontalPadding value)
+         (u/not-valid plugin-id :horizontalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :horizontalPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :horizontalPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p2 value :p4 value}}))))}
@@ -195,10 +194,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :topPadding value)
+         (u/not-valid plugin-id :topPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :topPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :topPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p1 value}}))))}
@@ -210,10 +209,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :rightPadding value)
+         (u/not-valid plugin-id :rightPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :rightPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :rightPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p2 value}}))))}
@@ -225,10 +224,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :bottomPadding value)
+         (u/not-valid plugin-id :bottomPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :bottomPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :bottomPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p3 value}}))))}
@@ -240,10 +239,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :leftPadding value)
+         (u/not-valid plugin-id :leftPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :leftPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :leftPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p4 value}}))))}
@@ -256,13 +255,13 @@
     (fn [child]
       (cond
         (not (shape-proxy? child))
-        (u/display-not-valid :appendChild child)
+        (u/not-valid plugin-id :appendChild child)
 
         :else
         (let [child-id (obj/get child "$id")
               shape (u/locate-shape file-id page-id id)
               index
-              (if (and (natural-child-ordering? plugin-id) (not (ctl/reverse? shape)))
+              (if (and (u/natural-child-ordering? plugin-id) (not (ctl/reverse? shape)))
                 0
                 (count (:shapes shape)))]
           (st/emit! (dwsh/relocate-shapes #{child-id} id index)))))
@@ -275,10 +274,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/item-h-sizing-types value))
-           (u/display-not-valid :horizontalSizing value)
+           (u/not-valid plugin-id :horizontalSizing value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :horizontalSizing "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :horizontalSizing "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-item-h-sizing value})))))}
@@ -291,10 +290,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/item-v-sizing-types value))
-           (u/display-not-valid :verticalSizing value)
+           (u/not-valid plugin-id :verticalSizing value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :verticalSizing "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :verticalSizing "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-item-v-sizing value})))))}))
@@ -317,10 +316,10 @@
      (fn [_ value]
        (cond
          (not (boolean? value))
-         (u/display-not-valid :absolute value)
+         (u/not-valid plugin-id :absolute value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :absolute "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :absolute "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-item-absolute value}))))}
@@ -332,10 +331,10 @@
      (fn [_ value]
        (cond
          (sm/valid-safe-int? value)
-         (u/display-not-valid :zIndex value)
+         (u/not-valid plugin-id :zIndex value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :zIndex "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :zIndex "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-z-index value}))))}
@@ -348,10 +347,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/item-h-sizing-types value))
-           (u/display-not-valid :horizontalPadding value)
+           (u/not-valid plugin-id :horizontalPadding value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :horizontalPadding "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :horizontalPadding "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout-child #{id} {:layout-item-h-sizing value})))))}
@@ -364,10 +363,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/item-v-sizing-types value))
-           (u/display-not-valid :verticalSizing value)
+           (u/not-valid plugin-id :verticalSizing value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :verticalSizing "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :verticalSizing "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout-child #{id} {:layout-item-v-sizing value})))))}
@@ -380,10 +379,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/item-align-self-types value))
-           (u/display-not-valid :alignSelf value)
+           (u/not-valid plugin-id :alignSelf value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :alignSelf "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :alignSelf "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout-child #{id} {:layout-item-align-self value})))))}
@@ -395,10 +394,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :verticalMargin value)
+         (u/not-valid plugin-id :verticalMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :verticalMargin "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :verticalMargin "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-margin {:m1 value :m3 value}}))))}
@@ -410,10 +409,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :horizontalMargin value)
+         (u/not-valid plugin-id :horizontalMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :horizontalMargin "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :horizontalMargin "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-margin {:m2 value :m4 value}}))))}
@@ -425,10 +424,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :topMargin value)
+         (u/not-valid plugin-id :topMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :topMargin "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :topMargin "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-margin {:m1 value}}))))}
@@ -440,10 +439,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :rightMargin value)
+         (u/not-valid plugin-id :rightMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :rightMargin "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :rightMargin "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-margin {:m2 value}}))))}
@@ -455,10 +454,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :bottomMargin value)
+         (u/not-valid plugin-id :bottomMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :bottomMargin "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :bottomMargin "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-margin {:m3 value}}))))}
@@ -470,10 +469,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :leftMargin value)
+         (u/not-valid plugin-id :leftMargin value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :leftMargin "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :leftMargin "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-margin {:m4 value}}))))}
@@ -485,10 +484,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :maxWidth value)
+         (u/not-valid plugin-id :maxWidth value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :maxWidth "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :maxWidth "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-max-w value}))))}
@@ -500,10 +499,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :minWidth value)
+         (u/not-valid plugin-id :minWidth value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :minWidth "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :minWidth "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-min-w value}))))}
@@ -515,10 +514,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :maxHeight value)
+         (u/not-valid plugin-id :maxHeight value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :maxHeight "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :maxHeight "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-max-h value}))))}
@@ -530,10 +529,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :minHeight value)
+         (u/not-valid plugin-id :minHeight value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :minHeight "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :minHeight "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout-child #{id} {:layout-item-min-h value}))))}))

--- a/frontend/src/app/plugins/fonts.cljs
+++ b/frontend/src/app/plugins/fonts.cljs
@@ -32,7 +32,7 @@
   (obj/type-of? p "FontProxy"))
 
 (defn font-proxy
-  [{:keys [id family name variants] :as font}]
+  [plugin-id {:keys [id family name variants] :as font}]
   (when (some? font)
     (let [default-variant (fonts/get-default-variant font)]
       (obj/reify {:name "FontProxy"}
@@ -55,10 +55,10 @@
         (fn [text variant]
           (cond
             (not (shape/shape-proxy? text))
-            (u/display-not-valid :applyToText text)
+            (u/not-valid plugin-id :applyToText text)
 
             (not (r/check-permission (obj/get text "$plugin") "content:write"))
-            (u/display-not-valid :applyToText "Plugin doesn't have 'content:write' permission")
+            (u/not-valid plugin-id :applyToText "Plugin doesn't have 'content:write' permission")
 
             :else
             (let [id (obj/get text "$id")
@@ -73,10 +73,10 @@
         (fn [range variant]
           (cond
             (not (text/text-range-proxy? range))
-            (u/display-not-valid :applyToRange range)
+            (u/not-valid plugin-id :applyToRange range)
 
             (not (r/check-permission (obj/get range "$plugin") "content:write"))
-            (u/display-not-valid :applyToRange "Plugin doesn't have 'content:write' permission")
+            (u/not-valid plugin-id :applyToRange "Plugin doesn't have 'content:write' permission")
 
             :else
             (let [id    (obj/get range "$id")
@@ -98,53 +98,53 @@
     {:get
      (fn []
        (format/format-array
-        font-proxy
+        (partial font-proxy plugin-id)
         (vals @fonts/fontsdb)))}
 
     :findById
     (fn [id]
       (cond
         (not (string? id))
-        (u/display-not-valid :findbyId id)
+        (u/not-valid plugin-id :findbyId id)
 
         :else
         (->> (vals @fonts/fontsdb)
              (d/seek #(str/includes? (str/lower (:id %)) (str/lower id)))
-             (font-proxy))))
+             (font-proxy plugin-id))))
 
     :findByName
     (fn [name]
       (cond
         (not (string? name))
-        (u/display-not-valid :findByName name)
+        (u/not-valid plugin-id :findByName name)
 
         :else
         (->> (vals @fonts/fontsdb)
              (d/seek #(str/includes? (str/lower (:name %)) (str/lower name)))
-             (font-proxy))))
+             (font-proxy plugin-id))))
 
     :findAllById
     (fn [id]
       (cond
         (not (string? id))
-        (u/display-not-valid :findAllById name)
+        (u/not-valid plugin-id :findAllById name)
 
         :else
         (format/format-array
          (fn [font]
            (when (str/includes? (str/lower (:id font)) (str/lower id))
-             (font-proxy font)))
+             (font-proxy plugin-id font)))
          (vals @fonts/fontsdb))))
 
     :findAllByName
     (fn [name]
       (cond
         (not (string? name))
-        (u/display-not-valid :findAllByName name)
+        (u/not-valid plugin-id :findAllByName name)
 
         :else
         (format/format-array
          (fn [font]
            (when (str/includes? (str/lower (:name font)) (str/lower name))
-             (font-proxy font)))
+             (font-proxy plugin-id font)))
          (vals @fonts/fontsdb))))))

--- a/frontend/src/app/plugins/grid.cljs
+++ b/frontend/src/app/plugins/grid.cljs
@@ -40,10 +40,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/grid-direction-types value))
-           (u/display-not-valid :dir value)
+           (u/not-valid plugin-id :dir value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :dir "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :dir "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-grid-dir value})))))}
@@ -64,10 +64,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/align-items-types value))
-           (u/display-not-valid :alignItems value)
+           (u/not-valid plugin-id :alignItems value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :alignItems "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :alignItems "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-align-items value})))))}
@@ -80,10 +80,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/align-content-types value))
-           (u/display-not-valid :alignContent value)
+           (u/not-valid plugin-id :alignContent value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :alignContent "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :alignContent "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-align-content value})))))}
@@ -96,10 +96,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/justify-items-types value))
-           (u/display-not-valid :justifyItems value)
+           (u/not-valid plugin-id :justifyItems value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :justifyItems "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :justifyItems "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-justify-items value})))))}
@@ -112,10 +112,10 @@
        (let [value (keyword value)]
          (cond
            (not (contains? ctl/justify-content-types value))
-           (u/display-not-valid :justifyContent value)
+           (u/not-valid plugin-id :justifyContent value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :justifyContent "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :justifyContent "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwsl/update-layout #{id} {:layout-justify-content value})))))}
@@ -127,10 +127,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :rowGap value)
+         (u/not-valid plugin-id :rowGap value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :rowGap "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :rowGap "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-gap {:row-gap value}}))))}
@@ -142,10 +142,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :columnGap value)
+         (u/not-valid plugin-id :columnGap value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :columnGap "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :columnGap "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-gap {:column-gap value}}))))}
@@ -157,10 +157,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :verticalPadding value)
+         (u/not-valid plugin-id :verticalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :verticalPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :verticalPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p1 value :p3 value}}))))}
@@ -172,10 +172,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :horizontalPadding value)
+         (u/not-valid plugin-id :horizontalPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :horizontalPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :horizontalPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p2 value :p4 value}}))))}
@@ -187,10 +187,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :topPadding value)
+         (u/not-valid plugin-id :topPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :topPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :topPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p1 value}}))))}
@@ -202,10 +202,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :rightPadding value)
+         (u/not-valid plugin-id :rightPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :righPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :righPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p2 value}}))))}
@@ -217,10 +217,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :bottomPadding value)
+         (u/not-valid plugin-id :bottomPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :bottomPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :bottomPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p3 value}}))))}
@@ -232,10 +232,10 @@
      (fn [_ value]
        (cond
          (not (sm/valid-safe-int? value))
-         (u/display-not-valid :leftPadding value)
+         (u/not-valid plugin-id :leftPadding value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :leftPadding "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :leftPadding "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwsl/update-layout #{id} {:layout-padding {:p4 value}}))))}
@@ -245,14 +245,14 @@
       (let [type (keyword type)]
         (cond
           (not (contains? ctl/grid-track-types type))
-          (u/display-not-valid :addRow-type type)
+          (u/not-valid plugin-id :addRow-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
                (not (sm/valid-safe-number? value)))
-          (u/display-not-valid :addRow-value value)
+          (u/not-valid plugin-id :addRow-value value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :addRow "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :addRow "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwsl/add-layout-track #{id} :row {:type type :value value})))))
@@ -262,17 +262,17 @@
       (let [type (keyword type)]
         (cond
           (not (sm/valid-safe-int? index))
-          (u/display-not-valid :addRowAtIndex-index index)
+          (u/not-valid plugin-id :addRowAtIndex-index index)
 
           (not (contains? ctl/grid-track-types type))
-          (u/display-not-valid :addRowAtIndex-type type)
+          (u/not-valid plugin-id :addRowAtIndex-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
                (not (sm/valid-safe-number? value)))
-          (u/display-not-valid :addRowAtIndex-value value)
+          (u/not-valid plugin-id :addRowAtIndex-value value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :addRowAtIndex "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :addRowAtIndex "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwsl/add-layout-track #{id} :row {:type type :value value} index)))))
@@ -282,14 +282,14 @@
       (let [type (keyword type)]
         (cond
           (not (contains? ctl/grid-track-types type))
-          (u/display-not-valid :addColumn-type type)
+          (u/not-valid plugin-id :addColumn-type type)
 
           (and (or (= :percent type) (= :flex type) (= :lex type))
                (not (sm/valid-safe-number? value)))
-          (u/display-not-valid :addColumn-value value)
+          (u/not-valid plugin-id :addColumn-value value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :addColumn "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :addColumn "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwsl/add-layout-track #{id} :column {:type type :value value})))))
@@ -298,17 +298,17 @@
     (fn [index type value]
       (cond
         (not (sm/valid-safe-int? index))
-        (u/display-not-valid :addColumnAtIndex-index index)
+        (u/not-valid plugin-id :addColumnAtIndex-index index)
 
         (not (contains? ctl/grid-track-types type))
-        (u/display-not-valid :addColumnAtIndex-type type)
+        (u/not-valid plugin-id :addColumnAtIndex-type type)
 
         (and (or (= :percent type) (= :flex type) (= :fixed type))
              (not (sm/valid-safe-number? value)))
-        (u/display-not-valid :addColumnAtIndex-value value)
+        (u/not-valid plugin-id :addColumnAtIndex-value value)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :addColumnAtIndex "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :addColumnAtIndex "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [type (keyword type)]
@@ -318,10 +318,10 @@
     (fn [index]
       (cond
         (not (sm/valid-safe-int? index))
-        (u/display-not-valid :removeRow index)
+        (u/not-valid plugin-id :removeRow index)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :removeRow "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :removeRow "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dwsl/remove-layout-track #{id} :row index))))
@@ -330,10 +330,10 @@
     (fn [index]
       (cond
         (not (sm/valid-safe-int? index))
-        (u/display-not-valid :removeColumn index)
+        (u/not-valid plugin-id :removeColumn index)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :removeColumn "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :removeColumn "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dwsl/remove-layout-track #{id} :column index))))
@@ -343,17 +343,17 @@
       (let [type (keyword type)]
         (cond
           (not (sm/valid-safe-int? index))
-          (u/display-not-valid :setColumn-index index)
+          (u/not-valid plugin-id :setColumn-index index)
 
           (not (contains? ctl/grid-track-types type))
-          (u/display-not-valid :setColumn-type type)
+          (u/not-valid plugin-id :setColumn-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
                (not (sm/valid-safe-number? value)))
-          (u/display-not-valid :setColumn-value value)
+          (u/not-valid plugin-id :setColumn-value value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :setColumn "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :setColumn "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwsl/change-layout-track #{id} :column index (d/without-nils {:type type :value value}))))))
@@ -363,17 +363,17 @@
       (let [type (keyword type)]
         (cond
           (not (sm/valid-safe-int? index))
-          (u/display-not-valid :setRow-index index)
+          (u/not-valid plugin-id :setRow-index index)
 
           (not (contains? ctl/grid-track-types type))
-          (u/display-not-valid :setRow-type type)
+          (u/not-valid plugin-id :setRow-type type)
 
           (and (or (= :percent type) (= :flex type) (= :fixed type))
                (not (sm/valid-safe-number? value)))
-          (u/display-not-valid :setRow-value value)
+          (u/not-valid plugin-id :setRow-value value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :setRow "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :setRow "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwsl/change-layout-track #{id} :row index (d/without-nils {:type type :value value}))))))
@@ -382,7 +382,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :remove "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :remove "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dwsl/remove-layout #{id}))))
@@ -391,16 +391,16 @@
     (fn [child row column]
       (cond
         (not (shape-proxy? child))
-        (u/display-not-valid :appendChild-child child)
+        (u/not-valid plugin-id :appendChild-child child)
 
         (or (< row 0) (not (sm/valid-safe-int? row)))
-        (u/display-not-valid :appendChild-row row)
+        (u/not-valid plugin-id :appendChild-row row)
 
         (or (< column 0) (not (sm/valid-safe-int? column)))
-        (u/display-not-valid :appendChild-column column)
+        (u/not-valid plugin-id :appendChild-column column)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :appendChild "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :appendChild "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [child-id  (obj/get child "$id")]
@@ -432,13 +432,13 @@
                shape (u/proxy->shape self)]
            (cond
              (not (sm/valid-safe-int? value))
-             (u/display-not-valid :row-value value)
+             (u/not-valid plugin-id :row-value value)
 
              (nil? cell)
-             (u/display-not-valid :row-cell "cell not found")
+             (u/not-valid plugin-id :row-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :row "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :row "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cell-position (:parent-id shape) (:id cell) {:row value})))))}
@@ -452,13 +452,13 @@
                cell (locate-cell self)]
            (cond
              (not (sm/valid-safe-int? value))
-             (u/display-not-valid :rowSpan-value value)
+             (u/not-valid plugin-id :rowSpan-value value)
 
              (nil? cell)
-             (u/display-not-valid :rowSpan-cell "cell not found")
+             (u/not-valid plugin-id :rowSpan-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :rowSpan "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :rowSpan "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cell-position (:parent-id shape) (:id cell) {:row-span value})))))}
@@ -472,13 +472,13 @@
                cell (locate-cell self)]
            (cond
              (not (sm/valid-safe-int? value))
-             (u/display-not-valid :column-value value)
+             (u/not-valid plugin-id :column-value value)
 
              (nil? cell)
-             (u/display-not-valid :column-cell "cell not found")
+             (u/not-valid plugin-id :column-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :column "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :column "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cell-position (:parent-id shape) (:id cell) {:column value})))))}
@@ -492,13 +492,13 @@
                cell (locate-cell self)]
            (cond
              (not (sm/valid-safe-int? value))
-             (u/display-not-valid :columnSpan-value value)
+             (u/not-valid plugin-id :columnSpan-value value)
 
              (nil? cell)
-             (u/display-not-valid :columnSpan-cell "cell not found")
+             (u/not-valid plugin-id :columnSpan-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :columnSpan "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :columnSpan "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cell-position (:parent-id shape) (:id cell) {:column-span value})))))}
@@ -512,13 +512,13 @@
                cell (locate-cell self)]
            (cond
              (not (string? value))
-             (u/display-not-valid :areaName-value value)
+             (u/not-valid plugin-id :areaName-value value)
 
              (nil? cell)
-             (u/display-not-valid :areaName-cell "cell not found")
+             (u/not-valid plugin-id :areaName-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :areaName "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :areaName "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cells (:parent-id shape) #{(:id cell)} {:area-name value})))))}
@@ -533,13 +533,13 @@
                value (keyword value)]
            (cond
              (not (contains? ctl/grid-position-types value))
-             (u/display-not-valid :position-value value)
+             (u/not-valid plugin-id :position-value value)
 
              (nil? cell)
-             (u/display-not-valid :position-cell "cell not found")
+             (u/not-valid plugin-id :position-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :position "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :position "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/change-cells-mode (:parent-id shape) #{(:id cell)} value)))))}
@@ -554,13 +554,13 @@
                cell (locate-cell self)]
            (cond
              (not (contains? ctl/grid-cell-align-self-types value))
-             (u/display-not-valid :alignSelf-value value)
+             (u/not-valid plugin-id :alignSelf-value value)
 
              (nil? cell)
-             (u/display-not-valid :alignSelf-cell "cell not found")
+             (u/not-valid plugin-id :alignSelf-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :alignSelf "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :alignSelf "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cells (:parent-id shape) #{(:id cell)} {:align-self value})))))}
@@ -575,13 +575,13 @@
                cell (locate-cell self)]
            (cond
              (not (contains? ctl/grid-cell-justify-self-types value))
-             (u/display-not-valid :justifySelf-value value)
+             (u/not-valid plugin-id :justifySelf-value value)
 
              (nil? cell)
-             (u/display-not-valid :justifySelf-cell "cell not found")
+             (u/not-valid plugin-id :justifySelf-cell "cell not found")
 
              (not (r/check-permission plugin-id "content:write"))
-             (u/display-not-valid :justifySelf "Plugin doesn't have 'content:write' permission")
+             (u/not-valid plugin-id :justifySelf "Plugin doesn't have 'content:write' permission")
 
              :else
              (st/emit! (dwsl/update-grid-cells (:parent-id shape) #{(:id cell)} {:justify-self value})))))})))

--- a/frontend/src/app/plugins/history.cljs
+++ b/frontend/src/app/plugins/history.cljs
@@ -24,7 +24,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :resize "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :resize "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [id (js/Symbol)]
@@ -35,10 +35,10 @@
     (fn [block-id]
       (cond
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :resize "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :resize "Plugin doesn't have 'content:write' permission")
 
         (not block-id)
-        (u/display-not-valid :undoBlockFinish block-id)
+        (u/not-valid plugin-id :undoBlockFinish block-id)
 
         :else
         (st/emit! (dwu/commit-undo-transaction block-id))))))

--- a/frontend/src/app/plugins/library.cljs
+++ b/frontend/src/app/plugins/library.cljs
@@ -60,10 +60,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :name value)
+         (u/not-valid plugin-id :name value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :name "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :name "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [color (u/proxy->library-color self)
@@ -77,10 +77,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :path value)
+         (u/not-valid plugin-id :path value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :path "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :path "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [color (-> (u/proxy->library-color self)
@@ -94,10 +94,10 @@
      (fn [self value]
        (cond
          (or (not (string? value)) (not (clr/valid-hex-color? value)))
-         (u/display-not-valid :color value)
+         (u/not-valid plugin-id :color value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :color "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :color "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [color (-> (u/proxy->library-color self)
@@ -111,10 +111,10 @@
      (fn [self value]
        (cond
          (or (not (number? value)) (< value 0) (> value 1))
-         (u/display-not-valid :opacity value)
+         (u/not-valid plugin-id :opacity value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :opacity "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :opacity "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [color (-> (u/proxy->library-color self)
@@ -129,10 +129,10 @@
        (let [value (parser/parse-gradient value)]
          (cond
            (not (sm/validate clr/schema:gradient value))
-           (u/display-not-valid :gradient value)
+           (u/not-valid plugin-id :gradient value)
 
            (not (r/check-permission plugin-id "library:write"))
-           (u/display-not-valid :gradient "Plugin doesn't have 'library:write' permission")
+           (u/not-valid plugin-id :gradient "Plugin doesn't have 'library:write' permission")
 
            :else
            (let [color (-> (u/proxy->library-color self)
@@ -147,10 +147,10 @@
        (let [value (parser/parse-image-data value)]
          (cond
            (not (sm/validate clr/schema:image value))
-           (u/display-not-valid :image value)
+           (u/not-valid plugin-id :image value)
 
            (not (r/check-permission plugin-id "library:write"))
-           (u/display-not-valid :image "Plugin doesn't have 'library:write' permission")
+           (u/not-valid plugin-id :image "Plugin doesn't have 'library:write' permission")
 
            :else
            (let [color (-> (u/proxy->library-color self)
@@ -161,7 +161,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :remove "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :remove "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dwl/delete-color {:id id}))))
@@ -170,7 +170,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :clone "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :clone "Plugin doesn't have 'library:write' permission")
 
         :else
         (let [color-id (uuid/next)
@@ -207,7 +207,7 @@
     (fn [key]
       (cond
         (not (string? key))
-        (u/display-not-valid :getPluginData-key key)
+        (u/not-valid plugin-id :getPluginData-key key)
 
         :else
         (let [color (u/locate-library-color file-id id)]
@@ -217,16 +217,16 @@
     (fn [key value]
       (cond
         (not= file-id (:current-file-id @st/state))
-        (u/display-not-valid :setPluginData-non-local-library file-id)
+        (u/not-valid plugin-id :setPluginData-non-local-library file-id)
 
         (not (string? key))
-        (u/display-not-valid :setPluginData-key key)
+        (u/not-valid plugin-id :setPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setPluginData-value value)
+        (u/not-valid plugin-id :setPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :color id (keyword "plugin" (str plugin-id)) key value))))
@@ -240,10 +240,10 @@
     (fn [namespace key]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :getSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :getSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :getSharedPluginData-key key)
+        (u/not-valid plugin-id :getSharedPluginData-key key)
 
         :else
         (let [color (u/locate-library-color file-id id)]
@@ -253,19 +253,19 @@
     (fn [namespace key value]
       (cond
         (not= file-id (:current-file-id @st/state))
-        (u/display-not-valid :setSharedPluginData-non-local-library file-id)
+        (u/not-valid plugin-id :setSharedPluginData-non-local-library file-id)
 
         (not (string? namespace))
-        (u/display-not-valid :setSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :setSharedPluginData-key key)
+        (u/not-valid plugin-id :setSharedPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setSharedPluginData-value value)
+        (u/not-valid plugin-id :setSharedPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :color id (keyword "shared" namespace) key value))))
@@ -274,7 +274,7 @@
     (fn [namespace]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :getSharedPluginDataKeys-namespace namespace)
+        (u/not-valid plugin-id :getSharedPluginDataKeys-namespace namespace)
 
         :else
         (let [color (u/locate-library-color file-id id)]
@@ -301,10 +301,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :name value)
+         (u/not-valid plugin-id :name value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :name "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :name "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (u/proxy->library-typography self)
@@ -318,10 +318,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :path value)
+         (u/not-valid plugin-id :path value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :path "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :path "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -335,10 +335,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :fontId value)
+         (u/not-valid plugin-id :fontId value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :fontId "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :fontId "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -352,10 +352,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :fontFamily value)
+         (u/not-valid plugin-id :fontFamily value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :fontFamily "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :fontFamily "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -369,10 +369,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :fontVariantId value)
+         (u/not-valid plugin-id :fontVariantId value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :fontVariantId "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :fontVariantId "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -386,10 +386,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :fontSize value)
+         (u/not-valid plugin-id :fontSize value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :fontSize "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :fontSize "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -403,10 +403,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :fontWeight value)
+         (u/not-valid plugin-id :fontWeight value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :fontWeight "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :fontWeight "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -420,10 +420,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :fontStyle value)
+         (u/not-valid plugin-id :fontStyle value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :fontStyle "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :fontStyle "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -437,10 +437,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :lineHeight value)
+         (u/not-valid plugin-id :lineHeight value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :lineHeight "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :lineHeight "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -454,10 +454,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :letterSpacing value)
+         (u/not-valid plugin-id :letterSpacing value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :letterSpacing "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :letterSpacing "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -471,10 +471,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :textTransform value)
+         (u/not-valid plugin-id :textTransform value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :textTransform "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :textTransform "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [typo (-> (u/proxy->library-typography self)
@@ -485,7 +485,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :remove "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :remove "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dwl/delete-typography {:id id}))))
@@ -494,7 +494,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :clone "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :clone "Plugin doesn't have 'library:write' permission")
 
         :else
         (let [typo-id (uuid/next)
@@ -507,10 +507,10 @@
     (fn [shape]
       (cond
         (not (shape/shape-proxy? shape))
-        (u/display-not-valid :applyToText shape)
+        (u/not-valid plugin-id :applyToText shape)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :applyToText "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :applyToText "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [shape-id   (obj/get shape "$id")
@@ -521,10 +521,10 @@
     (fn [range]
       (cond
         (not (text/text-range-proxy? range))
-        (u/display-not-valid :applyToText range)
+        (u/not-valid plugin-id :applyToText range)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :applyToText "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :applyToText "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [shape-id (obj/get range "$id")
@@ -542,7 +542,7 @@
     (fn [key]
       (cond
         (not (string? key))
-        (u/display-not-valid :typography-plugin-data-key key)
+        (u/not-valid plugin-id :typography-plugin-data-key key)
 
         :else
         (let [typography (u/locate-library-typography file-id id)]
@@ -552,16 +552,16 @@
     (fn [key value]
       (cond
         (not= file-id (:current-file-id @st/state))
-        (u/display-not-valid :setPluginData-non-local-library file-id)
+        (u/not-valid plugin-id :setPluginData-non-local-library file-id)
 
         (not (string? key))
-        (u/display-not-valid :setPluginData-key key)
+        (u/not-valid plugin-id :setPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setPluginData-value value)
+        (u/not-valid plugin-id :setPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :typography id (keyword "plugin" (str plugin-id)) key value))))
@@ -575,10 +575,10 @@
     (fn [namespace key]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :getSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :getSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :getSharedPluginData-key key)
+        (u/not-valid plugin-id :getSharedPluginData-key key)
 
         :else
         (let [typography (u/locate-library-typography file-id id)]
@@ -588,19 +588,19 @@
     (fn [namespace key value]
       (cond
         (not= file-id (:current-file-id @st/state))
-        (u/display-not-valid :setSharedPluginData-non-local-library file-id)
+        (u/not-valid plugin-id :setSharedPluginData-non-local-library file-id)
 
         (not (string? namespace))
-        (u/display-not-valid :setSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :setSharedPluginData-key key)
+        (u/not-valid plugin-id :setSharedPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setSharedPluginData-value value)
+        (u/not-valid plugin-id :setSharedPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :typography id (keyword "shared" namespace) key value))))
@@ -609,7 +609,7 @@
     (fn [namespace]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :getSharedPluginDataKeys-namespace namespace)
+        (u/not-valid plugin-id :getSharedPluginDataKeys-namespace namespace)
 
         :else
         (let [typography (u/locate-library-typography file-id id)]
@@ -674,7 +674,7 @@
     :removeProperty
     (fn [pos]
       (if (not (nat-int? pos))
-        (u/display-not-valid :pos pos)
+        (u/not-valid plugin-id :pos pos)
         (st/emit!
          (ev/event {::ev/name "remove-property" ::ev/origin "plugin:remove-property"})
          (dwv/remove-property id pos))))
@@ -683,10 +683,10 @@
     (fn [pos name]
       (cond
         (not (nat-int? pos))
-        (u/display-not-valid :pos pos)
+        (u/not-valid plugin-id :pos pos)
 
         (not (string? name))
-        (u/display-not-valid :name name)
+        (u/not-valid plugin-id :name name)
 
         :else
         (st/emit!
@@ -715,10 +715,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :name value)
+         (u/not-valid plugin-id :name value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :name "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :name "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [component (u/proxy->library-component self)
@@ -732,10 +732,10 @@
      (fn [self value]
        (cond
          (not (string? value))
-         (u/display-not-valid :path value)
+         (u/not-valid plugin-id :path value)
 
          (not (r/check-permission plugin-id "library:write"))
-         (u/display-not-valid :path "Plugin doesn't have 'library:write' permission")
+         (u/not-valid plugin-id :path "Plugin doesn't have 'library:write' permission")
 
          :else
          (let [component (u/proxy->library-component self)
@@ -746,7 +746,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :remove "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :remove "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dwl/delete-component {:id id}))))
@@ -755,7 +755,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :instance "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :instance "Plugin doesn't have 'content:write' permission")
 
         :else
         (let [id-ref (atom nil)]
@@ -766,7 +766,7 @@
     (fn [key]
       (cond
         (not (string? key))
-        (u/display-not-valid :component-plugin-data-key key)
+        (u/not-valid plugin-id :component-plugin-data-key key)
 
         :else
         (let [component (u/locate-library-component file-id id)]
@@ -776,16 +776,16 @@
     (fn [key value]
       (cond
         (not= file-id (:current-file-id @st/state))
-        (u/display-not-valid :setPluginData-non-local-library file-id)
+        (u/not-valid plugin-id :setPluginData-non-local-library file-id)
 
         (not (string? key))
-        (u/display-not-valid :setPluginData-key key)
+        (u/not-valid plugin-id :setPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setPluginData-value value)
+        (u/not-valid plugin-id :setPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :component id (keyword "plugin" (str plugin-id)) key value))))
@@ -799,10 +799,10 @@
     (fn [namespace key]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :component-plugin-data-namespace namespace)
+        (u/not-valid plugin-id :component-plugin-data-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :component-plugin-data-key key)
+        (u/not-valid plugin-id :component-plugin-data-key key)
 
         :else
         (let [component (u/locate-library-component file-id id)]
@@ -812,19 +812,19 @@
     (fn [namespace key value]
       (cond
         (not= file-id (:current-file-id @st/state))
-        (u/display-not-valid :setSharedPluginData-non-local-library file-id)
+        (u/not-valid plugin-id :setSharedPluginData-non-local-library file-id)
 
         (not (string? namespace))
-        (u/display-not-valid :setSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :setSharedPluginData-key key)
+        (u/not-valid plugin-id :setSharedPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setSharedPluginData-value value)
+        (u/not-valid plugin-id :setSharedPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :component id (keyword "shared" namespace) key value))))
@@ -833,7 +833,7 @@
     (fn [namespace]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :component-plugin-data-namespace namespace)
+        (u/not-valid plugin-id :component-plugin-data-namespace namespace)
 
         :else
         (let [component (u/locate-library-component file-id id)]
@@ -901,10 +901,10 @@
     (fn [pos value]
       (cond
         (not (nat-int? pos))
-        (u/display-not-valid :pos (str pos))
+        (u/not-valid plugin-id :pos (str pos))
 
         (not (string? value))
-        (u/display-not-valid :name value)
+        (u/not-valid plugin-id :name value)
 
         :else
         (st/emit!
@@ -970,7 +970,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :createColor "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :createColor "Plugin doesn't have 'library:write' permission")
 
         :else
         (let [color-id (uuid/next)]
@@ -981,7 +981,7 @@
     (fn []
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :createTypography "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :createTypography "Plugin doesn't have 'library:write' permission")
 
         :else
         (let [typography-id (uuid/next)]
@@ -992,7 +992,7 @@
     (fn [shapes]
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :createComponent "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :createComponent "Plugin doesn't have 'library:write' permission")
 
         :else
         (let [id-ref (atom nil)
@@ -1005,7 +1005,7 @@
     (fn [key]
       (cond
         (not (string? key))
-        (u/display-not-valid :file-plugin-data-key key)
+        (u/not-valid plugin-id :file-plugin-data-key key)
 
         :else
         (let [file (u/locate-file file-id)]
@@ -1015,13 +1015,13 @@
     (fn [key value]
       (cond
         (not (string? key))
-        (u/display-not-valid :setPluginData-key key)
+        (u/not-valid plugin-id :setPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setPluginData-value value)
+        (u/not-valid plugin-id :setPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :file (keyword "plugin" (str plugin-id)) key value))))
@@ -1035,10 +1035,10 @@
     (fn [namespace key]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :file-plugin-data-namespace namespace)
+        (u/not-valid plugin-id :file-plugin-data-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :file-plugin-data-key key)
+        (u/not-valid plugin-id :file-plugin-data-key key)
 
         :else
         (let [file (u/locate-file file-id)]
@@ -1048,16 +1048,16 @@
     (fn [namespace key value]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :setSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :setSharedPluginData-key key)
+        (u/not-valid plugin-id :setSharedPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setSharedPluginData-value value)
+        (u/not-valid plugin-id :setSharedPluginData-value value)
 
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'library:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :file (keyword "shared" namespace) key value))))
@@ -1066,7 +1066,7 @@
     (fn [namespace]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :namespace namespace)
+        (u/not-valid plugin-id :namespace namespace)
 
         :else
         (let [file (u/locate-file file-id)]
@@ -1110,14 +1110,14 @@
     (fn [library-id]
       (cond
         (not (r/check-permission plugin-id "library:write"))
-        (u/display-not-valid :connectLibrary "Plugin doesn't have 'library:write' permission")
+        (u/not-valid plugin-id :connectLibrary "Plugin doesn't have 'library:write' permission")
 
         :else
         (js/Promise.
          (fn [resolve reject]
            (cond
              (not (string? library-id))
-             (do (u/display-not-valid :connectLibrary library-id)
+             (do (u/not-valid plugin-id :connectLibrary library-id)
                  (reject nil))
 
              :else

--- a/frontend/src/app/plugins/local_storage.cljs
+++ b/frontend/src/app/plugins/local_storage.cljs
@@ -30,10 +30,10 @@
     (fn [key]
       (cond
         (not (r/check-permission plugin-id "allow:localstorage"))
-        (u/display-not-valid :getItem "Plugin doesn't have 'allow:localstorage' permission")
+        (u/not-valid plugin-id :getItem "Plugin doesn't have 'allow:localstorage' permission")
 
         (not (string? key))
-        (u/display-not-valid :getItem "The key must be a string")
+        (u/not-valid plugin-id :getItem "The key must be a string")
 
         :else
         (.getItem ^js local-storage (prefix-key plugin-id key))))
@@ -42,10 +42,10 @@
     (fn [key value]
       (cond
         (not (r/check-permission plugin-id "allow:localstorage"))
-        (u/display-not-valid :setItem "Plugin doesn't have 'allow:localstorage' permission")
+        (u/not-valid plugin-id :setItem "Plugin doesn't have 'allow:localstorage' permission")
 
         (not (string? key))
-        (u/display-not-valid :setItem "The key must be a string")
+        (u/not-valid plugin-id :setItem "The key must be a string")
 
         :else
         (.setItem ^js local-storage (prefix-key plugin-id key) value)))
@@ -54,10 +54,10 @@
     (fn [key]
       (cond
         (not (r/check-permission plugin-id "allow:localstorage"))
-        (u/display-not-valid :removeItem "Plugin doesn't have 'allow:localstorage' permission")
+        (u/not-valid plugin-id :removeItem "Plugin doesn't have 'allow:localstorage' permission")
 
         (not (string? key))
-        (u/display-not-valid :removeItem "The key must be a string")
+        (u/not-valid plugin-id :removeItem "The key must be a string")
 
         :else
         (.getItem ^js local-storage (prefix-key plugin-id key))))

--- a/frontend/src/app/plugins/page.cljs
+++ b/frontend/src/app/plugins/page.cljs
@@ -59,7 +59,7 @@
      (fn [_ value]
        (cond
          (or (not (string? value)) (empty? value))
-         (u/display-not-valid :name value)
+         (u/not-valid plugin-id :name value)
 
          :else
          (st/emit! (dwi/update-flow page-id id #(assoc % :name value)))))}
@@ -74,7 +74,7 @@
      (fn [_ value]
        (cond
          (not (shape/shape-proxy? value))
-         (u/display-not-valid :startingBoard value)
+         (u/not-valid plugin-id :startingBoard value)
 
          :else
          (st/emit! (dwi/update-flow page-id id #(assoc % :starting-frame (obj/get value "$id"))))))}
@@ -103,10 +103,10 @@
      (fn [_ value]
        (cond
          (not (string? value))
-         (u/display-not-valid :name value)
+         (u/not-valid plugin-id :name value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :name "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :name "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dw/rename-page id value))))}
@@ -127,10 +127,10 @@
      (fn [_ value]
        (cond
          (or (not (string? value)) (not (cc/valid-hex-color? value)))
-         (u/display-not-valid :background value)
+         (u/not-valid plugin-id :background value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :background "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :background "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dw/change-canvas-color id {:color value}))))}
@@ -158,7 +158,7 @@
     (fn [shape-id]
       (cond
         (not (string? shape-id))
-        (u/display-not-valid :getShapeById shape-id)
+        (u/not-valid plugin-id :getShapeById shape-id)
 
         :else
         (let [shape-id (uuid/parse shape-id)
@@ -195,7 +195,7 @@
     (fn [key]
       (cond
         (not (string? key))
-        (u/display-not-valid :page-plugin-data-key key)
+        (u/not-valid plugin-id :page-plugin-data-key key)
 
         :else
         (let [page (u/locate-page file-id id)]
@@ -205,13 +205,13 @@
     (fn [key value]
       (cond
         (not (string? key))
-        (u/display-not-valid :setPluginData-key key)
+        (u/not-valid plugin-id :setPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setPluginData-value value)
+        (u/not-valid plugin-id :setPluginData-value value)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :setPluginData "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :page id (keyword "plugin" (str plugin-id)) key value))))
@@ -225,10 +225,10 @@
     (fn [namespace key]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :page-plugin-data-namespace namespace)
+        (u/not-valid plugin-id :page-plugin-data-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :page-plugin-data-key key)
+        (u/not-valid plugin-id :page-plugin-data-key key)
 
         :else
         (let [page (u/locate-page file-id id)]
@@ -238,16 +238,16 @@
     (fn [namespace key value]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :setSharedPluginData-namespace namespace)
+        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
         (not (string? key))
-        (u/display-not-valid :setSharedPluginData-key key)
+        (u/not-valid plugin-id :setSharedPluginData-key key)
 
         (and (some? value) (not (string? value)))
-        (u/display-not-valid :setSharedPluginData-value value)
+        (u/not-valid plugin-id :setSharedPluginData-value value)
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'content:write' permission")
 
         :else
         (st/emit! (dp/set-plugin-data file-id :page id (keyword "shared" namespace) key value))))
@@ -256,7 +256,7 @@
     (fn [self namespace]
       (cond
         (not (string? namespace))
-        (u/display-not-valid :page-plugin-data-namespace namespace)
+        (u/not-valid plugin-id :page-plugin-data-namespace namespace)
 
         :else
         (let [page (u/proxy->page self)]
@@ -266,7 +266,7 @@
     (fn [new-window]
       (cond
         (not (r/check-permission plugin-id "content:read"))
-        (u/display-not-valid :openPage "Plugin doesn't have 'content:read' permission")
+        (u/not-valid plugin-id :openPage "Plugin doesn't have 'content:read' permission")
 
         :else
         (let [new-window (if (boolean? new-window) new-window false)]
@@ -276,10 +276,10 @@
     (fn [name frame]
       (cond
         (or (not (string? name)) (empty? name))
-        (u/display-not-valid :createFlow-name name)
+        (u/not-valid plugin-id :createFlow-name name)
 
         (not (shape/shape-proxy? frame))
-        (u/display-not-valid :createFlow-frame frame)
+        (u/not-valid plugin-id :createFlow-frame frame)
 
         :else
         (let [flow-id (uuid/next)]
@@ -290,7 +290,7 @@
     (fn [flow]
       (cond
         (not (flow-proxy? flow))
-        (u/display-not-valid :removeFlow-flow flow)
+        (u/not-valid plugin-id :removeFlow-flow flow)
 
         :else
         (st/emit! (dwi/remove-flow id (obj/get flow "$id")))))
@@ -300,18 +300,18 @@
       (let [shape (u/proxy->shape board)]
         (cond
           (not (sm/valid-safe-number? value))
-          (u/display-not-valid :addRulerGuide "Value not a safe number")
+          (u/not-valid plugin-id :addRulerGuide "Value not a safe number")
 
           (not (contains? #{"vertical" "horizontal"} orientation))
-          (u/display-not-valid :addRulerGuide "Orientation should be either 'vertical' or 'horizontal'")
+          (u/not-valid plugin-id :addRulerGuide "Orientation should be either 'vertical' or 'horizontal'")
 
           (and (some? shape)
                (or (not (shape/shape-proxy? board))
                    (not (cfh/frame-shape? shape))))
-          (u/display-not-valid :addRulerGuide "The shape is not a board")
+          (u/not-valid plugin-id :addRulerGuide "The shape is not a board")
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :addRulerGuide "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :addRulerGuide "Plugin doesn't have 'content:write' permission")
 
           :else
           (let [ruler-id (uuid/next)]
@@ -328,10 +328,10 @@
     (fn [value]
       (cond
         (not (rg/ruler-guide-proxy? value))
-        (u/display-not-valid :removeRulerGuide "Guide not provided")
+        (u/not-valid plugin-id :removeRulerGuide "Guide not provided")
 
         (not (r/check-permission plugin-id "content:write"))
-        (u/display-not-valid :removeRulerGuide "Plugin doesn't have 'comment:write' permission")
+        (u/not-valid plugin-id :removeRulerGuide "Plugin doesn't have 'comment:write' permission")
 
         :else
         (let [guide (u/proxy->ruler-guide value)]
@@ -343,17 +343,17 @@
             position (parser/parse-point position)]
         (cond
           (or (not (string? content)) (empty? content))
-          (u/display-not-valid :addCommentThread "Content not valid")
+          (u/not-valid plugin-id :addCommentThread "Content not valid")
 
           (or (not (sm/valid-safe-number? (:x position)))
               (not (sm/valid-safe-number? (:y position))))
-          (u/display-not-valid :addCommentThread "Position not valid")
+          (u/not-valid plugin-id :addCommentThread "Position not valid")
 
           (and (some? board) (or (not (shape/shape-proxy? board)) (not (cfh/frame-shape? shape))))
-          (u/display-not-valid :addCommentThread "Board not valid")
+          (u/not-valid plugin-id :addCommentThread "Board not valid")
 
           (not (r/check-permission plugin-id "comment:write"))
-          (u/display-not-valid :addCommentThread "Plugin doesn't have 'comment:write' permission")
+          (u/not-valid plugin-id :addCommentThread "Plugin doesn't have 'comment:write' permission")
 
           :else
           (let [position
@@ -378,10 +378,10 @@
     (fn [thread]
       (cond
         (not (pc/comment-thread-proxy? thread))
-        (u/display-not-valid :removeCommentThread "Comment thread not valid")
+        (u/not-valid plugin-id :removeCommentThread "Comment thread not valid")
 
         (not (r/check-permission plugin-id "comment:write"))
-        (u/display-not-valid :removeCommentThread "Plugin doesn't have 'content:write' permission")
+        (u/not-valid plugin-id :removeCommentThread "Plugin doesn't have 'content:write' permission")
 
         :else
         (js/Promise.
@@ -400,7 +400,7 @@
            (cond
              (not (r/check-permission plugin-id "comment:read"))
              (do
-               (u/display-not-valid :findCommentThreads "Plugin doesn't have 'comment:read' permission")
+               (u/not-valid plugin-id :findCommentThreads "Plugin doesn't have 'comment:read' permission")
                (reject "Plugin doesn't have 'comment:read' permission"))
 
              :else

--- a/frontend/src/app/plugins/public_utils.cljs
+++ b/frontend/src/app/plugins/public_utils.cljs
@@ -14,10 +14,10 @@
    [app.plugins.utils :as u]))
 
 (defn ^:export centerShapes
-  [shapes]
+  [plugin-id shapes]
   (cond
     (not (every? shape/shape-proxy? shapes))
-    (u/display-not-valid :centerShapes shapes)
+    (u/not-valid plugin-id :centerShapes shapes)
 
     :else
     (let [shapes (->> shapes (map u/proxy->shape))]

--- a/frontend/src/app/plugins/ruler_guides.cljs
+++ b/frontend/src/app/plugins/ruler_guides.cljs
@@ -44,13 +44,13 @@
        (let [shape (u/locate-shape file-id page-id (obj/get value "$id"))]
          (cond
            (not (shape-proxy? value))
-           (u/display-not-valid :board "The board is not a shape proxy")
+           (u/not-valid plugin-id :board "The board is not a shape proxy")
 
            (not (cfh/frame-shape? shape))
-           (u/display-not-valid :board "The shape is not a board")
+           (u/not-valid plugin-id :board "The shape is not a board")
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :board "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :board "Plugin doesn't have 'content:write' permission")
 
            :else
            (let [board-id (when value (obj/get value "$id"))
@@ -78,10 +78,10 @@
      (fn [self value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :position "Not valid position")
+         (u/not-valid plugin-id :position "Not valid position")
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :position "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :position "Plugin doesn't have 'content:write' permission")
 
          :else
          (let [guide (u/proxy->ruler-guide self)

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -46,7 +46,6 @@
    [app.main.data.workspace.variants :as dwv]
    [app.main.repo :as rp]
    [app.main.store :as st]
-   [app.plugins.flags :refer [natural-child-ordering?]]
    [app.plugins.flex :as flex]
    [app.plugins.format :as format]
    [app.plugins.grid :as grid]
@@ -91,7 +90,7 @@
        (let [value (parser/parse-keyword value)]
          (cond
            (not (contains? ctsi/event-types value))
-           (u/display-not-valid :trigger value)
+           (u/not-valid plugin-id :trigger value)
 
            :else
            (st/emit! (dwi/update-interaction
@@ -107,7 +106,7 @@
      (fn [_ value]
        (cond
          (or (not (number? value)) (not (pos? value)))
-         (u/display-not-valid :delay value)
+         (u/not-valid plugin-id :delay value)
 
          :else
          (st/emit! (dwi/update-interaction
@@ -127,7 +126,7 @@
                  (d/patch-object params))]
          (cond
            (not (sm/validate ctsi/schema:interaction interaction))
-           (u/display-not-valid :action interaction)
+           (u/not-valid plugin-id :action interaction)
 
            :else
            (st/emit! (dwi/update-interaction
@@ -192,7 +191,8 @@
    (assert (uuid? id))
 
    (let [data (u/locate-shape file-id page-id id)]
-     (-> (obj/reify {:name "ShapeProxy" :on-error u/handle-error}
+     (-> (obj/reify {:name "ShapeProxy"
+                     :on-error (u/handle-error plugin-id)}
            :$plugin {:enumerable false :get (fn [] plugin-id)}
            :$id {:enumerable false :get (fn [] id)}
            :$file {:enumerable false :get (fn [] file-id)}
@@ -218,10 +218,10 @@
                                 (not (str/blank? value)))]
                 (cond
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :name "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :name "Plugin doesn't have 'content:write' permission")
 
                   (not valid?)
-                  (u/display-not-valid :name value)
+                  (u/not-valid plugin-id :name value)
 
                   :else
                   (st/emit! (dw/rename-shape-or-variant file-id page-id id value)))))}
@@ -233,10 +233,10 @@
             (fn [self value]
               (cond
                 (not (boolean? value))
-                (u/display-not-valid :blocked value)
+                (u/not-valid plugin-id :blocked value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :blocked "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :blocked "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")]
@@ -249,10 +249,10 @@
             (fn [self value]
               (cond
                 (not (boolean? value))
-                (u/display-not-valid :hidden value)
+                (u/not-valid plugin-id :hidden value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :hidden "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :hidden "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")]
@@ -265,10 +265,10 @@
             (fn [self value]
               (cond
                 (not (boolean? value))
-                (u/display-not-valid :visible value)
+                (u/not-valid plugin-id :visible value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :visible "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :visible "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")]
@@ -281,10 +281,10 @@
             (fn [self value]
               (cond
                 (not (boolean? value))
-                (u/display-not-valid :proportionLock value)
+                (u/not-valid plugin-id :proportionLock value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :proportionLock "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :proportionLock "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")]
@@ -299,10 +299,10 @@
                     value (keyword value)]
                 (cond
                   (not (contains? cts/horizontal-constraint-types value))
-                  (u/display-not-valid :constraintsHorizontal value)
+                  (u/not-valid plugin-id :constraintsHorizontal value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :constraintsHorizontal "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :constraintsHorizontal "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :constraints-h value))))))}
@@ -316,10 +316,10 @@
                     value (keyword value)]
                 (cond
                   (not (contains? cts/vertical-constraint-types value))
-                  (u/display-not-valid :constraintsVertical value)
+                  (u/not-valid plugin-id :constraintsVertical value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :constraintsVertical "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :constraintsVertical "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :constraints-v value))))))}
@@ -332,10 +332,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (or (not (sm/valid-safe-int? value)) (< value 0))
-                  (u/display-not-valid :borderRadius value)
+                  (u/not-valid plugin-id :borderRadius value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :borderRadius "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :borderRadius "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(ctsr/set-radius-to-all-corners % value))))))}
@@ -348,10 +348,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (not (sm/valid-safe-int? value))
-                  (u/display-not-valid :borderRadiusTopLeft value)
+                  (u/not-valid plugin-id :borderRadiusTopLeft value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :borderRadiusTopLeft "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :borderRadiusTopLeft "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(ctsr/set-radius-to-single-corner % :r1 value))))))}
@@ -364,10 +364,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (not (sm/valid-safe-int? value))
-                  (u/display-not-valid :borderRadiusTopRight value)
+                  (u/not-valid plugin-id :borderRadiusTopRight value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :borderRadiusTopRight "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :borderRadiusTopRight "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(ctsr/set-radius-to-single-corner % :r2 value))))))}
@@ -380,10 +380,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (not (sm/valid-safe-int? value))
-                  (u/display-not-valid :borderRadiusBottomRight value)
+                  (u/not-valid plugin-id :borderRadiusBottomRight value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :borderRadiusBottomRight "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :borderRadiusBottomRight "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(ctsr/set-radius-to-single-corner % :r3 value))))))}
@@ -396,10 +396,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (not (sm/valid-safe-int? value))
-                  (u/display-not-valid :borderRadiusBottomLeft value)
+                  (u/not-valid plugin-id :borderRadiusBottomLeft value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :borderRadiusBottomLeft "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :borderRadiusBottomLeft "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(ctsr/set-radius-to-single-corner % :r4 value))))))}
@@ -412,10 +412,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (or (not (sm/valid-safe-number? value)) (< value 0) (> value 1))
-                  (u/display-not-valid :opacity value)
+                  (u/not-valid plugin-id :opacity value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :opacity "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :opacity "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :opacity value))))))}
@@ -429,10 +429,10 @@
                     value (keyword value)]
                 (cond
                   (not (contains? cts/blend-modes value))
-                  (u/display-not-valid :blendMode value)
+                  (u/not-valid plugin-id :blendMode value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :blendMode "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :blendMode "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :blend-mode value))))))}
@@ -446,10 +446,10 @@
                     value (mapv #(shadow-defaults (parser/parse-shadow %)) value)]
                 (cond
                   (not (sm/validate [:vector ctss/schema:shadow] value))
-                  (u/display-not-valid :shadows value)
+                  (u/not-valid plugin-id :shadows value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :shadows "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :shadows "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :shadow value))))))}
@@ -465,10 +465,10 @@
                       value (blur-defaults (parser/parse-blur value))]
                   (cond
                     (not (sm/validate ctsb/schema:blur value))
-                    (u/display-not-valid :blur value)
+                    (u/not-valid plugin-id :blur value)
 
                     (not (r/check-permission plugin-id "content:write"))
-                    (u/display-not-valid :blur "Plugin doesn't have 'content:write' permission")
+                    (u/not-valid plugin-id :blur "Plugin doesn't have 'content:write' permission")
 
                     :else
                     (st/emit! (dwsh/update-shapes [id] #(assoc % :blur value)))))))}
@@ -482,10 +482,10 @@
                     value (parser/parse-exports value)]
                 (cond
                   (not (sm/validate [:vector ctse/schema:export] value))
-                  (u/display-not-valid :exports value)
+                  (u/not-valid plugin-id :exports value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :exports "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :exports "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :exports value))))))}
@@ -499,10 +499,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (not (sm/valid-safe-number? value))
-                  (u/display-not-valid :x value)
+                  (u/not-valid plugin-id :x value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :x "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :x "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dw/update-position id
@@ -517,10 +517,10 @@
               (let [id (obj/get self "$id")]
                 (cond
                   (not (sm/valid-safe-number? value))
-                  (u/display-not-valid :y value)
+                  (u/not-valid plugin-id :y value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :y "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :y "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dw/update-position id
@@ -562,10 +562,10 @@
             (fn [self value]
               (cond
                 (not (sm/valid-safe-number? value))
-                (u/display-not-valid :parentX value)
+                (u/not-valid plugin-id :parentX value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :parentX "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :parentX "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")
@@ -589,10 +589,10 @@
             (fn [self value]
               (cond
                 (not (sm/valid-safe-number? value))
-                (u/display-not-valid :parentY value)
+                (u/not-valid plugin-id :parentY value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :parentY "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :parentY "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")
@@ -616,10 +616,10 @@
             (fn [self value]
               (cond
                 (not (sm/valid-safe-number? value))
-                (u/display-not-valid :frameX value)
+                (u/not-valid plugin-id :frameX value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :frameX "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :frameX "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")
@@ -643,10 +643,10 @@
             (fn [self value]
               (cond
                 (not (sm/valid-safe-number? value))
-                (u/display-not-valid :frameY value)
+                (u/not-valid plugin-id :frameY value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :frameY "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :frameY "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")
@@ -680,10 +680,10 @@
             (fn [self value]
               (cond
                 (not (number? value))
-                (u/display-not-valid :rotation value)
+                (u/not-valid plugin-id :rotation value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :rotation "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :rotation "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [shape (u/proxy->shape self)]
@@ -696,10 +696,10 @@
             (fn [self value]
               (cond
                 (not (boolean? value))
-                (u/display-not-valid :flipX value)
+                (u/not-valid plugin-id :flipX value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :flipX "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :flipX "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")]
@@ -712,10 +712,10 @@
             (fn [self value]
               (cond
                 (not (boolean? value))
-                (u/display-not-valid :flipY value)
+                (u/not-valid plugin-id :flipY value)
 
                 (not (r/check-permission plugin-id "content:write"))
-                (u/display-not-valid :flipY "Plugin doesn't have 'content:write' permission")
+                (u/not-valid plugin-id :flipY "Plugin doesn't have 'content:write' permission")
 
                 :else
                 (let [id (obj/get self "$id")]
@@ -734,13 +734,13 @@
                     value (parser/parse-fills value)]
                 (cond
                   (not (sm/validate [:vector types.fills/schema:fill] value))
-                  (u/display-not-valid :fills value)
+                  (u/not-valid plugin-id :fills value)
 
                   (cfh/text-shape? shape)
                   (st/emit! (dwt/update-attrs id {:fills value}))
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :fills "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :fills "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :fills value))))))}
@@ -754,10 +754,10 @@
                     value (parser/parse-strokes value)]
                 (cond
                   (not (sm/validate [:vector cts/schema:stroke] value))
-                  (u/display-not-valid :strokes value)
+                  (u/not-valid plugin-id :strokes value)
 
                   (not (r/check-permission plugin-id "content:write"))
-                  (u/display-not-valid :strokes "Plugin doesn't have 'content:write' permission")
+                  (u/not-valid plugin-id :strokes "Plugin doesn't have 'content:write' permission")
 
                   :else
                   (st/emit! (dwsh/update-shapes [id] #(assoc % :strokes value))))))}
@@ -802,13 +802,13 @@
            (fn [width height]
              (cond
                (or (not (sm/valid-safe-number? width)) (<= width 0))
-               (u/display-not-valid :resize width)
+               (u/not-valid plugin-id :resize width)
 
                (or (not (sm/valid-safe-number? height)) (<= height 0))
-               (u/display-not-valid :resize height)
+               (u/not-valid plugin-id :resize height)
 
                (not (r/check-permission plugin-id "content:write"))
-               (u/display-not-valid :resize "Plugin doesn't have 'content:write' permission")
+               (u/not-valid plugin-id :resize "Plugin doesn't have 'content:write' permission")
 
                :else
                (st/emit! (dw/update-dimensions [id] :width width)
@@ -819,13 +819,13 @@
              (let [center (when center {:x (obj/get center "x") :y (obj/get center "y")})]
                (cond
                  (not (number? angle))
-                 (u/display-not-valid :rotate-angle angle)
+                 (u/not-valid plugin-id :rotate-angle angle)
 
                  (and (some? center) (or (not (number? (:x center))) (not (number? (:y center)))))
-                 (u/display-not-valid :rotate-center center)
+                 (u/not-valid plugin-id :rotate-center center)
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :rotate "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :rotate "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (st/emit! (dw/increase-rotation [id] angle {:center center :delta? true})))))
@@ -835,7 +835,7 @@
              (let [ret-v (atom nil)]
                (cond
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :clone "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :clone "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (do (st/emit! (dws/duplicate-shapes #{id} :change-selection? false :return-ref ret-v))
@@ -845,7 +845,7 @@
            (fn []
              (cond
                (not (r/check-permission plugin-id "content:write"))
-               (u/display-not-valid :remove "Plugin doesn't have 'content:write' permission")
+               (u/not-valid plugin-id :remove "Plugin doesn't have 'content:write' permission")
 
                :else
                (st/emit! (dwsh/delete-shapes #{id}))))
@@ -855,7 +855,7 @@
            (fn [key]
              (cond
                (not (string? key))
-               (u/display-not-valid :getPluginData key)
+               (u/not-valid plugin-id :getPluginData key)
 
                :else
                (let [shape (u/locate-shape file-id page-id id)]
@@ -865,13 +865,13 @@
            (fn [key value]
              (cond
                (not (string? key))
-               (u/display-not-valid :setPluginData-key key)
+               (u/not-valid plugin-id :setPluginData-key key)
 
                (and (some? value) (not (string? value)))
-               (u/display-not-valid :setPluginData-value value)
+               (u/not-valid plugin-id :setPluginData-value value)
 
                (not (r/check-permission plugin-id "content:write"))
-               (u/display-not-valid :setPluginData "Plugin doesn't have 'content:write' permission")
+               (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'content:write' permission")
 
                :else
                (st/emit! (dp/set-plugin-data file-id :shape id page-id (keyword "plugin" (str plugin-id)) key value))))
@@ -885,10 +885,10 @@
            (fn [namespace key]
              (cond
                (not (string? namespace))
-               (u/display-not-valid :getSharedPluginData-namespace namespace)
+               (u/not-valid plugin-id :getSharedPluginData-namespace namespace)
 
                (not (string? key))
-               (u/display-not-valid :getSharedPluginData-key key)
+               (u/not-valid plugin-id :getSharedPluginData-key key)
 
                :else
                (let [shape (u/locate-shape file-id page-id id)]
@@ -898,16 +898,16 @@
            (fn [namespace key value]
              (cond
                (not (string? namespace))
-               (u/display-not-valid :setSharedPluginData-namespace namespace)
+               (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
 
                (not (string? key))
-               (u/display-not-valid :setSharedPluginData-key key)
+               (u/not-valid plugin-id :setSharedPluginData-key key)
 
                (and (some? value) (not (string? value)))
-               (u/display-not-valid :setSharedPluginData-value value)
+               (u/not-valid plugin-id :setSharedPluginData-value value)
 
                (not (r/check-permission plugin-id "content:write"))
-               (u/display-not-valid :setSharedPluginData "Plugin doesn't have 'content:write' permission")
+               (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'content:write' permission")
 
                :else
                (st/emit! (dp/set-plugin-data file-id :shape id page-id (keyword "shared" namespace) key value))))
@@ -916,7 +916,7 @@
            (fn [namespace]
              (cond
                (not (string? namespace))
-               (u/display-not-valid :getSharedPluginDataKeys namespace)
+               (u/not-valid plugin-id :getSharedPluginDataKeys namespace)
 
                :else
                (let [shape (u/locate-shape file-id page-id id)]
@@ -931,12 +931,12 @@
                       (not (cfh/group-shape? shape))
                       (not (cfh/svg-raw-shape? shape))
                       (not (cfh/bool-shape? shape)))
-                 (u/display-not-valid :getChildren (:type shape))
+                 (u/not-valid plugin-id :getChildren (:type shape))
 
                  :else
                  (let [is-reversed? (ctl/flex-layout? shape)
                        reverse-fn
-                       (if (and (natural-child-ordering? plugin-id) is-reversed?)
+                       (if (and (u/natural-child-ordering? plugin-id) is-reversed?)
                          reverse identity)]
                    (->> (u/locate-shape file-id page-id id)
                         (:shapes)
@@ -951,19 +951,19 @@
                       (not (cfh/group-shape? shape))
                       (not (cfh/svg-raw-shape? shape))
                       (not (cfh/bool-shape? shape)))
-                 (u/display-not-valid :appendChild (:type shape))
+                 (u/not-valid plugin-id :appendChild (:type shape))
 
                  (not (shape-proxy? child))
-                 (u/display-not-valid :appendChild-child child)
+                 (u/not-valid plugin-id :appendChild-child child)
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :appendChild "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :appendChild "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (let [child-id     (obj/get child "$id")
                        is-reversed? (ctl/flex-layout? shape)
                        index
-                       (if (or (not (natural-child-ordering? plugin-id)) is-reversed?)
+                       (if (or (not (u/natural-child-ordering? plugin-id)) is-reversed?)
                          0
                          (count (:shapes shape)))]
                    (st/emit! (dwsh/relocate-shapes #{child-id} id index))))))
@@ -976,19 +976,19 @@
                       (not (cfh/group-shape? shape))
                       (not (cfh/svg-raw-shape? shape))
                       (not (cfh/bool-shape? shape)))
-                 (u/display-not-valid :insertChild (:type shape))
+                 (u/not-valid plugin-id :insertChild (:type shape))
 
                  (not (shape-proxy? child))
-                 (u/display-not-valid :insertChild-child child)
+                 (u/not-valid plugin-id :insertChild-child child)
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :insertChild "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :insertChild "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (let [child-id (obj/get child "$id")
                        is-reversed? (ctl/flex-layout? shape)
                        index
-                       (if (or (not (natural-child-ordering? plugin-id)) is-reversed?)
+                       (if (or (not (u/natural-child-ordering? plugin-id)) is-reversed?)
                          (- (count (:shapes shape)) index)
                          index)]
                    (st/emit! (dwsh/relocate-shapes #{child-id} id index))))))
@@ -999,10 +999,10 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (cfh/frame-shape? shape))
-                 (u/display-not-valid :addFlexLayout (:type shape))
+                 (u/not-valid plugin-id :addFlexLayout (:type shape))
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :addFlexLayout "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :addFlexLayout "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (do (st/emit! (dwsl/create-layout-from-id id :flex :from-frame? true :calculate-params? false))
@@ -1013,10 +1013,10 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (cfh/frame-shape? shape))
-                 (u/display-not-valid :addGridLayout (:type shape))
+                 (u/not-valid plugin-id :addGridLayout (:type shape))
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :addGridLayout "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :addGridLayout "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (do (st/emit! (dwsl/create-layout-from-id id :grid :from-frame? true :calculate-params? false))
@@ -1028,10 +1028,10 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (cfh/group-shape? shape))
-                 (u/display-not-valid :makeMask (:type shape))
+                 (u/not-valid plugin-id :makeMask (:type shape))
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :makeMask "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :makeMask "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (st/emit! (dwg/mask-group #{id})))))
@@ -1041,10 +1041,10 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (cfh/mask-shape? shape))
-                 (u/display-not-valid :removeMask (:type shape))
+                 (u/not-valid plugin-id :removeMask (:type shape))
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :removeMask "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :removeMask "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (st/emit! (dwg/unmask-group #{id})))))
@@ -1055,7 +1055,7 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (and (not (cfh/path-shape? shape)) (not (cfh/bool-shape? shape)))
-                 (u/display-not-valid :toD (:type shape))
+                 (u/not-valid plugin-id :toD (:type shape))
 
                  :else
                  (.toString (:content shape)))))
@@ -1066,13 +1066,13 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (cfh/text-shape? shape))
-                 (u/display-not-valid :getRange-shape "shape is not text")
+                 (u/not-valid plugin-id :getRange-shape "shape is not text")
 
                  (or (not (sm/valid-safe-int? start)) (< start 0) (> start end))
-                 (u/display-not-valid :getRange-start start)
+                 (u/not-valid plugin-id :getRange-start start)
 
                  (not (sm/valid-safe-int? end))
-                 (u/display-not-valid :getRange-end end)
+                 (u/not-valid plugin-id :getRange-end end)
 
                  :else
                  (text/text-range-proxy plugin-id file-id page-id id start end))))
@@ -1082,13 +1082,13 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (lib-typography-proxy? typography))
-                 (u/display-not-valid :applyTypography-typography typography)
+                 (u/not-valid plugin-id :applyTypography-typography typography)
 
                  (not (cfh/text-shape? shape))
-                 (u/display-not-valid :applyTypography-shape (:type shape))
+                 (u/not-valid plugin-id :applyTypography-shape (:type shape))
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :applyTypography "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :applyTypography "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (let [typography (u/proxy->library-typography typography)]
@@ -1099,10 +1099,10 @@
            (fn [index]
              (cond
                (not (sm/valid-safe-int? index))
-               (u/display-not-valid :setParentIndex index)
+               (u/not-valid plugin-id :setParentIndex index)
 
                (not (r/check-permission plugin-id "content:write"))
-               (u/display-not-valid :setParentIndex "Plugin doesn't have 'content:write' permission")
+               (u/not-valid plugin-id :setParentIndex "Plugin doesn't have 'content:write' permission")
 
                :else
                (st/emit! (dw/set-shape-index file-id page-id id index))))
@@ -1197,7 +1197,7 @@
              (let [value (parser/parse-export value)]
                (cond
                  (not (sm/validate ctse/schema:export value))
-                 (u/display-not-valid :export value)
+                 (u/not-valid plugin-id :export value)
 
                  :else
                  (let [shape (u/locate-shape file-id page-id id)
@@ -1233,7 +1233,7 @@
                        (d/patch-object (parser/parse-interaction trigger action delay)))]
                (cond
                  (not (sm/validate ctsi/schema:interaction interaction))
-                 (u/display-not-valid :addInteraction interaction)
+                 (u/not-valid plugin-id :addInteraction interaction)
 
                  :else
                  (let [index (-> (u/locate-shape file-id page-id id) (:interactions [])  count)]
@@ -1244,7 +1244,7 @@
            (fn [interaction]
              (cond
                (not (interaction-proxy? interaction))
-               (u/display-not-valid :removeInteraction interaction)
+               (u/not-valid plugin-id :removeInteraction interaction)
 
                :else
                (st/emit! (dwi/remove-interaction {:id id} (obj/get interaction "$index")))))
@@ -1255,16 +1255,16 @@
              (let [shape (u/locate-shape file-id page-id id)]
                (cond
                  (not (sm/valid-safe-number? value))
-                 (u/display-not-valid :addRulerGuide "Value not a safe number")
+                 (u/not-valid plugin-id :addRulerGuide "Value not a safe number")
 
                  (not (contains? #{"vertical" "horizontal"} orientation))
-                 (u/display-not-valid :addRulerGuide "Orientation should be either 'vertical' or 'horizontal'")
+                 (u/not-valid plugin-id :addRulerGuide "Orientation should be either 'vertical' or 'horizontal'")
 
                  (not (cfh/frame-shape? shape))
-                 (u/display-not-valid :addRulerGuide "The shape is not a board")
+                 (u/not-valid plugin-id :addRulerGuide "The shape is not a board")
 
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :addRulerGuide "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :addRulerGuide "Plugin doesn't have 'content:write' permission")
 
                  :else
                  (let [id        (uuid/next)
@@ -1285,10 +1285,10 @@
            (fn [_ value]
              (cond
                (not (rg/ruler-guide-proxy? value))
-               (u/display-not-valid :removeRulerGuide "Guide not provided")
+               (u/not-valid plugin-id :removeRulerGuide "Guide not provided")
 
                (not (r/check-permission plugin-id "content:write"))
-               (u/display-not-valid :removeRulerGuide "Plugin doesn't have 'content:write' permission")
+               (u/not-valid plugin-id :removeRulerGuide "Plugin doesn't have 'content:write' permission")
 
                :else
                (let [guide (u/proxy->ruler-guide value)]
@@ -1317,7 +1317,7 @@
                   (let [token (u/locate-token file-id (obj/get token "$set-id") (obj/get token "$id"))
                         kw-attrs (into #{} (map token-attr-plugin->token-attr attrs))]
                     (if (some #(not (token-attr? %)) kw-attrs)
-                      (u/display-not-valid :applyToken attrs)
+                      (u/not-valid plugin-id :applyToken attrs)
                       (st/emit!
                        (dwta/toggle-token {:token token
                                            :attrs kw-attrs
@@ -1339,10 +1339,10 @@
            (fn [pos value]
              (cond
                (not (nat-int? pos))
-               (u/display-not-valid :pos pos)
+               (u/not-valid plugin-id :pos pos)
 
                (not (string? value))
-               (u/display-not-valid :value value)
+               (u/not-valid plugin-id :value value)
 
                :else
                (let [shape     (u/locate-shape file-id page-id id)
@@ -1354,7 +1354,7 @@
            (fn [ids]
              (cond
                (or (not (seq ids)) (not (every? uuid/parse* ids)))
-               (u/display-not-valid :ids ids)
+               (u/not-valid plugin-id :ids ids)
 
                :else
                (let [shape     (u/locate-shape file-id page-id id)
@@ -1382,21 +1382,21 @@
              (fn [^js self children]
                (cond
                  (not (r/check-permission plugin-id "content:write"))
-                 (u/display-not-valid :children "Plugin doesn't have 'content:write' permission")
+                 (u/not-valid plugin-id :children "Plugin doesn't have 'content:write' permission")
 
                  (not (every? shape-proxy? children))
-                 (u/display-not-valid :children "Every children needs to be shape proxies")
+                 (u/not-valid plugin-id :children "Every children needs to be shape proxies")
 
                  :else
                  (let [shape (u/proxy->shape self)
                        file-id (obj/get self "$file")
                        page-id (obj/get self "$page")
-                       reverse-fn (if (natural-child-ordering? plugin-id) reverse identity)
+                       reverse-fn (if (u/natural-child-ordering? plugin-id) reverse identity)
                        ids (->> children reverse-fn (map #(obj/get % "$id")))]
 
                    (cond
                      (not= (set ids) (set (:shapes shape)))
-                     (u/display-not-valid :children "Not all children are present in the input")
+                     (u/not-valid plugin-id :children "Not all children are present in the input")
 
                      :else
                      (st/emit! (dw/reorder-children file-id page-id (:id shape) ids))))))}))
@@ -1412,10 +1412,10 @@
                  (fn [_ value]
                    (cond
                      (not (boolean? value))
-                     (u/display-not-valid :clipContent value)
+                     (u/not-valid plugin-id :clipContent value)
 
                      (not (r/check-permission plugin-id "content:write"))
-                     (u/display-not-valid :clipContent "Plugin doesn't have 'content:write' permission")
+                     (u/not-valid plugin-id :clipContent "Plugin doesn't have 'content:write' permission")
 
                      :else
                      (st/emit! (dwsh/update-shapes [id] #(assoc % :show-content (not value))))))}
@@ -1428,10 +1428,10 @@
                  (fn [_ value]
                    (cond
                      (not (boolean? value))
-                     (u/display-not-valid :showInViewMode value)
+                     (u/not-valid plugin-id :showInViewMode value)
 
                      (not (r/check-permission plugin-id "content:write"))
-                     (u/display-not-valid :showInViewMode "Plugin doesn't have 'content:write' permission")
+                     (u/not-valid plugin-id :showInViewMode "Plugin doesn't have 'content:write' permission")
 
                      :else
                      (st/emit! (dwsh/update-shapes [id] #(assoc % :hide-in-viewer (not value))))))}
@@ -1463,10 +1463,10 @@
                               value (parser/parse-frame-guides value)]
                           (cond
                             (not (sm/validate [:vector ::ctg/grid] value))
-                            (u/display-not-valid :guides value)
+                            (u/not-valid plugin-id :guides value)
 
                             (not (r/check-permission plugin-id "content:write"))
-                            (u/display-not-valid :guides "Plugin doesn't have 'content:write' permission")
+                            (u/not-valid plugin-id :guides "Plugin doesn't have 'content:write' permission")
 
                             :else
                             (st/emit! (dwsh/update-shapes [id] #(assoc % :grids value))))))}
@@ -1488,10 +1488,10 @@
                          value (keyword value)]
                      (cond
                        (not (contains? #{:fix :auto} value))
-                       (u/display-not-valid :horizontalSizing value)
+                       (u/not-valid plugin-id :horizontalSizing value)
 
                        (not (r/check-permission plugin-id "content:write"))
-                       (u/display-not-valid :horizontalSizing "Plugin doesn't have 'content:write' permission")
+                       (u/not-valid plugin-id :horizontalSizing "Plugin doesn't have 'content:write' permission")
 
                        :else
                        (st/emit! (dwsl/update-layout #{id} {:layout-item-h-sizing value})))))}
@@ -1504,10 +1504,10 @@
                          value (keyword value)]
                      (cond
                        (not (contains? #{:fix :auto} value))
-                       (u/display-not-valid :verticalSizing value)
+                       (u/not-valid plugin-id :verticalSizing value)
 
                        (not (r/check-permission plugin-id "content:write"))
-                       (u/display-not-valid :verticalSizing "Plugin doesn't have 'content:write' permission")
+                       (u/not-valid plugin-id :verticalSizing "Plugin doesn't have 'content:write' permission")
 
                        :else
                        (st/emit! (dwsl/update-layout #{id} {:layout-item-v-sizing value})))))}
@@ -1531,10 +1531,10 @@
                (let [segments (parser/parse-commands value)]
                  (cond
                    (not (r/check-permission plugin-id "content:write"))
-                   (u/display-not-valid :content "Plugin doesn't have 'content:write' permission")
+                   (u/not-valid plugin-id :content "Plugin doesn't have 'content:write' permission")
 
                    (not (sm/validate path/schema:segments segments))
-                   (u/display-not-valid :content segments)
+                   (u/not-valid plugin-id :content segments)
 
                    :else
                    (let [selrect (path/calc-selrect segments)
@@ -1557,13 +1557,13 @@
                        value)]
                  (cond
                    (not (r/check-permission plugin-id "content:write"))
-                   (u/display-not-valid :content "Plugin doesn't have 'content:write' permission")
+                   (u/not-valid plugin-id :content "Plugin doesn't have 'content:write' permission")
 
                    (not (cfh/path-shape? data))
-                   (u/display-not-valid :content-type type)
+                   (u/not-valid plugin-id :content-type type)
 
                    (not (sm/validate path/schema:segments segments))
-                   (u/display-not-valid :content segments)
+                   (u/not-valid plugin-id :content segments)
 
                    :else
                    (let [selrect (path/calc-selrect segments)

--- a/frontend/src/app/plugins/text.cljs
+++ b/frontend/src/app/plugins/text.cljs
@@ -119,10 +119,10 @@
              variant (fonts/get-default-variant font)]
          (cond
            (not font)
-           (u/display-not-valid :fontId value)
+           (u/not-valid plugin-id :fontId value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fontId "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fontId "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end (font-data font variant))))))}
@@ -141,10 +141,10 @@
              variant (fonts/get-default-variant font)]
          (cond
            (not (string? value))
-           (u/display-not-valid :fontFamily value)
+           (u/not-valid plugin-id :fontFamily value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fontFamily "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fontFamily "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end (font-data font variant))))))}
@@ -162,10 +162,10 @@
              variant (fonts/get-variant font value)]
          (cond
            (not (string? value))
-           (u/display-not-valid :fontVariantId value)
+           (u/not-valid plugin-id :fontVariantId value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fontVariantId "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fontVariantId "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end (variant-data variant))))))}
@@ -182,10 +182,10 @@
        (let [value (str/trim (dm/str value))]
          (cond
            (or (empty? value) (not (re-matches font-size-re value)))
-           (u/display-not-valid :fontSize value)
+           (u/not-valid plugin-id :fontSize value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fontSize "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fontSize "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end {:font-size value})))))}
@@ -209,10 +209,10 @@
               (fonts/find-variant font {:weight weight}))]
          (cond
            (nil? variant)
-           (u/display-not-valid :fontWeight (dm/str "Font weight '" value "' not supported for the current font"))
+           (u/not-valid plugin-id :fontWeight (dm/str "Font weight '" value "' not supported for the current font"))
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fontWeight "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fontWeight "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end (variant-data variant))))))}
@@ -235,10 +235,10 @@
               (fonts/find-variant font {:style style}))]
          (cond
            (nil? variant)
-           (u/display-not-valid :fontStyle (dm/str "Font style '" value "' not supported for the current font"))
+           (u/not-valid plugin-id :fontStyle (dm/str "Font style '" value "' not supported for the current font"))
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fontStyle "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fontStyle "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end (variant-data variant))))))}
@@ -255,10 +255,10 @@
        (let [value (str/trim (dm/str value))]
          (cond
            (or (empty? value) (not (re-matches line-height-re value)))
-           (u/display-not-valid :lineHeight value)
+           (u/not-valid plugin-id :lineHeight value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :lineHeight "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :lineHeight "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end {:line-height value})))))}
@@ -275,10 +275,10 @@
        (let [value (str/trim (dm/str value))]
          (cond
            (or (empty? value) (re-matches letter-spacing-re value))
-           (u/display-not-valid :letterSpacing value)
+           (u/not-valid plugin-id :letterSpacing value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :letterSpacing "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :letterSpacing "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end {:letter-spacing value})))))}
@@ -294,10 +294,10 @@
      (fn [_ value]
        (cond
          (and (string? value) (not (re-matches text-transform-re value)))
-         (u/display-not-valid :textTransform value)
+         (u/not-valid plugin-id :textTransform value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :textTransform "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :textTransform "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwt/update-text-range id start end {:text-transform value}))))}
@@ -313,10 +313,10 @@
      (fn [_ value]
        (cond
          (and (string? value) (re-matches text-decoration-re value))
-         (u/display-not-valid :textDecoration value)
+         (u/not-valid plugin-id :textDecoration value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :textDecoration "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :textDecoration "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwt/update-text-range id start end {:text-decoration value}))))}
@@ -332,10 +332,10 @@
      (fn [_ value]
        (cond
          (and (string? value) (re-matches text-direction-re value))
-         (u/display-not-valid :direction value)
+         (u/not-valid plugin-id :direction value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :direction "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :direction "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwt/update-text-range id start end {:direction value}))))}
@@ -351,10 +351,10 @@
      (fn [_ value]
        (cond
          (and (string? value) (re-matches text-align-re value))
-         (u/display-not-valid :align value)
+         (u/not-valid plugin-id :align value)
 
          (not (r/check-permission plugin-id "content:write"))
-         (u/display-not-valid :align "Plugin doesn't have 'content:write' permission")
+         (u/not-valid plugin-id :align "Plugin doesn't have 'content:write' permission")
 
          :else
          (st/emit! (dwt/update-text-range id start end {:text-align value}))))}
@@ -371,10 +371,10 @@
        (let [value (parser/parse-fills value)]
          (cond
            (not (sm/validate [:vector ::cts/fill] value))
-           (u/display-not-valid :fills value)
+           (u/not-valid plugin-id :fills value)
 
            (not (r/check-permission plugin-id "content:write"))
-           (u/display-not-valid :fills "Plugin doesn't have 'content:write' permission")
+           (u/not-valid plugin-id :fills "Plugin doesn't have 'content:write' permission")
 
            :else
            (st/emit! (dwt/update-text-range id start end {:fills value})))))}
@@ -401,10 +401,10 @@
         ;; editor as well
         (cond
           (or (not (string? value)) (empty? value))
-          (u/display-not-valid :characters value)
+          (u/not-valid plugin-id :characters value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :characters "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :characters "Plugin doesn't have 'content:write' permission")
 
           (contains? (:workspace-editor-state @st/state) id)
           (let [shape (u/proxy->shape self)
@@ -428,10 +428,10 @@
             value (keyword value)]
         (cond
           (not (contains? #{:auto-width :auto-height :fixed} value))
-          (u/display-not-valid :growType value)
+          (u/not-valid plugin-id :growType value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :growType "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :growType "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwsh/update-shapes [id] #(assoc % :grow-type value))))))}
@@ -445,10 +445,10 @@
             variant (fonts/get-default-variant font)]
         (cond
           (not font)
-          (u/display-not-valid :fontId value)
+          (u/not-valid plugin-id :fontId value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :fontId "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :fontId "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id (font-data font variant))))))}
@@ -462,10 +462,10 @@
             variant (fonts/get-default-variant font)]
         (cond
           (not font)
-          (u/display-not-valid :fontFamily value)
+          (u/not-valid plugin-id :fontFamily value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :fontFamily "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :fontFamily "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id (font-data font variant))))))}
@@ -479,10 +479,10 @@
             variant (fonts/get-variant font value)]
         (cond
           (not variant)
-          (u/display-not-valid :fontVariantId value)
+          (u/not-valid plugin-id :fontVariantId value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :fontVariantId "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :fontVariantId "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id (variant-data variant))))))}
@@ -495,10 +495,10 @@
             value (str/trim (dm/str value))]
         (cond
           (or (empty? value) (not (re-matches font-size-re value)))
-          (u/display-not-valid :fontSize value)
+          (u/not-valid plugin-id :fontSize value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :fontSize "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :fontSize "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:font-size value})))))}
@@ -517,10 +517,10 @@
              (fonts/find-variant font {:weight weight}))]
         (cond
           (nil? variant)
-          (u/display-not-valid :fontWeight (dm/str "Font weight '" value "' not supported for the current font"))
+          (u/not-valid plugin-id :fontWeight (dm/str "Font weight '" value "' not supported for the current font"))
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :fontWeight "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :fontWeight "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id (variant-data variant))))))}
@@ -539,10 +539,10 @@
              (fonts/find-variant font {:style style}))]
         (cond
           (nil? variant)
-          (u/display-not-valid :fontStyle (dm/str "Font style '" value "' not supported for the current font"))
+          (u/not-valid plugin-id :fontStyle (dm/str "Font style '" value "' not supported for the current font"))
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :fontStyle "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :fontStyle "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id (variant-data variant))))))}
@@ -555,10 +555,10 @@
             value (str/trim (dm/str value))]
         (cond
           (or (empty? value) (not (re-matches line-height-re value)))
-          (u/display-not-valid :lineHeight value)
+          (u/not-valid plugin-id :lineHeight value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :lineHeight "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :lineHeight "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:line-height value})))))}
@@ -571,10 +571,10 @@
             value (str/trim (dm/str value))]
         (cond
           (or (not (string? value)) (not (re-matches letter-spacing-re value)))
-          (u/display-not-valid :letterSpacing value)
+          (u/not-valid plugin-id :letterSpacing value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :letterSpacing "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :letterSpacing "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:letter-spacing value})))))}
@@ -586,10 +586,10 @@
       (let [id (obj/get self "$id")]
         (cond
           (or (not (string? value)) (not (re-matches text-transform-re value)))
-          (u/display-not-valid :textTransform value)
+          (u/not-valid plugin-id :textTransform value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :textTransform "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :textTransform "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:text-transform value})))))}
@@ -601,10 +601,10 @@
       (let [id (obj/get self "$id")]
         (cond
           (or (not (string? value)) (not (re-matches text-decoration-re value)))
-          (u/display-not-valid :textDecoration value)
+          (u/not-valid plugin-id :textDecoration value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :textDecoration "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :textDecoration "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:text-decoration value})))))}
@@ -616,10 +616,10 @@
       (let [id (obj/get self "$id")]
         (cond
           (or (not (string? value)) (not (re-matches text-direction-re value)))
-          (u/display-not-valid :textDirection value)
+          (u/not-valid plugin-id :textDirection value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :textDirection "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :textDirection "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:text-direction value})))))}
@@ -631,10 +631,10 @@
       (let [id (obj/get self "$id")]
         (cond
           (or (not (string? value)) (not (re-matches text-align-re value)))
-          (u/display-not-valid :align value)
+          (u/not-valid plugin-id :align value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :align "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :align "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:text-align value})))))}
@@ -646,10 +646,10 @@
       (let [id (obj/get self "$id")]
         (cond
           (or (not (string? value)) (not (re-matches vertical-align-re value)))
-          (u/display-not-valid :verticalAlign value)
+          (u/not-valid plugin-id :verticalAlign value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/display-not-valid :verticalAlign "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :verticalAlign "Plugin doesn't have 'content:write' permission")
 
           :else
           (st/emit! (dwt/update-attrs id {:vertical-align value})))))}

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -63,11 +63,11 @@
   (cto/token-attr? (token-attr-plugin->token-attr attr)))
 
 (defn- apply-token-to-shapes
-  [file-id set-id id shape-ids attrs]
+  [plugin-id file-id set-id id shape-ids attrs]
 
   (let [token (u/locate-token file-id set-id id)]
     (if (some #(not (token-attr? %)) attrs)
-      (u/display-not-valid :applyToSelected attrs)
+      (u/not-valid plugin-id :applyToSelected attrs)
       (st/emit!
        (dwta/toggle-token {:token token
                            :attrs (into #{} (map token-attr-plugin->token-attr) attrs)
@@ -92,7 +92,7 @@
 (defn token-proxy
   [plugin-id file-id set-id id]
   (obj/reify {:name "TokenProxy"
-              :on-error u/handle-error}
+              :on-error (u/handle-error plugin-id)}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$file-id {:enumerable false :get (constantly file-id)}
     :$set-id {:enumerable false :get (constantly set-id)}
@@ -188,14 +188,14 @@
               [:vector [:fn shape-proxy?]]
               [:maybe [:set [:and ::sm/keyword [:fn token-attr?]]]]]
      :fn (fn [shapes attrs]
-           (apply-token-to-shapes file-id set-id id (map #(obj/get % "$id") shapes) attrs))}
+           (apply-token-to-shapes plugin-id file-id set-id id (map #(obj/get % "$id") shapes) attrs))}
 
     :applyToSelected
     {:enumerable false
      :schema [:tuple [:maybe [:set [:and ::sm/keyword [:fn token-attr?]]]]]
      :fn (fn [attrs]
            (let [selected (get-in @st/state [:workspace-local :selected])]
-             (apply-token-to-shapes file-id set-id id selected attrs)))}))
+             (apply-token-to-shapes plugin-id file-id set-id id selected attrs)))}))
 
 ;; === Token Set
 
@@ -205,7 +205,7 @@
 (defn token-set-proxy
   [plugin-id file-id id]
   (obj/reify {:name "TokenSetProxy"
-              :on-error u/handle-error}
+              :on-error (u/handle-error plugin-id)}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$file-id {:enumerable false :get (constantly file-id)}
     :$id {:enumerable false :get (constantly id)}
@@ -310,7 +310,7 @@
              (if resolved-value
                (do (st/emit! (dwtl/create-token id token))
                    (token-proxy plugin-id file-id id (:id token)))
-               (do (u/display-not-valid :addToken (str errors))
+               (do (u/not-valid plugin-id :addToken (str errors))
                    nil))))}
 
     :duplicate
@@ -327,7 +327,7 @@
 (defn token-theme-proxy
   [plugin-id file-id id]
   (obj/reify {:name "TokenThemeProxy"
-              :on-error u/handle-error}
+              :on-error (u/handle-error plugin-id)}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$file-id {:enumerable false :get (constantly file-id)}
     :$id {:enumerable false :get (constantly id)}
@@ -434,7 +434,7 @@
 (defn tokens-catalog
   [plugin-id file-id]
   (obj/reify {:name "TokensCatalog"
-              :on-error u/handle-error}
+              :on-error (u/handle-error plugin-id)}
     :$plugin {:enumerable false :get (constantly plugin-id)}
     :$id {:enumerable false :get (constantly file-id)}
 

--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -9,7 +9,6 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
-   [app.common.json :as json]
    [app.common.schema :as sm]
    [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
@@ -222,6 +221,16 @@
               (resolve value)))))]
     [ret-v ret-p]))
 
+(defn natural-child-ordering?
+  [plugin-id]
+  (boolean
+   (dm/get-in @st/state [:plugins :flags plugin-id :natural-child-ordering])))
+
+(defn throw-validation-errors?
+  [plugin-id]
+  (boolean
+   (dm/get-in @st/state [:plugins :flags plugin-id :throw-validation-errors])))
+
 (defn display-not-valid
   [code value]
   (if (some? value)
@@ -229,22 +238,24 @@
     (.error js/console (dm/str "[PENPOT PLUGIN] Value not valid. Code: " code)))
   nil)
 
+(defn throw-not-valid
+  [code value]
+  (if (some? value)
+    (throw (js/Error. (dm/str "[PENPOT PLUGIN] Value not valid: " value ". Code: " code)))
+    (throw (js/Error. (dm/str "[PENPOT PLUGIN] Value not valid. Code: " code))))
+  nil)
+
+(defn not-valid
+  [plugin-id code value]
+  (if (throw-validation-errors? plugin-id)
+    (throw-not-valid code value)
+    (display-not-valid code value)))
+
 (defn reject-not-valid
   [reject code value]
   (let [msg (dm/str "[PENPOT PLUGIN] Value not valid: " value ". Code: " code)]
     (.error js/console msg)
     (reject msg)))
-
-(defn coerce
-  "Decodes a javascript object into clj and check against schema. If schema validation fails,
-   displays a not-valid message with the code and hint provided and returns nil."
-  [attrs schema code hint]
-  (let [decoder   (sm/decoder schema sm/json-transformer)
-        explainer (sm/explainer schema)
-        attrs     (-> attrs json/->clj decoder)]
-    (if-let [explain (explainer attrs)]
-      (display-not-valid code (str hint " " (sm/humanize-explain explain)))
-      attrs)))
 
 (defn mixed-value
   [values]
@@ -254,12 +265,14 @@
 (defn handle-error
   "Function to be used in plugin proxies methods to handle errors and print a readable
    message to the console."
-  [cause]
-  (display-not-valid (ex-message cause) nil)
-  (if-let [explain (-> cause ex-data ::sm/explain)]
-    (println (sm/humanize-explain explain))
-    (js/console.log (ex-data cause)))
-  (js/console.log (.-stack cause)))
+  [plugin-id]
+  (fn [cause]
+    (let [message
+          (if-let [explain (-> cause ex-data ::sm/explain)]
+            (sm/humanize-explain explain)
+            (ex-data cause))]
+      (js/console.log (.-stack cause))
+      (not-valid plugin-id :error message))))
 
 (defn is-main-component-proxy?
   [p]

--- a/frontend/src/app/plugins/viewport.cljs
+++ b/frontend/src/app/plugins/viewport.cljs
@@ -38,10 +38,10 @@
              new-y (obj/get value "y")]
          (cond
            (not (sm/valid-safe-number? new-x))
-           (u/display-not-valid :center-x new-x)
+           (u/not-valid plugin-id :center-x new-x)
 
            (not (sm/valid-safe-number? new-y))
-           (u/display-not-valid :center-y new-y)
+           (u/not-valid plugin-id :center-y new-y)
 
            :else
            (let [vb (dm/get-in @st/state [:workspace-local :vbox])
@@ -63,7 +63,7 @@
      (fn [value]
        (cond
          (not (sm/valid-safe-number? value))
-         (u/display-not-valid :zoom value)
+         (u/not-valid plugin-id :zoom value)
 
          :else
          (let [z (dm/get-in @st/state [:workspace-local :zoom])]
@@ -87,7 +87,7 @@
     (fn [shapes]
       (cond
         (not (every? ps/shape-proxy? shapes))
-        (u/display-not-valid :zoomIntoView "Argument should be valid shapes")
+        (u/not-valid plugin-id :zoomIntoView "Argument should be valid shapes")
 
         :else
         (let [ids (->> shapes

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **plugin-types**: Added `createVariantFromComponents`
 - **plugin-types**: Change return type of `combineAsVariants`
 - **plugin-types**: Added `textBounds` property for text shapes
+- **plugin-types**: Added flag `throwValidationErrors` to enable exceptions on validation
 
 ## 1.4.2 (2026-01-21)
 

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -1715,6 +1715,13 @@ export interface Flags {
    * Defaults to false
    */
   naturalChildOrdering: boolean;
+
+  /**
+   * If `true` the validation errors will throw an exception instead of displaying an
+   * error in the debugger console.
+   * Defaults to false
+   */
+  throwValidationErrors: boolean;
 }
 
 /**


### PR DESCRIPTION
### Summary

Adds a flag to plugins to enable throwing exceptions on validation errors.

### Steps to reproduce 

```js
penpot.flags.throwValidationErrors = true;

// example error
try {
    penpot.createText(100);
} catch(e) {
    console.log("Catch exception");
}
```

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
