### PR TITLE
:bug: Guard against null focusNode/anchorNode in text-editor

### DIFF
--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -961,7 +961,7 @@ export class SelectionController extends EventTarget {
    * @type {boolean}
    */
   get isTextFocus() {
-    return this.focusNode.nodeType === Node.TEXT_NODE;
+    return this.focusNode != null && this.focusNode.nodeType === Node.TEXT_NODE;
   }
 
   /**
@@ -970,7 +970,9 @@ export class SelectionController extends EventTarget {
    * @type {boolean}
    */
   get isTextAnchor() {
-    return this.anchorNode.nodeType === Node.TEXT_NODE;
+    return (
+      this.anchorNode != null && this.anchorNode.nodeType === Node.TEXT_NODE
+    );
   }
 
   /**


### PR DESCRIPTION
### Trace 

```
TypeError: Cannot read properties of null (reading 'nodeType')
  at get isTextFocus (https://design.penpot.dev/js/libs.js?version=2.15.0-RC1-74-gee1c96f3a1-1774299127:796:13843)
  at FKe (https://design.penpot.dev/js/libs.js?version=2.15.0-RC1-74-gee1c96f3a1-1774299127:796:1057)
  at #w (https://design.penpot.dev/js/libs.js?version=2.15.0-RC1-74-gee1c96f3a1-1774299127:796:29242)
```