### PR TITLE
:bug: Fix problem with component thumbnails

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -411,9 +411,16 @@
              (when id-ref
                (reset! id-ref component-id))
              (when-not (empty? (:redo-changes changes))
-               (rx/of (dch/commit-changes changes)
-                      (dws/select-shapes (d/ordered-set (:id root)))
-                      (ptk/data-event :layout/update {:ids parents}))))))))))
+               (rx/concat
+                (rx/of (dch/commit-changes changes)
+                       (dws/select-shapes (d/ordered-set (:id root)))
+                       (ptk/data-event :layout/update {:ids parents}))
+
+                ;; When activated the wasm rendering we need to recreate its thumbnail on creation
+                (if (features/active-feature? state "render-wasm/v1")
+                  (rx/of (dwt.wasm/render-thumbnail file-id page-id (:id root))
+                         (dwt.wasm/persist-thumbnail file-id page-id (:id root)))
+                  (rx/empty)))))))))))
 
 (defn add-component
   "Add a new component to current file library, from the currently selected shapes.

--- a/frontend/src/app/main/data/workspace/thumbnails_wasm.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails_wasm.cljs
@@ -15,11 +15,15 @@
    - persist-thumbnail: pushes current data-uri to the server (debounced)"
   (:require
    [app.common.data.macros :as dm]
+   [app.common.files.helpers :as cfh]
    [app.common.logging :as l]
+   [app.common.math :as mth]
    [app.common.thumbnails :as thc]
    [app.common.time :as ct]
+   [app.main.data.helpers :as dsh]
    [app.main.data.workspace.thumbnails :as dwt]
    [app.main.repo :as rp]
+   [app.main.store :as st]
    [app.render-wasm.api :as wasm.api]
    [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
@@ -41,27 +45,38 @@
              (fn [e] (reject e)))
        (.readAsDataURL reader blob)))))
 
+;; This constant stores the target thumbnail minimum max-size so
+;; the images doesn't lose quality when rendered
+(def target-size 200)
+
 (defn- render-component-pixels
   "Renders a component frame using the workspace WASM context.
    Returns an observable that emits a data-uri string.
    Deferred by one animation frame so that process-shape-changes!
    has time to sync all child shapes to WASM memory first."
-  [frame-id]
+  [file-id page-id frame-id]
   (rx/create
    (fn [subs]
      (js/requestAnimationFrame
       (fn [_]
         (try
-          (let [png-bytes (wasm.api/render-shape-pixels frame-id 1)]
+          (let [objects (dsh/lookup-page-objects @st/state file-id page-id)
+                frame (get objects frame-id)
+                {:keys [width height]} (:selrect frame)
+                max-size (mth/max width height)
+                scale (mth/max 1 (/ target-size max-size))
+                png-bytes (wasm.api/render-shape-pixels frame-id scale)]
             (if (or (nil? png-bytes) (zero? (.-length png-bytes)))
-              (do (js/console.error "[thumbnails] render-shape-pixels returned empty for" (str frame-id))
-                  (rx/end! subs))
-              (.then (png-bytes->data-uri png-bytes)
-                     (fn [data-uri]
-                       (rx/push! subs data-uri)
-                       (rx/end! subs))
-                     (fn [err]
-                       (rx/error! subs err)))))
+              (do
+                (js/console.error "[thumbnails] render-shape-pixels returned empty for" (str frame-id))
+                (rx/end! subs))
+              (.then
+               (png-bytes->data-uri png-bytes)
+               (fn [data-uri]
+                 (rx/push! subs data-uri)
+                 (rx/end! subs))
+               (fn [err]
+                 (rx/error! subs err)))))
           (catch :default err
             (rx/error! subs err)))))
      nil)))
@@ -71,29 +86,57 @@
    Does NOT persist to the server — persistence is handled separately
    by `persist-thumbnail` on a debounced schedule."
   [file-id page-id frame-id]
