### PR TITLE
:bug: Improve error reporting on request parsing failures

### DIFF
--- a/backend/src/app/http/errors.clj
+++ b/backend/src/app/http/errors.clj
@@ -220,12 +220,14 @@
                          (assoc :hint (ex-message error)))}))))
 
 (defmethod handle-exception java.io.IOException
-  [cause _ _]
-  (l/wrn :hint "io exception" :cause cause)
-  {::yres/status 500
-   ::yres/body {:type :server-error
-                :code :io-exception
-                :hint (ex-message cause)}})
+  [cause request _]
+  (binding [l/*context* (request->context request)]
+    (l/wrn :hint "io exception" :cause cause)
+    {::yres/status 500
+     ::yres/body {:type :server-error
+                  :code :io-exception
+                  :hint (ex-message cause)
+                  :path (:path request)}}))
 
 (defmethod handle-exception java.util.concurrent.CompletionException
   [cause request _]

--- a/frontend/src/app/main/repo.cljs
+++ b/frontend/src/app/main/repo.cljs
@@ -53,7 +53,7 @@
                         :code :challenge-required}))
 
     (and (>= status 400) (map? body))
-    (rx/throw (ex-info "http error" body))
+    (rx/throw (ex-info "http error" (assoc body :uri uri :status status)))
 
     :else
     (rx/throw


### PR DESCRIPTION
### Summary 

Include request URI and status in frontend handle-response error data, and add request path/context to backend IOException handler logs and response body. Previously these errors had no identifying information about which endpoint or request caused the failure.
