### PR TITLE
:sparkles: Add 'page' shapeId to MCP export_shape for full-page snapshot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,7 @@
 ## 2.13.0
 
 ### :heart: Community contributions (Thank you!)
+- Add 'page' special shapeId to MCP export_shape tool for full-page snapshots [Github #8689](https://github.com/penpot/penpot/issues/8689)
 
 - Fix mask issues with component swap (by @dfelinto) [Github #7675](https://github.com/penpot/penpot/issues/7675)
 

--- a/mcp/packages/server/src/tools/ExportShapeTool.ts
+++ b/mcp/packages/server/src/tools/ExportShapeTool.ts
@@ -16,8 +16,8 @@ export class ExportShapeArgs {
             .string()
             .min(1, "shapeId cannot be empty")
             .describe(
-                "Identifier of the shape to export. Use the special identifier 'selection' to " +
-                    "export the first shape currently selected by the user."
+                "Identifier of the shape to export. " +
+                    "Special identifiers you can use: 'selection' (first shape currently selected by the user), 'page' (entire current page)"
             ),
         format: z.enum(["svg", "png"]).default("png").describe("The output format, either 'png' (default) or 'svg'."),
         mode: z
@@ -71,7 +71,7 @@ export class ExportShapeTool extends Tool<ExportShapeArgs> {
     public getToolDescription(): string {
         let description =
             "Exports a shape (or a shape's image fill) from the Penpot design to a PNG or SVG image, " +
-            "such that you can get an impression of what it looks like. ";
+            "such that you can get an impression of what it looks like.";
         if (this.mcpServer.isFileSystemAccessEnabled()) {
             description += "\nAlternatively, you can save it to a file.";
         }
@@ -88,6 +88,8 @@ export class ExportShapeTool extends Tool<ExportShapeArgs> {
         let shapeCode: string;
         if (args.shapeId === "selection") {
             shapeCode = `penpot.selection[0]`;
+        } else if (args.shapeId === "page") {
+            shapeCode = `penpot.root`;
         } else {
             shapeCode = `penpotUtils.findShapeById("${args.shapeId}")`;
         }


### PR DESCRIPTION
## Summary of changes

This PR adds a `'page'` special shapeId to the MCP `export_shape` tool, enabling callers to capture a full snapshot of the currently active Penpot page without knowing any specific shape ID.

Before this change the tool required a concrete shape UUID. The `'page'` shorthand maps to `penpot.root`, which is the root node of the current page.

Closes https://github.com/penpot/penpot/issues/8689

## How was it tested

Manually invoked the MCP tool with `shapeId: "page"` against a running Penpot instance and confirmed a full-page PNG was returned.

## DCO

By submitting this patch, I confirm that my contribution is made according to the terms of the [Penpot contributing guide](https://github.com/penpot/penpot/blob/mcp-prod/CONTRIBUTING.md) and the DCO:

Signed-off-by: Abhishek Mittal <abhishekmittaloffice@gmail.com>
