### PR TITLE
:bug: Fix error on path and review UI

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
@@ -42,36 +42,37 @@
                          (not (get-in @form [:touched :name]))
                          (= (get-in @form [:clean-data :name]) (:name node)))
 
-        new-path (mf/with-memo [@form node]
-                   (let [new-name (get-in @form [:clean-data :name])
-                         path (str (:path node))
-                         new-path (str/replace path (:name node) new-name)]
-                     new-path))]
+        hint-path (mf/with-memo [@form node]
+                    (let [new-name (get-in @form [:clean-data :name])
+                          path (str (:path node))
+                          new-path (str/replace path (:name node) new-name)]
+                      (if (get-in @form [:touched :name])
+                        new-path
+                        path)))]
 
-    [:*
+    [:> fc/form* {:class (stl/css :form-wrapper)
+                  :form form
+                  :on-submit on-submit}
      [:> heading* {:level 2
                    :typography "headline-medium"
                    :class (stl/css :form-modal-title)}
       (tr "workspace.tokens.rename-group")]
-     [:> fc/form* {:class (stl/css :form-wrapper)
-                   :form form
-                   :on-submit on-submit}
-      [:> fc/form-input* {:id "rename-node"
-                          :name :name
-                          :label (tr "workspace.tokens.token-name")
-                          :placeholder (tr "workspace.tokens.token-name")
-                          :max-length 255
-                          :variant "comfortable"
-                          :hint-type "hint"
-                          :hint-message (tr "workspace.tokens.rename-group-name-hint" new-path)
-                          :auto-focus true}]
-      [:div {:class (stl/css :form-actions)}
-       [:> button* {:variant "secondary"
-                    :name "cancel"
-                    :on-click on-close} (tr "labels.cancel")]
-       [:> fc/form-submit* {:variant "primary"
-                            :disabled is-disabled?
-                            :name "rename"} (tr "labels.rename")]]]]))
+     [:> fc/form-input* {:id "rename-node"
+                         :name :name
+                         :label (tr "workspace.tokens.token-name")
+                         :placeholder (tr "workspace.tokens.token-name")
+                         :max-length 255
+                         :variant "comfortable"
+                         :hint-type "hint"
+                         :hint-message (tr "workspace.tokens.rename-group-name-hint" hint-path)
+                         :auto-focus true}]
+     [:div {:class (stl/css :form-actions)}
+      [:> button* {:variant "secondary"
+                   :name "cancel"
+                   :on-click on-close} (tr "labels.cancel")]
+      [:> fc/form-submit* {:variant "primary"
+                           :disabled is-disabled?
+                           :name "rename"} (tr "labels.rename")]]]))
 
 (mf/defc rename-node-modal
   {::mf/register modal/components

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.scss
@@ -41,8 +41,20 @@
   position: relative;
 }
 
+.form-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-l);
+}
+
 .form-modal-title {
   @include t.use-typography("headline-medium");
 
   color: var(--color-foreground-primary);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-m);
 }


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/13211

### Summary

- Add regular gap (same as in other modals) between title, inputs and buttons (vertical and horizontal)
- Fix null in tokens group name (hint) before renaming it

### Steps to reproduce 

-  Create a token group
- Rename it and check form UI
- Edit the group name and check the hint message

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
