### PR TITLE
:bug: Forward email when adding user to Nitrate organization

### DIFF
--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -250,9 +250,11 @@
                         schema:team params)))
 
 (defn- add-profile-to-org-api
-  [cfg {:keys [profile-id org-id team-id] :as params}]
+  [cfg {:keys [profile-id org-id team-id email] :as params}]
   (let [baseuri (cf/get :nitrate-backend-uri)
-        params (assoc params :request-params {:user-id profile-id :team-id team-id})]
+        request-params (cond-> {:user-id profile-id :team-id team-id}
+                         (some? email) (assoc :email email))
+        params (assoc params :request-params request-params)]
     (request-to-nitrate cfg :post
                         (str baseuri
                              "/api/organizations/"

--- a/backend/src/app/rpc/commands/teams.clj
+++ b/backend/src/app/rpc/commands/teams.clj
@@ -542,26 +542,29 @@
 (defn initialize-user-in-nitrate-org
   "If needed, create a default team for the user on the organization,
    and notify Nitrate that an user has been added to an org."
-  [cfg profile-id org-id]
-  (assert (db/connection-map? cfg)
-          "expected cfg with valid connection")
-  (when (contains? cf/flags :nitrate)
-    (db/tx-run!
-     cfg
-     (fn [{:keys [::db/conn] :as tx-cfg}]
-       (let [org-id           org-id
-             default-team     (create-default-org-team (assoc tx-cfg ::db/conn conn) profile-id org-id)
-             default-team-id  (:id default-team)
-             result           (nitrate/call tx-cfg :add-profile-to-org {:profile-id profile-id
-                                                                        :team-id default-team-id
-                                                                        :org-id org-id})]
-         (when (not (:is-member result))
-           (ex/raise :type :internal
-                     :code :failed-add-profile-org-nitrate
-                     :context {:profile-id profile-id
-                               :org-id org-id
-                               :default-team-id default-team-id}))
-         default-team-id)))))
+  ([cfg profile-id org-id]
+   (initialize-user-in-nitrate-org cfg profile-id org-id nil))
+  ([cfg profile-id org-id email]
+   (assert (db/connection-map? cfg)
+           "expected cfg with valid connection")
+   (when (contains? cf/flags :nitrate)
+     (db/tx-run!
+      cfg
+      (fn [{:keys [::db/conn] :as tx-cfg}]
+        (let [org-id           org-id
+              default-team     (create-default-org-team (assoc tx-cfg ::db/conn conn) profile-id org-id)
+              default-team-id  (:id default-team)
+              result           (nitrate/call tx-cfg :add-profile-to-org (cond-> {:profile-id profile-id
+                                                                                 :team-id default-team-id
+                                                                                 :org-id org-id}
+                                                                          (some? email) (assoc :email email)))]
+          (when (not (:is-member result))
+            (ex/raise :type :internal
+                      :code :failed-add-profile-org-nitrate
+                      :context {:profile-id profile-id
+                                :org-id org-id
+                                :default-team-id default-team-id}))
+          default-team-id))))))
 
 (defn add-profile-to-team!
   ([cfg params]

--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -137,7 +137,7 @@
         (if organization
           ;; Insert the invited member to the org
           (when (contains? cf/flags :nitrate)
-            (teams/initialize-user-in-nitrate-org cfg (:id member) (:id organization)))
+            (teams/initialize-user-in-nitrate-org cfg (:id member) (:id organization) email))
           ;; Insert the invited member to the team
           (teams/add-profile-to-team! cfg params {::db/on-conflict-do-nothing? true}))
 

--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -111,7 +111,7 @@
           accepted-team-id (if org-id
                              ;; Insert the invited member to the org
                              (when (contains? cf/flags :nitrate)
-                               (teams/initialize-user-in-nitrate-org cfg id-member org-id))
+                               (teams/initialize-user-in-nitrate-org cfg id-member org-id member-email))
                              ;; Insert the invited member to the team
                              (do (teams/add-profile-to-team! cfg params {::db/on-conflict-do-nothing? true})
                                  team-id))]

--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -57,7 +57,8 @@
      (let [href (dm/str "/control-center/org/"
                         (u/percent-encode organization-slug)
                         "/"
-                        (u/percent-encode (str organization-id)))]
+                        (u/percent-encode (str organization-id))
+                        "/people/")]
        (st/emit! (rt/nav-raw :href href)))
      (st/emit! (rt/nav-raw :href "/control-center/")))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26263

### Summary

Pass the user email to the Nitrate API when initializing a profile
in an organization, both from invitation and token verification flows.
Also fix navigation URL to include the /people/ path segment.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
