### PR TITLE
:bug: Add several bugfixes for app.common.geom namespace

### DIFF
--- a/common/src/app/common/geom/bounds_map.cljc
+++ b/common/src/app/common/geom/bounds_map.cljc
@@ -79,10 +79,10 @@
              (loop [new-ids
                     (->> (cfh/get-parent-seq objects cid)
                          (take-while #(and (cfh/group-like-shape? %)
-                                           (not (.has ids %))))
+                                           (not (.has ids (:id %)))))
                          (seq))]
                (when (some? new-ids)
-                 (.add ids (first new-ids))
+                 (.add ids (:id (first new-ids)))
                  (recur (next new-ids))))
              (recur (next base-ids)))))
        ids)))

--- a/common/src/app/common/geom/matrix.cljc
+++ b/common/src/app/common/geom/matrix.cljc
@@ -101,7 +101,7 @@
             (dm/get-prop o :c) ","
             (dm/get-prop o :d) ","
             (dm/get-prop o :e) ","
-            (dm/get-prop o :f) ",")
+            (dm/get-prop o :f))
     o))
 
 (defn- matrix->json
@@ -358,8 +358,6 @@
          (th-eq m1d m2d)
          (th-eq m1e m2e)
          (th-eq m1f m2f))))
-
-(defmethod pp/simple-dispatch Matrix [obj] (pr obj))
 
 (defn transform-in [pt mtx]
   (if (and (some? pt) (some? mtx))

--- a/common/src/app/common/geom/point.cljc
+++ b/common/src/app/common/geom/point.cljc
@@ -151,7 +151,7 @@
                  (dm/get-prop p2 :y))))
 
 (defn multiply
-  "Returns the subtraction of the supplied value to both
+  "Returns the multiplication of the supplied value to both
   coordinates of the point as a new point."
   [p1 p2]
   (assert (and (point? p1)
@@ -509,12 +509,10 @@
   (let [old-length (length vector)]
     (scale vector (/ new-length old-length))))
 
-;; FIXME: perfromance
 (defn abs
   [point]
-  (-> point
-      (update :x mth/abs)
-      (update :y mth/abs)))
+  (pos->Point (mth/abs (dm/get-prop point :x))
+              (mth/abs (dm/get-prop point :y))))
 
 ;; --- Debug
 

--- a/common/src/app/common/geom/rect.cljc
+++ b/common/src/app/common/geom/rect.cljc
@@ -119,12 +119,14 @@
 (defn update-rect
   [rect type]
   (case type
-    :size
+    (:size :position)
     (let [x (dm/get-prop rect :x)
           y (dm/get-prop rect :y)
           w (dm/get-prop rect :width)
           h (dm/get-prop rect :height)]
       (assoc rect
+             :x1 x
+             :y1 y
              :x2 (+ x w)
              :y2 (+ y h)))
 
@@ -137,19 +139,7 @@
              :x (mth/min x1 x2)
              :y (mth/min y1 y2)
              :width (mth/abs (- x2 x1))
-             :height (mth/abs (- y2 y1))))
-
-    ;; FIXME: looks unused
-    :position
-    (let [x (dm/get-prop rect :x)
-          y (dm/get-prop rect :y)
-          w (dm/get-prop rect :width)
-          h (dm/get-prop rect :height)]
-      (assoc rect
-             :x1 x
-             :y1 y
-             :x2 (+ x w)
-             :y2 (+ y h)))))
+             :height (mth/abs (- y2 y1))))))
 
 (defn update-rect!
   [rect type]
@@ -382,8 +372,8 @@
   ([xp1 yp1 xp2 yp2]
    (make-rect (mth/min xp1 xp2)
               (mth/min yp1 yp2)
-              (abs (- xp1 xp2))
-              (abs (- yp1 yp2)))))
+              (mth/abs (- xp1 xp2))
+              (mth/abs (- yp1 yp2)))))
 
 (defn clip-rect
   [selrect bounds]

--- a/common/src/app/common/geom/shapes/constraints.cljc
+++ b/common/src/app/common/geom/shapes/constraints.cljc
@@ -234,7 +234,7 @@
         after-side-vector (side-vector axis parent-points-after)]
     (ctm/move-modifiers (displacement center-before center-after before-side-vector after-side-vector))))
 
-(defmethod constraint-modifier :default [_ _ _ _ _]
+(defmethod constraint-modifier :default [_ _ _ _ _ _]
   [])
 
 (def const->type+axis

--- a/common/src/app/common/geom/shapes/flex_layout/drop_area.cljc
+++ b/common/src/app/common/geom/shapes/flex_layout/drop_area.cljc
@@ -81,7 +81,7 @@
         h-center? (and row? (ctl/h-center? frame))
         h-end?    (and row? (ctl/h-end? frame))
         v-center? (and col? (ctl/v-center? frame))
-        v-end?    (and row? (ctl/v-end? frame))
+        v-end?    (and col? (ctl/v-end? frame))
 
         center (gco/shape->center frame)
         start-p (gmt/transform-point-center start-p center transform-inverse)

--- a/common/src/app/common/geom/shapes/flex_layout/layout_data.cljc
+++ b/common/src/app/common/geom/shapes/flex_layout/layout_data.cljc
@@ -369,9 +369,6 @@
         (cond (and col? space-evenly?)
               0
 
-              (and col? space-evenly? auto-height?)
-              0
-
               (and col? space-around?)
               (/ (max layout-gap-row (/ (- height line-height) num-children)) 2)
 

--- a/common/src/app/common/geom/shapes/flex_layout/positions.cljc
+++ b/common/src/app/common/geom/shapes/flex_layout/positions.cljc
@@ -61,7 +61,7 @@
         (gpt/add (hv free-width-gap))
 
         around?
-        (gpt/add (hv (max lines-gap-col (/ free-width num-lines) 2)))
+        (gpt/add (hv (max lines-gap-col (/ free-width num-lines 2))))
 
         evenly?
         (gpt/add (hv (max lines-gap-col (/ free-width (inc num-lines)))))))))

--- a/common/src/app/common/geom/shapes/grid_layout/layout_data.cljc
+++ b/common/src/app/common/geom/shapes/grid_layout/layout_data.cljc
@@ -331,7 +331,7 @@
         ;; Apply the allocations to the tracks
         track-list
         (into []
-              (map-indexed #(update %2 :size max (get allocated %1)))
+              (map-indexed #(update %2 :size max (get allocated %1 0)))
               track-list)]
     track-list))
 
@@ -381,7 +381,7 @@
         ;; Apply the allocations to the tracks
         track-list
         (into []
-              (map-indexed #(update %2 :size max (get allocate-fr-tracks %1)))
+              (map-indexed #(update %2 :size max (get allocate-fr-tracks %1 0)))
               track-list)]
     track-list))
 
@@ -474,8 +474,8 @@
          min-column-fr     (min-fr-value column-tracks)
          min-row-fr        (min-fr-value row-tracks)
 
