### PR TITLE
:bug: Fix dissoc error when detaching stroke color from library

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -205,10 +205,10 @@
 
         detach-value
         (mf/use-fn
-         (mf/deps on-detach index)
+         (mf/deps on-detach index color)
          (fn [_]
            (when on-detach
-             (on-detach index))))
+             (on-detach index color))))
 
         handle-select
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
@@ -80,7 +80,7 @@
         on-color-detach
         (mf/use-fn
          (mf/deps index on-color-detach)
-         (fn [color]
+         (fn [_ color]
            (on-color-detach index color)))
 
         on-remove


### PR DESCRIPTION
### Summary

The detach-value function in color-row was only passing index to on-detach, but the stroke's on-color-detach handler expects both index and color arguments. This caused a protocol error when trying to dissoc from a number instead of a map.

### Related Ticket
```
Context:
--------------------
Hint:     No protocol method IMap.-dissoc defined for type number: 0
Version:  2.14.0-RC5
HREF:     https://design.penpot.app/#/workspace

Trace:
--------------------
Error: No protocol method IMap.-dissoc defined for type number: 0
  at $APP.$cljs$core$missing_protocol$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:431:392)
  at $APP.$cljs$core$_dissoc$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:481:166)
  at $APP.$cljs$core$dissoc$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:18785:144)
  at $APP.$cljs$core$dissoc$$.$cljs$core$IFn$_invoke$arity$variadic$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:18786:291)
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:11141:295
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:6431:22
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:3805:215
  at h4e (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:128545)
  at https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:133621
  at h6e (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:15240)
  at ZZ (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:42:129792)
  at jte (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:43:28735)
  at zer (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:43:28544)
```

**MERGE with SQUASH**
