### PR TITLE
:bug: Default MCP listen addresses to localhost instead of 0.0.0.0

### DIFF
--- a/mcp/packages/plugin/vite.config.ts
+++ b/mcp/packages/plugin/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         },
     },
     preview: {
-        host: "0.0.0.0",
+        host: process.env.PENPOT_MCP_PLUGIN_SERVER_LISTEN_ADDRESS ?? "localhost",
         port: 4400,
         cors: true,
         allowedHosts: [],

--- a/mcp/packages/server/src/PenpotMcpServer.ts
+++ b/mcp/packages/server/src/PenpotMcpServer.ts
@@ -75,7 +75,7 @@ export class PenpotMcpServer {
 
     constructor(private isMultiUser: boolean = false) {
         // read port configuration from environment variables
-        this.host = process.env.PENPOT_MCP_SERVER_HOST ?? "0.0.0.0";
+        this.host = process.env.PENPOT_MCP_SERVER_LISTEN_ADDRESS ?? "localhost";
         this.port = parseInt(process.env.PENPOT_MCP_SERVER_PORT ?? "4401", 10);
         this.webSocketPort = parseInt(process.env.PENPOT_MCP_WEBSOCKET_PORT ?? "4402", 10);
         this.replPort = parseInt(process.env.PENPOT_MCP_REPL_PORT ?? "4403", 10);


### PR DESCRIPTION
Fixes #8683

The MCP server and plugin preview server were binding to `0.0.0.0` by default, exposing all network interfaces even in local-only mode. This contradicts the documented defaults and the security model described in the README.

Changes:
- `PenpotMcpServer.ts`: Read `PENPOT_MCP_SERVER_LISTEN_ADDRESS` (matching the documented env var name) instead of the undocumented `PENPOT_MCP_SERVER_HOST`, and default to `localhost`
- `vite.config.ts`: Use the `PENPOT_MCP_PLUGIN_SERVER_LISTEN_ADDRESS` env var with `localhost` fallback instead of hardcoded `0.0.0.0`