### PR TITLE
:bug: Fix path drawing preview passing shape instead of content to next-node

### DIFF
--- a/frontend/src/app/main/data/workspace/path/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/path/drawing.cljs
@@ -58,12 +58,12 @@
             last-point (get-in state [:workspace-local :edit-path id :last-point])
             position   (cond-> (gpt/point x y)
                          fix-angle? (path.helpers/position-fixed-angle last-point))
-            shape      (st/get-path state)
+            content    (st/get-path state :content)
 
             {:keys [last-point prev-handler]}
             (get-in state [:workspace-local :edit-path id])
 
-            segment (path/next-node shape position last-point prev-handler)]
+            segment (path/next-node content position last-point prev-handler)]
         (assoc-in state [:workspace-local :edit-path id :preview] segment)))))
 
 (defn add-node


### PR DESCRIPTION
### Related ticket

https://tree.taiga.io/project/penpot/issue/13945

### Summary

In `preview-next-point`, `st/get-path` was called without extra keys, which returns the full Shape record. That value was then passed directly to `path/next-node` as its `content` argument.

`path/next-node` delegates to `impl/path-data`, which only accepts a `PathData` instance, `nil`, or a sequential collection of segments. A Shape record matches none of those cases, so `path-data` threw "unexpected data" every time the user moved the mouse while drawing a path.

The fix is to call `(st/get-path state :content)` so that only the `:content` field (a `PathData` instance) is extracted and forwarded to `path/next-node`.
