### PR TITLE
:bug: Fix layout lines not disappearing on shape deletion (wasm)

### DIFF
--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -168,8 +168,16 @@ impl State {
                 }
             }
 
-            if let Some(shape_to_delete) = self.shapes.get_mut(&id) {
-                shape_to_delete.set_deleted(true);
+            if let Some(shape_to_delete) = self.shapes.get(&id) {
+                let to_delete = shape_to_delete.all_children(&self.shapes, true, true);
+                for shape_id in to_delete {
+                    if let Some(shape_to_delete) = self.shapes.get_mut(&shape_id) {
+                        shape_to_delete.set_deleted(true);
+                    }
+                    if self.render_state.show_grid == Some(shape_id) {
+                        self.render_state.show_grid = None;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13803

### Summary

This fixes layout lines from children shapes not disappearing when a shape is deleted, by properly marking the descendants as deleted too.

https://github.com/user-attachments/assets/b4886ab8-a859-48dc-a035-7cce6258257c


### Steps to reproduce 

1. Create a component (or a board)
2. Add a board with a grid layout as the children of that component.
3. Delete the component

Expected behavior: the shape is deleted and no layout lines remain visible in the viewport.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
