### PR TITLE
:tada: Save tokens tree state in local storage

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
@@ -69,16 +69,16 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Helper functions for localStorage persistence
-(defn- get-stored-unfolded-token-types
+(defn- get-unfolded-token-types-from-storage
   [file-id set-id]
-  (set (get-in storage/user [::unfolded-token-types file-id set-id] #{})))
+  (get-in storage/user [:app.main.ui.workspace.tokens/unfolded-token-types file-id set-id] #{}))
 
-(defn- save-unfolded-token-types
+(defn- save-unfolded-token-types-in-storage
   [file-id set-id types]
-  (when (and file-id set-id)
-    (swap! storage/user update ::unfolded-token-types
-           assoc-in [file-id set-id] (vec types))))
+  (swap! storage/user update :app.main.ui.workspace.tokens/unfolded-token-types
+         assoc-in [file-id set-id] (vec types)))
 
+;; Helper functions for app state persistence
 (defn- make-unfolded-token-types-state
   [file-id set-id types]
   {:file-id file-id
@@ -88,9 +88,7 @@
 (defn- get-unfolded-token-types-from-state
   [state]
   (let [value (get-in state [:workspace-tokens :unfolded-token-types])]
-    (if (map? value)
-      (set (:types value))
-      (set (or value #{})))))
+    (or (:types value) #{})))
 
 (defn restore-unfolded-token-types
   "Loads unfolded token types from localStorage for the current file and set"
@@ -100,10 +98,10 @@
     (update [_ state]
       (let [file-id (:current-file-id state)
             set-id  (get-in state [:workspace-tokens :selected-token-set-id])
-            stored  (get-stored-unfolded-token-types file-id set-id)]
+            stored  (get-unfolded-token-types-from-storage file-id set-id)]
         (assoc-in state
-              [:workspace-tokens :unfolded-token-types]
-              (make-unfolded-token-types-state file-id set-id stored))))))
+                  [:workspace-tokens :unfolded-token-types]
+                  (make-unfolded-token-types-state file-id set-id stored))))))
 
 (defn open-token-type
   ([types type]
@@ -119,8 +117,8 @@
              new-state (assoc-in state
                                  [:workspace-tokens :unfolded-token-types]
                                  (make-unfolded-token-types-state file-id set-id new-types))]
-         (save-unfolded-token-types file-id set-id
-                                    new-types)
+         (save-unfolded-token-types-in-storage file-id set-id
+                                               new-types)
          new-state)))))
 
 (defn close-token-type
@@ -137,11 +135,12 @@
              new-state (assoc-in state
                                  [:workspace-tokens :unfolded-token-types]
                                  (make-unfolded-token-types-state file-id set-id new-types))]
-         (save-unfolded-token-types file-id set-id
-                                    new-types)
+         (save-unfolded-token-types-in-storage file-id set-id
+                                               new-types)
          new-state)))))
 
