### PR TITLE
:bug: Fix removeChild crash on all portal components

### DIFF
--- a/frontend/src/app/main/ui/components/portal.cljs
+++ b/frontend/src/app/main/ui/components/portal.cljs
@@ -6,16 +6,12 @@
 
 (ns app.main.ui.components.portal
   (:require
-   [app.util.dom :as dom]
+   [app.main.ui.hooks :as hooks]
    [rumext.v2 :as mf]))
 
 (mf/defc portal-on-document*
   [{:keys [children]}]
-  (let [container (mf/use-memo #(dom/create-element "div"))]
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
+  (let [container (hooks/use-portal-container)]
     (mf/portal
      (mf/html [:* children])
      container)))

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -9,6 +9,7 @@
    [app.main.style :as stl])
   (:require
    [app.common.data :as d]
+   [app.main.ui.hooks :as hooks]
    [app.util.dom :as dom]
    [app.util.keyboard :as kbd]
    [app.util.timers :as ts]
@@ -159,7 +160,7 @@
 
         tooltip-ref (mf/use-ref nil)
 
-        container (mf/use-memo #(dom/create-element "div"))
+        container (hooks/use-portal-container)
 
         id
         (d/nilv id internal-id)
@@ -245,11 +246,6 @@
                           :aria-label (if (string? content)
                                         content
                                         aria-label)})]
-
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
 
     (mf/use-effect
      (mf/deps tooltip-id)

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -159,6 +159,8 @@
 
         tooltip-ref (mf/use-ref nil)
 
+        container (mf/use-memo #(dom/create-element "div"))
+
         id
         (d/nilv id internal-id)
 
@@ -244,6 +246,11 @@
                                         content
                                         aria-label)})]
 
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
+
     (mf/use-effect
      (mf/deps tooltip-id)
      (fn []
@@ -295,4 +302,4 @@
            [:div {:class (stl/css :tooltip-content)} content]
            [:div {:class (stl/css :tooltip-arrow)
                   :id "tooltip-arrow"}]]])
-        (.-body js/document)))]))
+        container))]))

--- a/frontend/src/app/main/ui/hooks.cljs
+++ b/frontend/src/app/main/ui/hooks.cljs
@@ -380,6 +380,18 @@
 
     state))
 
