### PR TITLE
:tada: Add get-org-member-team-counts endpoint to Nitrate API

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -296,6 +296,48 @@ RETURNING id, name;")
     (profile-to-map profile)))
 
 
+;; ---- API: get-org-member-team-counts
+
+(def ^:private sql:get-org-member-team-counts
+  "SELECT tpr.profile_id, COUNT(DISTINCT t.id) AS team_count
+     FROM team_profile_rel AS tpr
+     JOIN team AS t ON t.id = tpr.team_id
+    WHERE t.id = ANY(?)
+      AND t.deleted_at IS NULL
+      AND t.is_default IS FALSE
+    GROUP BY tpr.profile_id;")
+
+(def ^:private schema:get-org-member-team-counts-params
+  [:map [:team-ids [:or ::sm/uuid [:vector ::sm/uuid]]]])
+
+(def ^:private schema:get-org-member-team-counts-result
+  [:vector [:map
+            [:profile-id ::sm/uuid]
+            [:team-count ::sm/int]]])
+
+(sv/defmethod ::get-org-member-team-counts
+  "Get the number of non-default teams each profile belongs to within a set of teams."
+  {::doc/added "2.15"
+   ::sm/params schema:get-org-member-team-counts-params
+   ::sm/result schema:get-org-member-team-counts-result
+   ::rpc/auth false}
+  [cfg {:keys [team-ids]}]
+  (let [team-ids (cond
+                   (uuid? team-ids)
+                   [team-ids]
+
+                   (and (vector? team-ids) (every? uuid? team-ids))
+                   team-ids
+
+                   :else
+                   [])]
+    (if (empty? team-ids)
+      []
+      (db/run! cfg (fn [{:keys [::db/conn]}]
+                     (let [ids-array (db/create-array conn "uuid" team-ids)]
+                       (db/exec! conn [sql:get-org-member-team-counts ids-array])))))))
+
+
 ;; API: invite-to-org
 
 (sv/defmethod ::invite-to-org


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/us/13440?milestone=511529

### Summary

Add new RPC endpoint that returns the number of non-default teams each
profile belongs to, given a list of team IDs. The caller (Nitrate) is
responsible for providing the team IDs since Penpot does not store the
team-organization relationship.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
