### PR TITLE
:zap: Add scroll and zoom raf throttling

### DIFF
--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -231,6 +231,9 @@
 (def inspect-expanded
   (l/derived :inspect-expanded workspace-local))
 
+(def workspace-vport
+  (l/derived :vport workspace-local))
+
 (def vbox
   (l/derived :vbox workspace-local))
 

--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -56,7 +56,7 @@
         selected    (mf/deref refs/selected-shapes)
         page-id     (get page :id)
 
-        {:keys [vport] :as wlocal} (mf/deref refs/workspace-local)
+        vport       (mf/deref refs/workspace-vport)
         {:keys [options-mode]} wglobal
 
 
@@ -105,7 +105,6 @@
        [:> viewport*
         {:file file
          :page page
-         :wlocal wlocal
          :wglobal wglobal
          :selected selected
          :layout layout

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -81,10 +81,8 @@
    selected))
 
 (mf/defc viewport-classic*
-  [{:keys [selected wglobal wlocal layout file page palete-size]}]
-  (let [;; When adding data from workspace-local revisit `app.main.ui.workspace` to check
-        ;; that the new parameter is sent
-        {:keys [edit-path
+  [{:keys [selected wglobal layout file page palete-size]}]
+  (let [{:keys [edit-path
                 panning
                 selrect
                 transform
@@ -94,7 +92,7 @@
                 zoom
                 zoom-inverse
                 edition]}
-        wlocal
+        (mf/deref refs/workspace-local)
 
         {:keys [options-mode
                 tooltip

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -431,7 +431,7 @@
                             {:x #(+ % dx)
                              :y #(+ % dy)})))))))))
 
-(defn on-mouse-wheel [zoom]
+(defn on-mouse-wheel [zoom-ref]
   (let [;; Mutable accumulator for scroll/zoom deltas, throttled to one
         ;; state update per animation frame. This prevents rapid wheel
         ;; events from causing cascading synchronous React re-renders
@@ -439,7 +439,6 @@
         scroll-state (mf/use-ref #js {:dx 0 :dy 0 :rafId 0
                                       :scale 1 :zoomPt nil :zoomRafId 0})]
     (mf/use-callback
-     (mf/deps zoom)
      (fn [event]
        (let [event      (.getBrowserEvent ^js event)
 
@@ -467,7 +466,7 @@
            (dom/stop-propagation event)
            (if (or ctrl? mod?)
              (schedule-zoom! (mf/ref-val scroll-state) scale pt)
-             (schedule-scroll! (mf/ref-val scroll-state) zoom event delta-x delta-y)))
+             (schedule-scroll! (mf/ref-val scroll-state) (mf/ref-val zoom-ref) event delta-x delta-y)))
 
          (when (and comments-layer? (or ctrl? mod?))
            (dom/prevent-default event)

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -384,6 +384,53 @@
                                        (kbd/alt? event)
                                        (kbd/meta? event))))))))
 
+(defn- schedule-zoom!
+  "Accumulate a compound zoom scale and a cursor point into `state`, scheduling
+  a single requestAnimationFrame flush if one is not already pending.  On the
+  next frame the accumulated scale is applied via `dw/set-zoom` and the state
+  is reset to its idle values."
+  [^js state scale pt]
+  (let [pending? (pos? (.-zoomRafId state))]
+    (set! (.-scale state) (* (.-scale state) scale))
+    (set! (.-zoomPt state) pt)
+    (when-not pending?
+      (set! (.-zoomRafId state)
+            (ts/raf
+             (fn []
+               (let [s  (.-scale state)
+                     zp (.-zoomPt state)]
+                 (set! (.-scale state) 1)
+                 (set! (.-zoomPt state) nil)
+                 (set! (.-zoomRafId state) 0)
+                 (st/emit! (dw/set-zoom zp s)))))))))
+
+(defn- schedule-scroll!
+  "Accumulate scroll deltas into `state`, scheduling a single
+  requestAnimationFrame flush if one is not already pending.  On the next
+  frame the accumulated dx/dy are applied via `dw/update-viewport-position`
+  and the state is reset to its idle values."
+  [^js state zoom event delta-x delta-y]
+  (let [pending? (pos? (.-rafId state))]
+    (if (and (not (cfg/check-platform? :macos)) (kbd/shift? event))
+      ;; macOS sends delta-x automatically, so on other platforms we
+      ;; remap shift+scroll-y to horizontal panning.
+      (set! (.-dx state) (+ (.-dx state) (/ delta-y zoom)))
+      (do
+        (set! (.-dx state) (+ (.-dx state) (/ delta-x zoom)))
+        (set! (.-dy state) (+ (.-dy state) (/ delta-y zoom)))))
+    (when-not pending?
+      (set! (.-rafId state)
+            (ts/raf
+             (fn []
+               (let [dx (.-dx state)
+                     dy (.-dy state)]
+                 (set! (.-dx state) 0)
+                 (set! (.-dy state) 0)
+                 (set! (.-rafId state) 0)
+                 (st/emit! (dw/update-viewport-position
+                            {:x #(+ % dx)
+                             :y #(+ % dy)})))))))))
+
 (defn on-mouse-wheel [zoom]
   (let [;; Mutable accumulator for scroll/zoom deltas, throttled to one
         ;; state update per animation frame. This prevents rapid wheel
@@ -419,64 +466,13 @@
            (dom/prevent-default event)
            (dom/stop-propagation event)
            (if (or ctrl? mod?)
-             ;; Zoom: accumulate compound scale, use latest point
-             (let [^js state (mf/ref-val scroll-state)
-                   pending?  (pos? (.-zoomRafId state))]
-               (set! (.-scale state) (* (.-scale state) scale))
-               (set! (.-zoomPt state) pt)
-               (when-not pending?
-                 (set! (.-zoomRafId state)
-                       (ts/raf
-                        (fn []
-                          (let [s  (.-scale state)
-                                zp (.-zoomPt state)]
-                            (set! (.-scale state) 1)
-                            (set! (.-zoomPt state) nil)
-                            (set! (.-zoomRafId state) 0)
-                            (st/emit! (dw/set-zoom zp s))))))))
-
-             ;; Scroll: accumulate deltas
-             (let [^js state (mf/ref-val scroll-state)
-                   pending?  (pos? (.-rafId state))]
-
-               (if (and (not (cfg/check-platform? :macos)) (kbd/shift? event))
-                 ;; macos sends delta-x automatically, don't need to do it
-                 (set! (.-dx state) (+ (.-dx state) (/ delta-y zoom)))
-                 (do
-                   (set! (.-dx state) (+ (.-dx state) (/ delta-x zoom)))
-                   (set! (.-dy state) (+ (.-dy state) (/ delta-y zoom)))))
-
-               ;; Schedule a single RAF to flush accumulated deltas
-               (when-not pending?
-                 (set! (.-rafId state)
-                       (ts/raf
-                        (fn []
-                          (let [dx (.-dx state)
-                                dy (.-dy state)]
-                            (set! (.-dx state) 0)
-                            (set! (.-dy state) 0)
-                            (set! (.-rafId state) 0)
-                            (st/emit! (dw/update-viewport-position
-                                       {:x #(+ % dx)
-                                        :y #(+ % dy)}))))))))))
+             (schedule-zoom! (mf/ref-val scroll-state) scale pt)
+             (schedule-scroll! (mf/ref-val scroll-state) zoom event delta-x delta-y)))
 
          (when (and comments-layer? (or ctrl? mod?))
            (dom/prevent-default event)
            (dom/stop-propagation event)
-           (let [^js state (mf/ref-val scroll-state)
-                 pending?  (pos? (.-zoomRafId state))]
-             (set! (.-scale state) (* (.-scale state) scale))
-             (set! (.-zoomPt state) pt)
-             (when-not pending?
-               (set! (.-zoomRafId state)
-                     (ts/raf
-                      (fn []
-                        (let [s  (.-scale state)
-                              zp (.-zoomPt state)]
-                          (set! (.-scale state) 1)
-                          (set! (.-zoomPt state) nil)
-                          (set! (.-zoomRafId state) 0)
-                          (st/emit! (dw/set-zoom zp s))))))))))))))
+           (schedule-zoom! (mf/ref-val scroll-state) scale pt)))))))
 
 (defn on-drag-enter
   [comp-inst-ref]

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -385,45 +385,98 @@
                                        (kbd/meta? event))))))))
 
 (defn on-mouse-wheel [zoom]
-  (mf/use-callback
-   (mf/deps zoom)
-   (fn [event]
-     (let [event      (.getBrowserEvent ^js event)
+  (let [;; Mutable accumulator for scroll/zoom deltas, throttled to one
+        ;; state update per animation frame. This prevents rapid wheel
+        ;; events from causing cascading synchronous React re-renders
+        ;; that can exceed the maximum update depth.
+        scroll-state (mf/use-ref #js {:dx 0 :dy 0 :rafId 0
+                                      :scale 1 :zoomPt nil :zoomRafId 0})]
+    (mf/use-callback
+     (mf/deps zoom)
+     (fn [event]
+       (let [event      (.getBrowserEvent ^js event)
 
-           target     (dom/get-target event)
-           mod?       (kbd/mod? event)
-           ctrl?      (kbd/ctrl? event)
+             target     (dom/get-target event)
+             mod?       (kbd/mod? event)
+             ctrl?      (kbd/ctrl? event)
 
-           picking-color?   (= "pixel-overlay" (.-id target))
-           comments-layer?  (dom/is-child? (dom/get-element "comments") target)
+             picking-color?   (= "pixel-overlay" (.-id target))
+             comments-layer?  (dom/is-child? (dom/get-element "comments") target)
 
-           raw-pt     (dom/get-client-position event)
-           pt         (uwvv/point->viewport raw-pt)
+             raw-pt     (dom/get-client-position event)
+             pt         (uwvv/point->viewport raw-pt)
 
-           norm-event ^js (nw/normalize-wheel event)
+             norm-event ^js (nw/normalize-wheel event)
 
-           delta-y    (.-pixelY norm-event)
-           delta-x    (.-pixelX norm-event)
-           delta-zoom (+ delta-y delta-x)
+             delta-y    (.-pixelY norm-event)
+             delta-x    (.-pixelX norm-event)
+             delta-zoom (+ delta-y delta-x)
 
-           scale      (+ 1 (mth/abs (* scale-per-pixel delta-zoom)))
-           scale      (if (pos? delta-zoom) (/ 1 scale) scale)]
+             scale      (+ 1 (mth/abs (* scale-per-pixel delta-zoom)))
+             scale      (if (pos? delta-zoom) (/ 1 scale) scale)]
 
-       (when (or (uwvv/inside-viewport? target) picking-color?)
-         (dom/prevent-default event)
-         (dom/stop-propagation event)
-         (if (or ctrl? mod?)
-           (st/emit! (dw/set-zoom pt scale))
-           (if (and (not (cfg/check-platform? :macos)) (kbd/shift? event))
-             ;; macos sends delta-x automatically, don't need to do it
-             (st/emit! (dw/update-viewport-position {:x #(+ % (/ delta-y zoom))}))
-             (st/emit! (dw/update-viewport-position {:x #(+ % (/ delta-x zoom))
-                                                     :y #(+ % (/ delta-y zoom))})))))
+         (when (or (uwvv/inside-viewport? target) picking-color?)
+           (dom/prevent-default event)
+           (dom/stop-propagation event)
+           (if (or ctrl? mod?)
+             ;; Zoom: accumulate compound scale, use latest point
+             (let [^js state (mf/ref-val scroll-state)
+                   pending?  (pos? (.-zoomRafId state))]
+               (set! (.-scale state) (* (.-scale state) scale))
+               (set! (.-zoomPt state) pt)
+               (when-not pending?
+                 (set! (.-zoomRafId state)
+                       (ts/raf
+                        (fn []
+                          (let [s  (.-scale state)
+                                zp (.-zoomPt state)]
+                            (set! (.-scale state) 1)
+                            (set! (.-zoomPt state) nil)
+                            (set! (.-zoomRafId state) 0)
+                            (st/emit! (dw/set-zoom zp s))))))))
 
-       (when (and comments-layer? (or ctrl? mod?))
-         (dom/prevent-default event)
-         (dom/stop-propagation event)
-         (st/emit! (dw/set-zoom pt scale)))))))
+             ;; Scroll: accumulate deltas
+             (let [^js state (mf/ref-val scroll-state)
+                   pending?  (pos? (.-rafId state))]
+
+               (if (and (not (cfg/check-platform? :macos)) (kbd/shift? event))
+                 ;; macos sends delta-x automatically, don't need to do it
+                 (set! (.-dx state) (+ (.-dx state) (/ delta-y zoom)))
+                 (do
+                   (set! (.-dx state) (+ (.-dx state) (/ delta-x zoom)))
+                   (set! (.-dy state) (+ (.-dy state) (/ delta-y zoom)))))
+
+               ;; Schedule a single RAF to flush accumulated deltas
+               (when-not pending?
+                 (set! (.-rafId state)
+                       (ts/raf
+                        (fn []
+                          (let [dx (.-dx state)
+                                dy (.-dy state)]
+                            (set! (.-dx state) 0)
+                            (set! (.-dy state) 0)
+                            (set! (.-rafId state) 0)
+                            (st/emit! (dw/update-viewport-position
+                                       {:x #(+ % dx)
+                                        :y #(+ % dy)}))))))))))
+
+         (when (and comments-layer? (or ctrl? mod?))
+           (dom/prevent-default event)
+           (dom/stop-propagation event)
+           (let [^js state (mf/ref-val scroll-state)
+                 pending?  (pos? (.-zoomRafId state))]
+             (set! (.-scale state) (* (.-scale state) scale))
+             (set! (.-zoomPt state) pt)
+             (when-not pending?
+               (set! (.-zoomRafId state)
+                     (ts/raf
+                      (fn []
+                        (let [s  (.-scale state)
+                              zp (.-zoomPt state)]
+                          (set! (.-scale state) 1)
+                          (set! (.-zoomPt state) nil)
+                          (set! (.-zoomRafId state) 0)
+                          (st/emit! (dw/set-zoom zp s))))))))))))))
 
 (defn on-drag-enter
   [comp-inst-ref]

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -44,9 +44,12 @@
 
 (defn setup-dom-events
   [zoom disable-paste-ref in-viewport-ref workspace-read-only? drawing-tool drawing-path?]
-  (let [on-key-down       (actions/on-key-down)
+  (let [zoom-ref          (mf/use-ref zoom)
+        _                 (mf/with-effect [zoom]
+                            (mf/set-ref-val! zoom-ref zoom))
+        on-key-down       (actions/on-key-down)
         on-key-up         (actions/on-key-up)
-        on-mouse-wheel    (actions/on-mouse-wheel zoom)
+        on-mouse-wheel    (actions/on-mouse-wheel zoom-ref)
         on-paste          (actions/on-paste disable-paste-ref in-viewport-ref workspace-read-only?)
         on-pointer-down   (mf/use-fn
                            (mf/deps drawing-tool drawing-path?)
@@ -67,7 +70,7 @@
 
         #(events/unlistenByKey key)))
 
-    (mf/with-layout-effect [on-key-down on-key-up on-mouse-wheel on-paste workspace-read-only?]
+    (mf/with-layout-effect [on-key-down on-key-up on-paste workspace-read-only?]
       (let [keys [(events/listen js/document EventType.KEYDOWN on-key-down)
                   (events/listen js/document EventType.KEYUP on-key-up)
                   ;; bind with passive=false to allow the event to be cancelled

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -74,9 +74,10 @@
         objects)))
 
 (mf/defc viewport*
-  [{:keys [selected wglobal wlocal layout file page palete-size file-version-id]}]
+  [{:keys [selected wglobal layout file page palete-size file-version-id]}]
   (let [;; When adding data from workspace-local revisit `app.main.ui.workspace` to check
         ;; that the new parameter is sent
+
         {:keys [edit-path
                 panning
                 selrect
@@ -86,17 +87,18 @@
                 vport
                 zoom
                 zoom-inverse
-                edition]} wlocal
+                edition]}
+        (mf/deref refs/workspace-local)
 
         {:keys [options-mode
                 tooltip
                 show-distances?
-                picking-color?]} wglobal
+                picking-color?]}
+        wglobal
 
         permissions       (mf/use-ctx ctx/permissions)
         read-only?        (mf/use-ctx ctx/workspace-read-only?)
 
-        ;; DEREFS
         drawing           (mf/deref refs/workspace-drawing)
         focus             (mf/deref refs/workspace-focus-selected)
         wasm-modifiers    (mf/deref refs/workspace-wasm-modifiers)

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "fmt": "./scripts/fmt"
   },
   "devDependencies": {
-    "@github/copilot": "^1.0.11",
+    "@github/copilot": "^1.0.12",
     "@types/node": "^20.12.7",
     "esbuild": "^0.25.9",
-    "opencode-ai": "^1.3.0"
+    "opencode-ai": "^1.3.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@github/copilot':
-        specifier: ^1.0.11
-        version: 1.0.11
+        specifier: ^1.0.12
+        version: 1.0.12
       '@types/node':
         specifier: ^20.12.7
         version: 20.19.37
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.25.9
         version: 0.25.12
       opencode-ai:
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.7
+        version: 1.3.7
 
 packages:
 
@@ -179,44 +179,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@github/copilot-darwin-arm64@1.0.11':
-    resolution: {integrity: sha512-wdKimjtbsVeXqMqQSnGpGBPFEYHljxXNuWeH8EIJTNRgFpAsimcivsFgql3Twq4YOp0AxfsH36icG4IEen30mA==}
+  '@github/copilot-darwin-arm64@1.0.12':
+    resolution: {integrity: sha512-fjbwRIUZAH06Eyg5ZkfZXg8SVXpqI3HaFhtXZ803CZs9mfIgfOSR3URZxUnv7SIv6aI/7f6ws8RxKnPGavJ/tg==}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@github/copilot-darwin-x64@1.0.11':
-    resolution: {integrity: sha512-VeuPv8rzBVGBB8uDwMEhcHBpldoKaq26yZ5YQm+G9Ka5QIF+1DMah8ZNRMVsTeNKkb1ji9G8vcuCsaPbnG3fKg==}
+  '@github/copilot-darwin-x64@1.0.12':
+    resolution: {integrity: sha512-/tJGJEEm8kpTW/sJRNnvhMSHKIHApNun14biuIkC5CXDqVgFakbKlckn/FlIkT48eEUysc0YbEatrHIDz/8XbA==}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@github/copilot-linux-arm64@1.0.11':
-    resolution: {integrity: sha512-/d8p6RlFYKj1Va2hekFIcYNMHWagcEkaxgcllUNXSyQLnmEtXUkaWtz62VKGWE+n/UMkEwCB6vI2xEwPTlUNBQ==}
+  '@github/copilot-linux-arm64@1.0.12':
+    resolution: {integrity: sha512-4977LVJi3/9Yc+ivj+VKDVtHg0kT5yqOrN8F35/jgqerx4Mdtk1pOMlWztXxLicBHN4y2V7/EY/wc0WqFW0Zvg==}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@github/copilot-linux-x64@1.0.11':
-    resolution: {integrity: sha512-UujTRO3xkPFC1CybchBbCnaTEAG6JrH0etIst07JvfekMWgvRxbiCHQPpDPSzBCPiBcGu0gba0/IT+vUCORuIw==}
+  '@github/copilot-linux-x64@1.0.12':
+    resolution: {integrity: sha512-9QevJZD29PVltYDV4xHWbdN6ud/966clERL5Frh2+9D3+spaVDO1hFllzoFiEwD/M4f2GkSh7/fT3hV0LKl9Ag==}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@github/copilot-win32-arm64@1.0.11':
-    resolution: {integrity: sha512-EOW8HUM+EmnHEZEa+iUMl4pP1+2eZUk2XCbynYiMehwX9sidc4BxEHp2RuxADSzFPTieQEWzgjQmHWrtet8pQg==}
+  '@github/copilot-win32-arm64@1.0.12':
+    resolution: {integrity: sha512-RLAbAsLniI8vA2utgZdIsvD8slZpz1fb8l6cmIiQvDE/BwQb2zNV9VepZ+CwzYtNx9ifxBtgIwYwUJq5bxeSaQ==}
     cpu: [arm64]
     os: [win32]
     hasBin: true
 
-  '@github/copilot-win32-x64@1.0.11':
-    resolution: {integrity: sha512-fKGkSNamzs3h9AbmswNvPYJBORCb2Y8CbusijU3C7fT3ohvqnHJwKo5iHhJXLOKZNOpFZgq9YKha410u9sIs6Q==}
+  '@github/copilot-win32-x64@1.0.12':
+    resolution: {integrity: sha512-4SYV09F4Sw20DAib1do26+ALZmCZrghzo+5e6IZbQOsm4B7NhBFaLpKFU+kEijfmWacLlh/at5CpGGGKlwlbcg==}
     cpu: [x64]
     os: [win32]
     hasBin: true
 
-  '@github/copilot@1.0.11':
-    resolution: {integrity: sha512-cptVopko/tNKEXyBP174yBjHQBEwg6CqaKN2S0M3J+5LEB8u31bLL75ioOPd+5vubqBrA0liyTdcHeZ8UTRbmg==}
+  '@github/copilot@1.0.12':
+    resolution: {integrity: sha512-GpmoJbs1ECyLLKtY4PcFzO8Cz6GgDTOKkrzwNdkirNdfsB+o6x0OOlFyrOdNXNPII7pk9+GcpIjF87sLwWzpPQ==}
     hasBin: true
 
   '@types/node@20.19.37':
@@ -227,67 +227,67 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  opencode-ai@1.3.0:
-    resolution: {integrity: sha512-il/dC3B55m5mZV2u72emfPqkZBTzrlZwqGI4Ds5Ld6kt2LTUzBZtKB8sOfy7Bmw2qIel0hLZdoKc8wxLjaXQDw==}
+  opencode-ai@1.3.7:
+    resolution: {integrity: sha512-AtqTOcPvHkAF/zPGs/08/8m2DeiWADCGhT/WAJ1drGem4WdPOt45jkJLPdOCheN1gqmLxTcNV0veKFVHmbjKKQ==}
     hasBin: true
 
-  opencode-darwin-arm64@1.3.0:
-    resolution: {integrity: sha512-OB+yl/BZkjQhnjjFc+KT57iqhPlXNq3E0oIcHHlGiG63L2LTY3zfi9OhzaoemL+or2CWnpCITUe91yTAddiSEQ==}
+  opencode-darwin-arm64@1.3.7:
+    resolution: {integrity: sha512-TRglBnrSzeR9pEFV8Z1ACqhD3r3WYl8v1y9TkgvHviTD/EXGL3Nu7f/fy3XOQprPGSLPyrlOwZXb1i9XrfTo1A==}
     cpu: [arm64]
     os: [darwin]
 
-  opencode-darwin-x64-baseline@1.3.0:
-    resolution: {integrity: sha512-Th5yiWOSDeEcjnKWhR8b267Uf8r+jwLFhv30JK4x07Zdmu3Jjjr6TdMvjLgEOv3PWmHf/1yYz22Xachb+QST0A==}
+  opencode-darwin-x64-baseline@1.3.7:
+    resolution: {integrity: sha512-YLl+peZIC1m295JNSMzM/NM5uNs2GVewZply2GV3P6WApS5JuRIaMNvzOk7jpL90yt6pur6oEwC8g0WWwP8G4A==}
     cpu: [x64]
     os: [darwin]
 
-  opencode-darwin-x64@1.3.0:
-    resolution: {integrity: sha512-jivDUpmhzkT7WZp7pXVSb9fdnEVuhKBsnve/9fIkI/UFHxomiZ2NIaNRbHxG26PYT9a1IR4D5QvXBq623g2Mnw==}
+  opencode-darwin-x64@1.3.7:
+    resolution: {integrity: sha512-Nsyh3vLAqqfVyWD4qrcyRJit+CmZZpm6IdXTk9wo1hUAE/RmYIBDz1To99ZBwA3SJB1fLrciYicMN2uq8r1XNw==}
     cpu: [x64]
     os: [darwin]
 
-  opencode-linux-arm64-musl@1.3.0:
-    resolution: {integrity: sha512-EmXBHyRSzWCnD/KDpaSi8ldgjOa+1t5c5tRASyL/lnbinsrZekxub3lI+oxRvKJXESKdgq9EP4gkp6t2fqGsFw==}
+  opencode-linux-arm64-musl@1.3.7:
+    resolution: {integrity: sha512-D4gCn7oVLCc3xN0BSJOfYerCr1E1ktUkixfHQEmkoR1CLZ77Z/aHSgcm0Ln01Q+ie6MsVukvuyUQn9GEY1Dn/A==}
     cpu: [arm64]
     os: [linux]
 
-  opencode-linux-arm64@1.3.0:
-    resolution: {integrity: sha512-rWEEKo4oqgJ/zk670ywg6uhEPwbUIQCwYCeh+xJ3IlgPltQNiIjqUbzbRqAmEfI1Uj9DCdbZ2TUtHayRv8umKw==}
+  opencode-linux-arm64@1.3.7:
+    resolution: {integrity: sha512-72OnT20wIhkXMGclmw7S+d8JjIb9lx8pPIW8pkyI79+qxLTp6AuTHsmUG/qDhw3NMtVDs9efAb0C/FjLXATeAA==}
     cpu: [arm64]
     os: [linux]
 
-  opencode-linux-x64-baseline-musl@1.3.0:
-    resolution: {integrity: sha512-sb7LyPlf+5/t4pQ3whcHPVlb7R7SRY0Bgjgy55amEs3xRuKnC3BfSoj8CAoY50M/yVAbOj0haoxu4LFixljwNw==}
+  opencode-linux-x64-baseline-musl@1.3.7:
+    resolution: {integrity: sha512-DE8eqPF2benmdzUdMG+rnr0J3DtrP+x8sUzq7gecuNnU4iHo4s8Itx+gCLP978ZBdYwTkNRtNZ5BKN0ePT5KYQ==}
     cpu: [x64]
     os: [linux]
 
-  opencode-linux-x64-baseline@1.3.0:
-    resolution: {integrity: sha512-STZtcgGgeRlaFCmkk+mNm+01d02JCzCPvP9kWwNpRF6FBGTcFZ97MxEoGvk+7mEqMueImVQZOR21NiYN6anQhw==}
+  opencode-linux-x64-baseline@1.3.7:
+    resolution: {integrity: sha512-Aztdiq0U6H8Nww7mmARK/ZGkllTrePuyEEdzg2+0LWfUpDO5Cl/pMJ8btqVtTjfb/pLw+BU3JtYxw8oOhRkl/A==}
     cpu: [x64]
     os: [linux]
 
-  opencode-linux-x64-musl@1.3.0:
-    resolution: {integrity: sha512-Jc/EbYgqmT2J2WLPm7EQWBYfSqetWTrI4Ipc4KFrSB/LbM/7lfXkjpemjQaYNlDTVkvPXaUPFJUpisH64xZ+4g==}
+  opencode-linux-x64-musl@1.3.7:
+    resolution: {integrity: sha512-L0ohQAbw1Ib1koawV/yJAYIGIel2zMPafbdeMXELIvpes3Sq9qIfCSRB/2ROu8gjN8P1TGnUU6Vx1F3MtJOvIA==}
     cpu: [x64]
     os: [linux]
 
-  opencode-linux-x64@1.3.0:
-    resolution: {integrity: sha512-U9aS0wl0uBDxXncqSYhYBDDQP2ZwiTiuJSLM6MgtFJTbUXuTZZCKmQ8p7C5/+Nxpl4sY5xK+ZaCJcS3k3WGN3g==}
+  opencode-linux-x64@1.3.7:
+    resolution: {integrity: sha512-rCFXrgDLhPuHazomDgzBXGLE0wJ4VRHrIe26WCHm4iqmGu9O6ExZd612Y07/CGQm4bVBHlaalcWh7N/z6GOPkA==}
     cpu: [x64]
     os: [linux]
 
-  opencode-windows-arm64@1.3.0:
-    resolution: {integrity: sha512-3iWo9lOctaWQ+8QHRKszINPTLjLtb0ztzedlvdY5HAiot9MUK/G5MHeskutxQ7sMvTACiAp02ey+Ml/f/jyf7Q==}
+  opencode-windows-arm64@1.3.7:
+    resolution: {integrity: sha512-s6emZ28ORIMtKyrBKvo96q2qanRwbjPHK/rOMinZ22SW7DLzNKKf1p92JMkSni0dXXGL64jsy1se5IvELc7Mvg==}
     cpu: [arm64]
     os: [win32]
 
-  opencode-windows-x64-baseline@1.3.0:
-    resolution: {integrity: sha512-pYuY+9LqPLB/GrlZQr67Cl8RlV6vcay4fW8L3TjabwJOinFMDX9OpNo+DkdKJW7YtPtHD78cXaNDEV8tv9Nx2A==}
+  opencode-windows-x64-baseline@1.3.7:
+    resolution: {integrity: sha512-CGbhvn9rMXV4xEjw1lxPFbsWuOPf/xJ1AAblqKsF2VmSbqe25QG5VIf88hsJo8YmYIHz6U7tNGI4lTF1zVx9cw==}
     cpu: [x64]
     os: [win32]
 
-  opencode-windows-x64@1.3.0:
-    resolution: {integrity: sha512-iFd/6GwfM3jlI2tOb3f12m5ddDY8Ug2HiUU1xmxWJvDnbDBdftlHrzD5twlbIHnKoGvohepX8iWk+A/UN2cXKQ==}
+  opencode-windows-x64@1.3.7:
+    resolution: {integrity: sha512-q7V9p10Q7BH03tnYMG4k6B1ZXLDriDMtXkkw+NW1p22F7dQ22WmaMoCWnv3d4b2vNyjMjIYuPm97q0v02QI08w==}
     cpu: [x64]
     os: [win32]
 
@@ -374,32 +374,32 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@github/copilot-darwin-arm64@1.0.11':
+  '@github/copilot-darwin-arm64@1.0.12':
     optional: true
 
-  '@github/copilot-darwin-x64@1.0.11':
+  '@github/copilot-darwin-x64@1.0.12':
     optional: true
 
-  '@github/copilot-linux-arm64@1.0.11':
+  '@github/copilot-linux-arm64@1.0.12':
     optional: true
 
-  '@github/copilot-linux-x64@1.0.11':
+  '@github/copilot-linux-x64@1.0.12':
     optional: true
 
-  '@github/copilot-win32-arm64@1.0.11':
+  '@github/copilot-win32-arm64@1.0.12':
     optional: true
 
-  '@github/copilot-win32-x64@1.0.11':
+  '@github/copilot-win32-x64@1.0.12':
     optional: true
 
-  '@github/copilot@1.0.11':
+  '@github/copilot@1.0.12':
     optionalDependencies:
-      '@github/copilot-darwin-arm64': 1.0.11
-      '@github/copilot-darwin-x64': 1.0.11
-      '@github/copilot-linux-arm64': 1.0.11
-      '@github/copilot-linux-x64': 1.0.11
-      '@github/copilot-win32-arm64': 1.0.11
-      '@github/copilot-win32-x64': 1.0.11
+      '@github/copilot-darwin-arm64': 1.0.12
+      '@github/copilot-darwin-x64': 1.0.12
+      '@github/copilot-linux-arm64': 1.0.12
+      '@github/copilot-linux-x64': 1.0.12
+      '@github/copilot-win32-arm64': 1.0.12
+      '@github/copilot-win32-x64': 1.0.12
 
   '@types/node@20.19.37':
     dependencies:
@@ -434,55 +434,55 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  opencode-ai@1.3.0:
+  opencode-ai@1.3.7:
     optionalDependencies:
-      opencode-darwin-arm64: 1.3.0
-      opencode-darwin-x64: 1.3.0
-      opencode-darwin-x64-baseline: 1.3.0
-      opencode-linux-arm64: 1.3.0
-      opencode-linux-arm64-musl: 1.3.0
-      opencode-linux-x64: 1.3.0
-      opencode-linux-x64-baseline: 1.3.0
-      opencode-linux-x64-baseline-musl: 1.3.0
-      opencode-linux-x64-musl: 1.3.0
-      opencode-windows-arm64: 1.3.0
-      opencode-windows-x64: 1.3.0
-      opencode-windows-x64-baseline: 1.3.0
+      opencode-darwin-arm64: 1.3.7
+      opencode-darwin-x64: 1.3.7
+      opencode-darwin-x64-baseline: 1.3.7
+      opencode-linux-arm64: 1.3.7
+      opencode-linux-arm64-musl: 1.3.7
+      opencode-linux-x64: 1.3.7
+      opencode-linux-x64-baseline: 1.3.7
+      opencode-linux-x64-baseline-musl: 1.3.7
+      opencode-linux-x64-musl: 1.3.7
+      opencode-windows-arm64: 1.3.7
+      opencode-windows-x64: 1.3.7
+      opencode-windows-x64-baseline: 1.3.7
 
-  opencode-darwin-arm64@1.3.0:
+  opencode-darwin-arm64@1.3.7:
     optional: true
 
-  opencode-darwin-x64-baseline@1.3.0:
+  opencode-darwin-x64-baseline@1.3.7:
     optional: true
 
-  opencode-darwin-x64@1.3.0:
+  opencode-darwin-x64@1.3.7:
     optional: true
 
-  opencode-linux-arm64-musl@1.3.0:
+  opencode-linux-arm64-musl@1.3.7:
     optional: true
 
-  opencode-linux-arm64@1.3.0:
+  opencode-linux-arm64@1.3.7:
     optional: true
 
-  opencode-linux-x64-baseline-musl@1.3.0:
+  opencode-linux-x64-baseline-musl@1.3.7:
     optional: true
 
-  opencode-linux-x64-baseline@1.3.0:
+  opencode-linux-x64-baseline@1.3.7:
     optional: true
 
-  opencode-linux-x64-musl@1.3.0:
+  opencode-linux-x64-musl@1.3.7:
     optional: true
 
-  opencode-linux-x64@1.3.0:
+  opencode-linux-x64@1.3.7:
     optional: true
 
-  opencode-windows-arm64@1.3.0:
+  opencode-windows-arm64@1.3.7:
     optional: true
 
-  opencode-windows-x64-baseline@1.3.0:
+  opencode-windows-x64-baseline@1.3.7:
     optional: true
 
-  opencode-windows-x64@1.3.0:
+  opencode-windows-x64@1.3.7:
     optional: true
 
   undici-types@6.21.0: {}


### PR DESCRIPTION
### Summary

Move workspace-local subscription from workspace-content* (parent) into viewport* and viewport-classic* (children). workspace-content* now only subscribes to the new workspace-vport derived atom, which changes only on window resize — not on every scroll event. This prevents the sidebar, palette and other workspace-content children from re-rendering on scroll

Accumulate wheel event deltas in a mutable ref and flush them via `requestAnimationFrame`, so that multiple wheel events between frames produce a single state mutation instead of one per event. This prevents the cascade of synchronous React re-renders (via useSyncExternalStore) that can exceed the maximum update depth on rapid scrolling.

Both panning (scroll) and zoom (ctrl/mod+wheel) are throttled. Scroll deltas are summed additively; zoom scales are compounded multiplicatively with the latest cursor point used as the zoom center.

This PR tries to fix the following reported trace. I'm unable to reproduce it my self with scrolling but scrolling optimization looks reasonable independently if fixed the issue or not.

### Related Trace

```
Error: Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
  at k5 (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:42:27911)
  at pS (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:42:27482)
  at X6e (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:42:53119)
  at https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:42:52997
  at https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:4655:180
  at https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:24744:495
  at $okulary$util$doiter$$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:4426:1)
  at https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:24744:79
  at https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:24737:62
  at $okulary$util$doiter$$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:4426:1)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IWatchable$_notify_watches$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:24736:186)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReset$_reset_BANG_$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:24731:241)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$ISwap$_swap_BANG_$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:24732:129)
  at $cljs$core$_swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:18660:204)
  at $cljs$core$_swap_BANG_$$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:18658:471)
  at $APP.$cljs$core$swap_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:19103:302)
  at $process_update$$ (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:26362:148)
  at Object.next (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:26366:1)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:7168)
  at Object.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:24020)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:25768)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:7168)
  at Object.next (https://design.penpot.app/js/shared.js?version=2.14.1-RC1-1774440923:26359:420)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:16543)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:16543)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:14021)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:18696)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:14021)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.1-RC1-1774440923:802:1877)
```
