### PR TITLE
:sparkles: Add wait time before export_shape to account for async updates

### DIFF
--- a/mcp/packages/plugin/src/PenpotUtils.ts
+++ b/mcp/packages/plugin/src/PenpotUtils.ts
@@ -420,6 +420,11 @@ export class PenpotUtils {
      *   - For mode="fill", it will be whatever format the fill image is stored in.
      */
     public static async exportImage(shape: Shape, mode: "shape" | "fill", asSVG: boolean): Promise<Uint8Array> {
+        // Updates are asynchronous in Penpot, so wait a tick to ensure any pending updates are applied before export.
+        // The constant wait time is a temporary workardound until a better solution for penpot/penpot-mcp#27
+        // is implemented.
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        // Perform export
         switch (mode) {
             case "shape":
                 return shape.export({ type: asSVG ? "svg" : "png" });


### PR DESCRIPTION
Add wait time in exportImage to account for async updates #8836

This is a temporary workaround for penpot/penpot-mcp#27.
It adds a wait time before exports via the export_shape tool to account for asynchronous updates in Penpot, increasing the likelihood of exporting the fully updated state.
