### PR TITLE
:books: Add changelog entry for undo/redo selection state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Add natural sorting on token names [Taiga #13713](https://tree.taiga.io/project/penpot/issue/13713)
 - Add drag-to-change for numeric inputs in workspace sidebar [Github #2466](https://github.com/penpot/penpot/issues/2466)
 - Add CSS linter [Taiga #13790](https://tree.taiga.io/project/penpot/us/13790)
+- Save and restore selection state in undo/redo (by @eureka928) [Github #6007](https://github.com/penpot/penpot/issues/6007)
 
 ### :bug: Bugs fixed
 


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/6007
https://github.com/penpot/penpot/pull/8652

### Summary

Adds a changelog entry under the `Enhancements` section for the undo/redo selection state feature, as requested in [this comment](https://github.com/penpot/penpot/pull/8652#issuecomment-4199748369).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->