### PR TITLE
:sparkles: Further MCP improvements in preparation of beta-test

### DIFF
--- a/mcp/.serena/project.yml
+++ b/mcp/.serena/project.yml
@@ -150,3 +150,17 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -50,13 +50,33 @@ Follow the steps below to enable the integration.
 
 ### Prerequisites
 
-The project requires [Node.js](https://nodejs.org/) (tested with v22.x).  
-Following the installation of Node.js, the tools `corepack` and `npx`
-should be available in your terminal.
+The project requires [Node.js](https://nodejs.org/) (tested with v22.x).
+
+### 1. Starting the MCP Server and the Plugin Server
+
+#### Running a Released Version via npx
+
+The easiest way to launch the servers is to use `npx` to run the appropriate
+version that matches your Penpot version.
+
+* If you are using the latest Penpot release, e.g. as served on [design.penpot.app](https://design.penpot.app), run:
+  ```shell
+  npx -y @penpot/mcp@">=0"
+  ```
+* If you are participating in the MCP beta-test, which uses [test-mcp.penpot.dev](https://test-mcp.penpot.dev), run:
+  ```shell
+  npx -y @penpot/mcp@"*"
+  ```
+
+Once the servers are running, continue with step 2.
+
+#### Running the Source Version from the Repository
+
+The tools `corepack` and `npx` should be available in your terminal.
 
 On Windows, use the Git Bash terminal to ensure compatibility with the provided scripts.
 
-### 0. Clone the Appropriate Branch of the Repository 
+##### Clone the Appropriate Branch of the Repository 
 
 > [!IMPORTANT]
 > The branches are subject to change in the future.  
@@ -65,13 +85,13 @@ On Windows, use the Git Bash terminal to ensure compatibility with the provided 
 Clone the Penpot repository, using the proper branch depending on the
 version of Penpot you want to use the MCP server with.
 
-  * For released versions of Penpot, use the `mcp-prod` branch:
+  * For the current Penpot release 2.14, use the `mcp-prod-2.14.0` branch:
 
     ```shell
-    git clone https://github.com/penpot/penpot.git --branch mcp-prod --depth 1
+    git clone https://github.com/penpot/penpot.git --branch mcp-prod-2.14.0 --depth 1
     ```
 
-  * For the latest development version of Penpot, use the `develop` branch:
+  * For the latest development version of Penpot (including the MCP beta-test), use the `develop` branch:
 
     ```shell
     git clone https://github.com/penpot/penpot.git --branch develop --depth 1
@@ -83,7 +103,7 @@ Then change into the `mcp` directory:
 cd penpot/mcp
 ```
 
-### 1. Build & Launch the MCP Server and the Plugin Server
+##### Build & Launch the MCP Server and the Plugin Server
 
 If it's your first execution, install the required dependencies.
 (If you are using the Penpot devenv, this step is not necessary, as dependencies are already installed.)

--- a/mcp/packages/plugin/src/task-handlers/ExecuteCodeTaskHandler.ts
+++ b/mcp/packages/plugin/src/task-handlers/ExecuteCodeTaskHandler.ts
@@ -195,16 +195,19 @@ export class ExecuteCodeTaskHandler extends TaskHandler<ExecuteCodeTaskParams> {
         const context = this.context;
         const code = task.params.code;
 
-        // set the penpot.flags.naturalChildOrdering to true during code execution.
-        // NOTE: This significantly simplifies API usage (see )
-        // TODO: Remove ts-ignore once Penpot types have been updated
-        let originalNaturalChildOrdering: any;
+        // set the flags naturalChildOrdering and throwValidationErrors to true during code execution.
+        // TODO: Remove all ts-ignore once Penpot types have been updated
+        let originalNaturalChildOrdering: any, originalThrowValidationErrors: any;
         // @ts-ignore
         if (penpot.flags) {
             // @ts-ignore
             originalNaturalChildOrdering = penpot.flags.naturalChildOrdering;
             // @ts-ignore
             penpot.flags.naturalChildOrdering = true;
+            // @ts-ignore
+            originalThrowValidationErrors = penpot.flags.throwValidationErrors;
+            // @ts-ignore
+            penpot.flags.throwValidationErrors = true;
         } else {
             // TODO: This can be removed once `flags` has been merged to PROD
             throw new Error(
@@ -224,9 +227,11 @@ export class ExecuteCodeTaskHandler extends TaskHandler<ExecuteCodeTaskParams> {
                 return fn(...Object.values(ctx));
             })(context);
         } finally {
-            // restore the original value of penpot.flags.naturalChildOrdering
+            // restore the original value of the flags
             // @ts-ignore
             penpot.flags.naturalChildOrdering = originalNaturalChildOrdering;
+            // @ts-ignore
+            penpot.flags.throwValidationErrors = originalThrowValidationErrors;
         }
 
         console.log("Code execution result:", result);

--- a/mcp/packages/server/data/initial_instructions.md
+++ b/mcp/packages/server/data/initial_instructions.md
@@ -138,13 +138,23 @@ Boards can have layout systems that automatically control the positioning and sp
 
 # Text Elements
 
-The rendered content of a `Text` element is given by the `characters` property.
-
-To change the size of the text, change the `fontSize` property; applying `resize()` does NOT change the font size,
-it only changes the formal bounding box; if the text does not fit it, it will overflow; use `textBounds` for the actual bounding box of the rendered text.
-The bounding box is sized automatically as long as the `growType` property is set to "auto-width" or "auto-height".
-`resize` always sets `growType` to "fixed", so ALWAYS set it back to "auto-*" if you want automatic sizing!
-The auto-sizing is not immediate; sleep for a short time (100ms) if you want to read the updated bounding box.
+`Text` elements:
+  * The text to be rendered is given by the `characters` property.
+  * To change the size of the text, change the `fontSize` property; applying `resize()` does NOT change the font size,
+    it only changes the formal bounding box; if the text does not fit it, it will overflow; use `textBounds` for the actual bounding box of the rendered text.
+  * Property `bounds` is sized automatically (in one dimension) if the `growType` property is set to "auto-width" or "auto-height".
+    `resize` always sets `growType` to "fixed", so ALWAYS set it back to "auto-width" or "auto-height" if you want automatic sizing!
+    The auto-sizing is not immediate; sleep for a short time (100ms) if you want to read the updated bounding box.
+  * Method `getRange(start, end): TextRange` to reference a range of characters as a `TextRange` object, which can be styled separately from the rest of the text; `start` index inclusive, `end` exclusive
+  * Other Writable font properties: `fontId`, `fontFamily`, `fontWeight`, `fontVariant`, `fontStyle`
+     - To discover valid values, check available fonts in `penpot.fonts: FontContext`
+         - `FontContext` provides `Font` instances; each font has property `variants: FontVariant[]` 
+         - Example: Determine available weights for a font using `penpot.fonts.findByName("Laila").variants.map(v => v.fontWeight)`
+     - To apply a `Font` to a `Text` instance and set all font properties at once:
+         - `font.applyToText(text: Text, variant?: FontVariant)`
+         - `applyToRange(range: TextRange, variant?: FontVariant)`
+  * Further writable properties: `align`, `verticalAlign`, `lineHeight`, `letterSpacing`, `textTransform`, `textDecoration` (see API info)
+  * Method `applyTypography(typography: LibraryTypography)`
 
 # The `penpot` and `penpotUtils` Objects, Exploring Designs
 


### PR DESCRIPTION
### Summary

* Improved instructions on `Text` elements and fonts
* Update README to account for `npx` #8535
* Apply `throwValidationErrors` flag during MCP code executions #8682