### PR TITLE
:bug: Fix infinite recursion in get-frame-ids for thumbnail extraction

### DIFF
--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -228,25 +228,25 @@
                                       instance-root?
                                       (conj ["component" id]))]
 
-                (swap! frame-id-cache assoc id {:status :in-progress
-                                                :result local-result})
+                (swap! frame-id-cache assoc id local-result)
 
                 (let [result
                       (cond-> local-result
                         (and (uuid? (:frame-id old-shape))
-                             (not= uuid/zero (:frame-id old-shape)))
+                             (not= uuid/zero (:frame-id old-shape))
+                             (not= id (:frame-id old-shape)))
                         (into (get-frame-ids-cached (:frame-id old-shape)))
 
                         (and (uuid? (:frame-id new-shape))
-                             (not= uuid/zero (:frame-id new-shape)))
+                             (not= uuid/zero (:frame-id new-shape))
+                             (not= id (:frame-id new-shape)))
                         (into (get-frame-ids-cached (:frame-id new-shape))))]
-                  (swap! frame-id-cache assoc id {:status :done
-                                                  :result result})
+                  (swap! frame-id-cache assoc id result)
                   result)))
 
             (get-frame-ids-cached [id]
-              (if-let [cached (get @frame-id-cache id)]
-                (:result cached)
+              (if (contains? @frame-id-cache id)
+                (get @frame-id-cache id)
                 (get-frame-ids id)))]
       (into #{}
             (comp (mapcat extract-ids)


### PR DESCRIPTION
### Summary

The get-frame-ids function could enter infinite recursion when:
1. There's a circular reference in the frame hierarchy
2. A shape's frame-id points to itself (corrupt data)

The fix uses the cached version (get-frame-ids-cached) in recursive calls and adds a guard to prevent self-referencing.

### Related Trace

```
RangeError: Maximum call stack size exceeded
  at $APP.$JSCompiler_prototypeAlias$$.$inode_lookup$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19493:58)
  at $APP.$JSCompiler_prototypeAlias$$.$inode_lookup$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19494:180)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ILookup$_lookup$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19612:277)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ILookup$_lookup$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19611:128)
  at $APP.$cljs$core$_lookup$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:18630:200)
  at Object.$cljs$core$_lookup$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:18629:140)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ILookup$_lookup$arity$2$ (https://design.penpot.app/js/main.js?version=2.14.0-RC5-1773771852:2306:258)
  at $APP.$cljs$core$get$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:18771:299)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1384:188)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1390:1)
  at $app$main$data$workspace$thumbnails$extract_frame_changes_$_get_frame_ids$$ (https://design.penpot.app/js/main-workspace.js?version=2.14.0-RC5-1773771852:1389:1)
```
