### PR TITLE
:sparkles: Show professional card when has nitrate subscription

### DIFF
--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -416,7 +416,7 @@
         (-> profile :props :subscription)
 
         subscription-type
-        (get-subscription-type subscription)
+        (if (and (contains? cf/flags :nitrate) nitrate?) (:type nitrate-license) (get-subscription-type subscription))
 
         subscription-is-trial?
         (= (:status subscription) "trialing")


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26250
The Professional card wasn't visible when the user had a Nitrate subscription. We made it visible to allow the user to subscribe to the Professional plan.

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
