### PR TITLE
:sparkles: Add nitrate subscription expected cancel date

### DIFF
--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -29,6 +29,7 @@
   [{:keys [card-title
            card-title-icon
            price-value price-period
+           cancel-at
            benefits-title benefits
            cta-text
            cta-link
@@ -57,7 +58,10 @@
     (when (and price-value price-period)
       [:div {:class (stl/css :plan-price)}
        [:span {:class (stl/css :plan-price-value)} price-value]
-       [:span {:class (stl/css :plan-price-period)} " / " price-period]])]
+       [:span {:class (stl/css :plan-price-period)} " / " price-period]])
+    (when cancel-at
+      [:div {:class (stl/css :plan-cancel)}
+       [:span {:class (stl/css :plan-cancel-date)} cancel-at]])]
    (when benefits-title [:h5 {:class (stl/css :benefits-title)} benefits-title])
    [:ul {:class (stl/css :benefits-list)}
     (for [benefit  benefits]
@@ -511,6 +515,8 @@
          ;; TODO add translations for this texts when we have the definitive ones
          [:> plan-card* {:card-title "Business Nitrate"
                          :card-title-icon i/character-b
+                         :cancel-at (when (:cancel-at nitrate-license)
+                                      (dm/str "Active until " (ct/format-inst (:cancel-at nitrate-license) "d MMMM, yyyy")))
                          :benefits-title "Loren ipsum",
                          :benefits ["Loren ipsum",
                                     "Loren ipsum",

--- a/frontend/src/app/main/ui/settings/subscription.scss
+++ b/frontend/src/app/main/ui/settings/subscription.scss
@@ -137,6 +137,20 @@
   color: var(--color-foreground-primary);
 }
 
+.plan-cancel {
+  align-items: center;
+  background-color: var(--color-background-secondary);
+  border-radius: var(--sp-xs);
+  display: flex;
+  padding-inline: var(--sp-s);
+}
+
+.plan-cancel-date {
+  @include t.use-typography("body-medium");
+
+  color: var(--color-foreground-primary);
+}
+
 .benefits-list {
   margin-block: 0;
 }


### PR DESCRIPTION
### Related Ticket

https://design.penpot.app/#/workspace?team-id=8fd8c29f-33f9-8038-8007-28bdc8c029f0&file-id=71bc4f81-468d-8163-8007-87dd424cbf26&page-id=24638977-c774-8055-8007-87ddd77ea15e&board-id=09a4ef43-2b93-8091-8007-dcb1b62b089b

### Summary
When a user cancels their subscription, the expected cancellation date will be displayed

### Steps to reproduce 
Subscribe to a nitrate plan
Go to manage your subscription and cancel your plan

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
