### PR TITLE
:sparkles: Update delete team modal when in org

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -516,14 +516,19 @@
 
         on-delete-clicked
         (mf/use-fn
-         (mf/deps delete-fn)
-         #(st/emit!
-           (modal/show
-            {:type :confirm
-             :title (tr "modals.delete-team-confirm.title")
-             :message (tr "modals.delete-team-confirm.message")
-             :accept-label (tr "modals.delete-team-confirm.accept")
-             :on-accept delete-fn})))]
+         (mf/deps team delete-fn)
+         (fn []
+           (let [is-org-team? (some? (:organization-id team))
+                 message (if is-org-team?
+                           (tr "modals.delete-org-team-confirm.message" (:organization-name team))
+                           (tr "modals.delete-team-confirm.message"))]
+             (st/emit!
+              (modal/show
+               {:type :confirm
+                :title (tr "modals.delete-team-confirm.title")
+                :message message
+                :accept-label (tr "modals.delete-team-confirm.accept")
+                :on-accept delete-fn})))))]
     [:> dropdown-menu* props
 
      [:> dropdown-menu-item* {:on-click    go-members

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -8950,3 +8950,6 @@ msgstr "Autosaved versions will be kept for %s days."
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Click to close the path"
+
+msgid "modals.delete-org-team-confirm.message"
+msgstr "Are you sure you want to delete this team that is part of %s org?"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -8783,3 +8783,6 @@ msgstr "Los autoguardados duran %s días."
 #, unused
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Pulsar para cerrar la ruta"
+
+msgid "modals.delete-org-team-confirm.message"
+msgstr "¿Estás seguro de que deseas eliminar este equipo que forma parte de la organización %s?"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/13835

### Summary

When the team is part of an organization the modal message changes to: “Are you sure you want to delete this team that is part of [organization name] org?”

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.