### PR TITLE
:bug: Fix error when get-parent-with-data encounters non-Element nodes

### DIFF
--- a/frontend/src/app/util/dom.cljs
+++ b/frontend/src/app/util/dom.cljs
@@ -170,8 +170,17 @@
   [^js node name]
   (let [name (str/camel name)]
     (loop [current node]
-      (if (or (nil? current) (obj/in? (.-dataset current) name))
+      (cond
+        (nil? current)
+        nil
+
+        (not= (.-nodeType current) js/Node.ELEMENT_NODE)
+        (recur (.-parentElement current))
+
+        (obj/in? (.-dataset current) name)
         current
+
+        :else
         (recur (.-parentElement current))))))
 
 (defn get-parent-with-selector


### PR DESCRIPTION
### Summary

The get-parent-with-data function traverses the DOM using parentElement to find an ancestor with a specific data-* attribute. When the current node is a non-Element DOM node (e.g. Document node reached from event handlers on window), accessing .-dataset returns undefined, causing obj/in? to throw "right-hand side of 'in' should be an object".

This adds a nodeType check to skip non-Element nodes during traversal and continue up the parent chain.

### Related Ticket

```
Context:
--------------------
Hint:     right-hand side of 'in' should be an object, got undefined
Version:  2.14.0-RC5
HREF:     https://design.penpot.app/#/workspace

Trace:
--------------------
$APP.$app$util$dom$get_parent_with_data$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:4467:316
$app$main$ui$workspace$viewport$hooks$setup_dom_events$$/$on_pointer_down$jscomp$17$$<@https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:9079:432
$goog$events$handleBrowserEvent_$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:4577:339
$f$jscomp$702$$@https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:4566:118
```