### PR TITLE
:sparkles: Add response to nitrate request when nitrate is down

### DIFF
--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -51,6 +51,11 @@
   (fn []
     (let [response (handler)
           status (:status response)]
+      (when-not status
+        (l/error :hint "could't do the nitrate request, it is probably down"
+                 :uri uri)
+        ;; TODO decide what to do when Nitrate is inaccesible
+        nil)
       (if (>= status 400)
         ;; For error status codes (4xx, 5xx), fail immediately without validation
         (do


### PR DESCRIPTION
### Summary

Add response to nitrate request when nitrate is down

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
