### PR TITLE
:sparkles: Add several bugfixes for app.common.data namespace

### DIFF
--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -1149,11 +1149,11 @@
               (> start 0) (< start (count v)))
      (subvec v start)))
   ([v start end]
-   (let [size (count v)]
-     (when (and (some? v)
-                (>= start 0) (< start size)
-                (>= end 0) (<= start end) (<= end size))
-       (subvec v start end)))))
+   (when (some? v)
+     (let [size (count v)]
+       (when (and (>= start 0) (< start size)
+                  (>= end 0) (<= start end) (<= end size))
+         (subvec v start end))))))
 
 (defn append-class
   [class current-class]

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -5,7 +5,7 @@
 ;; Copyright (c) KALEIDOS INC
 
 (ns app.common.data
-  "A collection if helpers for working with data structures and other
+  "A collection of helpers for working with data structures and other
   data resources."
   (:refer-clojure :exclude [read-string hash-map merge name update-vals
                             parse-double group-by iteration concat mapcat

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -782,7 +782,8 @@
                 (not (js/isNaN v))
                 (not (js/isNaN (parse-double v))))
 
-     :clj  (not= (parse-double v :nan) :nan)))
+     :clj  (and (string? v)
+                (not= (parse-double v :nan) :nan))))
 
 (defn read-string
   [v]

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -718,7 +718,7 @@
 (defn nan?
   [v]
   #?(:cljs (js/isNaN v)
-     :clj  (not= v v)))
+     :clj  (and (number? v) (Double/isNaN v))))
 
 (defn- impl-parse-integer
   [v]

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -952,7 +952,7 @@
               (assoc diff key (map-diff v1 v2))
 
               :else
-              (assoc diff key [(get m1 key) (get m2 key)]))))]
+              (assoc diff key [v1 v2]))))]
 
     (->> keys
          (reduce diff-attr {}))))

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -377,7 +377,7 @@
                (assoc object key nil)
 
                (nil? value)
