### PR TITLE
feat(mcp): add 'page' special shapeId to export_shape tool for full-page snapshots

### DIFF
--- a/mcp/packages/server/src/tools/ExportShapeTool.ts
+++ b/mcp/packages/server/src/tools/ExportShapeTool.ts
@@ -17,7 +17,8 @@ export class ExportShapeArgs {
             .min(1, "shapeId cannot be empty")
             .describe(
                 "Identifier of the shape to export. Use the special identifier 'selection' to " +
-                    "export the first shape currently selected by the user."
+                    "export the first shape currently selected by the user. " +
+                    "Use the special identifier 'page' to export the entire current page as a snapshot."
             ),
         format: z.enum(["svg", "png"]).default("png").describe("The output format, either 'png' (default) or 'svg'."),
         mode: z
@@ -71,7 +72,9 @@ export class ExportShapeTool extends Tool<ExportShapeArgs> {
     public getToolDescription(): string {
         let description =
             "Exports a shape (or a shape's image fill) from the Penpot design to a PNG or SVG image, " +
-            "such that you can get an impression of what it looks like. ";
+            "such that you can get an impression of what it looks like. " +
+            "Use the special shapeId 'page' to take a full snapshot of the entire current page. " +
+            "Use the special shapeId 'selection' to export the currently selected shape.";
         if (this.mcpServer.isFileSystemAccessEnabled()) {
             description += "\nAlternatively, you can save it to a file.";
         }
@@ -88,6 +91,8 @@ export class ExportShapeTool extends Tool<ExportShapeArgs> {
         let shapeCode: string;
         if (args.shapeId === "selection") {
             shapeCode = `penpot.selection[0]`;
+        } else if (args.shapeId === "page") {
+            shapeCode = `penpot.root`;
         } else {
             shapeCode = `penpotUtils.findShapeById("${args.shapeId}")`;
         }


### PR DESCRIPTION
## Summary

Adds support for a new special `shapeId` value — `'page'` — in the `export_shape` MCP tool.

## Motivation

When working with an AI agent via the MCP server, it is often useful to get a bird's-eye snapshot of the entire current page (e.g. to understand layout, identify shapes by visual inspection, or provide context). Previously, the only way to export everything visible was to know the ID of the root frame or to iterate over all shapes. Introducing `'page'` as a reserved identifier removes that friction.

## Changes

**`mcp/packages/server/src/tools/ExportShapeTool.ts`**

- Extended the `shapeId` parameter description to document the new `'page'` special value alongside the existing `'selection'` value.
- Updated `getToolDescription()` to explicitly mention both `'page'` and `'selection'` so LLM clients know which shortcuts are available.
- Added an `else if (args.shapeId === "page")` branch in `executeCore()` that maps the identifier to `penpot.root`, exporting the full current page.

## Usage

```json
{ "shapeId": "page", "format": "png" }
```

This will export the entire current Penpot page as a PNG snapshot — equivalent to calling `penpotUtils.exportImage(penpot.root, "shape", false)`.

## Backwards Compatibility

No breaking changes. The `'page'` identifier did not previously have any meaning (it would have been passed to `penpotUtils.findShapeById("page")` and returned `null`). Existing calls using real shape IDs or `'selection'` are unaffected.