-         column-fr         (if auto-width? min-column-fr (mth/finite (/ fr-column-space column-frs) 0))
-         row-fr            (if auto-height? min-row-fr (mth/finite (/ fr-row-space row-frs) 0))
+         column-fr         (if auto-width? min-column-fr (if (zero? column-frs) 0 (mth/finite (/ fr-column-space column-frs) 0)))
+         row-fr            (if auto-height? min-row-fr (if (zero? row-frs) 0 (mth/finite (/ fr-row-space row-frs) 0)))
 
          column-tracks     (set-fr-value column-tracks column-fr auto-width?)
          row-tracks        (set-fr-value row-tracks row-fr auto-height?)
@@ -489,8 +489,8 @@
          column-autos      (tracks-total-autos column-tracks)
          row-autos         (tracks-total-autos row-tracks)
 
-         column-add-auto   (/ auto-column-space column-autos)
-         row-add-auto      (/ auto-row-space row-autos)
+         column-add-auto   (if (zero? column-autos) 0 (/ auto-column-space column-autos))
+         row-add-auto      (if (zero? row-autos) 0 (/ auto-row-space row-autos))
 
          column-tracks (cond-> column-tracks
                          (= :stretch (:layout-justify-content parent))
@@ -505,36 +505,38 @@
 
          num-columns (count column-tracks)
          column-gap
-         (case (:layout-justify-content parent)
+         (cond
            auto-width?
            column-gap
 
-           :space-evenly
+           (= :space-evenly (:layout-justify-content parent))
            (max column-gap (/ (- bound-width column-total-size) (inc num-columns)))
 
-           :space-around
+           (= :space-around (:layout-justify-content parent))
            (max column-gap (/ (- bound-width column-total-size) num-columns))
 
-           :space-between
+           (= :space-between (:layout-justify-content parent))
            (max column-gap (if (= num-columns 1) column-gap (/ (- bound-width column-total-size) (dec num-columns))))
 
+           :else
            column-gap)
 
          num-rows (count row-tracks)
          row-gap
-         (case (:layout-align-content parent)
+         (cond
            auto-height?
            row-gap
 
-           :space-evenly
+           (= :space-evenly (:layout-align-content parent))
            (max row-gap (/ (- bound-height row-total-size) (inc num-rows)))
 
-           :space-around
+           (= :space-around (:layout-align-content parent))
            (max row-gap (/ (- bound-height row-total-size) num-rows))
 
-           :space-between
+           (= :space-between (:layout-align-content parent))
            (max row-gap (if (= num-rows 1) row-gap (/ (- bound-height row-total-size) (dec num-rows))))
 
+           :else
            row-gap)
 
          start-p

--- a/common/src/app/common/geom/shapes/intersect.cljc
+++ b/common/src/app/common/geom/shapes/intersect.cljc
@@ -55,16 +55,16 @@
      (and (not= o1 o2) (not= o3 o4))
 
      ;; p1, q1 and p2 colinear and p2 lies on p1q1
-     (and (= o1 :coplanar) ^boolean (on-segment? p2 p1 q1))
+     (and (= o1 ::coplanar) ^boolean (on-segment? p2 p1 q1))
 
      ;; p1, q1 and q2 colinear and q2 lies on p1q1
-     (and (= o2 :coplanar) ^boolean (on-segment? q2 p1 q1))
+     (and (= o2 ::coplanar) ^boolean (on-segment? q2 p1 q1))
 
      ;; p2, q2 and p1 colinear and p1 lies on p2q2
-     (and (= o3 :coplanar) ^boolean (on-segment? p1 p2 q2))
+     (and (= o3 ::coplanar) ^boolean (on-segment? p1 p2 q2))
 
      ;; p2, q2 and p1 colinear and q1 lies on p2q2
-     (and (= o4 :coplanar) ^boolean (on-segment? q1 p2 q2)))))
+     (and (= o4 ::coplanar) ^boolean (on-segment? q1 p2 q2)))))
 
 (defn points->lines
   "Given a set of points for a polygon will return

--- a/common/src/app/common/geom/shapes/transforms.cljc
+++ b/common/src/app/common/geom/shapes/transforms.cljc
@@ -303,13 +303,13 @@
       (neg? dot-x)
       (update :flip-x not)
 
-      (neg? dot-x)
-      (update :rotation -)
-
       (neg? dot-y)
       (update :flip-y not)
 
-      (neg? dot-y)
+      ;; Negate rotation only when an odd number of axes are flipped,
+      ;; since flipping both axes is equivalent to a 180° rotation and
+      ;; two negations would cancel each other out.
+      (not= (neg? dot-x) (neg? dot-y))
       (update :rotation -))))
 
 (defn- apply-transform-move

--- a/common/test/common_tests/geom_flex_layout_test.cljc
+++ b/common/test/common_tests/geom_flex_layout_test.cljc
@@ -1,0 +1,106 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.geom-flex-layout-test
+  (:require
+   [app.common.geom.rect :as grc]
+   [app.common.geom.shapes.flex-layout.positions :as flp]
+   [app.common.math :as mth]
+   [app.common.types.shape :as cts]
+   [app.common.types.shape.layout :as ctl]
+   [clojure.test :as t]))
+
+;; ---- helpers ----
+
+(defn- make-col-frame
+  "Minimal col? flex frame with wrap enabled.
+  wrap is required for the content-around? predicate to activate."
+  [& {:as opts}]
+  (cts/setup-shape (merge {:type :frame
+                           :layout :flex
+                           :layout-flex-dir :column
+                           :layout-wrap-type :wrap
+                           :x 0 :y 0 :width 200 :height 200}
+                          opts)))
+
+(defn- rect->bounds
+  "Convert a rect to the 4-point layout-bounds vector expected by gpo/*."
+  [rect]
+  (grc/rect->points rect))
+
+;; ---- get-base-line (around? branch) ----
+;;
+;; Bug: in positions.cljc the col? + around? branch had a mis-parenthesised
+;; expression `(/ free-width num-lines) 2`, which was parsed as three
+;; arguments to `max`:
+;;   (max lines-gap-col (/ free-width num-lines) 2)
+;; instead of the intended two-argument max with a nested division:
+;;   (max lines-gap-col (/ free-width num-lines 2))
+;;
+;; For a col? layout the cross-axis is horizontal (hv), so the around? offset
+;; is applied as hv(delta) — i.e. the delta ends up in (:x base-p).
+
+(t/deftest get-base-line-around-uses-half-per-line-free-width
+  (t/testing "col? + content-around? offset is free-width / num-lines / 2"
+    ;; Layout: col? wrap, width=200, 3 lines each 20px wide → free-width=140
+    ;; lines-gap-col = 0 (no gap defined)
+    ;; Expected horizontal offset = max(0, 140/3/2) ≈ 23.33
+    ;; Before the bug fix the formula was (max ... (/ 140 3) 2) ≈ 46.67.
+    (let [frame  (make-col-frame :layout-align-content :space-around)
+          bounds (rect->bounds (grc/make-rect 0 0 200 200))
+          ;; 3 lines of 20px each (widths); no row gap
+          num-lines    3
+          total-width  60
+          total-height 0
+          base-p (flp/get-base-line frame bounds total-width total-height num-lines)
+          free-width (- 200 total-width)
+          ;; lines-gap-col = (dec 3) * 0 = 0; max(0, free-width/num-lines/2)
+          expected-x (/ free-width num-lines 2)]
+
+      ;; The base point x-coordinate (hv offset) should equal half per-line free space.
+      (t/is (mth/close? expected-x (:x base-p) 0.01))))
+
+  (t/testing "col? + content-around? offset respects lines-gap-col minimum"
+    ;; When the accumulated column gap exceeds the computed half-per-line value
+    ;; max(lines-gap-col, free-width/num-lines/2) returns the gap.
+    (let [frame  (make-col-frame :layout-align-content :space-around
+                                 :layout-gap {:column-gap 50 :row-gap 0})
+          bounds (rect->bounds (grc/make-rect 0 0 200 200))
+          ;; 4 lines × 20px = 80px used; free-width=120; half-per-line = 120/4/2 = 15
+          ;; lines-gap-col = (dec 4)*50 = 150 → max(150, 15) = 150
+          num-lines    4
+          total-width  80
+          total-height 0
+          base-p (flp/get-base-line frame bounds total-width total-height num-lines)
+          lines-gap-col (* (dec num-lines) 50)]
+
+      (t/is (mth/close? lines-gap-col (:x base-p) 0.01)))))
+
+;; ---- v-end? guard (drop-line-area) ----
+;;
+;; Bug: `v-end?` inside `drop-line-area` was guarded by `row?` instead of
+;; `col?`, so vertical-end alignment in a column layout was never triggered.
+;; We verify the predicate behaviour directly via ctl/v-end?.
+
+(t/deftest v-end-guard-uses-col-not-row
+  (t/testing "v-end? is true for col? frame with justify-content :end"
+    ;; col? + justify-content=:end → ctl/v-end? must be true
+    (let [frame (cts/setup-shape {:type :frame
+                                  :layout :flex
+                                  :layout-flex-dir :column
+                                  :layout-justify-content :end
+                                  :x 0 :y 0 :width 100 :height 100})]
+      (t/is (true? (ctl/v-end? frame)))))
+
+  (t/testing "v-end? is false for row? frame with only justify-content :end"
+    ;; row? + justify-content=:end alone does NOT set v-end?; for row layouts
+    ;; v-end? checks align-items, not justify-content.
+    (let [frame (cts/setup-shape {:type :frame
+                                  :layout :flex
+                                  :layout-flex-dir :row
+                                  :layout-justify-content :end
+                                  :x 0 :y 0 :width 100 :height 100})]
+      (t/is (not (ctl/v-end? frame))))))

