### PR TITLE
:bug: Fix visibility of go to cc option

### DIFF
--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -97,7 +97,8 @@
    [:id ::sm/uuid]
    [:name ::sm/text]
    [:slug ::sm/text]
-   [:is-your-penpot :boolean]])
+   [:is-your-penpot :boolean]
+   [:owner-id ::sm/uuid]])
 
 (def ^:private schema:team
   [:map
@@ -248,7 +249,7 @@
 
 (defn add-org-info-to-team
   "Enriches a team map with organization information from Nitrate.
-  Adds organization-id, organization-name, organization-slug, and your-penpot fields.
+  Adds organization-id, organization-name, organization-slug, organization-owner-id, and your-penpot fields.
   Returns the original team unchanged if the request fails or org data is nil."
   [cfg team params]
   (try
@@ -259,6 +260,7 @@
                :organization-id (:id org)
                :organization-name (:name org)
                :organization-slug (:slug org)
+               :organization-owner-id (:owner-id org)
                :is-default (or (:is-default team) (true? (:is-your-penpot org))))
         team))
     (catch Throwable cause

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -328,12 +328,7 @@
                             (:default-team-id profile))
         organizations (dissoc organizations default-team-id)
 
-        ;; Check if user is owner of any NON-DEFAULT organization
-        ;; Default org doesn't count as user is always owner of it
-        is-owner-of-any-org? (or (and (not= (:id organization) default-team-id)
-                                      (= (:id profile) (:organization-owner-id organization)))
-                                 (some #(= (:id profile) (:organization-owner-id %))
-                                       (vals organizations)))]
+        is-valid-license? (dnt/is-valid-license? profile)]
 
     [:> dropdown-menu* props
 
@@ -365,7 +360,7 @@
                               :class       (stl/css :org-dropdown-item :action)}
       [:span {:class (stl/css :icon-wrapper)} add-org-icon]
       [:span {:class (stl/css :team-text)} (tr "dashboard.create-new-org")]]
-     (when is-owner-of-any-org?
+     (when is-valid-license?
        [:> dropdown-menu-item* {:on-click    on-go-to-cc-click
                                 :class       (stl/css :org-dropdown-item :action)}
         [:span {:class (stl/css :icon-wrapper)} arrow-up-right-icon]

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -312,9 +312,11 @@
 
         on-go-to-cc-click
         (mf/use-fn
-         (mf/deps organization)
+         (mf/deps organization profile)
          (fn []
-           (if (:organization-id organization)
+           ;; Navigate to active org if user owns it, otherwise to last visited org
+           (if (and (:organization-id organization)
+                    (= (:id profile) (:organization-owner-id organization)))
              (dnt/go-to-nitrate-cc organization)
              (dnt/go-to-nitrate-cc))))
 
@@ -329,8 +331,8 @@
         ;; Check if user is owner of any NON-DEFAULT organization
         ;; Default org doesn't count as user is always owner of it
         is-owner-of-any-org? (or (and (not= (:id organization) default-team-id)
-                                      (get-in organization [:permissions :is-owner]))
-                                 (some #(get-in % [:permissions :is-owner])
+                                      (= (:id profile) (:organization-owner-id organization)))
+                                 (some #(= (:id profile) (:organization-owner-id %))
                                        (vals organizations)))]
 
     [:> dropdown-menu* props
@@ -583,7 +585,7 @@
 
 
 (defn- team->org [team]
-  (assoc (dm/select-keys team [:id :organization-id :organization-slug :permissions])
+  (assoc (dm/select-keys team [:id :organization-id :organization-slug :organization-owner-id])
          :name (:organization-name team)))
 
 (mf/defc sidebar-org-switch*

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -324,7 +324,14 @@
                                  first
                                  :id)
                             (:default-team-id profile))
-        organizations (dissoc organizations default-team-id)]
+        organizations (dissoc organizations default-team-id)
+
+        ;; Check if user is owner of any NON-DEFAULT organization
+        ;; Default org doesn't count as user is always owner of it
+        is-owner-of-any-org? (or (and (not= (:id organization) default-team-id)
+                                      (get-in organization [:permissions :is-owner]))
+                                 (some #(get-in % [:permissions :is-owner])
+                                       (vals organizations)))]
 
     [:> dropdown-menu* props
 
@@ -356,10 +363,11 @@
                               :class       (stl/css :org-dropdown-item :action)}
       [:span {:class (stl/css :icon-wrapper)} add-org-icon]
       [:span {:class (stl/css :team-text)} (tr "dashboard.create-new-org")]]
-     [:> dropdown-menu-item* {:on-click    on-go-to-cc-click
-                              :class       (stl/css :org-dropdown-item :action)}
-      [:span {:class (stl/css :icon-wrapper)} arrow-up-right-icon]
-      [:span {:class (stl/css :team-text)} (tr "dashboard.go-to-control-center")]]]))
+     (when is-owner-of-any-org?
+       [:> dropdown-menu-item* {:on-click    on-go-to-cc-click
+                                :class       (stl/css :org-dropdown-item :action)}
+        [:span {:class (stl/css :icon-wrapper)} arrow-up-right-icon]
+        [:span {:class (stl/css :team-text)} (tr "dashboard.go-to-control-center")]])]))
 
 (mf/defc teams-selector-dropdown*
   {::mf/private true}
@@ -575,7 +583,7 @@
 
 
 (defn- team->org [team]
-  (assoc (dm/select-keys team [:id :organization-id :organization-slug])
+  (assoc (dm/select-keys team [:id :organization-id :organization-slug :permissions])
          :name (:organization-name team)))
 
 (mf/defc sidebar-org-switch*


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13721 and https://tree.taiga.io/project/penpot/task/13751

### Summary

"Go to Control Center" dropdown option should only be visible for subscriptors, and:
- When the active org is yours goes to that org.
- When the active org is not yours goes to last visited one.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.