### PR TITLE
:bug: Fix initializing guards in viewport loading

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -376,7 +376,7 @@
               (wasm.api/request-render "content"))))))
 
     (mf/with-effect [vport]
-      (when @canvas-init?
+      (when (and @canvas-init? @initialized?)
         (wasm.api/resize-viewbox (:width vport) (:height vport))))
 
     (mf/with-effect [@canvas-init? preview-blend]
@@ -403,11 +403,11 @@
                     (wasm.api/set-focus-mode focus)))))
 
     (mf/with-effect [vbox zoom]
-      (when (and @canvas-init? initialized?)
+      (when (and @canvas-init? @initialized?)
         (wasm.api/set-view-box zoom vbox)))
 
     (mf/with-effect [background]
-      (when (and @canvas-init? initialized?)
+      (when (and @canvas-init? @initialized?)
         (wasm.api/set-canvas-background background)))
 
     (mf/with-effect [@canvas-init? hover-grid? @hover-top-frame-id]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13949

### Summary

Prevents calling `resize_viewbox` wasm function when the viewport has not been fully loaded yet.

This PR also fixes some other guards not checking the actual value of the `@initialized` but just that the atom existed (i.e. `initialized`).

### Steps to reproduce 

See Taiga ticket (I have not been able to reproduce it with the STR provided, though)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
