### PR TITLE
:sparkles: Add callback to nitrate billing url

### DIFF
--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -65,9 +65,12 @@
   []
   (st/emit! (rt/nav-raw :href "/control-center/?action=create-org")))
 
+(def go-to-subscription-url (u/join cf/public-uri "#/settings/subscriptions"))
+
 (defn go-to-nitrate-billing
   []
-  (st/emit! (rt/nav-raw :href "/control-center/licenses/billing")))
+  (let [href (dm/str "/control-center/licenses/billing?callback=" (js/encodeURIComponent go-to-subscription-url))]
+    (st/emit! (rt/nav-raw :href href))))
 
 (defn go-to-buy-nitrate-license
   ([subscription]
@@ -77,8 +80,6 @@
                   callback (assoc :callback callback))
          href   (dm/str "/control-center/licenses/start?" (u/map->query-string params))]
      (st/emit! (rt/nav-raw :href href)))))
-
-(def go-to-subscription-url (u/join cf/public-uri "#/settings/subscriptions"))
 
 (defn is-valid-license?
   [profile]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26250

When navigating to the Billing Portal, we must send a callback URL so that we can return to the same place after leaving stripe and going to penpot.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
