### PR TITLE
:sparkles: Add createComponent() helper to PenpotUtils with API guard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### :heart: Community contributions (Thank you!)
 
+- Add 'page' special shapeId to MCP export_shape tool for full-page snapshots [Github #8689](https://github.com/penpot/penpot/issues/8689)
+- Add createComponent() helper to PenpotUtils with board-on-root guard and API constraint documentation [Github #8691](https://github.com/penpot/penpot/issues/8691)
+
 ### :sparkles: New features & Enhancements
 
 - Access to design tokens in Penpot Plugins [Taiga #8990](https://tree.taiga.io/project/penpot/us/8990)

--- a/mcp/packages/plugin/src/PenpotUtils.ts
+++ b/mcp/packages/plugin/src/PenpotUtils.ts
@@ -511,6 +511,32 @@ export class PenpotUtils {
     }
 
     /**
+     * Wraps a board in a library component.
+     *
+     * The underlying API only works with boards freshly created via `penpot.createBoard()`
+     * that are already inserted into `penpot.root` before this call. Existing or cloned
+     * boards silently produce an empty component.
+     *
+     * Cross-page reparenting is unsupported by the Plugin API — main instances always
+     * land on the current page. Move them to another page manually in the Penpot UI.
+     *
+     * Use `"/"` in `name` to create nested groups in the Assets panel (e.g. `"Buttons/Primary"`).
+     */
+    public static createComponent(board: Board, name: string): any {
+        const isOnRoot = !!(penpot.root.children?.some((child) => child.id === board.id));
+        if (!isOnRoot) {
+            throw new Error(
+                "createComponent() requires the board to already be a direct child of penpot.root. " +
+                    "Insert it first: penpot.root.insertChild(penpot.root.children.length, board)"
+            );
+        }
+        // @ts-ignore — createComponent is not yet in the TS type definitions
+        const component = penpot.library.local.createComponent([board]);
+        component.name = name;
+        return component;
+    }
+
+    /**
      * Generates an overview of all tokens organized by token set name, token type, and token name.
      * The result is a nested object structure: {tokenSetName: {tokenType: [tokenName, ...]}}.
      *


### PR DESCRIPTION
## Summary

Wraps `penpot.library.local.createComponent()` in a `PenpotUtils.createComponent()` helper that:

1. **Guards against silent failure** — the underlying API only works with boards that are freshly created and already inserted into `penpot.root`. Passing any other shape silently produces an empty component with no error. The helper validates this precondition and throws a descriptive error when violated.
2. **Documents the cross-page limitation** — component main instances always land on the current page; cross-page reparenting is unsupported by the Plugin API.
3. **Documents the `"/"` group separator** — component names like `"Buttons/Primary"` automatically create nested groups in the Assets panel.

Closes https://github.com/penpot/penpot/issues/8691

Signed-off-by: Abhishek Mittal <abhishekmittaloffice@gmail.com>
