### PR TITLE
:sparkles: Add subscribe-nitrate route with post-registration nitrate modal

### DIFF
--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -10,9 +10,35 @@
    [app.main.repo :as rp]
    [app.main.router :as rt]
    [app.main.store :as st]
-   [app.util.i18n :as i18n :refer [tr]]
+   [app.util.i18n :refer [tr]]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
+
+(def ^:private nitrate-entry-active-key ::nitrate-entry-active)
+(def ^:private nitrate-entry-pending-popup-key ::nitrate-entry-pending-popup)
+
+(defn activate-nitrate-entry-popup!
+  []
+  (binding [storage/*sync* true]
+    (swap! storage/storage assoc
+           nitrate-entry-active-key true
+           nitrate-entry-pending-popup-key true)))
+
+(defn nitrate-entry-active?
+  []
+  (true? (get storage/storage nitrate-entry-active-key)))
+
+(defn nitrate-entry-popup-pending?
+  []
+  (true? (get storage/storage nitrate-entry-pending-popup-key)))
+
+(defn consume-nitrate-entry-popup!
+  []
+  (binding [storage/*sync* true]
+    (swap! storage/storage dissoc
+           nitrate-entry-active-key
+           nitrate-entry-pending-popup-key)))
 
 (defn show-nitrate-popup
   [popup-type]

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -10,6 +10,7 @@
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.common :as dcm]
+   [app.main.data.nitrate :as dnt]
    [app.main.data.team :as dtm]
    [app.main.errors :as errors]
    [app.main.refs :as refs]
@@ -23,6 +24,7 @@
    [app.main.ui.error-boundary :refer [error-boundary*]]
    [app.main.ui.exports.files]
    [app.main.ui.frame-preview :as frame-preview]
+   [app.main.ui.nitrate.entry :as nitrate-entry]
    [app.main.ui.notifications :as notifications]
    [app.main.ui.onboarding.questions :refer [questions-modal]]
    [app.main.ui.onboarding.team-choice :refer [onboarding-team-modal]]
@@ -152,21 +154,25 @@
         props   (get profile :props)
         section (get data :name)
         team    (mf/deref refs/team)
+        nitrate-entry-active? (dnt/nitrate-entry-active?)
 
 
         show-question-modal?
         (and (contains? cf/flags :onboarding)
+             (not nitrate-entry-active?)
              (not (:onboarding-viewed props))
              (not (contains? props :onboarding-questions)))
 
         show-team-modal?
         (and (contains? cf/flags :onboarding)
+             (not nitrate-entry-active?)
              (not (:onboarding-viewed props))
              (not (contains? props :onboarding-team-id))
              (:is-default team))
 
         show-release-modal?
         (and (contains? cf/flags :onboarding)
+             (not nitrate-entry-active?)
              (not (contains? cf/flags :hide-release-modal))
              (:onboarding-viewed props)
              (not= (:release-notes-viewed props) (:main cf/version))
@@ -184,6 +190,9 @@
 
        :auth-verify-token
        [:? [:& verify-token-page* {:route route}]]
+
+       :nitrate-entry
+       [:> nitrate-entry/nitrate-entry-page* {:profile profile}]
 
        (:settings-profile
         :settings-password

--- a/frontend/src/app/main/ui/auth/register.cljs
+++ b/frontend/src/app/main/ui/auth/register.cljs
@@ -221,6 +221,7 @@
                      :class (stl/css :demo-account-link)}
          (tr "auth.create-demo-account")]]])]])
 
+
 ;; --- PAGE: register success page
 
 (mf/defc register-success-page*

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -13,6 +13,7 @@
    [app.main.data.dashboard.shortcuts :as sc]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
+   [app.main.data.nitrate :as dnt]
    [app.main.data.notifications :as notif]
    [app.main.data.plugins :as dp]
    [app.main.data.project :as dpj]
@@ -262,6 +263,13 @@
         (binding [storage/*sync* true]
           (swap! storage/session dissoc :template))))))
 
+(defn- use-nitrate-entry-popup
+  []
+  (mf/with-effect []
+    (when (dnt/nitrate-entry-popup-pending?)
+      (dnt/consume-nitrate-entry-popup!)
+      (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
+
 (mf/defc dashboard*
   [{:keys [profile project-id team-id search-term plugin-url template section]}]
   (let [team            (mf/deref refs/team)
@@ -300,6 +308,7 @@
 
     (use-plugin-register plugin-url team-id (:id default-project))
     (use-templates-import can-edit? template default-project)
+    (use-nitrate-entry-popup)
 
     [:& (mf/provider ctx/current-project-id) {:value project-id}
      [:> modal-container*]

--- a/frontend/src/app/main/ui/nitrate/entry.cljs
+++ b/frontend/src/app/main/ui/nitrate/entry.cljs
@@ -1,0 +1,31 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.main.ui.nitrate.entry
+  (:require
+   [app.main.data.auth :as da]
+   [app.main.data.nitrate :as dnt]
+   [app.main.router :as rt]
+   [app.main.store :as st]
+   [app.main.ui.ds.product.loader :refer [loader*]]
+   [app.util.i18n :refer [tr]]
+   [rumext.v2 :as mf]))
+
+(mf/defc nitrate-entry*
+  {::mf/private true}
+  [{:keys [profile]}]
+  (mf/with-effect [profile]
+    (dnt/activate-nitrate-entry-popup!)
+    (if (da/is-authenticated? profile)
+      (st/emit! (rt/nav :dashboard-recent {:team-id (:default-team-id profile)}))
+      (st/emit! (rt/nav :auth-register))))
+
+  [:> loader* {:title (tr "labels.loading")
+               :overlay true}])
+
+(mf/defc nitrate-entry-page*
+  [props]
+  [:> nitrate-entry* props])

--- a/frontend/src/app/main/ui/routes.cljs
+++ b/frontend/src/app/main/ui/routes.cljs
@@ -30,6 +30,9 @@
     ["/recovery"          :auth-recovery]
     ["/verify-token"      :auth-verify-token]]
 
+   (when (contains? cf/flags :nitrate)
+     ["/subscribe-nitrate" :nitrate-entry])
+
    ["/settings"
     ["/profile"       :settings-profile]
     ["/password"      :settings-password]


### PR DESCRIPTION


### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/us/12265?milestone=511529

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
