### PR TITLE
:bug: Fix internal error on invalid max-h/max-w values (wasm)

### DIFF
--- a/render-wasm/src/wasm/layouts.rs
+++ b/render-wasm/src/wasm/layouts.rs
@@ -63,10 +63,11 @@ pub extern "C" fn set_layout_data(
         let h_sizing = RawSizing::from(h_sizing);
         let v_sizing = RawSizing::from(v_sizing);
 
-        let max_h = if has_max_h { Some(max_h) } else { None };
-        let min_h = if has_min_h { Some(min_h) } else { None };
-        let max_w = if has_max_w { Some(max_w) } else { None };
-        let min_w = if has_min_w { Some(min_w) } else { None };
+        let max_h = has_max_h.then(|| max_h.max(0.01));
+        let min_h = has_min_h.then(|| min_h.clamp(0.01, max_h.unwrap_or(f32::INFINITY)));
+        let max_w = has_max_w.then(|| max_w.max(0.01));
+        let min_w = has_min_w.then(|| min_w.clamp(0.01, max_w.unwrap_or(f32::INFINITY)));
+
         let z_index = if z_index != 0 { Some(z_index) } else { None };
 
         let raw_align_self = align::RawAlignSelf::from(align_self);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13785

### Summary

This fixes internal errors on invalid max width / height values in layouts. This happened when they were `0` or the min value was higher than the max value.

![Max height bug](https://github.com/user-attachments/assets/342e7c09-c58d-4bd0-bb43-b057852c5b69)

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
