### PR TITLE
:books: Clarify version 2 requirement for relative plugin asset paths

### DIFF
--- a/docs/plugins/create-a-plugin.md
+++ b/docs/plugins/create-a-plugin.md
@@ -219,8 +219,9 @@ Now that everything is in place you need a <code class="language-js">manifest.js
 {
   "name": "Plugin name",
   "description": "Plugin description",
-  "code": "/plugin.js",
-  "icon": "/icon.png",
+  "version": 2,
+  "code": "plugin.js",
+  "icon": "icon.png",
   "permissions": [
     "content:read",
     "content:write",
@@ -233,6 +234,13 @@ Now that everything is in place you need a <code class="language-js">manifest.js
   ]
 }
 ```
+
+<p class="advice">
+Use <code class="language-js">"version": 2</code> when your
+<code class="language-js">code</code> and <code class="language-js">icon</code> values
+are relative paths. Version 2 resolves these assets from the manifest location.
+If omitted, Penpot treats the manifest as version 1.
+</p>
 
 ### Icon
 

--- a/docs/plugins/getting-started.md
+++ b/docs/plugins/getting-started.md
@@ -131,6 +131,7 @@ The <code class="language-js">manifest.json</code> file contains the basic infor
 {
   "name": "Your plugin name",
   "description": "Your plugin description",
+  "version": 2,
   "code": "plugin.js",
   "icon": "Your icon",
   "permissions": [
@@ -146,6 +147,12 @@ The <code class="language-js">manifest.json</code> file contains the basic infor
   ]
 }
 ```
+
+<p class="advice">
+Set <code class="language-js">"version": 2</code> in your
+<code class="language-js">manifest.json</code> if you use relative paths for
+<code class="language-js">code</code> or <code class="language-js">icon</code>.
+</p>
 
 #### Properties
 


### PR DESCRIPTION
### Related Ticket

Closes #8713

### Summary
- Update plugin documentation examples to include `"version": 2`.
- Add explicit guidance that relative `code` and `icon` paths are resolved from the manifest location when using manifest version 2.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

