### PR TITLE
:bug: Ensure path content is always PathData when saving

### DIFF
--- a/frontend/src/app/main/data/workspace/path/changes.cljs
+++ b/frontend/src/app/main/data/workspace/path/changes.cljs
@@ -69,7 +69,7 @@
              content (if (and (not preserve-move-to)
                               (= (-> content last :command) :move-to))
                        (path/content (take (dec (count content)) content))
-                       content)]
+                       (path/content content))]
          (st/set-content state content)))
 
      ptk/WatchEvent


### PR DESCRIPTION
### Summary

The save-path-content function only converted content to PathData when there was a trailing :move-to command. When there was no trailing :move-to, the content from get-path was stored as-is, which could be a plain vector if the shape was already a :path type with non-PathData content. This caused segment/get-points to fail with 'can't access property "get", cache is undefined' when the with-cache macro tried to access the cache field on a non-PathData object.

The fix ensures content is always converted to PathData via path/content before being stored in the state.
