### PR TITLE
:bug: Fix text selection on Safari 18/26 (wasm)

### DIFF
--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -27,7 +27,7 @@
 ;; --- Auxiliar Functions
 
 (def valid-browsers
-  #{:chrome :firefox :safari :safari-16 :safari-17 :edge :other})
+  #{:chrome :firefox :safari :safari-16 :safari-17 :safari-18 :safari-26 :edge :other})
 
 (def valid-platforms
   #{:windows :linux :macos :other})
@@ -40,13 +40,17 @@
         check-edge? (fn [] (str/includes? user-agent "edg"))
         check-safari? (fn [] (str/includes? user-agent "safari"))
         check-safari-16? (fn [] (and (check-safari?) (str/includes? user-agent "version/16")))
-        check-safari-17? (fn [] (and (check-safari?) (str/includes? user-agent "version/17")))]
+        check-safari-17? (fn [] (and (check-safari?) (str/includes? user-agent "version/17")))
+        check-safari-18? (fn [] (and (check-safari?) (str/includes? user-agent "version/18")))
+        check-safari-26? (fn [] (and (check-safari?) (str/includes? user-agent "version/26")))]
     (cond
       ^boolean (check-edge?)      :edge
       ^boolean (check-chrome?)    :chrome
       ^boolean (check-firefox?)   :firefox
       ^boolean (check-safari-16?) :safari-16
       ^boolean (check-safari-17?) :safari-17
+      ^boolean (check-safari-18?) :safari-18
+      ^boolean (check-safari-26?) :safari-26
       ^boolean (check-safari?)    :safari
       :else                       :unknown)))
 

--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -216,7 +216,7 @@
 (defn ^boolean check-browser? [candidate]
   (dm/assert! (contains? valid-browsers candidate))
   (if (= candidate :safari)
-    (contains? #{:safari :safari-16 :safari-17} browser)
+    (contains? #{:safari :safari-16 :safari-17 :safari-18 :safari-26} browser)
     (= candidate browser)))
 
 (defn ^boolean check-platform? [candidate]

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -331,7 +331,7 @@
         ;; NOTE: this teoretically breaks hooks rules, but in practice
         ;; it is imposible to really break it
         maybe-zoom
-        (when (cf/check-browser? :safari-16)
+        (when (or (cf/check-browser? :safari) (cf/check-browser? :safari-26) (cf/check-browser? :safari-18))
           (mf/deref refs/selected-zoom))
 
         shape (cond-> shape
@@ -387,16 +387,22 @@
           ;; Transform is necessary when there is a text overflow and the vertical
           ;; aligment is center or bottom.
           (and (not render-wasm?)
-               (not (cf/check-browser? :safari)))
+               (not (cf/check-browser? :safari-16)))
           (obj/merge!
            #js {:transform (dm/fmt "translate(%px, %px)" (- (dm/get-prop shape :x) x) (- (dm/get-prop shape :y) y))})
 
-          (cf/check-browser? :safari-17)
+          (or (cf/check-browser? :safari-18) (cf/check-browser? :safari-26) (cf/check-browser? :safari-17))
           (obj/merge!
            #js {:height "100%"
                 :display "flex"
                 :flexDirection "column"
                 :justifyContent (shape->justify shape)})
+
+          (or (cf/check-browser? :safari-26) (cf/check-browser? :safari-18))
+          (obj/merge!
+           #js {:position "fixed"
+                :transform-origin "top left"
+                :transform (dm/fmt "scale(%)" maybe-zoom)})
 
           (cf/check-browser? :safari-16)
           (obj/merge!

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -331,7 +331,7 @@
         ;; NOTE: this teoretically breaks hooks rules, but in practice
         ;; it is imposible to really break it
         maybe-zoom
-        (when (or (cf/check-browser? :safari) (cf/check-browser? :safari-26) (cf/check-browser? :safari-18))
+        (when (cf/check-browser? :safari)
           (mf/deref refs/selected-zoom))
 
         shape (cond-> shape
@@ -391,7 +391,7 @@
           (obj/merge!
            #js {:transform (dm/fmt "translate(%px, %px)" (- (dm/get-prop shape :x) x) (- (dm/get-prop shape :y) y))})
 
-          (or (cf/check-browser? :safari-18) (cf/check-browser? :safari-26) (cf/check-browser? :safari-17))
+          (and (cf/check-browser? :safari) (not (cf/check-browser? :safari-16)))
           (obj/merge!
            #js {:height "100%"
                 :display "flex"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13798

### Summary

This fixes text selection in editor v2 for Safari 18 and 26.

Safari 16 (tried on Lambdatest with local tunnel)

<img width="1211" height="852" alt="Screenshot 2026-03-27 at 1 46 01 PM" src="https://github.com/user-attachments/assets/24cf7af3-948f-45c9-9e56-e5f9ddaca55d" />

Safari 26 (tried on a real machine)

<img width="931" height="714" alt="Screenshot 2026-03-27 at 1 46 24 PM" src="https://github.com/user-attachments/assets/6bbab2ef-f184-478e-988c-2a71221c3147" />

### Steps to reproduce 

See Taiga ticket and download attached file. Try it out with different zoom levels and panning.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
