### PR TITLE
:sparkles: Show nitrate org name on invitation to join team email

### DIFF
--- a/backend/resources/app/email/invite-to-team/en.html
+++ b/backend/resources/app/email/invite-to-team/en.html
@@ -186,7 +186,8 @@
                     <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
                         style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;">
-                        {{invited-by|abbreviate:25}} has invited you to join the team “{{ team|abbreviate:25 }}”.</div>
+                        {{invited-by|abbreviate:25}} has invited you to join the team “{{ team|abbreviate:25 }}”{% if organization %}
+                         part of the organization “{{ organization|abbreviate:25 }}”{% endif %}.</div>
                     </td>
                   </tr>
                   <tr>

--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -21,6 +21,7 @@
    [app.email :as eml]
    [app.loggers.audit :as audit]
    [app.main :as-alias main]
+   [app.nitrate :as nitrate]
    [app.rpc :as-alias rpc]
    [app.rpc.commands.profile :as profile]
    [app.rpc.commands.teams :as teams]
@@ -154,14 +155,18 @@
             (audit/submit! cfg event))
 
           (when (allow-invitation-emails? member)
-            (eml/send! {::eml/conn conn
-                        ::eml/factory eml/invite-to-team
-                        :public-uri (cf/get :public-uri)
-                        :to email
-                        :invited-by (:fullname profile)
-                        :team (:name team)
-                        :token itoken
-                        :extra-data ptoken}))
+            (let [team (if (contains? cf/flags :nitrate)
+                         (nitrate/add-org-info-to-team cfg team {})
+                         team)]
+              (eml/send! {::eml/conn conn
+                          ::eml/factory eml/invite-to-team
+                          :public-uri (cf/get :public-uri)
+                          :to email
+                          :invited-by (:fullname profile)
+                          :team (:name team)
+                          :organization (:organization-name team)
+                          :token itoken
+                          :extra-data ptoken})))
 
           itoken)))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13796

### Summary

Show nitrate org name on invitation to join team email

### Steps to reproduce 

Invite someone to a team that is part of an organization, and check the email

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
