### PR TITLE
:bug: Reset account submenu state when profile menu closes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 
 ### :bug: Bugs fixed
 
+- Reset profile submenu state when the account menu closes (by @eureka928) [Github #8947](https://github.com/penpot/penpot/issues/8947)
 - Add export panel to inspect styles tab [Taiga #13582](https://tree.taiga.io/project/penpot/issue/13582)
 - Fix styles between grid layout inputs [Taiga #13526](https://tree.taiga.io/project/penpot/issue/13526)
 - Fix id prop on switch component [Taiga #13534](https://tree.taiga.io/project/penpot/issue/13534)

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -1323,6 +1323,10 @@
            (st/emit! (ptk/event ::ev/event {::ev/name "explore-pricing-click" ::ev/origin "dashboard" :section "sidebar"}))
            (dom/open-new-window "https://penpot.app/pricing")))]
 
+    (mf/with-effect [show-profile-menu?]
+      (when-not show-profile-menu?
+        (reset! sub-menu* nil)))
+
     [:*
      (if (contains? cf/flags :nitrate)
        [:> nitrate-sidebar* {:profile profile :teams teams}]


### PR DESCRIPTION
## Summary
Fixes a dashboard bug where the previously-opened account submenu (Help & Learning, Community Contributions, or About Penpot) was still visible when the user reopened the profile/avatar menu, instead of resetting to the top level.

Closes #8947

## Root cause
`profile-section*` in `frontend/src/app/main/ui/dashboard/sidebar.cljs` has two independent states:
- `show-profile-menu*` — main dropdown visibility
- `sub-menu*` — which submenu is currently expanded

All close paths (`on-close`, item `on-click`, `handle-click` toggle) only reset `show-profile-menu*`. `sub-menu*` persisted across open/close cycles, so the previously expanded submenu rendered immediately on reopen.

## Fix
A single `mf/with-effect [show-profile-menu?]` that resets `sub-menu*` to `nil` whenever the main menu closes. Covers every close path uniformly without touching individual handlers.

## Test plan
- [ ] On the dashboard, click the avatar/profile name
- [ ] Hover **Help & Learning** → verify the submenu opens
- [ ] Click outside the menu → menu closes
- [ ] Click the avatar again → verify the main menu opens at the top level (no submenu visible)
- [ ] Repeat with **Community Contributions** and **About Penpot**
- [ ] Verify toggling the menu open/closed by re-clicking the avatar also resets
- [ ] Verify clicking a direct menu item (e.g. "Your Account", "Logout") still works