### PR TITLE
:zap: Add efficiency improvements to several components

### DIFF
--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -41,6 +41,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def xf:map-id (map :id))
+(def xf:add-index (map-indexed (fn [index item] (assoc item ::index index))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Data Structures

--- a/frontend/src/app/main/ui/shapes/custom_stroke.cljs
+++ b/frontend/src/app/main/ui/shapes/custom_stroke.cljs
@@ -485,6 +485,10 @@
         shape-shadow  (get shape :shadow)
         shape-strokes (not-empty strokes)
 
+        strokes
+        (mf/with-memo [strokes]
+          (rseq (into [] d/xf:add-index strokes)))
+
         svg-attrs     (attrs/get-svg-props shape render-id)
 
         style         (-> (obj/get props "style")
@@ -509,7 +513,7 @@
 
     (when (some? shape-strokes)
       [:> :g props
-       (for [[index value] (reverse (d/enumerate shape-strokes))]
+       (for [{:keys [::d/index] :as value} strokes]
          [:& shape-custom-stroke {:shape shape
                                   :stroke value
                                   :index index

--- a/frontend/src/app/main/ui/shapes/filters.cljs
+++ b/frontend/src/app/main/ui/shapes/filters.cljs
@@ -170,7 +170,11 @@
         selrect       (:selrect shape)
 
         [filter-x filter-y filter-width filter-height filter-units]
-        (filter-coords bounds selrect padding)]
+        (filter-coords bounds selrect padding)
+
+        filters
+        (mf/with-memo [filters]
+          (into [] d/xf:add-index filters))]
 
     (when (> (count filters) 2)
       [:filter {:id          filter-id
@@ -180,7 +184,7 @@
                 :height      filter-height
                 :filterUnits filter-units
                 :color-interpolation-filters "sRGB"}
-       (for [[index entry] (d/enumerate filters)]
+       (for [{:keys [::d/index] :as entry} filters]
          [:& filter-entry {:key (dm/str filter-id "-" index)
                            :entry entry}])])))
 

--- a/frontend/src/app/main/ui/shapes/gradients.cljs
+++ b/frontend/src/app/main/ui/shapes/gradients.cljs
@@ -41,13 +41,17 @@
                        :y1 (:start-y gradient)
                        :x2 (:end-x gradient)
                        :y2 (:end-y gradient)
-                       :gradientTransform (dm/str transform)}]
+                       :gradientTransform (dm/str transform)}
+
+        stops
+        (mf/with-memo [gradient]
+          (into [] d/xf:add-index (sort-by :offset (:stops gradient))))]
 
     (when ^boolean metadata?
       (add-metadata! props gradient))
 
     [:> :linearGradient props
-     (for [[index {:keys [offset color opacity]}] (d/enumerate (sort-by :offset (:stops gradient)))]
+     (for [{:keys [::d/index offset color opacity]} stops]
        [:stop {:key (dm/str id "-stop-" index)
                :offset (d/nilv offset 0)
                :stop-color color
@@ -103,13 +107,17 @@
                            :cx start-x
                            :cy start-y
                            :r (gpt/length gradient-vec)
-                           :gradientTransform transform}]
+                           :gradientTransform transform}
+
+        stops
+        (mf/with-memo [gradient]
+          (into [] d/xf:add-index (:stops gradient)))]
 
     (when ^boolean metadata?
       (add-metadata! props gradient))
 
     [:> :radialGradient props
-     (for [[index {:keys [offset color opacity]}] (d/enumerate (:stops gradient))]
+     (for [{:keys [::d/index offset color opacity]} stops]
        [:stop {:key (dm/str id "-stop-" index)
                :offset (d/nilv offset 0)
                :stop-color color

--- a/frontend/src/app/main/ui/shapes/text/svg_text.cljs
+++ b/frontend/src/app/main/ui/shapes/text/svg_text.cljs
@@ -55,13 +55,17 @@
                         (attrs/add-border-props! shape))
         get-gradient-id
         (fn [index]
-          (str render-id "-" (:id shape) "-" index))]
+          (str render-id "-" (:id shape) "-" index))
+
+        position-data
+        (mf/with-memo [position-data]
+          (into [] d/xf:add-index position-data))]
 
     [:*
      ;; Definition of gradients for partial elements
      (when (d/seek :fill-color-gradient position-data)
        [:defs
-        (for [[index data] (d/enumerate position-data)]
+        (for [{:keys [::d/index] :as data} position-data]
           (when (some? (:fill-color-gradient data))
             (let [id (dm/str "fill-color-gradient-" (get-gradient-id index))]
               [:& grad/gradient {:id id
@@ -70,7 +74,7 @@
                                  :shape data}])))])
 
      [:> :g group-props
-      (for [[index data] (d/enumerate position-data)]
+      (for [{:keys [::d/index] :as data} position-data]
         (let [rtl? (= "rtl" (:direction data))
 
               browser-props

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
@@ -44,16 +44,12 @@
        (filterv (fn [[idx _]] (not= idx index)))
        (mapv second)))
 
-(def ^:private xf:add-index
-  (map-indexed (fn [index shadow]
-                 (assoc shadow ::index index))))
-
 (mf/defc shadow-menu*
   [{:keys [ids type values] :as props}]
   (let [shadows        (mf/with-memo [values]
                          (if (= :multiple values)
                            values
-                           (not-empty (into [] xf:add-index values))))
+                           (not-empty (into [] d/xf:add-index values))))
 
         ids-ref        (h/use-update-ref ids)
 
@@ -161,7 +157,7 @@
          (some? shadows)
          [:> h/sortable-container* {}
           [:div {:class (stl/css :shadow-content)}
-           (for [{:keys [::index id] :as shadow} shadows]
+           (for [{:keys [::d/index id] :as shadow} shadows]
              [:> shadow-row*
               {:key (dm/str index)
                :index index

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -54,6 +54,9 @@
         strokes         (:strokes values)
         has-strokes?    (or (= :multiple strokes) (some? (seq strokes)))
 
+        strokes
+        (mf/with-memo [strokes]
+          (into [] d/xf:add-index strokes))
 
         on-color-change
         (mf/use-fn
@@ -206,7 +209,7 @@
                              :icon i/remove}]]
           (seq strokes)
           [:> h/sortable-container* {}
-           (for [[index value] (d/enumerate (:strokes values []))]
+           (for [{:keys [::d/index] :as value} strokes]
              [:> stroke-row* {:key (dm/str "stroke-" index)
                               :stroke value
                               :title (tr "workspace.options.stroke-color")


### PR DESCRIPTION
### Summary

This is a first part of multiple PRs for address this.

Current Issue: Presently, the component invokes d/enumerate during every render cycle to generate a sequence for iteration. This sequence is immediately discarded after use. Because components often re-render due to state or prop changes that do not affect the underlying collection, we are incurring unnecessary allocation overhead and processing costs.

Proposed Solution: Decouple the iteration logic from the render body by moving the d/enumerate call into a memoized step.

Benefits:

- Reduced Allocation: Prevents the constant creation and garbage collection of indexed sequences on every render.
- Performance Stability: Limits execution of the enumeration logic to only when the source collection actually changes.
