### PR TITLE
:bug: Fix problem with grid edition in Safari

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
@@ -162,7 +162,7 @@
            (let [raw-pt (mf/ref-val current-pos-ref)
                  position (uwvv/point->viewport raw-pt)
                  start (mf/ref-val start-pos-ref)
-                 delta (gpt/to-vec start (dom/get-client-position event))]
+                 delta (gpt/to-vec start raw-pt)]
              (dom/release-pointer event)
              (mf/set-ref-val! dragging-ref false)
              (mf/set-ref-val! start-pos-ref nil)


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/13802

### Summary

The problem was that the lost-pointer event in Safari doesn't include the mouse position. I've changed it so it uses the latest stored point from the move event (which makes senses in all browsers that's why you'll not see a `(if safari` ). 


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
