### PR TITLE
:bug: Fix null text crash on paste in text editor

### DIFF
--- a/frontend/packages/draft-js/index.js
+++ b/frontend/packages/draft-js/index.js
@@ -375,6 +375,10 @@ function splitTextIntoTextBlocks(text) {
 export function insertText(state, text, attrs, inlineStyles) {
   const blocks = splitTextIntoTextBlocks(text);
 
+  if (blocks.length === 0) {
+    return state;
+  }
+
   const character = CharacterMetadata.create({style: OrderedSet(inlineStyles)});
 
   let blockArray = DraftPasteProcessor.processText(

--- a/frontend/packages/draft-js/index.js
+++ b/frontend/packages/draft-js/index.js
@@ -366,6 +366,9 @@ export function getInlineStyle(state, blockKey, offset) {
 const NEWLINE_REGEX = /\r\n?|\n/g;
 
 function splitTextIntoTextBlocks(text) {
+  if (text == null) {
+    return [];
+  }
   return text.split(NEWLINE_REGEX);
 }
 

--- a/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
@@ -221,12 +221,13 @@
 
         handle-pasted-text
         (fn [text _ _]
-          (let [current-block-styles (ted/get-editor-current-block-data state)
-                inline-styles        (ted/get-editor-current-inline-styles state)
-                style                (merge current-block-styles inline-styles)
-                state                (-> (ted/insert-text state text style)
-                                         (handle-change))]
-            (st/emit! (dwt/update-editor-state shape state)))
+          (when (seq text)
+            (let [current-block-styles (ted/get-editor-current-block-data state)
+                  inline-styles        (ted/get-editor-current-inline-styles state)
+                  style                (merge current-block-styles inline-styles)
+                  state                (-> (ted/insert-text state text style)
+                                           (handle-change))]
+              (st/emit! (dwt/update-editor-state shape state))))
           "handled")]
 
     (mf/use-layout-effect on-mount)


### PR DESCRIPTION
### Summary

The `splitTextIntoTextBlocks` function in `@penpot/draft-js` called .split() on the text parameter without a null check. When pasting content without text data (e.g., images only), Draft.js passes null to `handlePastedText`, causing a `TypeError`.

### Related report

```
Context:
--------------------
Hint:     can't access property "split", e is null
Version:  2.14.0-RC5
HREF:     https://design.penpot.app/#/workspace
Trace:
--------------------
zmr@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:790:161179
fWe@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:790:161230
$app$util$text_editor$insert_text$$@https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1871:246
handlePastedText@https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:11554:90
b_r@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:61:3823
FHe</r._buildHandler/kHe@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:61:13914
h4e@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:128546
R4e</ZZ/<@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:133624
h6e@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:15241
ZZ@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:129795
jte@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:43:28737
zer@https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:43:28544
```
