### PR TITLE
:sparkles: Add unique email domains to telemetry report

### DIFF
--- a/backend/src/app/tasks/telemetry.clj
+++ b/backend/src/app/tasks/telemetry.clj
@@ -129,6 +129,12 @@
   (->> [sql:team-averages]
        (db/exec-one! conn)))
 
+(defn- get-email-domains
+  [conn]
+  (let [sql "SELECT DISTINCT split_part(email, '@', 2) AS domain FROM profile ORDER BY 1"]
+    (->> (db/exec! conn [sql])
+         (mapv :domain))))
+
 (defn- get-enabled-auth-providers
   [conn]
   (let [sql  (str "SELECT auth_backend AS backend, count(*) AS total "
@@ -192,7 +198,8 @@
          :total-fonts         (get-num-fonts conn)
          :total-comments      (get-num-comments conn)
          :total-file-changes  (get-num-file-changes conn)
-         :total-touched-files (get-num-touched-files conn)}
+         :total-touched-files (get-num-touched-files conn)
+         :email-domains       (get-email-domains conn)}
         (merge
          (get-team-averages conn)
          (get-jvm-stats)

--- a/backend/test/backend_tests/tasks_telemetry_test.clj
+++ b/backend/test/backend_tests/tasks_telemetry_test.clj
@@ -42,4 +42,6 @@
         (t/is (contains? data :avg-files-on-project))
         (t/is (contains? data :max-projects-on-team))
         (t/is (contains? data :avg-files-on-project))
-        (t/is (contains? data :version))))))
+        (t/is (contains? data :version))
+        (t/is (contains? data :email-domains))
+        (t/is (= ["nodomain.com"] (:email-domains data)))))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/13827?milestone=509270

### Summary

Extend the telemetry payload with a sorted list of unique email domains extracted from all registered profile email addresses. The new :email-domains field is populated via a single SQL query using split_part and DISTINCT, and is included in the stats sent when telemetry is enabled.

Also update the tasks-telemetry-test to assert the new field is present and contains the expected domain values.

