### PR TITLE
:bug: Fix move-files allowing same project as target when multiple files selected

### DIFF
--- a/frontend/src/app/main/ui/dashboard/file_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/file_menu.cljs
@@ -78,7 +78,8 @@
 
         current-team     (get teams current-team-id)
         other-teams      (remove #(= (:id %) current-team-id) (vals teams))
-        current-projects (remove #(= (:id %) (:project-id file))
+        file-project-ids (into #{} (map :project-id) files)
+        current-projects (remove #(contains? file-project-ids (:id %))
                                  (:projects current-team))
 
         on-new-tab


### PR DESCRIPTION
### Summary

The 'Move to' menu in the dashboard file context menu only filtered out the first selected file's project from the available target list. When multiple files from different projects were selected, the other files' projects still appeared as valid targets, causing a 400 'cant-move-to-same-project' backend error.

Now all selected files' project IDs are collected and excluded from the available target projects.

