### PR TITLE
:bug: Fix masked shapes causing render cuts at tile boundaries

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2454,6 +2454,7 @@ impl RenderState {
                 let has_effects = transformed_element.has_effects_that_extend_bounds();
 
                 let is_visible = export
+                    || mask
                     || if is_container || has_effects {
                         let element_extrect =
                             extrect.get_or_insert_with(|| transformed_element.extrect(tree, scale));


### PR DESCRIPTION
### Related Ticket

### Summary

 When a masked group's content extends beyond the mask shape's bounds and you zoom in to a tile that overlaps the content but not the mask, the mask shape gets culled by the visibility check:

**Before**
[screen-recorder-wed-apr-15-2026-16-00-11.webm](https://github.com/user-attachments/assets/193b82bf-e44d-47de-9657-aceaebc396eb)

**After**
[screen-recorder-wed-apr-15-2026-15-58-57.webm](https://github.com/user-attachments/assets/1edd74ad-4592-4e9e-9738-d6fc2be097f2)


### Steps to reproduce 

It can be reproduced in the plants-app library template as in the videos

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