-               (dissoc object key value)
+               (dissoc object key)
 
                :else
                (assoc object key value)))

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -143,7 +143,7 @@
     (oassoc-in o (cons k ks) v)))
 
 (defn vec2
-  "Creates a optimized vector compatible type of length 2 backed
+  "Creates an optimized vector compatible type of length 2 backed
   internally with MapEntry impl because it has faster access method
   for its fields."
   [o1 o2]
@@ -401,7 +401,7 @@
   (map vector col1 col2))
 
 (defn zip-all
-  "Return a zip of both collections, extended to the lenght of the longest one,
+  "Return a zip of both collections, extended to the length of the longest one,
    and padding the shorter one with nils as needed."
   [col1 col2]
   (let [diff (- (count col1) (count col2))]
@@ -440,7 +440,7 @@
 
   Optional parameters:
   `pred?`   A predicate that if not satisfied won't process the pair
-  `target?` A collection that will be used as seed to be stored
+  `target`  A collection that will be used as seed to be stored
 
   Example:
   (map-perm vector [1 2 3 4]) => [[1 2] [1 3] [1 4] [2 3] [2 4] [3 4]]"

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -1146,7 +1146,7 @@
   "Wrapper around subvec so it doesn't throw an exception but returns nil instead"
   ([v start]
    (when (and (some? v)
-              (> start 0) (< start (count v)))
+              (>= start 0) (< start (count v)))
      (subvec v start)))
   ([v start end]
    (when (some? v)

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -393,7 +393,7 @@
               (subvec v (inc index))))
 
 (defn without-obj
-  "Clear collection from specified obj and without nil values."
+  "Return a vector with all elements equal to `o` removed."
   [coll o]
   (into [] (filter #(not= % o)) coll))
 

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -252,13 +252,13 @@
   ([items] (enumerate items 0))
   ([items start]
    (loop [idx   start
-          items items
+          items (seq items)
           res   (transient [])]
-     (if (empty? items)
-       (persistent! res)
+     (if items
        (recur (inc idx)
-              (rest items)
-              (conj! res [idx (first items)]))))))
+              (next items)
+              (conj! res [idx (first items)]))
+       (persistent! res)))))
 
 (defn group-by
   ([kf coll] (group-by kf identity [] coll))

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -420,9 +420,9 @@
               coll)))
 
 (defn removev
-  "Returns a vector of the items in coll for which (fn item) returns logical false"
-  [fn coll]
-  (filterv (comp not fn) coll))
+  "Returns a vector of the items in coll for which (pred item) returns logical false"
+  [pred coll]
+  (filterv (comp not pred) coll))
 
 (defn filterm
   "Filter values of a map that satisfy a predicate"

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -602,12 +602,9 @@
   (let [do-map
         (fn [entry]
           (let [[k v] (mfn entry)]
-            (cond
-              (or (vector? v) (map? v))
+            (if (or (vector? v) (map? v))
               [k (deep-mapm mfn v)]
-
-              :else
-              (mfn [k v]))))]
+              [k v])))]
     (cond
       (map? m)
       (into {} (map do-map) m)

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -291,15 +291,12 @@
 
 (defn index-of-pred
   [coll pred]
-  (loop [c    (first coll)
-         coll (rest coll)
+  (loop [s     (seq coll)
          index 0]
-    (if (nil? c)
-      nil
-      (if (pred c)
+    (when s
+      (if (pred (first s))
         index
-        (recur (first coll)
-               (rest coll)
+        (recur (next s)
                (inc index))))))
 
 (defn index-of

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -1117,8 +1117,7 @@
   ([value {:keys [precision] :or {precision 2}}]
    (let [value (if (string? value) (parse-double value) value)]
      (when (num? value)
-       (let [value (format-precision value precision)]
-         (str value))))))
+       (format-precision value precision)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Util protocols

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -1156,5 +1156,6 @@
 
 (defn append-class
   [class current-class]
-  (str (if (some? class) (str class " ") "")
-       current-class))
+  (if (seq class)
+    (str class " " current-class)
+    current-class))

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -439,7 +439,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- without-obj
-  "Clear collection from specified obj and without nil values."
+  "Return a vector with all elements equal to `o` removed."
   [coll o]
   (into [] (filter #(not= % o)) coll))
 

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -791,7 +791,8 @@
 (t/deftest append-class-test
   (t/is (= "foo bar" (d/append-class "foo" "bar")))
   (t/is (= "bar" (d/append-class nil "bar")))
-  (t/is (= " bar" (d/append-class "" "bar"))))
+  ;; empty string is treated like nil — no leading space
+  (t/is (= "bar" (d/append-class "" "bar"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Additional helpers (5th batch)

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -372,12 +372,19 @@
   (t/is (= 0 (d/index-of-pred [1 2 3] odd?)))
   (t/is (= 1 (d/index-of-pred [2 3 4] odd?)))
   (t/is (nil? (d/index-of-pred [2 4 6] odd?)))
-  (t/is (nil? (d/index-of-pred [] odd?))))
+  (t/is (nil? (d/index-of-pred [] odd?)))
+  ;; works correctly when collection contains nil elements
+  (t/is (= 2 (d/index-of-pred [nil nil 3] some?)))
+  (t/is (= 0 (d/index-of-pred [nil 1 2] nil?)))
+  ;; works correctly when collection contains false elements
+  (t/is (= 1 (d/index-of-pred [false true false] true?))))
 
 (t/deftest index-of-test
   (t/is (= 0 (d/index-of [:a :b :c] :a)))
   (t/is (= 2 (d/index-of [:a :b :c] :c)))
-  (t/is (nil? (d/index-of [:a :b :c] :z))))
+  (t/is (nil? (d/index-of [:a :b :c] :z)))
+  ;; works when searching for nil in a collection
+  (t/is (= 1 (d/index-of [:a nil :c] nil))))
 
 (t/deftest replace-by-id-test
   (let [items [{:id 1 :v "a"} {:id 2 :v "b"} {:id 3 :v "c"}]

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -565,16 +565,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (t/deftest nan-test
-  ;; Note: nan? behaves differently per platform:
-  ;; - CLJS: uses js/isNaN, returns true for ##NaN
-  ;; - CLJ: uses (not= v v); Clojure's = uses .equals on doubles,
-  ;;   so (= ##NaN ##NaN) is true and nan? returns false for ##NaN.
-  ;; Either way, nan? returns false for regular numbers and nil.
+  (t/is (d/nan? ##NaN))
   (t/is (not (d/nan? 0)))
   (t/is (not (d/nan? 1)))
   (t/is (not (d/nan? nil)))
-  ;; Platform-specific: JS nan? correctly detects NaN
-  #?(:cljs (t/is (d/nan? ##NaN))))
+  ;; CLJS js/isNaN coerces non-numbers; JVM Double/isNaN is number-only
+  #?(:cljs (t/is (d/nan? "hello")))
+  #?(:clj  (t/is (not (d/nan? "hello")))))
 
 (t/deftest safe-plus-test
   (t/is (= 5 (d/safe+ 3 2)))
@@ -618,18 +615,13 @@
   (t/is (nil? (d/parse-uuid nil))))
 
 (t/deftest coalesce-str-test
-  ;; On JVM: nan? uses (not= v v), which is false for all normal values.
-  ;; On CLJS: nan? uses js/isNaN, which is true for non-numeric strings.
-  ;; coalesce-str returns default when value is nil or nan?.
   (t/is (= "default" (d/coalesce-str nil "default")))
   ;; Numbers always stringify on both platforms
   (t/is (= "42" (d/coalesce-str 42 "default")))
-  ;; ##NaN: nan? is true in CLJS, returns default;
-  ;;        nan? is false in CLJ, so str(##NaN)="NaN" is returned.
-  #?(:cljs (t/is (= "default" (d/coalesce-str ##NaN "default"))))
-  #?(:clj  (t/is (= "NaN" (d/coalesce-str ##NaN "default"))))
+  ;; ##NaN returns default on both platforms now that nan? is fixed on JVM
+  (t/is (= "default" (d/coalesce-str ##NaN "default")))
   ;; Strings: in CLJS js/isNaN("hello")=true so "default" is returned;
-  ;;          in CLJ nan? is false so (str "hello")="hello" is returned.
+  ;;          in CLJ nan? is false for strings so (str "hello")="hello" is returned.
   #?(:cljs (t/is (= "default" (d/coalesce-str "hello" "default"))))
   #?(:clj  (t/is (= "hello" (d/coalesce-str "hello" "default")))))
 

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -538,17 +538,20 @@
            (into [] (d/distinct-xf :id) [{:id 1 :v "a"} {:id 2 :v "x"} {:id 2 :v "b"}]))))
 
 (t/deftest deep-mapm-test
-  ;; Note: mfn is called twice on leaf entries (once initially, once again
-  ;; after checking if the value is a map/vector), so a doubling fn applied
-  ;; to value 1 gives 1*2*2=4.
-  (t/is (= {:a 4 :b {:c 8}}
+  ;; mfn is applied once per entry
+  (t/is (= {:a 2 :b {:c 4}}
            (d/deep-mapm (fn [[k v]] [k (if (number? v) (* v 2) v)])
                         {:a 1 :b {:c 2}})))
-  ;; Keyword renaming: keys are also transformed — and applied twice.
-  ;; Use an idempotent key transformation (uppercase once = uppercase twice).
+  ;; Keyword renaming: keys are transformed once per entry
   (let [result (d/deep-mapm (fn [[k v]] [(keyword (str (name k) "!")) v])
                             {:a 1})]
-    (t/is (contains? result (keyword "a!!")))))
+    (t/is (contains? result (keyword "a!"))))
+  ;; Vectors inside maps are recursed into
+  (t/is (= {:items [{:x 10}]}
+           (d/deep-mapm (fn [[k v]] [k (if (number? v) (* v 10) v)])
+                        {:items [{:x 1}]})))
+  ;; Plain scalar at top level map
+  (t/is (= {:a "hello"} (d/deep-mapm identity {:a "hello"}))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Numeric helpers

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -325,6 +325,8 @@
   (t/is (= [2 3] (d/safe-subvec [1 2 3 4] 1 3)))
   ;; single arg — from index to end
   (t/is (= [2 3 4] (d/safe-subvec [1 2 3 4] 1)))
+  ;; start=0 returns the full vector
+  (t/is (= [1 2 3 4] (d/safe-subvec [1 2 3 4] 0)))
   ;; out-of-range returns nil
   (t/is (nil? (d/safe-subvec [1 2 3] 5)))
   (t/is (nil? (d/safe-subvec [1 2 3] 0 5)))

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -445,6 +445,8 @@
   (t/is (= {:a {:x 10 :y 2}} (d/patch-object {:a {:x 1 :y 2}} {:a {:x 10}})))
   ;; nested nil removes nested key
   (t/is (= {:a {:y 2}} (d/patch-object {:a {:x 1 :y 2}} {:a {:x nil}})))
+  ;; nil value removes only the specified key, not other keys
+  (t/is (= {nil 0 :b 2} (d/patch-object {nil 0 :a 1 :b 2} {:a nil})))
   ;; transducer arity (1-arg returns a fn)
   (let [f (d/patch-object {:a 99})]
     (t/is (= {:a 99 :b 2} (f {:a 1 :b 2})))))

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -841,6 +841,9 @@
   (t/is (d/num-string? "-7"))
   (t/is (not (d/num-string? "hello")))
   (t/is (not (d/num-string? nil)))
+  ;; non-string types always return false
+  (t/is (not (d/num-string? 42)))
+  (t/is (not (d/num-string? :keyword)))
   ;; In CLJS, js/isNaN("") → false (empty string coerces to 0), so "" is numeric
   #?(:clj (t/is (not (d/num-string? ""))))
   #?(:cljs (t/is (d/num-string? ""))))


### PR DESCRIPTION
## Summary

Comprehensive analysis and fixes for bugs and optimizations in the `app.common.data` utility namespace (~1,162 lines), a foundational module used across the entire Penpot stack (frontend, backend, exporter).

## Critical Fixes

### 1. `nan?` returns false for NaN on JVM (Line 718-721)
**Bug:** Clojure's `=` operator uses `.equals()` on doubles. Since `Double.equals(Double.NaN)` returns `true`, the expression `(not= v v)` always returned `false` for `##NaN` on the JVM. CLJS was unaffected.

**Impact:** Any code using `nan?` directly on the JVM would fail to detect NaN. Also affected `coalesce-str`, `parse-double`, `parse-integer`, and `parse-percent` functions.

**Fix:** Use `(and (number? v) (Double/isNaN v))` on JVM instead of `(not= v v)`.

### 2. `safe-subvec` 2-arity rejects start=0 (Line 1147-1150)
**Bug:** Guard condition was `(> start 0)` instead of `(>= start 0)`, causing `(safe-subvec v 0)` to return `nil` instead of the full vector. The 3-arity was already correct.

**Impact:** Low in practice since 3-arity is the primary use; no production callers hit this path.

**Fix:** Changed guard to `(>= start 0)` to match the 3-arity and allow valid `start=0` index.

## Non-Critical Improvements

- **`patch-object` (Line 380):** Removed spurious `value` argument to `dissoc` call
- **`deep-mapm` (Line 612):** Fixed double-application of mapping function in `:else` branch
- **`index-of-pred` (Line 292-300):** Rewrote to handle `nil`/`false` elements correctly
- **`enumerate` (Line 251-261):** Replaced `empty?`/`rest` pattern with idiomatic `seq`/`next`
- **`safe-subvec` 3-arity (Line 1151-1156):** Restructured to check `nil` before evaluating `count`
- **`map-diff` (Line 939-959):** Removed redundant map lookups in diff computation
- **`format-number` (Line 1121):** Removed redundant `str` wrapper
- **`append-class` (Line 1160):** Changed to use `seq` instead of `some?` for proper empty-string handling
- **`removev` (Line 423-425):** Renamed shadowed `fn` parameter to `pred`
- **`num-string?` (Line 785-786):** Added missing `string?` guard on JVM
- **Docstring fixes:** Corrected typos in `vec2`, `zip-all`, `map-perm`, namespace docstring, and `without-obj`

