### PR TITLE
:bug: Fix exclusion being applied as union (wasm)

### DIFF
--- a/render-wasm/src/wasm/paths/bools.rs
+++ b/render-wasm/src/wasm/paths/bools.rs
@@ -18,7 +18,7 @@ pub enum RawBoolType {
     Union = 0,
     Difference = 1,
     Intersection = 2,
-    Exclusion = 3,
+    Exclude = 3,
 }
 
 impl From<u8> for RawBoolType {
@@ -33,7 +33,7 @@ impl From<RawBoolType> for BoolType {
             RawBoolType::Union => BoolType::Union,
             RawBoolType::Difference => BoolType::Difference,
             RawBoolType::Intersection => BoolType::Intersection,
-            RawBoolType::Exclusion => BoolType::Exclusion,
+            RawBoolType::Exclude => BoolType::Exclusion,
         }
     }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13773

### Summary

Fixes the boolean operation **Exclusion** being applied as an Union due to bad serialization.

<img width="641" height="439" alt="Exclusion" src="https://github.com/user-attachments/assets/5128a26a-6aad-4fdd-b7c7-08f7f9c8082b" />

### Steps to reproduce 

See Taiga ticket.

> :warning: **TO TRY THIS**: You need to regenerate `shared.js`. This means either restarting the script `watch:app` or doing a `cargo clean` then running our `build` script.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