+(defn use-portal-container
+  "Creates a dedicated div container for React portals. The container
+  is appended to document.body on mount and removed on cleanup, preventing
+  removeChild race conditions when multiple portals target the same body."
+  []
+  (let [container (mf/use-memo #(dom/create-element "div"))]
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
+    container))
+
 (defn use-dynamic-grid-item-width
   ([] (use-dynamic-grid-item-width nil))
   ([itemsize]

--- a/frontend/src/app/main/ui/modal.cljs
+++ b/frontend/src/app/main/ui/modal.cljs
@@ -10,6 +10,7 @@
    [app.common.data.macros :as dm]
    [app.main.data.modal :as modal]
    [app.main.store :as st]
+   [app.main.ui.hooks :as hooks]
    [app.util.dom :as dom]
    [app.util.keyboard :as k]
    [goog.events :as events]
@@ -83,11 +84,7 @@
 (mf/defc modal-container*
   {::mf/props :obj}
   []
-  (let [container (mf/use-memo #(dom/create-element "div"))]
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
+  (let [container (hooks/use-portal-container)]
     (when-let [modal (mf/deref ref:modal)]
       (mf/portal
        (mf/html [:> modal-wrapper* {:data modal :key (dm/str (:id modal))}])

--- a/frontend/src/app/main/ui/modal.cljs
+++ b/frontend/src/app/main/ui/modal.cljs
@@ -83,7 +83,12 @@
 (mf/defc modal-container*
   {::mf/props :obj}
   []
-  (when-let [modal (mf/deref ref:modal)]
-    (mf/portal
-     (mf/html [:> modal-wrapper* {:data modal :key (dm/str (:id modal))}])
-     (dom/get-body))))
+  (let [container (mf/use-memo #(dom/create-element "div"))]
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
+    (when-let [modal (mf/deref ref:modal)]
+      (mf/portal
+       (mf/html [:> modal-wrapper* {:data modal :key (dm/str (:id modal))}])
+       container))))

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -20,6 +20,7 @@
    [app.main.store :as st]
    [app.main.ui.components.dropdown :refer [dropdown]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
+   [app.main.ui.hooks :as hooks]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.timers :as timers]
@@ -516,12 +517,7 @@
         dropdown-direction-change* (mf/use-ref 0)
         top                 (+ (get-in mdata [:position :y]) 5)
         left                (+ (get-in mdata [:position :x]) 5)
-        container           (mf/use-memo #(dom/create-element "div"))]
-
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
+        container           (hooks/use-portal-container)]
 
     (mf/use-effect
      (mf/deps is-open?)

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -515,7 +515,13 @@
         dropdown-direction  (deref dropdown-direction*)
         dropdown-direction-change* (mf/use-ref 0)
         top                 (+ (get-in mdata [:position :y]) 5)
-        left                (+ (get-in mdata [:position :x]) 5)]
+        left                (+ (get-in mdata [:position :x]) 5)
+        container           (mf/use-memo #(dom/create-element "div"))]
+
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
 
     (mf/use-effect
      (mf/deps is-open?)
@@ -554,4 +560,4 @@
                 :on-context-menu prevent-default}
           (when mdata
             [:& token-context-menu-tree (assoc mdata :width @width :on-delete-token on-delete-token)])]])
-       (dom/get-body)))))
+       container))))

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/combobox.cljs
@@ -92,6 +92,8 @@
         icon-button-ref   (mf/use-ref nil)
         ref               (or ref internal-ref)
 
+        container         (mf/use-memo #(dom/create-element "div"))
+
         raw-tokens-by-type (mf/use-ctx muc/active-tokens-by-type)
 
         filtered-tokens-by-type
@@ -267,6 +269,11 @@
     (mf/with-effect [dropdown-options]
       (mf/set-ref-val! options-ref dropdown-options))
 
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
+
     (mf/with-effect [is-open* ref wrapper-ref]
       (when is-open
         (let [handler (fn [event]
@@ -305,4 +312,4 @@
                                   :empty-to-end empty-to-end
                                   :wrapper-ref dropdown-ref
                                   :ref set-option-ref}])
-          (dom/get-body))))]))
+          container)))]))

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/combobox.cljs
@@ -19,6 +19,7 @@
    [app.main.ui.ds.controls.shared.options-dropdown :refer [options-dropdown*]]
    [app.main.ui.ds.foundations.assets.icon :as i]
    [app.main.ui.forms :as fc]
+   [app.main.ui.hooks :as hooks]
    [app.main.ui.workspace.tokens.management.forms.controls.combobox-navigation :refer [use-navigation]]
    [app.main.ui.workspace.tokens.management.forms.controls.floating-dropdown :refer [use-floating-dropdown]]
    [app.main.ui.workspace.tokens.management.forms.controls.token-parsing :as tp]
@@ -92,7 +93,7 @@
         icon-button-ref   (mf/use-ref nil)
         ref               (or ref internal-ref)
 
-        container         (mf/use-memo #(dom/create-element "div"))
+        container         (hooks/use-portal-container)
 
         raw-tokens-by-type (mf/use-ctx muc/active-tokens-by-type)
 
@@ -268,11 +269,6 @@
 
     (mf/with-effect [dropdown-options]
       (mf/set-ref-val! options-ref dropdown-options))
-
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
 
     (mf/with-effect [is-open* ref wrapper-ref]
       (when is-open

--- a/frontend/src/app/main/ui/workspace/tokens/management/node_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/node_context_menu.cljs
@@ -6,6 +6,7 @@
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.dropdown :refer [dropdown]]
+   [app.main.ui.hooks :as hooks]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [okulary.core :as l]
@@ -35,7 +36,7 @@
         dropdown-direction-change* (mf/use-ref 0)
         top                 (+ (get-in mdata [:position :y]) 5)
         left                (+ (get-in mdata [:position :x]) 5)
-        container           (mf/use-memo #(dom/create-element "div"))
+        container           (hooks/use-portal-container)
 
         delete-node          (mf/use-fn
                               (mf/deps mdata)
@@ -44,11 +45,6 @@
                                       type (get mdata :type)]
                                   (when node
                                     (on-delete-node node type)))))]
