### PR TITLE
:bug: Fix openPage context sync and page/flow/ruler proxy async races

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -54,7 +54,8 @@
    [app.util.object :as obj]
    [app.util.theme :as theme]
    [beicon.v2.core :as rx]
-   [cuerdas.core :as str]))
+   [cuerdas.core :as str]
+   [potok.v2.core :as ptk]))
 
 ;;
 ;; PLUGINS PUBLIC API - The plugins will able to access this functions
@@ -554,7 +555,11 @@
             new-window (if (boolean? new-window) new-window false)]
         (if (nil? id)
           (u/not-valid plugin-id :openPage "Expected a Page object or a page UUID string")
-          (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
+          (st/emit! (ptk/reify ::open-page-context
+                      ptk/UpdateEvent
+                      (update [_ state]
+                        (assoc state :current-page-id id)))
+                    (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
 
     :alignHorizontal
     (fn [shapes direction]

--- a/frontend/src/app/plugins/page.cljs
+++ b/frontend/src/app/plugins/page.cljs
@@ -31,7 +31,8 @@
    [app.plugins.utils :as u]
    [app.util.object :as obj]
    [beicon.v2.core :as rx]
-   [cuerdas.core :as str]))
+   [cuerdas.core :as str]
+   [potok.v2.core :as ptk]))
 
 (declare page-proxy)
 
@@ -39,382 +40,414 @@
   (obj/type-of? p "FlowProxy"))
 
 (defn flow-proxy
-  [plugin-id file-id page-id id]
-  (obj/reify {:name "FlowProxy"}
-    :$plugin {:enumerable false :get (fn [] plugin-id)}
-    :$file {:enumerable false :get (fn [] file-id)}
-    :$page {:enumerable false :get (fn [] page-id)}
-    :$id {:enumerable false :get (fn [] id)}
+  ;; `initial-name` and `initial-starting-frame` — optional fallbacks for the
+  ;; :name and :startingBoard getters. When a flow is freshly created via
+  ;; `page.createFlow()`, `st/emit!` is async so the new flow is not yet in
+  ;; `@st/state`. Without these fallbacks, `u/proxy->flow` returns nil and the
+  ;; getters crash. Passing the known values at construction time avoids the race.
+  ([plugin-id file-id page-id id]
+   (flow-proxy plugin-id file-id page-id id nil nil))
+  ([plugin-id file-id page-id id initial-name initial-starting-frame]
+   (obj/reify {:name "FlowProxy"}
+     :$plugin {:enumerable false :get (fn [] plugin-id)}
+     :$file {:enumerable false :get (fn [] file-id)}
+     :$page {:enumerable false :get (fn [] page-id)}
+     :$id {:enumerable false :get (fn [] id)}
 
-    :page
-    {:enumerable false
-     :get
+     :page
+     {:enumerable false
+      :get
+      (fn []
+        (page-proxy plugin-id file-id page-id))}
+
+     :name
+     {:this true
+      :get
+      (fn [self]
+        ;; Prefer the authoritative state lookup; fall back to initial-name
+        ;; when the async state update from `page.createFlow()` hasn't
+        ;; propagated yet.
+        (let [flow (u/proxy->flow self)]
+          (if (some? flow)
+            (:name flow)
+            initial-name)))
+      :set
+      (fn [_ value]
+        (cond
+          (or (not (string? value)) (empty? value))
+          (u/display-not-valid :name value)
+
+          :else
+          (st/emit! (dwi/update-flow page-id id #(assoc % :name value)))))}
+
+     :startingBoard
+     {:this true
+      :get
+      (fn [self]
+        ;; Prefer the authoritative state lookup; fall back to initial-starting-frame
+        ;; when the async state update from `page.createFlow()` hasn't
+        ;; propagated yet.
+        (let [flow  (u/proxy->flow self)
+              frame (if (some? flow)
+                      (:starting-frame flow)
+                      initial-starting-frame)]
+          (when (some? frame)
+            (shape/shape-proxy file-id page-id frame))))
+      :set
+      (fn [_ value]
+        (cond
+          (not (shape/shape-proxy? value))
+          (u/display-not-valid :startingBoard value)
+
+          :else
+          (st/emit! (dwi/update-flow page-id id #(assoc % :starting-frame (obj/get value "$id"))))))}
+
+     :remove
      (fn []
-       (page-proxy plugin-id file-id page-id))}
-
-    :name
-    {:this true
-     :get #(-> % u/proxy->flow :name)
-     :set
-     (fn [_ value]
-       (cond
-         (or (not (string? value)) (empty? value))
-         (u/not-valid plugin-id :name value)
-
-         :else
-         (st/emit! (dwi/update-flow page-id id #(assoc % :name value)))))}
-
-    :startingBoard
-    {:this true
-     :get
-     (fn [self]
-       (when-let [frame (-> self u/proxy->flow :starting-frame)]
-         (shape/shape-proxy file-id page-id frame)))
-     :set
-     (fn [_ value]
-       (cond
-         (not (shape/shape-proxy? value))
-         (u/not-valid plugin-id :startingBoard value)
-
-         :else
-         (st/emit! (dwi/update-flow page-id id #(assoc % :starting-frame (obj/get value "$id"))))))}
-
-    :remove
-    (fn []
-      (st/emit! (dwi/remove-flow page-id id)))))
+       (st/emit! (dwi/remove-flow page-id id))))))
 
 (defn page-proxy? [proxy]
   (obj/type-of? proxy "PageProxy"))
 
 (defn page-proxy
-  [plugin-id file-id id]
-  (obj/reify {:name "PageProxy"}
-    :$plugin {:enumerable false :get (fn [] plugin-id)}
-    :$file {:enumerable false :get (fn [] file-id)}
-    :$id {:enumerable false :get (fn [] id)}
+  ([plugin-id file-id id]
+   (page-proxy plugin-id file-id id nil))
+  ([plugin-id file-id id initial-name]
+   (obj/reify {:name "PageProxy"}
+     :$plugin {:enumerable false :get (fn [] plugin-id)}
+     :$file {:enumerable false :get (fn [] file-id)}
+     :$id {:enumerable false :get (fn [] id)}
 
-    :id
-    {:get #(dm/str id)}
+     :id
+     {:get #(dm/str id)}
 
-    :name
-    {:this true
-     :get #(-> % u/proxy->page :name)
-     :set
-     (fn [_ value]
-       (cond
-         (not (string? value))
-         (u/not-valid plugin-id :name value)
-
-         (not (r/check-permission plugin-id "content:write"))
-         (u/not-valid plugin-id :name "Plugin doesn't have 'content:write' permission")
-
-         :else
-         (st/emit! (dw/rename-page id value))))}
-
-    :getRoot
-    (fn []
-      (shape/shape-proxy plugin-id file-id id uuid/zero))
-
-    :root
-    {:this true
-     :enumerable false
-     :get #(.getRoot ^js %)}
-
-    :background
-    {:this true
-     :get #(or (-> % u/proxy->page :background) cc/canvas)
-     :set
-     (fn [_ value]
-       (cond
-         (or (not (string? value)) (not (cc/valid-hex-color? value)))
-         (u/not-valid plugin-id :background value)
-
-         (not (r/check-permission plugin-id "content:write"))
-         (u/not-valid plugin-id :background "Plugin doesn't have 'content:write' permission")
-
-         :else
-         (st/emit! (dw/change-canvas-color id {:color value}))))}
-
-    :flows
-    {:this true
-     :get
-     (fn [self]
-       (let [flows (d/nilv (-> (u/proxy->page self) :flows) [])]
-         (->> (vals flows)
-              (format/format-array #(flow-proxy plugin-id file-id id (:id %))))))}
-
-    :rulerGuides
-    {:this true
-     :get
-     (fn [self]
-       (let [guides (-> (u/proxy->page self) :guides)]
-         (->> guides
-              (vals)
-              (filter #(nil? (:frame-id %)))
-              (format/format-array #(rg/ruler-guide-proxy plugin-id file-id id (:id %))))))}
-
-
-    :getShapeById
-    (fn [shape-id]
-      (cond
-        (not (string? shape-id))
-        (u/not-valid plugin-id :getShapeById shape-id)
-
-        :else
-        (let [shape-id (uuid/parse shape-id)
-              shape (u/locate-shape file-id id shape-id)]
-          (when (some? shape)
-            (shape/shape-proxy plugin-id file-id id shape-id)))))
-
-    :findShapes
-    (fn [criteria]
-      ;; Returns a lazy (iterable) of all available shapes
-      (let [criteria (parser/parse-criteria criteria)
-            match-criteria?
-            (if (some? criteria)
-              (fn [[_ shape]]
-                (and
-                 (or (not (:name criteria))
-                     (= (str/lower (:name criteria)) (str/lower (:name shape))))
-
-                 (or (not (:name-like criteria))
-                     (str/includes? (str/lower (:name shape)) (str/lower (:name-like criteria))))
-
-                 (or (not (:type criteria))
-                     (= (:type criteria) (:type shape)))))
-              identity)]
-        (when (and (some? file-id) (some? id))
-          (let [page (u/locate-page file-id id)
-                xf (comp
-                    (filter match-criteria?)
-                    (map #(shape/shape-proxy plugin-id file-id id (first %))))]
-            (apply array (sequence xf (:objects page)))))))
-
-    ;; Plugin data
-    :getPluginData
-    (fn [key]
-      (cond
-        (not (string? key))
-        (u/not-valid plugin-id :page-plugin-data-key key)
-
-        :else
-        (let [page (u/locate-page file-id id)]
-          (dm/get-in page [:plugin-data (keyword "plugin" (str plugin-id)) key]))))
-
-    :setPluginData
-    (fn [key value]
-      (cond
-        (not (string? key))
-        (u/not-valid plugin-id :setPluginData-key key)
-
-        (and (some? value) (not (string? value)))
-        (u/not-valid plugin-id :setPluginData-value value)
-
-        (not (r/check-permission plugin-id "content:write"))
-        (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'content:write' permission")
-
-        :else
-        (st/emit! (dp/set-plugin-data file-id :page id (keyword "plugin" (str plugin-id)) key value))))
-
-    :getPluginDataKeys
-    (fn []
-      (let [page (u/locate-page file-id id)]
-        (apply array (keys (dm/get-in page [:plugin-data (keyword "plugin" (str plugin-id))])))))
-
-    :getSharedPluginData
-    (fn [namespace key]
-      (cond
-        (not (string? namespace))
-        (u/not-valid plugin-id :page-plugin-data-namespace namespace)
-
-        (not (string? key))
-        (u/not-valid plugin-id :page-plugin-data-key key)
-
-        :else
-        (let [page (u/locate-page file-id id)]
-          (dm/get-in page [:plugin-data (keyword "shared" namespace) key]))))
-
-    :setSharedPluginData
-    (fn [namespace key value]
-      (cond
-        (not (string? namespace))
-        (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
-
-        (not (string? key))
-        (u/not-valid plugin-id :setSharedPluginData-key key)
-
-        (and (some? value) (not (string? value)))
-        (u/not-valid plugin-id :setSharedPluginData-value value)
-
-        (not (r/check-permission plugin-id "content:write"))
-        (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'content:write' permission")
-
-        :else
-        (st/emit! (dp/set-plugin-data file-id :page id (keyword "shared" namespace) key value))))
-
-    :getSharedPluginDataKeys
-    (fn [self namespace]
-      (cond
-        (not (string? namespace))
-        (u/not-valid plugin-id :page-plugin-data-namespace namespace)
-
-        :else
-        (let [page (u/proxy->page self)]
-          (apply array (keys (dm/get-in page [:plugin-data (keyword "shared" namespace)]))))))
-
-    :openPage
-    (fn [new-window]
-      (cond
-        (not (r/check-permission plugin-id "content:read"))
-        (u/not-valid plugin-id :openPage "Plugin doesn't have 'content:read' permission")
-
-        :else
-        (let [new-window (if (boolean? new-window) new-window false)]
-          (st/emit! (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
-
-    :createFlow
-    (fn [name frame]
-      (cond
-        (or (not (string? name)) (empty? name))
-        (u/not-valid plugin-id :createFlow-name name)
-
-        (not (shape/shape-proxy? frame))
-        (u/not-valid plugin-id :createFlow-frame frame)
-
-        :else
-        (let [flow-id (uuid/next)]
-          (st/emit! (dwi/add-flow flow-id id name (obj/get frame "$id")))
-          (flow-proxy plugin-id file-id id flow-id))))
-
-    :removeFlow
-    (fn [flow]
-      (cond
-        (not (flow-proxy? flow))
-        (u/not-valid plugin-id :removeFlow-flow flow)
-
-        :else
-        (st/emit! (dwi/remove-flow id (obj/get flow "$id")))))
-
-    :addRulerGuide
-    (fn [orientation value board]
-      (let [shape (u/proxy->shape board)]
+     :name
+     {:this true
+      :get (fn [self]
+             (let [page (u/proxy->page self)]
+               (if (some? page)
+                 (:name page)
+                 initial-name)))
+      :set
+      (fn [_ value]
         (cond
-          (not (sm/valid-safe-number? value))
-          (u/not-valid plugin-id :addRulerGuide "Value not a safe number")
-
-          (not (contains? #{"vertical" "horizontal"} orientation))
-          (u/not-valid plugin-id :addRulerGuide "Orientation should be either 'vertical' or 'horizontal'")
-
-          (and (some? shape)
-               (or (not (shape/shape-proxy? board))
-                   (not (cfh/frame-shape? shape))))
-          (u/not-valid plugin-id :addRulerGuide "The shape is not a board")
+          (not (string? value))
+          (u/not-valid plugin-id :name value)
 
           (not (r/check-permission plugin-id "content:write"))
-          (u/not-valid plugin-id :addRulerGuide "Plugin doesn't have 'content:write' permission")
+          (u/not-valid plugin-id :name "Plugin doesn't have 'content:write' permission")
 
           :else
-          (let [ruler-id (uuid/next)]
-            (st/emit!
-             (dwgu/update-guides
-              (d/without-nils
-               {:id       ruler-id
-                :axis     (parser/orientation->axis orientation)
-                :position value
-                :frame-id (when board (obj/get board "$id"))})))
-            (rg/ruler-guide-proxy plugin-id file-id id ruler-id)))))
+          (st/emit! (dw/rename-page id value))))}
 
-    :removeRulerGuide
-    (fn [value]
-      (cond
-        (not (rg/ruler-guide-proxy? value))
-        (u/not-valid plugin-id :removeRulerGuide "Guide not provided")
+     :getRoot
+     (fn []
+       (shape/shape-proxy plugin-id file-id id uuid/zero))
 
-        (not (r/check-permission plugin-id "content:write"))
-        (u/not-valid plugin-id :removeRulerGuide "Plugin doesn't have 'comment:write' permission")
+     :root
+     {:this true
+      :enumerable false
+      :get #(.getRoot ^js %)}
 
-        :else
-        (let [guide (u/proxy->ruler-guide value)]
-          (st/emit! (dwgu/remove-guide guide)))))
-
-    :addCommentThread
-    (fn [content position board]
-      (let [shape (when board (u/proxy->shape board))
-            position (parser/parse-point position)]
+     :background
+     {:this true
+      :get #(or (-> % u/proxy->page :background) cc/canvas)
+      :set
+      (fn [_ value]
         (cond
-          (or (not (string? content)) (empty? content))
-          (u/not-valid plugin-id :addCommentThread "Content not valid")
+          (or (not (string? value)) (not (cc/valid-hex-color? value)))
+          (u/not-valid plugin-id :background value)
 
-          (or (not (sm/valid-safe-number? (:x position)))
-              (not (sm/valid-safe-number? (:y position))))
-          (u/not-valid plugin-id :addCommentThread "Position not valid")
-
-          (and (some? board) (or (not (shape/shape-proxy? board)) (not (cfh/frame-shape? shape))))
-          (u/not-valid plugin-id :addCommentThread "Board not valid")
-
-          (not (r/check-permission plugin-id "comment:write"))
-          (u/not-valid plugin-id :addCommentThread "Plugin doesn't have 'comment:write' permission")
+          (not (r/check-permission plugin-id "content:write"))
+          (u/not-valid plugin-id :background "Plugin doesn't have 'content:write' permission")
 
           :else
-          (let [position
-                (cond-> position
-                  (some? board)
-                  (->  (update :x - (:x board))
-                       (update :y - (:y board))))]
-            (js/Promise.
-             (fn [resolve]
-               (st/emit!
-                (dc/create-thread-on-workspace
-                 {:file-id file-id
-                  :page-id id
-                  :position (gpt/point position)
-                  :content content}
+          (st/emit! (dw/change-canvas-color id {:color value}))))}
 
-                 (fn [data]
-                   (resolve (pc/comment-thread-proxy plugin-id file-id id data)))
-                 false))))))))
+     :flows
+     {:this true
+      :get
+      (fn [self]
+        (let [flows (d/nilv (-> (u/proxy->page self) :flows) [])]
+          (->> (vals flows)
+               (format/format-array #(flow-proxy plugin-id file-id id (:id %))))))}
 
-    :removeCommentThread
-    (fn [thread]
-      (cond
-        (not (pc/comment-thread-proxy? thread))
-        (u/not-valid plugin-id :removeCommentThread "Comment thread not valid")
+     :rulerGuides
+     {:this true
+      :get
+      (fn [self]
+        (let [guides (-> (u/proxy->page self) :guides)]
+          (->> guides
+               (vals)
+               (filter #(nil? (:frame-id %)))
+               (format/format-array #(rg/ruler-guide-proxy plugin-id file-id id (:id %))))))}
 
-        (not (r/check-permission plugin-id "comment:write"))
-        (u/not-valid plugin-id :removeCommentThread "Plugin doesn't have 'content:write' permission")
 
-        :else
-        (js/Promise.
-         (fn [resolve]
-           (let [thread-id (obj/get thread "$id")]
+     :getShapeById
+     (fn [shape-id]
+       (cond
+         (not (string? shape-id))
+         (u/not-valid plugin-id :getShapeById shape-id)
+
+         :else
+         (let [shape-id (uuid/parse shape-id)
+               shape (u/locate-shape file-id id shape-id)]
+           (when (some? shape)
+             (shape/shape-proxy plugin-id file-id id shape-id)))))
+
+     :findShapes
+     (fn [criteria]
+       ;; Returns a lazy (iterable) of all available shapes
+       (let [criteria (parser/parse-criteria criteria)
+             match-criteria?
+             (if (some? criteria)
+               (fn [[_ shape]]
+                 (and
+                  (or (not (:name criteria))
+                      (= (str/lower (:name criteria)) (str/lower (:name shape))))
+
+                  (or (not (:name-like criteria))
+                      (str/includes? (str/lower (:name shape)) (str/lower (:name-like criteria))))
+
+                  (or (not (:type criteria))
+                      (= (:type criteria) (:type shape)))))
+               identity)]
+         (when (and (some? file-id) (some? id))
+           (let [page (u/locate-page file-id id)
+                 xf (comp
+                     (filter match-criteria?)
+                     (map #(shape/shape-proxy plugin-id file-id id (first %))))]
+             (apply array (sequence xf (:objects page)))))))
+
+     ;; Plugin data
+     :getPluginData
+     (fn [key]
+       (cond
+         (not (string? key))
+         (u/not-valid plugin-id :page-plugin-data-key key)
+
+         :else
+         (let [page (u/locate-page file-id id)]
+           (dm/get-in page [:plugin-data (keyword "plugin" (str plugin-id)) key]))))
+
+     :setPluginData
+     (fn [key value]
+       (cond
+         (not (string? key))
+         (u/not-valid plugin-id :setPluginData-key key)
+
+         (and (some? value) (not (string? value)))
+         (u/not-valid plugin-id :setPluginData-value value)
+
+         (not (r/check-permission plugin-id "content:write"))
+         (u/not-valid plugin-id :setPluginData "Plugin doesn't have 'content:write' permission")
+
+         :else
+         (st/emit! (dp/set-plugin-data file-id :page id (keyword "plugin" (str plugin-id)) key value))))
+
+     :getPluginDataKeys
+     (fn []
+       (let [page (u/locate-page file-id id)]
+         (apply array (keys (dm/get-in page [:plugin-data (keyword "plugin" (str plugin-id))])))))
+
+     :getSharedPluginData
+     (fn [namespace key]
+       (cond
+         (not (string? namespace))
+         (u/not-valid plugin-id :page-plugin-data-namespace namespace)
+
+         (not (string? key))
+         (u/not-valid plugin-id :page-plugin-data-key key)
+
+         :else
+         (let [page (u/locate-page file-id id)]
+           (dm/get-in page [:plugin-data (keyword "shared" namespace) key]))))
+
+     :setSharedPluginData
+     (fn [namespace key value]
+       (cond
+         (not (string? namespace))
+         (u/not-valid plugin-id :setSharedPluginData-namespace namespace)
+
+         (not (string? key))
+         (u/not-valid plugin-id :setSharedPluginData-key key)
+
+         (and (some? value) (not (string? value)))
+         (u/not-valid plugin-id :setSharedPluginData-value value)
+
+         (not (r/check-permission plugin-id "content:write"))
+         (u/not-valid plugin-id :setSharedPluginData "Plugin doesn't have 'content:write' permission")
+
+         :else
+         (st/emit! (dp/set-plugin-data file-id :page id (keyword "shared" namespace) key value))))
+
+     :getSharedPluginDataKeys
+     (fn [self namespace]
+       (cond
+         (not (string? namespace))
+         (u/not-valid plugin-id :page-plugin-data-namespace namespace)
+
+         :else
+         (let [page (u/proxy->page self)]
+           (apply array (keys (dm/get-in page [:plugin-data (keyword "shared" namespace)]))))))
+
+     :openPage
+     (fn [new-window]
+       (cond
+         (not (r/check-permission plugin-id "content:read"))
+         (u/not-valid plugin-id :openPage "Plugin doesn't have 'content:read' permission")
+
+         :else
+         (let [new-window (if (boolean? new-window) new-window false)]
+           (st/emit! (ptk/reify ::open-page-context
+                       ptk/UpdateEvent
+                       (update [_ state]
+                         (assoc state :current-page-id id)))
+                     (dcm/go-to-workspace :page-id id ::rt/new-window new-window)))))
+
+     :createFlow
+     (fn [name frame]
+       (cond
+         (or (not (string? name)) (empty? name))
+         (u/not-valid plugin-id :createFlow-name name)
+
+         (not (shape/shape-proxy? frame))
+         (u/not-valid plugin-id :createFlow-frame frame)
+
+         :else
+         (let [flow-id  (uuid/next)
+               frame-id (obj/get frame "$id")]
+           (st/emit! (dwi/add-flow flow-id id name frame-id))
+           (flow-proxy plugin-id file-id id flow-id name frame-id))))
+
+     :removeFlow
+     (fn [flow]
+       (cond
+         (not (flow-proxy? flow))
+         (u/not-valid plugin-id :removeFlow-flow flow)
+
+         :else
+         (st/emit! (dwi/remove-flow id (obj/get flow "$id")))))
+
+     :addRulerGuide
+     (fn [orientation value board]
+       (let [shape (u/proxy->shape board)]
+         (cond
+           (not (sm/valid-safe-number? value))
+           (u/not-valid plugin-id :addRulerGuide "Value not a safe number")
+
+           (not (contains? #{"vertical" "horizontal"} orientation))
+           (u/not-valid plugin-id :addRulerGuide "Orientation should be either 'vertical' or 'horizontal'")
+
+           (and (some? shape)
+                (or (not (shape/shape-proxy? board))
+                    (not (cfh/frame-shape? shape))))
+           (u/not-valid plugin-id :addRulerGuide "The shape is not a board")
+
+           (not (r/check-permission plugin-id "content:write"))
+           (u/not-valid plugin-id :addRulerGuide "Plugin doesn't have 'content:write' permission")
+
+           :else
+           (let [ruler-id (uuid/next)
+                 guide (d/without-nils
+                        {:id       ruler-id
+                         :axis     (parser/orientation->axis orientation)
+                         :position value
+                         :frame-id (when board (obj/get board "$id"))})]
+             (st/emit! (dwgu/update-guides guide))
+             (rg/ruler-guide-proxy plugin-id file-id id ruler-id guide)))))
+
+     :removeRulerGuide
+     (fn [value]
+       (cond
+         (not (rg/ruler-guide-proxy? value))
+         (u/not-valid plugin-id :removeRulerGuide "Guide not provided")
+
+         (not (r/check-permission plugin-id "content:write"))
+         (u/not-valid plugin-id :removeRulerGuide "Plugin doesn't have 'comment:write' permission")
+
+         :else
+         (let [guide (u/proxy->ruler-guide value)]
+           (st/emit! (dwgu/remove-guide guide)))))
+
+     :addCommentThread
+     (fn [content position board]
+       (let [shape (when board (u/proxy->shape board))
+             position (parser/parse-point position)]
+         (cond
+           (or (not (string? content)) (empty? content))
+           (u/not-valid plugin-id :addCommentThread "Content not valid")
+
+           (or (not (sm/valid-safe-number? (:x position)))
+               (not (sm/valid-safe-number? (:y position))))
+           (u/not-valid plugin-id :addCommentThread "Position not valid")
+
+           (and (some? board) (or (not (shape/shape-proxy? board)) (not (cfh/frame-shape? shape))))
+           (u/not-valid plugin-id :addCommentThread "Board not valid")
+
+           (not (r/check-permission plugin-id "comment:write"))
+           (u/not-valid plugin-id :addCommentThread "Plugin doesn't have 'comment:write' permission")
+
+           :else
+           (let [position
+                 (cond-> position
+                   (some? board)
+                   (->  (update :x - (:x board))
+                        (update :y - (:y board))))]
              (js/Promise.
-              (st/emit! (dc/delete-comment-thread-on-workspace {:id thread-id} #(resolve)))))))))
+              (fn [resolve]
+                (st/emit!
+                 (dc/create-thread-on-workspace
+                  {:file-id file-id
+                   :page-id id
+                   :position (gpt/point position)
+                   :content content}
 
-    :findCommentThreads
-    (fn [criteria]
-      (let [only-yours    (boolean (obj/get criteria "onlyYours" false))
-            show-resolved (boolean (obj/get criteria "showResolved" true))
-            user-id       (:profile-id @st/state)]
-        (js/Promise.
-         (fn [resolve reject]
-           (cond
-             (not (r/check-permission plugin-id "comment:read"))
-             (do
-               (u/not-valid plugin-id :findCommentThreads "Plugin doesn't have 'comment:read' permission")
-               (reject "Plugin doesn't have 'comment:read' permission"))
+                  (fn [data]
+                    (resolve (pc/comment-thread-proxy plugin-id file-id id data)))
+                  false))))))))
 
-             :else
-             (->> (rp/cmd! :get-comment-threads {:file-id file-id})
-                  (rx/subs!
-                   (fn [threads]
-                     (let [threads
-                           (cond->> threads
-                             (not show-resolved)
-                             (filter (comp not :is-resolved))
+     :removeCommentThread
+     (fn [thread]
+       (cond
+         (not (pc/comment-thread-proxy? thread))
+         (u/not-valid plugin-id :removeCommentThread "Comment thread not valid")
 
-                             only-yours
-                             (filter #(contains? (:participants %) user-id)))]
-                       (resolve
-                        (format/format-array
-                         #(pc/comment-thread-proxy plugin-id file-id id %) threads))))
-                   reject)))))))))
+         (not (r/check-permission plugin-id "comment:write"))
+         (u/not-valid plugin-id :removeCommentThread "Plugin doesn't have 'content:write' permission")
+
+         :else
+         (js/Promise.
+          (fn [resolve]
+            (let [thread-id (obj/get thread "$id")]
+              (js/Promise.
+               (st/emit! (dc/delete-comment-thread-on-workspace {:id thread-id} #(resolve)))))))))
+
+     :findCommentThreads
+     (fn [criteria]
+       (let [only-yours    (boolean (obj/get criteria "onlyYours" false))
+             show-resolved (boolean (obj/get criteria "showResolved" true))
+             user-id       (:profile-id @st/state)]
+         (js/Promise.
+          (fn [resolve reject]
+            (cond
+              (not (r/check-permission plugin-id "comment:read"))
+              (do
+                (u/not-valid plugin-id :findCommentThreads "Plugin doesn't have 'comment:read' permission")
+                (reject "Plugin doesn't have 'comment:read' permission"))
+
+              :else
+              (->> (rp/cmd! :get-comment-threads {:file-id file-id})
+                   (rx/subs!
+                    (fn [threads]
+                      (let [threads
+                            (cond->> threads
+                              (not show-resolved)
+                              (filter (comp not :is-resolved))
+
+                              only-yours
+                              (filter #(contains? (:participants %) user-id)))]
+                        (resolve
+                         (format/format-array
+                          #(pc/comment-thread-proxy plugin-id file-id id %) threads))))
+                    reject))))))))))

--- a/frontend/src/app/plugins/ruler_guides.cljs
+++ b/frontend/src/app/plugins/ruler_guides.cljs
@@ -23,78 +23,87 @@
   (obj/type-of? p "RulerGuideProxy"))
 
 (defn ruler-guide-proxy
-  [plugin-id file-id page-id id]
-  (obj/reify {:name "RulerGuideProxy"}
-    :$plugin {:enumerable false :get (constantly plugin-id)}
-    :$file {:enumerable false :get (constantly file-id)}
-    :$page {:enumerable false :get (constantly page-id)}
-    :$id {:enumerable false :get (constantly id)}
+  ([plugin-id file-id page-id id]
+   (ruler-guide-proxy plugin-id file-id page-id id nil))
+  ([plugin-id file-id page-id id initial-guide]
+   (obj/reify {:name "RulerGuideProxy"}
+     :$plugin {:enumerable false :get (constantly plugin-id)}
+     :$file {:enumerable false :get (constantly file-id)}
+     :$page {:enumerable false :get (constantly page-id)}
+     :$id {:enumerable false :get (constantly id)}
 
-    :board
-    {:this true
-     :enumerable false
-     :get
-     (fn [self]
-       (let [board-id (-> self u/proxy->ruler-guide :frame-id)]
-         (when board-id
-           (shape-proxy plugin-id file-id page-id board-id))))
+     :board
+     {:this true
+      :enumerable false
+      :get
+      (fn [self]
+        (let [guide (u/proxy->ruler-guide self)
+              board-id (if (some? guide)
+                         (:frame-id guide)
+                         (:frame-id initial-guide))]
+          (when board-id
+            (shape-proxy plugin-id file-id page-id board-id))))
 
-     :set
-     (fn [self value]
-       (let [shape (u/locate-shape file-id page-id (obj/get value "$id"))]
-         (cond
-           (not (shape-proxy? value))
-           (u/not-valid plugin-id :board "The board is not a shape proxy")
+      :set
+      (fn [self value]
+        (let [shape (u/locate-shape file-id page-id (obj/get value "$id"))]
+          (cond
+            (not (shape-proxy? value))
+            (u/not-valid plugin-id :board "The board is not a shape proxy")
 
-           (not (cfh/frame-shape? shape))
-           (u/not-valid plugin-id :board "The shape is not a board")
+            (not (cfh/frame-shape? shape))
+            (u/not-valid plugin-id :board "The shape is not a board")
 
-           (not (r/check-permission plugin-id "content:write"))
-           (u/not-valid plugin-id :board "Plugin doesn't have 'content:write' permission")
+            (not (r/check-permission plugin-id "content:write"))
+            (u/not-valid plugin-id :board "Plugin doesn't have 'content:write' permission")
 
-           :else
-           (let [board-id (when value (obj/get value "$id"))
-                 guide    (-> self u/proxy->ruler-guide)]
-             (st/emit! (dwgu/update-guides (assoc guide :frame-id board-id)))))))}
+            :else
+            (let [board-id (when value (obj/get value "$id"))
+                  guide    (-> self u/proxy->ruler-guide)]
+              (st/emit! (dwgu/update-guides (assoc guide :frame-id board-id)))))))}
 
-    :orientation
-    {:this true
-     :get #(-> % u/proxy->ruler-guide :axis format/axis->orientation)}
+     :orientation
+     {:this true
+      :get (fn [self]
+             (let [guide (u/proxy->ruler-guide self)]
+               (if (some? guide)
+                 (-> guide :axis format/axis->orientation)
+                 (-> initial-guide :axis format/axis->orientation))))}
 
-    :position
-    {:this true
-     :get
-     (fn [self]
-       (let [guide (u/proxy->ruler-guide self)]
-         (if (:frame-id guide)
-           (let [objects   (u/locate-objects file-id page-id)
-                 board-pos (dm/get-in objects [(:frame-id guide) (:axis guide)])
-                 position  (:position guide)]
-             (- position board-pos))
+     :position
+     {:this true
+      :get
+      (fn [self]
+        (let [guide (u/proxy->ruler-guide self)]
+          (if (some? guide)
+            (if (:frame-id guide)
+              (let [objects   (u/locate-objects file-id page-id)
+                    board-pos (dm/get-in objects [(:frame-id guide) (:axis guide)])
+                    position  (:position guide)]
+                (- position board-pos))
+              (:position guide))
+            (:position initial-guide))))
+      :set
+      (fn [self value]
+        (cond
+          (not (sm/valid-safe-number? value))
+          (u/not-valid plugin-id :position "Not valid position")
 
-           ;; No frame
-           (:position guide))))
-     :set
-     (fn [self value]
-       (cond
-         (not (sm/valid-safe-number? value))
-         (u/not-valid plugin-id :position "Not valid position")
+          (not (r/check-permission plugin-id "content:write"))
+          (u/not-valid plugin-id :position "Plugin doesn't have 'content:write' permission")
 
-         (not (r/check-permission plugin-id "content:write"))
-         (u/not-valid plugin-id :position "Plugin doesn't have 'content:write' permission")
+          :else
+          (let [guide (u/proxy->ruler-guide self)
+                position
+                (if (:frame-id guide)
+                  (let [objects   (u/locate-objects file-id page-id)
+                        board-pos (dm/get-in objects [(:frame-id guide) (:axis guide)])]
+                    (+ board-pos value))
 
-         :else
-         (let [guide (u/proxy->ruler-guide self)
-               position
-               (if (:frame-id guide)
-                 (let [objects   (u/locate-objects file-id page-id)
-                       board-pos (dm/get-in objects [(:frame-id guide) (:axis guide)])]
-                   (+ board-pos value))
+                  value)]
+            (st/emit! (dwgu/update-guides (assoc guide :position position))))))}
 
-                 value)]
-           (st/emit! (dwgu/update-guides (assoc guide :position position))))))}
-
-    :remove
-    (fn []
-      (let [guide (u/locate-ruler-guide file-id page-id id)]
-        (st/emit! (dwgu/remove-guide guide))))))
+     :remove
+     (fn []
+       (let [guide (u/locate-ruler-guide file-id page-id id)]
+         (st/emit! (dwgu/remove-guide guide)))))))


### PR DESCRIPTION
## Summary

Fixes `openPage()` not updating the plugin execution context and async state races in page, flow, and ruler guide proxies.

**Part 1 of 3** — Split from #8711 for easier review.
- **Part 2:** #8795 — Fix library proxy async state races
- **Part 3:** #8796 — Fix token-set and shape proxy nil guards

### Changes

- **`openPage()` context sync** (`api.cljs`): Emit synchronous `UpdateEvent` to set `:current-page-id` immediately, so plugin code sees the correct page without waiting for React render cycles
- **flow-proxy** (`page.cljs`): Multi-arity constructor with `initial-name` and `initial-starting-frame` fallbacks; consistent `some?` guards on getters
- **page-proxy** (`page.cljs`): Nil guard on `name` getter for async state race
- **ruler-guide-proxy** (`ruler_guides.cljs`): Multi-arity constructor with initial value fallback in `addRulerGuide`; nil guards on getters

> **Review tip:** The diff looks large (~900 lines) because the multi-arity refactor re-indents proxy object bodies. Click **"Hide whitespace changes"** in the GitHub diff view — actual logic changes are ~77 lines.

## Test plan

- [ ] Call `penpot.openPage(pageId)` from a plugin and verify getters on the returned page proxy return correct values immediately
- [ ] Create a flow via `page.createFlow()` and read `.name` / `.startingBoard` on the returned proxy without awaiting
- [ ] Add a ruler guide via `page.addRulerGuide()` and read properties on the returned proxy immediately
- [ ] Verify existing plugin API tests pass