### PR TITLE
:bug: Clear cache canvas on zoom. Teep textures-only invalidation on pan

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2801,10 +2801,14 @@ impl RenderState {
 
         self.rebuild_tile_index(tree);
 
-        // Invalidate the tile texture cache so all tiles are re-rendered, but
-        // preserve the cache canvas so render_from_cache can still show a scaled
-        // preview of old content while new tiles load progressively.
-        self.surfaces.invalidate_tile_cache();
+        // Zoom changes world tile size: a partial cache update would mix scales in the
+        // mosaic and glitch. Same zoom as last finished render (typical pan): drop only
+        // tile textures and keep the cache canvas for render_from_cache.
+        if self.zoom_changed() {
+            self.surfaces.remove_cached_tiles(self.background_color);
+        } else {
+            self.surfaces.invalidate_tile_cache();
+        }
 
         performance::end_measure!("rebuild_tiles_shallow");
     }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13801

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
