### PR TITLE
:wrench: Add short tag to DocherHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,14 @@ jobs:
           echo "$PUB_DOCKER_PASSWORD" | skopeo login --username "$PUB_DOCKER_USERNAME" --password-stdin docker.io
 
           IMAGES=("frontend" "backend" "exporter" "storybook")
+          SHORT_TAG=${TAG%.*}
 
           for image in "${IMAGES[@]}"; do
             skopeo copy --all \
               docker://$DOCKER_REGISTRY/$image:$TAG \
               docker://docker.io/penpotapp/$image:$TAG
 
-            for alias in main latest; do
+            for alias in main latest "$SHORT_TAG"; do
               skopeo copy --all \
                 docker://$DOCKER_REGISTRY/$image:$TAG \
                 docker://docker.io/penpotapp/$image:$alias


### PR DESCRIPTION
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGUzaThsbm1saG0wc3R3ZDJsaGVmeGI1bmgzNGRtaWVyaHJjMmJvYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Xf8NBlkHYGOtmbIUgE/giphy.gif)

This PR adds a short_tag to the tags released in docker hub.
Currently: we publish tag, main, latest, where tag is something like 2.14.1
With these changes: we publish tag, short_tag, main latest, where tag is the same and short_tag is 2.14