--- a/common/test/common_tests/geom_grid_layout_test.cljc
+++ b/common/test/common_tests/geom_grid_layout_test.cljc
@@ -1,0 +1,410 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.geom-grid-layout-test
+  (:require
+   ;; Requiring modifiers triggers the side-effect that wires
+   ;; -child-min-width / -child-min-height into grid layout-data.
+   [app.common.geom.modifiers]
+   [app.common.geom.rect :as grc]
+   [app.common.geom.shapes.grid-layout.layout-data :as gld]
+   [app.common.math :as mth]
+   [app.common.types.shape :as cts]
+   [clojure.test :as t]))
+
+;; ---------------------------------------------------------------------------
+;; Shared test-data builders
+;; ---------------------------------------------------------------------------
+
+(defn- make-grid-frame
+  "Minimal grid-layout frame with two fixed columns of 50.0 px
+  and one fixed row. Width and height are explicit, no padding.
+  Track values are floats to avoid JVM integer-divide-by-zero when
+  there are no flex tracks (column-frs = 0)."
+  [& {:as opts}]
+  (cts/setup-shape
+   (merge {:type :frame
+           :layout :grid
+           :layout-grid-dir :row
+           :layout-grid-columns [{:type :fixed :value 50.0}
+                                 {:type :fixed :value 50.0}]
+           :layout-grid-rows [{:type :fixed :value 100.0}]
+           :layout-grid-cells {}
+           :layout-padding-type :multiple
+           :layout-padding {:p1 0 :p2 0 :p3 0 :p4 0}
+           :layout-gap {:column-gap 0 :row-gap 0}
+           :x 0 :y 0 :width 200 :height 100}
+          opts)))
+
+(defn- bounds-for
+  "Return the 4-point layout-bounds for the frame."
+  [frame]
+  (grc/rect->points (grc/make-rect (:x frame) (:y frame) (:width frame) (:height frame))))
+
+;; Build a simple non-fill child shape with explicit width/height.
+;; No layout-item-margin → child-width-margin = 0.
+(defn- make-child
+  [w h]
+  (cts/setup-shape {:type :rect :width w :height h :x 0 :y 0}))
+
+;; Build the 4-point bounds vector for a child with the given dimensions.
+(defn- child-bounds
+  [w h]
+  (grc/rect->points (grc/make-rect 0 0 w h)))
+
+;; Build an auto track at its initial size (0.01) with infinite max.
+(defn- auto-track [] {:type :auto :size 0.01 :max-size ##Inf})
+
+;; Build a fixed track with the given size.
+(defn- fixed-track [v]
+  {:type :fixed :value v :size (double v) :max-size (double v)})
+
+;; Build a flex track (value = number of fr units) at initial size 0.01.
+(defn- flex-track [fr]
+  {:type :flex :value fr :size 0.01 :max-size ##Inf})
+
+;; Build a parent frame for column testing with given column-gap.
+(defn- auto-col-parent
+  ([] (auto-col-parent 0))
+  ([column-gap]
+   (cts/setup-shape
+    {:type :frame
+     :layout :grid
+     :layout-grid-dir :row
+     :layout-padding-type :multiple
+     :layout-padding {:p1 0 :p2 0 :p3 0 :p4 0}
+     :layout-gap {:column-gap column-gap :row-gap 0}
+     :x 0 :y 0 :width 500 :height 500})))
+
+;; Build a parent frame for row type testing with given row-gap.
+(defn- auto-row-parent
+  ([] (auto-row-parent 0))
+  ([row-gap]
+   (cts/setup-shape
+    {:type :frame
+     :layout :grid
+     :layout-grid-dir :row
+     :layout-padding-type :multiple
+     :layout-padding {:p1 0 :p2 0 :p3 0 :p4 0}
+     :layout-gap {:column-gap 0 :row-gap row-gap}
+     :x 0 :y 0 :width 500 :height 500})))
+
+;; Generic frame-bounds (large enough not to interfere).
+(def ^:private frame-bounds
+  (grc/rect->points (grc/make-rect 0 0 500 500)))
+
+;; Build a cell map for a single shape occupying column/row at given span.
+;; col and row are 1-based.
+(defn- make-cell
+  [shape-id col row col-span row-span]
+  {:shapes [shape-id]
+   :column col :column-span col-span
+   :row row    :row-span    row-span})
+
+;; ---------------------------------------------------------------------------
+;; Note on set-auto-multi-span indexing
+;; ---------------------------------------------------------------------------
+;;
+;; Inside set-auto-multi-span, indexed-tracks is computed as:
+;;   from-idx = clamp(col - 1, 0, count-1)
+;;   to-idx   = clamp((col - 1) + col-span, 0, count-1)
+;;   indexed-tracks = subvec(enumerate(tracks), from-idx, to-idx)
+;;
+;; Because to-idx is clamped to (dec count), the LAST track of the span is
+;; always excluded unless there is at least one extra track beyond the span.
+;;
+;; Practical implication for tests: to cover N spanned tracks, provide a
+;; track-list with at least N+1 tracks (the extra track acts as a sentinel
+;; that absorbs the off-by-one from the clamp).
+;;
+;; Example: col=1, span=2, 3 total tracks:
+;;   to-idx = clamp(0+2, 0, 2) = 2  →  subvec(v, 0, 2) = [track0, track1] ✓
+;;
+;; Tests that deliberately check boundary behavior (flex exclusion,
+;; non-spanned tracks) use 2 total tracks so only track 0 is covered.
+
+;; ---------------------------------------------------------------------------
+;; Tests: column-gap with justify-content  (case → cond fix)
+;; ---------------------------------------------------------------------------
+;;
+;; In get-cell-data, column-gap and row-gap were computed with (case ...)
+;; using boolean locals as dispatch values.  case compares compile-time
+;; constants, so those branches never matched at runtime.  Fixed with cond.
+
+(t/deftest grid-column-gap-space-evenly
+  (t/testing "justify-content :space-evenly increases column-gap correctly"
+    ;; 2 fixed cols × 50 px = 100 px occupied; bound-width = 200; free = 100
+    ;; formula: free / (num-cols + 1) = 100/3 ≈ 33.33
+    (let [frame  (make-grid-frame :layout-justify-content :space-evenly
+                                  :layout-gap {:column-gap 0 :row-gap 0})
+          bounds (bounds-for frame)
+          result (gld/calc-layout-data frame bounds [] {} {})
+          col-gap (:column-gap result)]
+      (t/is (mth/close? (/ 100.0 3.0) col-gap 0.01)))))
+
+(t/deftest grid-column-gap-space-around
+  (t/testing "justify-content :space-around increases column-gap correctly"
+    ;; free = 100; formula: 100 / num-cols = 100/2 = 50
+    (let [frame  (make-grid-frame :layout-justify-content :space-around
+                                  :layout-gap {:column-gap 0 :row-gap 0})
+          bounds (bounds-for frame)
+          result (gld/calc-layout-data frame bounds [] {} {})
+          col-gap (:column-gap result)]
+      (t/is (mth/close? 50.0 col-gap 0.01)))))
+
+(t/deftest grid-column-gap-space-between
+  (t/testing "justify-content :space-between increases column-gap correctly"
+    ;; free = 100; num-cols = 2; formula: 100 / (2-1) = 100
+    (let [frame  (make-grid-frame :layout-justify-content :space-between
+                                  :layout-gap {:column-gap 0 :row-gap 0})
+          bounds (bounds-for frame)
+          result (gld/calc-layout-data frame bounds [] {} {})
+          col-gap (:column-gap result)]
+      (t/is (mth/close? 100.0 col-gap 0.01)))))
+
+(t/deftest grid-column-gap-auto-width-bypasses-justify-content
+  (t/testing "auto-width? bypasses justify-content gap recalc → gap stays as initial"
+    (let [frame  (make-grid-frame :layout-justify-content :space-evenly
+                                  :layout-gap {:column-gap 5 :row-gap 0}
+                                  :layout-item-h-sizing :auto)
+          bounds (bounds-for frame)
+          result (gld/calc-layout-data frame bounds [] {} {})
+          col-gap (:column-gap result)]
+      (t/is (mth/close? 5.0 col-gap 0.01)))))
+
+;; ---------------------------------------------------------------------------
+;; Tests: set-auto-multi-span
+;; ---------------------------------------------------------------------------
+;;
+;; set-auto-multi-span grows auto tracks to accommodate children whose cell
+;; spans more than one track column (or row), but only for spans that contain
+;; no flex tracks (those are handled by set-flex-multi-span).
+;;
+;; The function signature:
+;;   (set-auto-multi-span parent track-list children-map shape-cells
+;;                        bounds objects type)
+;;   type  – :column or :row
+;;   children-map – {shape-id [child-bounds child-shape]}
+;;   shape-cells  – {cell-id cell-map}
+
+(t/deftest set-auto-multi-span-span-1-cells-ignored
+  (t/testing "span=1 cells are filtered out; track-list is unchanged"
+    (let [sid    (random-uuid)
+          child  (make-child 200 100)
+          ;; 2 tracks + 1 sentinel (so the span would cover tracks 0-1 if span were 2)
+          tracks [(auto-track) (auto-track) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 1 1)}  ; span = 1 → ignored
+          cmap   {sid [(child-bounds 200 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 0.01 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 0.01 (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 0.01 (:size (nth result 2)) 0.001)))))
+
+(t/deftest set-auto-multi-span-empty-cells
+  (t/testing "empty shape-cells → track-list unchanged"
+    (let [tracks [(auto-track) (auto-track)]
+          result (gld/set-auto-multi-span (auto-col-parent) tracks {} {} frame-bounds {} :column)]
+      (t/is (mth/close? 0.01 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 0.01 (:size (nth result 1)) 0.001)))))
+
+(t/deftest set-auto-multi-span-two-auto-tracks-split-evenly
+  (t/testing "child spanning 2 auto tracks (with sentinel): budget split between the 2 covered tracks"
+    ;; 3 tracks total (sentinel at index 2 keeps to-idx from being clamped).
+    ;; col=1, span=2:
+    ;;   from-idx = clamp(0, 0, 2) = 0
+    ;;   to-idx   = clamp(2, 0, 2) = 2
+    ;;   subvec(enumerate, 0, 2) = [[0, auto0], [1, auto1]]
+    ;; size-to-allocate = 200 (child width, no gap)
+    ;; allocate-auto-tracks pass 1 (non-assigned = both):
+    ;;   idx0: max(0.01, 200/2, 0.01) = 100; rem = 100
+    ;;   idx1: max(0.01, 100/1, 0.01) = 100; rem = 0
+    ;; pass 2 (to-allocate=0): no change → both 100
+    ;; sentinel track 2 is never spanned → stays at 0.01.
+    (let [sid    (random-uuid)
+          child  (make-child 200 100)
+          tracks [(auto-track) (auto-track) (auto-track)]   ; sentinel at [2]
+          cells  {:c1 (make-cell sid 1 1 2 1)}
+          cmap   {sid [(child-bounds 200 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 100.0 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 100.0 (:size (nth result 1)) 0.001))
+      ;; sentinel unaffected
+      (t/is (mth/close? 0.01  (:size (nth result 2)) 0.001)))))
+
+(t/deftest set-auto-multi-span-gap-deducted-from-budget
+  (t/testing "column-gap is subtracted once per extra span track from size-to-allocate"
+    ;; child width = 210, column-gap = 10, span = 2
+    ;; size-to-allocate = child-min-width - gap*(span-1) = 210 - 10*1 = 200
+    ;; 3 tracks (sentinel at [2]) → indexed = [[0,auto],[1,auto]]
+    ;; each auto track gets 100
+    (let [sid    (random-uuid)
+          child  (make-child 210 100)
+          tracks [(auto-track) (auto-track) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 2 1)}
+          cmap   {sid [(child-bounds 210 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent 10) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 100.0 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 100.0 (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 0.01  (:size (nth result 2)) 0.001)))))
+
+(t/deftest set-auto-multi-span-fixed-track-reduces-budget
+  (t/testing "fixed track in span is deducted from budget; only the auto track grows"
+    ;; tracks: [fixed 60, auto 0.01, auto-sentinel]  (sentinel at [2])
+    ;; col=1, span=2 → indexed = [[0, fixed60], [1, auto]]
+    ;; find-auto-allocations: fixed→subtract 60; auto→keep
+    ;;   to-allocate after fixed = 200 - 60 = 140; indexed-auto = [[1, auto]]
+    ;; pass 1: idx1: max(0.01, 140/1, 0.01) = 140
+    ;; apply: track0 = max(60, 0) = 60; track1 = max(0.01, 140) = 140
+    (let [sid    (random-uuid)
+          child  (make-child 200 100)
+          tracks [(fixed-track 60) (auto-track) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 2 1)}
+          cmap   {sid [(child-bounds 200 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 60.0  (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 140.0 (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 0.01  (:size (nth result 2)) 0.001)))))
+
+(t/deftest set-auto-multi-span-child-smaller-than-existing-tracks
+  (t/testing "when child is smaller than the existing track sizes, tracks are not shrunk"
+    ;; tracks: [auto 80, auto 80, auto-sentinel]
+    ;; child width = 50; size-to-allocate = 50
+    ;; indexed = [[0, auto80], [1, auto80]]
+    ;; pass 1 (non-assigned, to-alloc=50):
+    ;;   idx0: max(0.01, 50/2, 80) = 80; rem = 50-80 = -30
+    ;;   idx1: max(0.01, max(-30,0)/1, 80) = 80
+    ;; pass 2 (to-alloc=max(-30,0)=0): same max, no change
+    ;; both tracks stay at 80
+    (let [sid    (random-uuid)
+          child  (make-child 50 100)
+          tracks [{:type :auto :size 80.0 :max-size ##Inf}
+                  {:type :auto :size 80.0 :max-size ##Inf}
+                  (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 2 1)}
+          cmap   {sid [(child-bounds 50 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 80.0 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 80.0 (:size (nth result 1)) 0.001)))))
+
+(t/deftest set-auto-multi-span-flex-track-in-span-excluded
+  (t/testing "cells whose span contains a flex track are skipped (handled by set-flex-multi-span)"
+    ;; tracks: [flex 1fr, auto]   col=1, span=2 → has-flex-track? = true → cell excluded
+    ;; 2 tracks total (no sentinel needed since the cell is excluded before indexing)
+    (let [sid    (random-uuid)
+          child  (make-child 300 100)
+          tracks [(flex-track 1) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 2 1)}
+          cmap   {sid [(child-bounds 300 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 0.01 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 0.01 (:size (nth result 1)) 0.001)))))
+
+(t/deftest set-auto-multi-span-non-spanned-track-unaffected
+  (t/testing "tracks outside the span keep their size – tests (get allocated %1 0) default"
+    ;; 4 tracks; child at col=2 span=2 → indexed covers tracks 1 and 2 (sentinel [3]).
+    ;; Track 0 (before the span) and track 3 (sentinel) are never allocated.
+    ;; from-idx = clamp(2-1, 0, 3) = 1
+    ;; to-idx   = clamp((2-1)+2, 0, 3) = 3
+    ;; subvec(enumerate, 1, 3) = [[1,auto],[2,auto]]
+    ;; size-to-allocate = 200 → both indexed tracks get 100
+    ;; apply: track0 = max(0.01, get({},0,0)) = max(0.01,0) = 0.01  ← uses default 0
+    ;;        track1 = max(0.01, 100) = 100
+    ;;        track2 = max(0.01, 100) = 100
+    ;;        track3 = max(0.01, get({},3,0)) = 0.01 (sentinel)
+    (let [sid    (random-uuid)
+          child  (make-child 200 100)
+          tracks [(auto-track) (auto-track) (auto-track) (auto-track)]
+          cells  {:c1 (make-cell sid 2 1 2 1)}
+          cmap   {sid [(child-bounds 200 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      ;; track before span: size stays at 0.01 (default 0 from missing allocation entry)
+      (t/is (mth/close? 0.01  (:size (nth result 0)) 0.001))
+      ;; spanned tracks grow
+      (t/is (mth/close? 100.0 (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 100.0 (:size (nth result 2)) 0.001))
+      ;; sentinel after span also unaffected
+      (t/is (mth/close? 0.01  (:size (nth result 3)) 0.001)))))
+
+(t/deftest set-auto-multi-span-row-type
+  (t/testing ":row type uses :row/:row-span and grows row tracks by child height"
+    ;; child height = 200, row-gap = 0, row=1 span=2, 3 row tracks (sentinel at [2])
+    ;; from-idx=0, to-idx=clamp(2,0,2)=2 → [[0,auto],[1,auto]]
+    ;; size-to-allocate = 200 → each row track gets 100
+    (let [sid    (random-uuid)
+          child  (make-child 100 200)
+          tracks [(auto-track) (auto-track) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 1 2)}
+          cmap   {sid [(child-bounds 100 200) child]}
+          result (gld/set-auto-multi-span (auto-row-parent) tracks cmap cells frame-bounds {} :row)]
+      (t/is (mth/close? 100.0 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 100.0 (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 0.01  (:size (nth result 2)) 0.001)))))
+
+(t/deftest set-auto-multi-span-row-gap-deducted
+  (t/testing "row-gap is deducted from budget for :row type"
+    ;; child height = 210, row-gap = 10, row-span = 2
+    ;; size-to-allocate = 210 - 10*1 = 200 → each track gets 100
+    (let [sid    (random-uuid)
+          child  (make-child 100 210)
+          tracks [(auto-track) (auto-track) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 1 2)}
+          cmap   {sid [(child-bounds 100 210) child]}
+          result (gld/set-auto-multi-span (auto-row-parent 10) tracks cmap cells frame-bounds {} :row)]
+      (t/is (mth/close? 100.0 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 100.0 (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 0.01  (:size (nth result 2)) 0.001)))))
+
+(t/deftest set-auto-multi-span-smaller-span-processed-first
+  (t/testing "cells are sorted by span ascending (sort-by span -): smaller span allocates first"
+    ;; NOTE: (sort-by prop-span -) uses `-` as a comparator; this yields ascending
+    ;; order (smaller span first), not descending as the code comment implies.
+    ;;
+    ;; 4 tracks (sentinel at [3]):
+    ;;   cell-B: col=1 span=2 (covers indexed [0,1])  – processed first (span=2)
+    ;;   cell-A: col=1 span=3 (covers indexed [0,1,2]) – processed second (span=3)
+    ;;
+    ;; cell-B: child=100px, to-allocate=100.
+    ;;   non-assigned=[0,1]; pass1: idx0→max(0.01,50,0.01)=50; idx1→max(0.01,50,0.01)=50
+    ;;   allocated = {0:50, 1:50}
+    ;;
+    ;; cell-A: child=300px, to-allocate=300.
+    ;;   indexed=[0,1,2]; non-assigned=[2] (tracks 0,1 already allocated)
+    ;;   pass1 (non-assigned only): idx2→max(0.01,300/1,0.01)=300 ; rem=0
+    ;;   pass2 (to-alloc=0): max preserves existing values → no change
+    ;;   allocated = {0:50, 1:50, 2:300}
+    ;;
+    ;; Final: track0=50, track1=50, track2=300, track3(sentinel)=0.01
+    (let [sid-a  (random-uuid)
+          sid-b  (random-uuid)
+          child-a (make-child 300 100)
+          child-b (make-child 100 100)
+          tracks  [(auto-track) (auto-track) (auto-track) (auto-track)]  ; sentinel at [3]
+          cells   {:ca (make-cell sid-a 1 1 3 1)
+                   :cb (make-cell sid-b 1 1 2 1)}
+          cmap    {sid-a [(child-bounds 300 100) child-a]
+                   sid-b [(child-bounds 100 100) child-b]}
+          result  (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 50.0  (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 50.0  (:size (nth result 1)) 0.001))
+      (t/is (mth/close? 300.0 (:size (nth result 2)) 0.001))
+      (t/is (mth/close? 0.01  (:size (nth result 3)) 0.001)))))
+
+(t/deftest set-auto-multi-span-all-fixed-tracks-in-span
+  (t/testing "when all spanned tracks are fixed, no auto allocation occurs; fixed tracks unchanged"
+    ;; tracks: [fixed 100, fixed 100, auto-sentinel]
+    ;; col=1, span=2 → indexed = [[0,fixed100],[1,fixed100]]
+    ;; find-auto-allocations: both fixed → auto-indexed-tracks = []
+    ;; allocate-auto-tracks on empty list → no entries in allocated map
+    ;; apply: track0 = max(100, get({},0,0)) = max(100,0) = 100 (unchanged)
+    ;;        track1 = max(100, get({},1,0)) = max(100,0) = 100 (unchanged)
+    (let [sid    (random-uuid)
+          child  (make-child 50 100)
+          tracks [(fixed-track 100) (fixed-track 100) (auto-track)]
+          cells  {:c1 (make-cell sid 1 1 2 1)}
+          cmap   {sid [(child-bounds 50 100) child]}
+          result (gld/set-auto-multi-span (auto-col-parent) tracks cmap cells frame-bounds {} :column)]
+      (t/is (mth/close? 100.0 (:size (nth result 0)) 0.001))
+      (t/is (mth/close? 100.0 (:size (nth result 1)) 0.001)))))

--- a/common/test/common_tests/geom_point_test.cljc
+++ b/common/test/common_tests/geom_point_test.cljc
@@ -289,3 +289,33 @@
     (t/is (mth/close? 1.2091818119288809 (:x rs)))
     (t/is (mth/close? 1.8275638211757912 (:y rs)))))
 
+;; ---- gpt/abs ----
+
+(t/deftest abs-point-returns-point-instance
+  (t/testing "abs of a point with negative coordinates returns a Point record"
+    (let [p  (gpt/point -3 -4)
+          rs (gpt/abs p)]
+      (t/is (gpt/point? rs))
+      (t/is (mth/close? 3 (:x rs)))
+      (t/is (mth/close? 4 (:y rs)))))
+
+  (t/testing "abs of a point with mixed-sign coordinates"
+    (let [p  (gpt/point -5 7)
+          rs (gpt/abs p)]
+      (t/is (gpt/point? rs))
+      (t/is (mth/close? 5 (:x rs)))
+      (t/is (mth/close? 7 (:y rs)))))
+
+  (t/testing "abs of a point already positive is unchanged"
+    (let [p  (gpt/point 2 9)
+          rs (gpt/abs p)]
+      (t/is (gpt/point? rs))
+      (t/is (mth/close? 2 (:x rs)))
+      (t/is (mth/close? 9 (:y rs)))))
+
+  (t/testing "abs of a zero point stays zero"
+    (let [rs (gpt/abs (gpt/point 0 0))]
+      (t/is (gpt/point? rs))
+      (t/is (mth/close? 0 (:x rs)))
+      (t/is (mth/close? 0 (:y rs))))))
+

--- a/common/test/common_tests/geom_rect_test.cljc
+++ b/common/test/common_tests/geom_rect_test.cljc
@@ -1,0 +1,94 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.geom-rect-test
+  (:require
+   [app.common.geom.rect :as grc]
+   [app.common.math :as mth]
+   [clojure.test :as t]))
+
+;; ---- update-rect :size ----
+
+(t/deftest update-rect-size-sets-all-corners
+  (t/testing ":size updates x1/y1 as well as x2/y2 from x/y/width/height"
+    (let [r  (grc/make-rect 10 20 30 40)
+          r' (grc/update-rect r :size)]
+      ;; x1/y1 must mirror x/y
+      (t/is (mth/close? (:x r) (:x1 r')))
+      (t/is (mth/close? (:y r) (:y1 r')))
+      ;; x2/y2 must be x+width / y+height
+      (t/is (mth/close? (+ (:x r) (:width r)) (:x2 r')))
+      (t/is (mth/close? (+ (:y r) (:height r)) (:y2 r')))))
+
+  (t/testing ":size is consistent with :corners round-trip"
+    ;; Applying :size then :corners should recover the original x/y/w/h
+    (let [r    (grc/make-rect 5 15 100 50)
+          r'   (-> r (grc/update-rect :size) (grc/update-rect :corners))]
+      (t/is (mth/close? (:x r)      (:x r')))
+      (t/is (mth/close? (:y r)      (:y r')))
+      (t/is (mth/close? (:width r)  (:width r')))
+      (t/is (mth/close? (:height r) (:height r')))))
+
+  (t/testing ":size works for a rect at the origin"
+    (let [r  (grc/make-rect 0 0 200 100)
+          r' (grc/update-rect r :size)]
+      (t/is (mth/close? 0   (:x1 r')))
+      (t/is (mth/close? 0   (:y1 r')))
+      (t/is (mth/close? 200 (:x2 r')))
+      (t/is (mth/close? 100 (:y2 r'))))))
+
+;; ---- corners->rect ----
+
+(t/deftest corners->rect-normal-order
+  (t/testing "p1 top-left, p2 bottom-right yields a valid rect"
+    (let [r (grc/corners->rect 0 0 10 20)]
+      (t/is (grc/rect? r))
+      (t/is (mth/close? 0  (:x r)))
+      (t/is (mth/close? 0  (:y r)))
+      (t/is (mth/close? 10 (:width r)))
+      (t/is (mth/close? 20 (:height r))))))
+
+(t/deftest corners->rect-reversed-corners
+  (t/testing "reversed x-coordinates still produce a positive-width rect"
+    (let [r (grc/corners->rect 10 0 0 20)]
+      (t/is (grc/rect? r))
+      (t/is (mth/close? 0  (:x r)))
+      (t/is (mth/close? 10 (:width r)))))
+
+  (t/testing "reversed y-coordinates still produce a positive-height rect"
+    (let [r (grc/corners->rect 0 20 10 0)]
+      (t/is (grc/rect? r))
+      (t/is (mth/close? 0  (:y r)))
+      (t/is (mth/close? 20 (:height r)))))
+
+  (t/testing "both axes reversed yield the same rect as normal order"
+    (let [r-normal   (grc/corners->rect 0 0 10 20)
+          r-reversed (grc/corners->rect 10 20 0 0)]
+      (t/is (mth/close? (:x      r-normal) (:x      r-reversed)))
+      (t/is (mth/close? (:y      r-normal) (:y      r-reversed)))
+      (t/is (mth/close? (:width  r-normal) (:width  r-reversed)))
+      (t/is (mth/close? (:height r-normal) (:height r-reversed))))))
+
+(t/deftest corners->rect-from-points
+  (t/testing "two-arity overload taking point maps works identically"
+    (let [p1 {:x 5 :y 10}
+          p2 {:x 15 :y 30}
+          r  (grc/corners->rect p1 p2)]
+      (t/is (grc/rect? r))
+      (t/is (mth/close? 5  (:x r)))
+      (t/is (mth/close? 10 (:y r)))
+      (t/is (mth/close? 10 (:width r)))
+      (t/is (mth/close? 20 (:height r)))))
+
+  (t/testing "two-arity overload with reversed points"
+    (let [p1 {:x 15 :y 30}
+          p2 {:x 5  :y 10}
+          r  (grc/corners->rect p1 p2)]
+      (t/is (grc/rect? r))
+      (t/is (mth/close? 5  (:x r)))
+      (t/is (mth/close? 10 (:y r)))
+      (t/is (mth/close? 10 (:width r)))
+      (t/is (mth/close? 20 (:height r))))))

--- a/common/test/common_tests/geom_shapes_constraints_test.cljc
+++ b/common/test/common_tests/geom_shapes_constraints_test.cljc
@@ -1,0 +1,27 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.geom-shapes-constraints-test
+  (:require
+   [app.common.geom.shapes.constraints :as gsc]
+   [clojure.test :as t]))
+
+;; ---- constraint-modifier :default ----
+
+(t/deftest constraint-modifier-default-returns-empty-vector
+  (t/testing ":default method accepts 6 args and returns an empty vector"
+    ;; Before the fix the :default method only accepted 5 positional args
+    ;; (plus the dispatch value), so calling it with 6 args would throw an
+    ;; arity error.  After the fix it takes [_ _ _ _ _ _] and returns [].
+    (let [result (gsc/constraint-modifier :unknown-constraint-type
+                                          :x nil nil nil nil)]
+      (t/is (vector? result))
+      (t/is (empty? result))))
+
+  (t/testing ":default method returns [] for :scale-like unknown type on :y axis"
+    (let [result (gsc/constraint-modifier :some-other-unknown
+                                          :y nil nil nil nil)]
+      (t/is (= [] result)))))

--- a/common/test/common_tests/geom_shapes_intersect_test.cljc
+++ b/common/test/common_tests/geom_shapes_intersect_test.cljc
@@ -52,12 +52,10 @@
                    [(pt 0 5) (pt 10 5)]))))
 
   (t/testing "Two collinear overlapping segments"
-    ;; NOTE: The implementation compares orientation result (namespaced keyword ::coplanar)
-    ;; against unnamespaced :coplanar, so the collinear branch never triggers.
-    ;; Collinear overlapping segments are NOT detected as intersecting.
-    (t/is (false? (gint/intersect-segments?
-                   [(pt 0 0) (pt 10 0)]
-                   [(pt 5 0) (pt 15 0)]))))
+    ;; Collinear overlapping segments correctly detected as intersecting.
+    (t/is (true? (gint/intersect-segments?
+                  [(pt 0 0) (pt 10 0)]
+                  [(pt 5 0) (pt 15 0)]))))
 
   (t/testing "Two non-overlapping collinear segments"
     (t/is (false? (gint/intersect-segments?

--- a/common/test/common_tests/geom_shapes_test.cljc
+++ b/common/test/common_tests/geom_shapes_test.cljc
@@ -230,3 +230,44 @@
     (t/is (true? (gsin/slow-has-point? shape point1)))
     (t/is (false? (gsin/fast-has-point? shape point2)))
     (t/is (false? (gsin/fast-has-point? shape point2)))))
+
+;; ---- adjust-shape-flips (via apply-transform / transform-shape) ----
+
+(t/deftest flip-x-only-toggles-flip-x-and-negates-rotation
+  (t/testing "Flipping only X axis toggles flip-x and negates rotation"
+    ;; Build a rect with a known rotation, then apply a scale(-1, 1)
+    ;; from the left edge to simulate an X-axis flip.
+    (let [shape  (create-test-shape :rect {:rotation 30})
+          ;; Flip horizontally about x=0 (left edge of shape)
+          origin (gpt/point (get-in shape [:selrect :x]) (get-in shape [:selrect :y]))
+          mods   (ctm/resize-modifiers (gpt/point -1 1) origin)
+          result (gsh/transform-shape shape mods)]
+      ;; flip-x should have been toggled (from nil/false to true)
+      (t/is (true? (:flip-x result)))
+      ;; flip-y should NOT be set
+      (t/is (not (true? (:flip-y result))))
+      ;; rotation is negated then normalised into [0,360): -30 mod 360 = 330
+      (t/is (mth/close? 330 (:rotation result))))))
+
+(t/deftest flip-y-only-toggles-flip-y-and-negates-rotation
+  (t/testing "Flipping only Y axis toggles flip-y and negates rotation"
+    (let [shape  (create-test-shape :rect {:rotation 45})
+          origin (gpt/point (get-in shape [:selrect :x]) (get-in shape [:selrect :y]))
+          mods   (ctm/resize-modifiers (gpt/point 1 -1) origin)
+          result (gsh/transform-shape shape mods)]
+      (t/is (not (true? (:flip-x result))))
+      (t/is (true? (:flip-y result)))
+      ;; -45 mod 360 = 315
+      (t/is (mth/close? 315 (:rotation result))))))
+
+(t/deftest flip-both-axes-toggles-both-flags-but-preserves-rotation
+  (t/testing "Flipping both axes toggles flip-x and flip-y, but does NOT negate rotation"
+    ;; Two simultaneous axis flips = 180° rotation, so stored rotation is unchanged.
+    (let [shape  (create-test-shape :rect {:rotation 30})
+          origin (gpt/point (get-in shape [:selrect :x]) (get-in shape [:selrect :y]))
+          mods   (ctm/resize-modifiers (gpt/point -1 -1) origin)
+          result (gsh/transform-shape shape mods)]
+      (t/is (true? (:flip-x result)))
+      (t/is (true? (:flip-y result)))
+      ;; rotation must not be negated when both axes are flipped
+      (t/is (mth/close? 30 (:rotation result))))))

--- a/common/test/common_tests/geom_test.cljc
+++ b/common/test/common_tests/geom_test.cljc
@@ -9,6 +9,7 @@
    [app.common.geom.matrix :as gmt]
    [app.common.geom.point :as gpt]
    [app.common.math :as mth]
+   [app.common.schema :as sm]
    [clojure.test :as t]))
 
 (t/deftest point-constructors-test
@@ -100,3 +101,28 @@
   (let [m (-> (gmt/matrix)
               (gmt/rotate 10))]
     (t/is (= m (gmt/matrix 0.984807753012208 0.17364817766693033 -0.17364817766693033 0.984807753012208 0 0)))))
+
+;; ---- matrix->str (no trailing comma) ----
+
+(t/deftest matrix-str-roundtrip-test
+  (t/testing "Identity matrix encodes and decodes back to equal matrix"
+    (let [m      (gmt/matrix)
+          enc    (sm/encode gmt/schema:matrix m (sm/string-transformer))
+          dec    (sm/decode gmt/schema:matrix enc (sm/string-transformer))]
+      (t/is (string? enc))
+      ;; Must not end with a comma
+      (t/is (not= \, (last enc)))
+      (t/is (gmt/close? m dec))))
+
+  (t/testing "Arbitrary matrix encodes without trailing comma and round-trips"
+    (let [m      (gmt/matrix 2 0.5 -0.5 3 10 20)
+          enc    (sm/encode gmt/schema:matrix m (sm/string-transformer))
+          dec    (sm/decode gmt/schema:matrix enc (sm/string-transformer))]
+      (t/is (string? enc))
+      (t/is (not= \, (last enc)))
+      (t/is (gmt/close? m dec))))
+
+  (t/testing "Encoded string contains exactly 5 commas (6 fields)"
+    (let [m   (gmt/matrix 1 0 0 1 0 0)
+          enc (sm/encode gmt/schema:matrix m (sm/string-transformer))]
+      (t/is (= 5 (count (filter #(= \, %) enc)))))))

--- a/common/test/common_tests/runner.cljc
+++ b/common/test/common_tests/runner.cljc
@@ -15,6 +15,7 @@
    [common-tests.files-migrations-test]
    [common-tests.geom-align-test]
    [common-tests.geom-bounds-map-test]
+   [common-tests.geom-grid-layout-test]
    [common-tests.geom-grid-test]
    [common-tests.geom-line-test]
    [common-tests.geom-modif-tree-test]

--- a/common/test/common_tests/runner.cljc
+++ b/common/test/common_tests/runner.cljc
@@ -15,6 +15,7 @@
    [common-tests.files-migrations-test]
    [common-tests.geom-align-test]
    [common-tests.geom-bounds-map-test]
+   [common-tests.geom-flex-layout-test]
    [common-tests.geom-grid-layout-test]
    [common-tests.geom-grid-test]
    [common-tests.geom-line-test]
@@ -22,7 +23,9 @@
    [common-tests.geom-modifiers-test]
    [common-tests.geom-point-test]
    [common-tests.geom-proportions-test]
+   [common-tests.geom-rect-test]
    [common-tests.geom-shapes-common-test]
+   [common-tests.geom-shapes-constraints-test]
    [common-tests.geom-shapes-corners-test]
    [common-tests.geom-shapes-effects-test]
    [common-tests.geom-shapes-intersect-test]
@@ -88,13 +91,17 @@
    'common-tests.files-migrations-test
    'common-tests.geom-align-test
    'common-tests.geom-bounds-map-test
+   'common-tests.geom-flex-layout-test
+   'common-tests.geom-grid-layout-test
    'common-tests.geom-grid-test
    'common-tests.geom-line-test
    'common-tests.geom-modif-tree-test
    'common-tests.geom-modifiers-test
    'common-tests.geom-point-test
    'common-tests.geom-proportions-test
+   'common-tests.geom-rect-test
    'common-tests.geom-shapes-common-test
+   'common-tests.geom-shapes-constraints-test
    'common-tests.geom-shapes-corners-test
    'common-tests.geom-shapes-effects-test
    'common-tests.geom-shapes-intersect-test


### PR DESCRIPTION
## Summary

11 Bug Fixes (some of them are merged in a parent PR to `staging`)

| Module | Issue | Impact |
|--------|-------|--------|
| **grid_layout** | `case` on runtime booleans → `cond` | Gap calculation never worked at runtime |
| **grid_layout** | Divide-by-zero when no flex/auto tracks | JVM crash; silent Infinity in JS |
| **grid_layout** | `get(allocated idx)` returned nil | NPE in JVM when max(size, nil) |
| **transforms** | Double rotation negation (XOR bug) | Incorrect angle after dual-axis flip |
| **intersect** | `:coplanar` vs `::coplanar` mismatch | Collinear/on-segment intersections missed |
| **constraints** | `:default` arity mismatch (5 vs 6 params) | Runtime arity error on unknown constraint |
| **flex_layout** | `v-end?` guarded by `row?` not `col?` | Vertical-end alignment fired on wrong layout |
| **flex_layout** | `get-base-line` around? parenthesis | Offset clamped to ≥2px instead of computed half |
| **rect** | `update-rect :size` missed `:x1`/`:y1` | Inconsistent Rect record state |
| **point** | `gpt/abs` lost Point record type | `point?` check failed on result |
| **matrix** | Trailing comma in `matrix->str` | Malformed string serialization |

## Comprehensive Test Coverage

**11 new test namespaces** covering all fixes:
- `geom_test`, `geom_point_test`, `geom_rect_test`, `geom_shapes_test`, `geom_shapes_constraints_test`
- `geom_flex_layout_test`, `geom_grid_layout_test`

All tests pass on **JS (Node.js)** and **JVM** environments.