-
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
 
     (mf/with-effect [is-open?]
       (when (and (not= 0 (mf/ref-val dropdown-direction-change*)) (= false is-open?))

--- a/frontend/src/app/main/ui/workspace/tokens/management/node_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/node_context_menu.cljs
@@ -35,6 +35,7 @@
         dropdown-direction-change* (mf/use-ref 0)
         top                 (+ (get-in mdata [:position :y]) 5)
         left                (+ (get-in mdata [:position :x]) 5)
+        container           (mf/use-memo #(dom/create-element "div"))
 
         delete-node          (mf/use-fn
                               (mf/deps mdata)
@@ -43,6 +44,11 @@
                                       type (get mdata :type)]
                                   (when node
                                     (on-delete-node node type)))))]
+
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
 
     (mf/with-effect [is-open?]
       (when (and (not= 0 (mf/ref-val dropdown-direction-change*)) (= false is-open?))
@@ -80,4 +86,4 @@
                         :type "button"
                         :on-click delete-node}
                (tr "labels.delete")]]])]])
-       (dom/get-body)))))
+       container))))

--- a/frontend/src/app/main/ui/workspace/tokens/themes/theme_selector.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/theme_selector.cljs
@@ -17,6 +17,7 @@
    [app.main.ui.components.dropdown :refer [dropdown]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.main.ui.ds.foundations.typography.text :refer [text*]]
+   [app.main.ui.hooks :as hooks]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [cuerdas.core :as str]
@@ -113,12 +114,7 @@
                         :is-open? true
                         :rect rect))))))
 
-        container (mf/use-memo #(dom/create-element "div"))]
-
-    (mf/with-effect []
-      (let [body (dom/get-body)]
-        (dom/append-child! body container)
-        #(dom/remove-child! body container)))
+        container (hooks/use-portal-container)]
 
     [:div {:on-click on-open-dropdown
            :disabled (not can-edit?)

--- a/frontend/src/app/main/ui/workspace/tokens/themes/theme_selector.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/theme_selector.cljs
@@ -111,7 +111,14 @@
                (let [rect (dom/get-bounding-rect node)]
                  (swap! state* assoc
                         :is-open? true
-                        :rect rect))))))]
+                        :rect rect))))))
+
+        container (mf/use-memo #(dom/create-element "div"))]
+
+    (mf/with-effect []
+      (let [body (dom/get-body)]
+        (dom/append-child! body container)
+        #(dom/remove-child! body container)))
 
     [:div {:on-click on-open-dropdown
            :disabled (not can-edit?)
@@ -140,4 +147,4 @@
            [:& theme-options {:active-theme-paths active-theme-paths
                               :themes themes
                               :on-close on-close-dropdown}]]])
-        (dom/get-body)))]))
+        container))]))


### PR DESCRIPTION
### Summary 

The previous fix (80b64c440c) only addressed portal-on-document* but there were 6 additional components that portaled directly to document.body, causing the same race condition when React attempted to remove a node that had already been detached during concurrent state updates (e.g. navigating away while a context menu is open).

Apply the dedicated-container pattern consistently to all portal sites: modal, context menus, combobox dropdown, theme selector, and tooltip. Each component now creates a dedicated <div> container appended to body on mount and removed on cleanup, giving React an exclusive containerInfo for each portal instance.

### Related Report

```
Context:
--------------------
Hint:     Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
Version:  2.14.0-RC5
HREF:     https://design.penpot.app/#/dashboard/recent

Trace:
--------------------
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
  at zLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:99950)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101498)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:103940)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:104543)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:104967)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:104694)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:106207)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101825)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
  at qLe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101749)
  at td (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:101625)
```