### PR TITLE
:bug: Fix dashboard navigation tabs overlap with content when scrolling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fix hover on layers [Taiga #13799](https://tree.taiga.io/project/penpot/issue/13799)
 - Fix highlight after name edition [Taiga #13783](https://tree.taiga.io/project/penpot/issue/13783)
 - Fix id prop on switch component [Taiga #13534](https://tree.taiga.io/project/penpot/issue/13534)
+- Fix dashboard navigation tabs overlap with projects content when scrolling [Taiga #13962](https://tree.taiga.io/project/penpot/issue/13962)
 
 
 ## 2.14.2

--- a/frontend/src/app/main/ui/dashboard/deleted.scss
+++ b/frontend/src/app/main/ui/dashboard/deleted.scss
@@ -51,6 +51,7 @@
   padding: var(--sp-xxl) var(--sp-xxl) var(--sp-s) var(--sp-xxl);
   position: sticky;
   top: 0;
+  z-index: $z-index-100;
 }
 
 .nav-inside {


### PR DESCRIPTION
### Related Ticket

Taiga [#13962](https://tree.taiga.io/project/penpot/issue/13962)

### Summary

The dashboard navigation tabs for Recent and Deleted become visually overlapped by the projects information when scrolling, causing a messy and confusing UI.