+
   (let [object-id (thc/fmt-object-id file-id page-id frame-id "component")]
     (ptk/reify ::render-thumbnail
       cljs.core/IDeref
       (-deref [_] object-id)
 
       ptk/WatchEvent
-      (watch [_ _ stream]
-        (let [tp (ct/tpoint-ms)]
-          (->> (render-component-pixels frame-id)
-               (rx/map
-                (fn [data-uri]
-                  (l/dbg :hint "component thumbnail rendered (wasm)"
-                         :elapsed (dm/str (tp) "ms"))
-                  (dwt/assoc-thumbnail object-id data-uri)))
+      (watch [_ state stream]
+        ;; When the component is removed it can arrived a render
+        ;; request with frame-id=null
+        (when (some? frame-id)
+          (letfn [(load-objects-stream
+                    []
+                    (rx/create
+                     (fn [subs]
+                       (let [objects (dsh/lookup-page-objects state file-id page-id)
 
-               (rx/catch (fn [err]
-                           (js/console.error "[thumbnails] error rendering component thumbnail" err)
-                           (rx/empty)))
+                             ;; retrieves a subtree with only the id and its children
+                             ;; to be loaded before rendering the thumbnail
+                             subtree
+                             (into {}
+                                   (map #(vector (:id %) %))
+                                   (cfh/get-children-with-self objects frame-id))]
+                         (try
+                           (wasm.api/set-objects subtree #(rx/push! subs %))
+                           (catch :default err
+                             (rx/error! subs err)))))))
 
-               (rx/take-until
-                (->> stream
-                     (rx/filter (ptk/type? ::dwt/clear-thumbnail))
-                     (rx/filter #(= (deref %) object-id))))))))))
+                  (do-render-thumbnail
+                    []
+                    (let [tp (ct/tpoint-ms)]
+                      (->> (render-component-pixels file-id page-id frame-id)
+                           (rx/map
+                            (fn [data-uri]
+                              (l/dbg :hint "component thumbnail rendered (wasm)"
+                                     :elapsed (dm/str (tp) "ms"))
+                              (dwt/assoc-thumbnail object-id data-uri)))
+
+                           (rx/catch (fn [err]
+                                       (js/console.error "[thumbnails] error rendering component thumbnail" err)
+                                       (rx/empty)))
+
+                           (rx/take-until
+                            (->> stream
+                                 (rx/filter (ptk/type? ::dwt/clear-thumbnail))
+                                 (rx/filter #(= (deref %) object-id)))))))]
+
+            (if (not= page-id (:current-page-id state))
+              (->> (load-objects-stream)
+                   (rx/mapcat do-render-thumbnail))
+              (do-render-thumbnail))))))))
 
 (defn persist-thumbnail
   "Persists the current component thumbnail data-uri to the server.

--- a/frontend/src/app/main/data/workspace/thumbnails_wasm.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails_wasm.cljs
@@ -47,7 +47,7 @@
 
 ;; This constant stores the target thumbnail minimum max-size so
 ;; the images doesn't lose quality when rendered
-(def target-size 200)
+(def ^:private ^:const target-size 200)
 
 (defn- render-component-pixels
   "Renders a component frame using the workspace WASM context.
@@ -57,29 +57,30 @@
   [file-id page-id frame-id]
   (rx/create
    (fn [subs]
-     (js/requestAnimationFrame
-      (fn [_]
-        (try
-          (let [objects (dsh/lookup-page-objects @st/state file-id page-id)
-                frame (get objects frame-id)
-                {:keys [width height]} (:selrect frame)
-                max-size (mth/max width height)
-                scale (mth/max 1 (/ target-size max-size))
-                png-bytes (wasm.api/render-shape-pixels frame-id scale)]
-            (if (or (nil? png-bytes) (zero? (.-length png-bytes)))
-              (do
-                (js/console.error "[thumbnails] render-shape-pixels returned empty for" (str frame-id))
-                (rx/end! subs))
-              (.then
-               (png-bytes->data-uri png-bytes)
-               (fn [data-uri]
-                 (rx/push! subs data-uri)
-                 (rx/end! subs))
-               (fn [err]
-                 (rx/error! subs err)))))
-          (catch :default err
-            (rx/error! subs err)))))
-     nil)))
+     (let [req-id
+           (js/requestAnimationFrame
+            (fn [_]
+              (try
+                (let [objects (dsh/lookup-page-objects @st/state file-id page-id)
+                      frame (get objects frame-id)
+                      {:keys [width height]} (:selrect frame)
+                      max-size (mth/max width height)
+                      scale (mth/max 1 (/ target-size max-size))
+                      png-bytes (wasm.api/render-shape-pixels frame-id scale)]
+                  (if (or (nil? png-bytes) (zero? (.-length png-bytes)))
+                    (do
+                      (l/error :hint "render-shape-pixels returned empty" :frame-id (str frame-id))
+                      (rx/end! subs))
+                    (.then
+                     (png-bytes->data-uri png-bytes)
+                     (fn [data-uri]
+                       (rx/push! subs data-uri)
+                       (rx/end! subs))
+                     (fn [err]
+                       (rx/error! subs err)))))
+                (catch :default err
+                  (rx/error! subs err)))))]
+       #(js/cancelAnimationFrame req-id)))))
 
 (defn render-thumbnail
   "Renders a component thumbnail via WASM and updates the UI immediately.
@@ -125,7 +126,8 @@
                               (dwt/assoc-thumbnail object-id data-uri)))
 
                            (rx/catch (fn [err]
-                                       (js/console.error "[thumbnails] error rendering component thumbnail" err)
+                                       (js/console.error err)
+                                       (l/error :hint "error rendering component thumbnail" :frame-id (str frame-id))
                                        (rx/empty)))
 
                            (rx/take-until

--- a/frontend/src/app/render_wasm/helpers.cljc
+++ b/frontend/src/app/render_wasm/helpers.cljc
@@ -24,7 +24,6 @@
         cause-sym (gensym "cause")]
     `(let [~fn-sym (cljs.core/unchecked-get ~module ~name)]
        (try
-         ;; (prn ~name ~@params)
          (~fn-sym ~@params)
          (catch :default ~cause-sym
            (let [read-code-fn# (cljs.core/unchecked-get ~module "_read_error_code")

--- a/frontend/src/app/render_wasm/helpers.cljc
+++ b/frontend/src/app/render_wasm/helpers.cljc
@@ -24,6 +24,7 @@
         cause-sym (gensym "cause")]
     `(let [~fn-sym (cljs.core/unchecked-get ~module ~name)]
        (try
+         ;; (prn ~name ~@params)
          (~fn-sym ~@params)
          (catch :default ~cause-sym
            (let [read-code-fn# (cljs.core/unchecked-get ~module "_read_error_code")


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13926

### Summary

- Fixes problem with thumbnail quality being low when component was small
- Fixes problem when changing a component from a different page than the one opened
- Fixes issue with the thumbnail not being rendered on creation

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
