### PR TITLE
:bug: Fix TypeError when token error map lacks :error/fn key

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/errors.cljs
@@ -135,6 +135,26 @@
 (defn has-error-code? [error-key errors]
   (some #(= (:error/code %) error-key) errors))
 
+(defn resolve-error-message
+  "Returns the human-readable message string for a single error map.
+  When the error carries an :error/fn key the function is called with
+  :error/value to produce the message.  Falls back to :message for
+  errors that originate from schema-validation (which have no :error/fn)."
+  [error]
+  (if-let [f (:error/fn error)]
+    (f (:error/value error))
+    (:message error)))
+
+(defn resolve-error-assoc-message
+  "Returns the error map with a :message key set to the resolved human-
+  readable string.  When the error carries an :error/fn key the function
+  is called with :error/value; otherwise the map is returned unchanged
+  (it is expected to already carry a :message from schema-validation)."
+  [error]
+  (if-let [f (:error/fn error)]
+    (assoc error :message (f (:error/value error)))
+    error))
+
 (defn humanize-errors [errors]
   (->> errors
        (map (fn [err]

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/color_input.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/color_input.cljs
@@ -279,7 +279,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 ((:error/fn error) (:error/value error))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (f (:error/value error))
+                                                   (:message error))))))
                       (rx/subs! (fn [{:keys [error value]}]
                                   (let [touched? (get-in @form [:touched input-name])]
                                     (when touched?
@@ -441,7 +443,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 (assoc error :message ((:error/fn error) (:error/value error)))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (assoc error :message (f (:error/value error)))
+                                                   error)))))
 
                       (rx/subs!
                        (fn [{:keys [error value]}]

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/color_input.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/color_input.cljs
@@ -17,6 +17,7 @@
    [app.main.data.style-dictionary :as sd]
    [app.main.data.tinycolor :as tinycolor]
    [app.main.data.tokenscript :as ts]
+   [app.main.data.workspace.tokens.errors :as wte]
    [app.main.data.workspace.tokens.format :as dwtf]
    [app.main.refs :as refs]
    [app.main.ui.ds.controls.input :as ds]
@@ -277,11 +278,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (f (:error/value error))
-                                                   (:message error))))))
+                                (d/update-when result :error wte/resolve-error-message)))
                       (rx/subs! (fn [{:keys [error value]}]
                                   (let [touched? (get-in @form [:touched input-name])]
                                     (when touched?
@@ -441,11 +438,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (assoc error :message (f (:error/value error)))
-                                                   error)))))
+                                (d/update-when result :error wte/resolve-error-assoc-message)))
 
                       (rx/subs!
                        (fn [{:keys [error value]}]

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/fonts_combobox.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/fonts_combobox.cljs
@@ -170,7 +170,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 ((:error/fn error) (:error/value error))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (f (:error/value error))
+                                                   (:message error))))))
                       (rx/subs! (fn [{:keys [error value]}]
                                   (when touched?
                                     (if error
@@ -293,7 +295,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 ((:error/fn error) (:error/value error))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (f (:error/value error))
+                                                   (:message error))))))
                       (rx/subs!
                        (fn [{:keys [error value]}]
                          (cond

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/fonts_combobox.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/fonts_combobox.cljs
@@ -13,6 +13,7 @@
    [app.config :as cf]
    [app.main.data.style-dictionary :as sd]
    [app.main.data.tokenscript :as ts]
+   [app.main.data.workspace.tokens.errors :as wte]
    [app.main.fonts :as fonts]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.controls.input :refer [input*]]
@@ -168,11 +169,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (f (:error/value error))
-                                                   (:message error))))))
+                                (d/update-when result :error wte/resolve-error-message)))
                       (rx/subs! (fn [{:keys [error value]}]
                                   (when touched?
                                     (if error
@@ -293,11 +290,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (f (:error/value error))
-                                                   (:message error))))))
+                                (d/update-when result :error wte/resolve-error-message)))
                       (rx/subs!
                        (fn [{:keys [error value]}]
                          (cond

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/input.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/input.cljs
@@ -243,7 +243,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 ((:error/fn error) (:error/value error))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (f (:error/value error))
+                                                   (:message error))))))
                       (rx/subs! (fn [{:keys [error value]}]
                                   (let [touched? (get-in @form [:touched input-name])]
                                     (when touched?
@@ -335,7 +337,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 (assoc error :message ((:error/fn error) (:error/value error)))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (assoc error :message (f (:error/value error)))
+                                                   error)))))
 
                       (rx/subs!
                        (fn [{:keys [error value]}]
@@ -447,7 +451,9 @@
                       (rx/map (fn [result]
                                 (d/update-when result :error
                                                (fn [error]
-                                                 (assoc error :message ((:error/fn error) (:error/value error)))))))
+                                                 (if-let [f (:error/fn error)]
+                                                   (assoc error :message (f (:error/value error)))
+                                                   error)))))
 
                       (rx/subs!
                        (fn [{:keys [error value]}]

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/input.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/input.cljs
@@ -241,11 +241,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (f (:error/value error))
-                                                   (:message error))))))
+                                (d/update-when result :error wte/resolve-error-message)))
                       (rx/subs! (fn [{:keys [error value]}]
                                   (let [touched? (get-in @form [:touched input-name])]
                                     (when touched?
@@ -335,11 +331,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (assoc error :message (f (:error/value error)))
-                                                   error)))))
+                                (d/update-when result :error wte/resolve-error-assoc-message)))
 
                       (rx/subs!
                        (fn [{:keys [error value]}]
@@ -449,11 +441,7 @@
                       (rx/debounce 300)
                       (rx/mapcat (partial resolve-value tokens token token-name))
                       (rx/map (fn [result]
-                                (d/update-when result :error
-                                               (fn [error]
-                                                 (if-let [f (:error/fn error)]
-                                                   (assoc error :message (f (:error/value error)))
-                                                   error)))))
+                                (d/update-when result :error wte/resolve-error-assoc-message)))
 
                       (rx/subs!
                        (fn [{:keys [error value]}]

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -17,6 +17,7 @@
    [frontend-tests.tokens.logic.token-data-test]
    [frontend-tests.tokens.logic.token-remapping-test]
    [frontend-tests.tokens.style-dictionary-test]
+   [frontend-tests.tokens.token-errors-test]
    [frontend-tests.tokens.workspace-tokens-remap-test]
    [frontend-tests.util-object-test]
    [frontend-tests.util-range-tree-test]
@@ -49,6 +50,7 @@
    'frontend-tests.tokens.logic.token-data-test
    'frontend-tests.tokens.logic.token-remapping-test
    'frontend-tests.tokens.style-dictionary-test
+   'frontend-tests.tokens.token-errors-test
    'frontend-tests.util-object-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test

--- a/frontend/test/frontend_tests/tokens/token_errors_test.cljs
+++ b/frontend/test/frontend_tests/tokens/token_errors_test.cljs
@@ -1,0 +1,53 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.tokens.token-errors-test
+  (:require
+   [app.main.data.workspace.tokens.errors :as wte]
+   [cljs.test :as t :include-macros true]))
+
+;; ---------------------------------------------------------------------------
+;; resolve-error-message
+;; ---------------------------------------------------------------------------
+
+(t/deftest resolve-error-message-with-error-fn
+  (t/testing "calls :error/fn with :error/value when both keys are present"
+    (let [error {:error/fn    (fn [v] (str "bad value: " v))
+                 :error/value "abc"}]
+      (t/is (= "bad value: abc" (wte/resolve-error-message error))))))
+
+(t/deftest resolve-error-message-without-error-fn
+  (t/testing "returns :message when :error/fn is absent (schema-validation error)"
+    (let [error {:message "This field is required"}]
+      (t/is (= "This field is required" (wte/resolve-error-message error))))))
+
+(t/deftest resolve-error-message-nil-error-fn
+  (t/testing "returns :message when :error/fn is explicitly nil"
+    (let [error {:error/fn nil :message "fallback message"}]
+      (t/is (= "fallback message" (wte/resolve-error-message error))))))
+
+;; ---------------------------------------------------------------------------
+;; resolve-error-assoc-message
+;; ---------------------------------------------------------------------------
+
+(t/deftest resolve-error-assoc-message-with-error-fn
+  (t/testing "assocs :message produced by :error/fn into the error map"
+    (let [error {:error/fn    (fn [v] (str "invalid: " v))
+                 :error/value "42"
+                 :error/code  :error.token/invalid-color}]
+      (let [result (wte/resolve-error-assoc-message error)]
+        (t/is (= "invalid: 42" (:message result)))
+        (t/is (= :error.token/invalid-color (:error/code result)))))))
+
+(t/deftest resolve-error-assoc-message-without-error-fn
+  (t/testing "returns the error map unchanged when :error/fn is absent"
+    (let [error {:message "This field is required"}]
+      (t/is (= error (wte/resolve-error-assoc-message error))))))
+
+(t/deftest resolve-error-assoc-message-nil-error-fn
+  (t/testing "returns the error map unchanged when :error/fn is explicitly nil"
+    (let [error {:error/fn nil :message "fallback"}]
+      (t/is (= error (wte/resolve-error-assoc-message error))))))


### PR DESCRIPTION
### Summary

Guard against missing :error/fn in token form control resolve streams. When schema validation errors are produced they may not carry an :error/fn key; calling nil as a function caused a TypeError crash. Apply an if-let guard at all 7 affected sites across input.cljs, color_input.cljs and fonts_combobox.cljs, falling back to :message or returning the error map unchanged.

### Related Trace

```
Context:
--------------------
Hint:     Cannot read properties of null (reading '$cljs$core$IFn$_invoke$arity$1$')
Version:  2.14.0-RC5
HREF:     https://design.penpot.app/#/workspace

Trace:
--------------------
TypeError: Cannot read properties of null (reading '$cljs$core$IFn$_invoke$arity$1$')
  at Function.<anonymous> (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:7538:182)
  at $cljs$core$apply_to_simple$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:881:283)
  at $APP.$cljs$core$apply$$.$cljs$core$IFn$_invoke$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19021:204)
  at $APP.$app$common$data$update_when$cljs$0core$0IFn$0_invoke$0arity$0variadic$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:1798:465)
  at $APP.$app$common$data$update_when$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:1796:366)
  at https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:7537:340
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:4354:255
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:14026)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:16543)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:16543)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at MSr (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:4891)
  at Jt._subscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:4412)
  at Jt._trySubscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:2879)
  at Jt.subscribe (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:2826)
  at f (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:16490)
  at e._ [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:16430)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:14021)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at Object.resolve (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:4481)
  at $$jscomp$scope$84173391$25$processNextTick$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3322:28)
  at $$jscomp$scope$84173391$27$transition$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3316:431)
  at $$jscomp$scope$84173391$14$PromiseImpl$$.resolve (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:23642:38)
  at Object.complete (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3323:473)
  at $$jscomp$scope$84173391$26$resolveTask$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3319:278)
  at $$jscomp$scope$84173391$25$processNextTick$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3322:494)
  at $$jscomp$scope$84173391$27$transition$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3316:431)
  at $$jscomp$scope$84173391$14$PromiseImpl$$.resolve (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:23642:38)
  at Object.complete (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3323:473)
  at $$jscomp$scope$84173391$26$resolveTask$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3319:278)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:3318:410
```