### PR TITLE
:bug: Fix text editor v1 focus not being handled correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 - Fix hover on layers [Taiga #13799](https://tree.taiga.io/project/penpot/issue/13799)
 - Fix highlight after name edition [Taiga #13783](https://tree.taiga.io/project/penpot/issue/13783)
 - Fix id prop on switch component [Taiga #13534](https://tree.taiga.io/project/penpot/issue/13534)
-
+- Fix text editor v1 focus [Taiga #13961](https://tree.taiga.io/project/penpot/issue/13961)
 
 ## 2.14.2
 

--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -85,7 +85,13 @@
     (effect [_ state _]
       (let [editor (:workspace-editor state)
             element (when editor (.-element editor))]
-        (when (and element (.-focus element))
+        (cond
+          ;; V1 (DraftEditor)
+          (.-focus editor)
+          (ts/schedule #(.focus ^js editor))
+
+          ;; V2
+          (and element (.-focus element))
           (ts/schedule #(.focus ^js element)))))))
 
 (defn gen-name


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #13961](https://tree.taiga.io/project/penpot/issue/13961)

### Summary

When creating a text layer as a fixed-size text box (dragging to define a rectangle), the layer enters text edit mode as expected. While in edit mode, clicking inside the text layer bounding box but not directly on any text character exits edit mode.

This is unexpected: clicking inside the text box bounds should keep the layer in edit mode (or place the caret), not exit editing.

### Steps to reproduce 

Select the text tool.
Create a text layer by dragging to define width and height (fixed-size text box).
Enter text edit mode (caret visible).
Click inside the bounding box area but not on a text character (e.g. empty space within the box).

#### Current result

The text layer exits edit mode.

#### Expected result

The text layer remains in edit mode and the caret is placed at the clicked position (or the nearest valid caret position).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
