### PR TITLE
:bug: Close expanded tree when switching or creating sets

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
@@ -96,6 +96,13 @@
                      (close-token-type types type)
                      (open-token-type types type)))))))
 
+(defn clear-tokens-types
+  []
+  (ptk/reify ::clear-tokens-types
+    ptk/UpdateEvent
+    (update [_ state]
+      (assoc-in state [:workspace-tokens :unfolded-token-types] []))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TOKENS TREE - Toggle tree nodes

--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -16,8 +16,9 @@
    [rumext.v2 :as mf]))
 
 (defn- on-select-token-set-click [id]
-  (st/emit! (dwtl/clear-tokens-paths))
-  (st/emit! (dwtl/set-selected-token-set-id id)))
+  (st/emit! (dwtl/clear-tokens-paths)
+            (dwtl/clear-tokens-types)
+            (dwtl/set-selected-token-set-id id)))
 
 (defn- on-toggle-token-set-click [name]
   (st/emit! (dwtl/toggle-token-set name)))

--- a/frontend/src/app/main/ui/workspace/tokens/sets/helpers.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/helpers.cljs
@@ -41,7 +41,9 @@
               (dwtl/clear-token-set-creation))
     (if (empty? errors)
       (let [token-set (ctob/make-token-set :name name)]
-        (st/emit! (dwtl/create-token-set token-set)))
+        (st/emit! (dwtl/create-token-set token-set)
+                  (dwtl/clear-tokens-paths)
+                  (dwtl/clear-tokens-types)))
       (st/emit! (ntf/show {:content (tr "errors.token-set-already-exists")
                            :type :toast
                            :level :error


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13956
<!-- Reference the related GitHub/Taiga ticket. -->

### Summary
When the user has some tokens tree types expanded and switches to other set or creates a new one, the token type remains unfolded. This could affect the UI if the token type is empty on other set.

### Steps to reproduce 
See issue

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
