### PR TITLE
:bug: Show check icon after copying team invitation link

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -34,6 +34,7 @@
    [app.main.ui.notifications.context-notification :refer [context-notification]]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
+   [app.util.timers :as tm]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
@@ -606,7 +607,10 @@
   {::mf/props :obj
    ::mf/private true}
   [{:keys [invitation team-id]}]
-  (let [email   (:email invitation)
+  (let [email    (:email invitation)
+        copied*  (mf/use-state false)
+        copied?  (deref copied*)
+
         on-error
         (mf/use-fn
          (mf/deps email)
@@ -632,6 +636,8 @@
         on-copy-success
         (mf/use-fn
          (fn []
+           (reset! copied* true)
+           (tm/schedule 1000 #(reset! copied* false))
            (st/emit! (ntf/success (tr "notifications.invitation-link-copied"))
                      (modal/hide))))
 
@@ -649,7 +655,7 @@
     [:> icon-button* {:variant "ghost"
                       :aria-label (tr "labels.copy-invitation-link")
                       :on-click on-copy
-                      :icon "clipboard"}]))
+                      :icon (if copied? "tick" "clipboard")}]))
 
 (mf/defc invitation-row*
   {::mf/wrap [mf/memo]


### PR DESCRIPTION
### Related Ticket

Closes #8966

### Summary

In Team management -> Invitations, the copy-link button performed the copy but never switched its icon, so the only confirmation was the transient toast. Users frequently missed it and weren't sure the copy actually happened.

The button now swaps the clipboard icon for a check (tick) immediately on a successful copy and reverts back to the clipboard after ~1 second, matching the pattern already used by `copy-button*` elsewhere in the app. The swap only happens on success, so error paths (muted profile, bounced email, etc.) keep the original icon and don't show a misleading confirmation.

### Steps to reproduce

1. Create a new team (or open one where invitations can be sent).
2. Go to **Team settings -> Invitations** and invite a member.
3. On the resulting invitation row, click the clipboard icon button.
4. Before the fix: icon stays as the clipboard; only the toast appears.
5. After the fix: icon switches to a check immediately, reverts to clipboard after ~1s, and clicking again re-triggers the feedback cleanly.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide. (no SCSS touched)
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.