### PR TITLE
fix: Make text and flex properties writable (Issue #8520)

### DIFF
--- a/frontend/src/app/plugins/flex.cljs
+++ b/frontend/src/app/plugins/flex.cljs
@@ -268,6 +268,7 @@
 
     :horizontalSizing
     {:this true
+     :writable true
      :get #(-> % u/proxy->shape :layout-item-h-sizing (d/nilv :fix) d/name)
      :set
      (fn [_ value]
@@ -284,6 +285,7 @@
 
     :verticalSizing
     {:this true
+     :writable true
      :get #(-> % u/proxy->shape :layout-item-v-sizing (d/nilv :fix) d/name)
      :set
      (fn [_ value]

--- a/frontend/src/app/plugins/text.cljs
+++ b/frontend/src/app/plugins/text.cljs
@@ -625,6 +625,7 @@
           (st/emit! (dwt/update-attrs id {:text-direction value})))))}
 
    {:name "align"
+    :writable true
     :get #(-> % u/proxy->shape text-props :text-align format/format-mixed)
     :set
     (fn [self value]
@@ -640,6 +641,7 @@
           (st/emit! (dwt/update-attrs id {:text-align value})))))}
 
    {:name "verticalAlign"
+    :writable true
     :get #(-> % u/proxy->shape text-props :vertical-align)
     :set
     (fn [self value]


### PR DESCRIPTION
Makes Plugin API properties writable to resolve "Cannot add property" errors:
- text.cljs: align, verticalAlign
- flex.cljs: horizontalSizing, verticalSizing

Fixes: #8520 (Multiple Plugin API silent failures - Bug #1 and Bug #3)

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
