### PR TITLE
fix: Make MCP flags properties writable to resolve "not extensible" e…

### DIFF
--- a/frontend/src/app/plugins/flags.cljs
+++ b/frontend/src/app/plugins/flags.cljs
@@ -30,6 +30,7 @@
   (obj/reify {:name "FlagProxy"}
     :naturalChildOrdering
     {:this false
+     :writable true
      :get
      (fn [] (u/natural-child-ordering? plugin-id))
 
@@ -44,6 +45,7 @@
 
     :throwValidationErrors
     {:this false
+     :writable true
      :get
      (fn [] (u/throw-validation-errors? plugin-id))
 


### PR DESCRIPTION
…rror

The obj/reify system creates Proxy objects where properties default to writable: false unless :writable is explicitly provided. This caused the MCP server's ExecuteCodeTaskHandler to fail when trying to set penpot.flags.throwValidationErrors = true during code execution.

Adds :writable true to both naturalChildOrdering and throwValidationErrors flag properties in flags.cljs.

Fixes: #8682 (MCP: Apply flag throwValidationErrors)

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