-(defn toggle-token-type
+(defn
+  toggle-token-type
   [type]
   (ptk/reify ::toggle-token-type
     ptk/UpdateEvent
@@ -155,8 +154,8 @@
             new-state (assoc-in state
                                 [:workspace-tokens :unfolded-token-types]
                                 (make-unfolded-token-types-state file-id set-id new-types))]
-        (save-unfolded-token-types file-id set-id
-                                   new-types)
+        (save-unfolded-token-types-in-storage file-id set-id
+                                              new-types)
         new-state))))
 
 (defn clear-tokens-types
@@ -166,11 +165,10 @@
     (update [_ state]
       (let [file-id (:current-file-id state)
             set-id  (get-in state [:workspace-tokens :selected-token-set-id])]
-        (save-unfolded-token-types file-id set-id #{})
+        (save-unfolded-token-types-in-storage file-id set-id #{})
         (assoc-in state
-              [:workspace-tokens :unfolded-token-types]
-              (make-unfolded-token-types-state file-id set-id #{}))))))
-
+                  [:workspace-tokens :unfolded-token-types]
+                  (make-unfolded-token-types-state file-id set-id #{}))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TOKENS TREE - Toggle tree nodes
@@ -725,7 +723,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (let [file-id (:current-file-id state)
-            stored  (get-stored-unfolded-token-types file-id id)]
+            stored  (get-unfolded-token-types-from-storage file-id id)]
         (-> state
             (update :workspace-tokens assoc :selected-token-set-id id)
             (assoc-in [:workspace-tokens :unfolded-token-types]

--- a/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
@@ -23,6 +23,7 @@
    [app.main.data.workspace.shapes :as dwsh]
    [app.main.data.workspace.tokens.propagation :as dwtp]
    [app.util.i18n :refer [tr]]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [potok.v2.core :as ptk]))
@@ -67,6 +68,43 @@
 ;; TOKENS TREE - Type folders
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Helper functions for localStorage persistence
+(defn- get-stored-unfolded-token-types
+  [file-id set-id]
+  (set (get-in storage/user [::unfolded-token-types file-id set-id] #{})))
+
+(defn- save-unfolded-token-types
+  [file-id set-id types]
+  (when (and file-id set-id)
+    (swap! storage/user update ::unfolded-token-types
+           assoc-in [file-id set-id] (vec types))))
+
+(defn- make-unfolded-token-types-state
+  [file-id set-id types]
+  {:file-id file-id
+   :set-id set-id
+   :types (set (or types #{}))})
+
+(defn- get-unfolded-token-types-from-state
+  [state]
+  (let [value (get-in state [:workspace-tokens :unfolded-token-types])]
+    (if (map? value)
+      (set (:types value))
+      (set (or value #{})))))
+
+(defn restore-unfolded-token-types
+  "Loads unfolded token types from localStorage for the current file and set"
+  []
+  (ptk/reify ::restore-unfolded-token-types
+    ptk/UpdateEvent
+    (update [_ state]
+      (let [file-id (:current-file-id state)
+            set-id  (get-in state [:workspace-tokens :selected-token-set-id])
+            stored  (get-stored-unfolded-token-types file-id set-id)]
+        (assoc-in state
+              [:workspace-tokens :unfolded-token-types]
+              (make-unfolded-token-types-state file-id set-id stored))))))
+
 (defn open-token-type
   ([types type]
    (conj (or types #{}) type))
@@ -74,8 +112,16 @@
    (ptk/reify ::open-token-type
      ptk/UpdateEvent
      (update [_ state]
-       (update-in state [:workspace-tokens :unfolded-token-types]
-                  #(open-token-type % type))))))
+       (let [file-id   (:current-file-id state)
+             set-id    (get-in state [:workspace-tokens :selected-token-set-id])
+             types     (get-unfolded-token-types-from-state state)
+             new-types (open-token-type types type)
+             new-state (assoc-in state
+                                 [:workspace-tokens :unfolded-token-types]
+                                 (make-unfolded-token-types-state file-id set-id new-types))]
+         (save-unfolded-token-types file-id set-id
+                                    new-types)
+         new-state)))))
 
 (defn close-token-type
   ([types type]
@@ -84,26 +130,46 @@
    (ptk/reify ::close-token-type
      ptk/UpdateEvent
      (update [_ state]
-       (update-in state [:workspace-tokens :unfolded-token-types]
-                  #(close-token-type % type))))))
+       (let [file-id   (:current-file-id state)
+             set-id    (get-in state [:workspace-tokens :selected-token-set-id])
+             types     (get-unfolded-token-types-from-state state)
+             new-types (close-token-type types type)
+             new-state (assoc-in state
+                                 [:workspace-tokens :unfolded-token-types]
+                                 (make-unfolded-token-types-state file-id set-id new-types))]
+         (save-unfolded-token-types file-id set-id
+                                    new-types)
+         new-state)))))
 
 (defn toggle-token-type
   [type]
   (ptk/reify ::toggle-token-type
     ptk/UpdateEvent
     (update [_ state]
-      (update-in state [:workspace-tokens :unfolded-token-types]
-                 (fn [types]
-                   (if (contains? (or types #{}) type)
-                     (close-token-type types type)
-                     (open-token-type types type)))))))
+      (let [file-id   (:current-file-id state)
+            set-id    (get-in state [:workspace-tokens :selected-token-set-id])
+            types     (get-unfolded-token-types-from-state state)
+            new-types (if (contains? types type)
+                        (close-token-type types type)
+                        (open-token-type types type))
+            new-state (assoc-in state
+                                [:workspace-tokens :unfolded-token-types]
+                                (make-unfolded-token-types-state file-id set-id new-types))]
+        (save-unfolded-token-types file-id set-id
+                                   new-types)
+        new-state))))
 
 (defn clear-tokens-types
   []
   (ptk/reify ::clear-tokens-types
     ptk/UpdateEvent
     (update [_ state]
-      (assoc-in state [:workspace-tokens :unfolded-token-types] []))))
+      (let [file-id (:current-file-id state)
+            set-id  (get-in state [:workspace-tokens :selected-token-set-id])]
+        (save-unfolded-token-types file-id set-id #{})
+        (assoc-in state
+              [:workspace-tokens :unfolded-token-types]
+              (make-unfolded-token-types-state file-id set-id #{}))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -658,7 +724,12 @@
   (ptk/reify ::set-selected-token-set-id
     ptk/UpdateEvent
     (update [_ state]
-      (update state :workspace-tokens assoc :selected-token-set-id id))))
+      (let [file-id (:current-file-id state)
+            stored  (get-stored-unfolded-token-types file-id id)]
+        (-> state
+            (update :workspace-tokens assoc :selected-token-set-id id)
+            (assoc-in [:workspace-tokens :unfolded-token-types]
+                      (make-unfolded-token-types-state file-id id stored)))))))
 
 (defn start-token-set-edition
   [edition-id]

--- a/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
@@ -77,22 +77,13 @@
 
         folded-token-paths (mf/deref ref:folded-token-paths)
         unfolded-token-types-state (mf/deref ref:unfolded-token-types)
-        unfolded-token-types-file-id (if (map? unfolded-token-types-state)
-                     (:file-id unfolded-token-types-state)
-                     nil)
-        unfolded-token-types-set-id (if (map? unfolded-token-types-state)
-                    (:set-id unfolded-token-types-state)
-                    nil)
-        unfolded-token-types (if (map? unfolded-token-types-state)
-                   (:types unfolded-token-types-state)
-                   unfolded-token-types-state)
-        current-file (mf/deref refs/file)
-        current-file-id (:id current-file)
 
-        is-same-context? (and (= unfolded-token-types-file-id current-file-id)
-                  (= unfolded-token-types-set-id selected-token-set-id))
-        is-type-unfolded (and is-same-context?
-                  (contains? (set unfolded-token-types) type))
+        current-file (mf/deref refs/file)
+
+        is-same-file-set? (and (= (:file-id unfolded-token-types-state) (:id current-file))
+                               (= (:set-id unfolded-token-types-state) selected-token-set-id))
+        is-type-unfolded (and is-same-file-set?
+                              (contains? (set (:types unfolded-token-types-state)) type))
 
         editing-ref  (mf/deref refs/workspace-editor-state)
         edition      (mf/deref refs/selected-edition)

--- a/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
@@ -76,9 +76,23 @@
         (get dwta/token-properties type)
 
         folded-token-paths (mf/deref ref:folded-token-paths)
-        unfolded-token-types (mf/deref ref:unfolded-token-types)
+        unfolded-token-types-state (mf/deref ref:unfolded-token-types)
+        unfolded-token-types-file-id (if (map? unfolded-token-types-state)
+                     (:file-id unfolded-token-types-state)
+                     nil)
+        unfolded-token-types-set-id (if (map? unfolded-token-types-state)
+                    (:set-id unfolded-token-types-state)
+                    nil)
+        unfolded-token-types (if (map? unfolded-token-types-state)
+                   (:types unfolded-token-types-state)
+                   unfolded-token-types-state)
+        current-file (mf/deref refs/file)
+        current-file-id (:id current-file)
 
-        is-type-unfolded (contains? (set unfolded-token-types) type)
+        is-same-context? (and (= unfolded-token-types-file-id current-file-id)
+                  (= unfolded-token-types-set-id selected-token-set-id))
+        is-type-unfolded (and is-same-context?
+                  (contains? (set unfolded-token-types) type))
 
         editing-ref  (mf/deref refs/workspace-editor-state)
         edition      (mf/deref refs/selected-edition)
@@ -156,6 +170,10 @@
                                         :type :toast
                                         :level :warning
                                         :timeout 3000}))))))))]
+
+    (mf/use-effect
+     (fn []
+       (st/emit! (dwtl/restore-unfolded-token-types))))
 
     [:div {:class (stl/css :token-section-wrapper)
            :data-testid (dm/str "section-" (name type))}

--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -17,7 +17,6 @@
 
 (defn- on-select-token-set-click [id]
   (st/emit! (dwtl/clear-tokens-paths)
-            (dwtl/clear-tokens-types)
             (dwtl/set-selected-token-set-id id)))
 
 (defn- on-toggle-token-set-click [name]


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/13951

### Summary
I want my collapsed/expanded token sections to remain in their last state when I navigate away and return to the tokens section, so that I don't lose my place in large design systems and can continue working without re-navigating.

### Steps to reproduce 

- Token fold/unfold states persist via localStorage
- State survives page refreshes and navigation
- State is scoped per file/set (not global)
- Creating a new token must unfold the token type
- Changing sets must rerender the tokens section and fold/unfold its appropiate types.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
