### PR TITLE
:bug: Guard delete undo against missing sibling order

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -355,7 +355,8 @@
         prt (get objects pid)
         shapes (:shapes prt)
         pos (d/index-of shapes id)]
-    (if (= 0 pos) nil (nth shapes (dec pos)))))
+    (when (and (some? pos) (pos? pos))
+      (nth shapes (dec pos)))))
 
 (defn get-immediate-children
   "Retrieve resolved shape objects that are immediate children

--- a/common/test/common_tests/files/helpers_test.cljc
+++ b/common/test/common_tests/files/helpers_test.cljc
@@ -7,6 +7,7 @@
 (ns common-tests.files.helpers-test
   (:require
    [app.common.files.helpers :as cfh]
+   [app.common.uuid :as uuid]
    [clojure.test :as t]))
 
 (t/deftest test-generate-unique-name
@@ -36,3 +37,19 @@
                                     #{"base-name 1" "base-name 2"}
                                     :immediate-suffix? true)
           "base-name 3")))
+
+(t/deftest test-get-prev-sibling
+  (let [parent-id (uuid/custom 1 1)
+        child-a   (uuid/custom 1 2)
+        child-b   (uuid/custom 1 3)
+        orphan-id (uuid/custom 1 4)
+        objects   {parent-id {:id parent-id :shapes [child-a child-b]}
+                   child-a   {:id child-a :parent-id parent-id}
+                   child-b   {:id child-b :parent-id parent-id}
+                   orphan-id {:id orphan-id :parent-id parent-id}}]
+    (t/testing "Returns previous sibling when present in parent ordering"
+      (t/is (= child-a
+               (cfh/get-prev-sibling objects child-b))))
+
+    (t/testing "Returns nil when the shape is missing from parent ordering"
+      (t/is (nil? (cfh/get-prev-sibling objects orphan-id))))))


### PR DESCRIPTION
### Summary

Return nil from get-prev-sibling when the shape is no longer present in the parent ordering so delete undo generation falls back to index-based restore instead of crashing on invalid vector access.

### Related Trace

```
Error: No item -1 in vector of length 0
  at $cljs$core$vector_index_out_of_bounds$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:1065:89)
  at $cljs$core$array_for$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:1067:278)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IIndexed$_nth$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19267:121)
  at $APP.$cljs$core$nth$cljs$0core$0IFn$0_invoke$0arity$02$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:728:566)
  at $app$common$files$helpers$get_prev_sibling$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:4793:447)
  at $add_undo_change_parent$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:9633:381)
  at $APP.$JSCompiler_prototypeAlias$$.$cljs$core$IReduce$_reduce$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19282:34)
  at $APP.$cljs$core$reduce$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:793:320)
  at https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:9641:279
  at $APP.$cljs$core$update$$.$cljs$core$IFn$_invoke$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:19236:1)
  at $app$common$files$changes_builder$remove_objects$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:9640:373)
  at $app$common$logic$shapes$generate_delete_shapes$cljs$0core$0IFn$0_invoke$0arity$03$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:10362:463)
  at $app$common$logic$shapes$generate_delete_shapes$cljs$0core$0IFn$0_invoke$0arity$06$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:10333:221)
  at $app$main$data$workspace$shapes$delete_shapes_67305$$.$potok$v2$core$WatchEvent$watch$arity$3$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:11229:350)
  at $potok$v2$core$watch$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:4433:354)
  at $process_watch$$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:26350:138)
  at Object.next (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:26357:90)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:7168)
  at Object.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:24020)
  at xoe.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:2263)
  at e._next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1647)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at e.next [as _nextOverride] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:25768)
  at e.CSr [as _next] (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1877)
  at e.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:1371)
  at vy.next (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:802:7168)
  at $state_STAR_$$.next (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:26357:549)
  at $potok$v2$core$emit_BANG_$$.$cljs$core$IFn$_invoke$arity$2$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:24749:367)
  at $APP.$app$main$store$emit_BANG_$$.$cljs$core$IFn$_invoke$arity$1$ (https://design.penpot.app/js/shared.js?version=2.14.0-RC5-1773771852:26367:124)
  at Object.<anonymous> (https://design.penpot.app/js/main.js?version=2.14.0-RC5-1773771852:2984:534)
  at eval (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:106:59)
  at Array.forEach (<anonymous>)
  at eval (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:106:36)
  at anonymous (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:180:6)
  at eval (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:3:141)
  at w.handle (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:3:163)
  at x (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:3:1059)
  at eval (eval at <anonymous> (eval at HQt (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:767:1961)), <anonymous>:3:780)
  at https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:790:59832
  at Array.forEach (<anonymous>)
  at Object.sendMessage (https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:790:59821)
  at https://design.penpot.app/js/libs.js?version=2.14.0-RC5-1773771852:790:66672
```
