### PR TITLE
:bug: Skip onboarding modal for nitrate entry users

### DIFF
--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -16,6 +16,7 @@
    [app.main.data.nitrate :as dnt]
    [app.main.data.notifications :as notif]
    [app.main.data.plugins :as dp]
+   [app.main.data.profile :as dprof]
    [app.main.data.project :as dpj]
    [app.main.refs :as refs]
    [app.main.router :as rt]
@@ -268,7 +269,8 @@
   (mf/with-effect []
     (when (dnt/nitrate-entry-popup-pending?)
       (dnt/consume-nitrate-entry-popup!)
-      (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
+      (st/emit! (dprof/update-profile-props {:onboarding-viewed true})
+                (dnt/show-nitrate-popup :nitrate-form)))))
 
 (mf/defc dashboard*
   [{:keys [profile project-id team-id search-term plugin-url template section]}]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26271

### Summary

Users coming from /subscribe-nitrate were shown the onboarding modal after completing registration. Mark onboarding as viewed when the nitrate entry popup is consumed so it never appears.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
