### PR TITLE
:bug: Fix text selection misalignment

### DIFF
--- a/render-wasm/src/render/text_editor.rs
+++ b/render-wasm/src/render/text_editor.rs
@@ -1,14 +1,9 @@
 use crate::shapes::{Shape, TextContent, Type, VerticalAlign};
 use crate::state::{TextEditorState, TextSelection};
 use skia_safe::textlayout::{RectHeightStyle, RectWidthStyle};
-use skia_safe::{BlendMode, Canvas, Matrix, Paint, Rect};
+use skia_safe::{BlendMode, Canvas, Paint, Rect};
 
-pub fn render_overlay(
-    canvas: &Canvas,
-    editor_state: &TextEditorState,
-    shape: &Shape,
-    transform: &Matrix,
-) {
+pub fn render_overlay(canvas: &Canvas, editor_state: &TextEditorState, shape: &Shape) {
     if !editor_state.is_active {
         return;
     }
@@ -18,16 +13,12 @@ pub fn render_overlay(
     };
 
     canvas.save();
-    canvas.concat(transform);
-
     if editor_state.selection.is_selection() {
         render_selection(canvas, editor_state, text_content, shape);
     }
-
     if editor_state.cursor_visible {
         render_cursor(canvas, editor_state, text_content, shape);
     }
-
     canvas.restore();
 }
 

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1212,6 +1212,7 @@ impl Shape {
         matrix
     }
 
+    #[allow(dead_code)]
     pub fn get_concatenated_matrix(&self, shapes: ShapesPoolRef) -> Matrix {
         let mut matrix = Matrix::new_identity();
         let mut current_id = self.id;

--- a/render-wasm/src/wasm/text_editor.rs
+++ b/render-wasm/src/wasm/text_editor.rs
@@ -2,6 +2,8 @@ use macros::{wasm_error, ToJs};
 
 use crate::math::{Matrix, Point, Rect};
 use crate::mem;
+use crate::render::text_editor as text_editor_render;
+use crate::render::SurfaceId;
 use crate::shapes::{Shape, TextContent, TextPositionWithAffinity, Type, VerticalAlign};
 use crate::state::TextSelection;
 use crate::utils::uuid_from_u32_quartet;
@@ -841,21 +843,13 @@ pub extern "C" fn text_editor_render_overlay() {
             return;
         };
 
-        let transform = shape.get_concatenated_matrix(&state.shapes);
-
-        use crate::render::text_editor as te_render;
-        use crate::render::SurfaceId;
-
         let canvas = state.render_state.surfaces.canvas(SurfaceId::Target);
-
         canvas.save();
         let viewbox = state.render_state.viewbox;
         let zoom = viewbox.zoom * state.render_state.options.dpr();
         canvas.scale((zoom, zoom));
         canvas.translate((-viewbox.area.left, -viewbox.area.top));
-
-        te_render::render_overlay(canvas, &state.text_editor_state, shape, &transform);
-
+        text_editor_render::render_overlay(canvas, &state.text_editor_state, shape);
         canvas.restore();
         state.render_state.flush_and_submit();
     });


### PR DESCRIPTION
### Related Ticket

[Taiga Task #13758](https://tree.taiga.io/project/penpot/task/13758)

### Summary

When editing a text shape inside a frame, the text caret and selection appears in [Cuenca](https://es.wikipedia.org/wiki/Cuenca_(Espa%C3%B1a)).

<img width="2554" height="1354" alt="Visit Cuenca, it is a beautiful place" src="https://github.com/user-attachments/assets/8a3c9b86-abca-46d4-a869-f5dafcb57b43" />

### Steps to reproduce 

1. Create a Frame
2. Add a Text shape inside the frame with some text like Hello, World!
3. Select a word
4. The Caret and the selection box appears completely misaligned

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
