### PR TITLE
:zap: Add efficiency improvements to workspace components (part 3)

### DIFF
--- a/frontend/src/app/main/ui/workspace/palette.cljs
+++ b/frontend/src/app/main/ui/workspace/palette.cljs
@@ -24,7 +24,7 @@
    [app.main.ui.workspace.color-palette :refer [color-palette*]]
    [app.main.ui.workspace.color-palette-ctx-menu :refer [color-palette-ctx-menu*]]
    [app.main.ui.workspace.text-palette :refer [text-palette*]]
-   [app.main.ui.workspace.text-palette-ctx-menu :refer [text-palette-ctx-menu]]
+   [app.main.ui.workspace.text-palette-ctx-menu :refer [text-palette-ctx-menu*]]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.object :as obj]
@@ -203,10 +203,10 @@
                   :ref container}
             (when text-palette?
               [:*
-               [:& text-palette-ctx-menu {:show-menu?  show-menu?
-                                          :close-menu on-close-menu
-                                          :on-select-palette on-select-text-palette-menu
-                                          :selected selected-text}]
+               [:> text-palette-ctx-menu* {:show-menu  show-menu?
+                                           :close-menu on-close-menu
+                                           :on-select-palette on-select-text-palette-menu
+                                           :selected selected-text}]
                [:> text-palette* {:size size
                                   :selected selected-text
                                   :width vport-width}]])

--- a/frontend/src/app/main/ui/workspace/shapes/text/text_edition_outline.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/text_edition_outline.cljs
@@ -16,7 +16,7 @@
    [app.render-wasm.api :as wasm.api]
    [rumext.v2 :as mf]))
 
-(mf/defc text-edition-outline
+(mf/defc text-edition-outline*
   [{:keys [shape zoom modifiers]}]
   (if (features/active-feature? @st/state "render-wasm/v1")
     (let [selrect-transform (mf/deref refs/workspace-selrect)

--- a/frontend/src/app/main/ui/workspace/sidebar/history.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/history.cljs
@@ -258,7 +258,7 @@
        (map (resolve-shape-types entries objects))
        (mapv select-entry)))
 
-(mf/defc history-entry-details [{:keys [entry]}]
+(mf/defc history-entry-details* [{:keys [entry]}]
   (let [{entries :items} (mf/deref workspace-undo)
         objects (mf/deref refs/workspace-page-objects)]
 
@@ -319,7 +319,7 @@
          deprecated-icon/arrow])]
 
      (when @show-detail?
-       [:& history-entry-details {:entry entry}])]))
+       [:> history-entry-details* {:entry entry}])]))
 
 (mf/defc history-toolbox*
   []

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -32,7 +32,7 @@
      :value 4
      :hidden false}))
 
-(mf/defc blur-menu [{:keys [ids type values]}]
+(mf/defc blur-menu* [{:keys [ids type values]}]
   (let [blur           (:blur values)
         has-value?     (not (nil? blur))
         render-wasm?   (features/use-feature "render-wasm/v1")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs
@@ -28,7 +28,7 @@
                        :parent-id
                        :frame-id])
 
-(mf/defc constraints-menu
+(mf/defc constraints-menu*
   [{:keys [ids values] :as props}]
   (let [state*          (mf/use-state true)
         open?           (deref state*)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -33,7 +33,7 @@
    :separator
    18 12 10 8 6 4 3 2])
 
-(mf/defc grid-options
+(mf/defc grid-options*
   {::mf/wrap [mf/memo]}
   [{:keys [shape-id index grid frame-width frame-height default-grid-params]}]
   (let [on-change           (mf/use-fn (mf/deps shape-id index) #(st/emit! (dw/set-frame-grid shape-id index %)))
@@ -296,7 +296,7 @@
                [:button {:class (stl/css :option-btn)
                          :on-click handle-set-as-default} (tr "workspace.options.grid.params.set-default")]])]])])]))
 
-(mf/defc frame-grid
+(mf/defc frame-grid*
   [{:keys [shape]}]
   (let [state*              (mf/use-state true)
         open?               (deref state*)
@@ -331,12 +331,12 @@
      (when (and open? (seq frame-grids))
        [:div  {:class (stl/css :element-set-content)}
         (for [[index grid] (map-indexed vector frame-grids)]
-          [:& grid-options {:key (str id "-" index)
-                            :shape-id id
-                            :grid grid
-                            :index index
-                            :frame-width (:width shape)
-                            :frame-height (:height shape)
-                            :default-grid-params default-grid-params}])])]))
+          [:> grid-options* {:key (str id "-" index)
+                             :shape-id id
+                             :grid grid
+                             :index index
+                             :frame-width (:width shape)
+                             :frame-height (:height shape)
+                             :default-grid-params default-grid-params}])])]))
 
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -37,7 +37,7 @@
    :stroke-cap-start
    :stroke-cap-end])
 
-(mf/defc stroke-menu
+(mf/defc stroke-menu*
   {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "show-caps" "applied-tokens"]))]}
   [{:keys [ids type values show-caps disable-stroke-style applied-tokens shapes objects] :as props}]
   (let [label (case type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/svg_attrs.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/svg_attrs.cljs
@@ -17,7 +17,8 @@
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(mf/defc attribute-value [{:keys [attr value on-change on-delete] :as props}]
+(mf/defc attribute-value*
+  [{:keys [attr value on-change on-delete]}]
   (let [last-value (mf/use-state value)
 
         handle-change*
@@ -56,13 +57,14 @@
          (str (d/name (last attr)))]
         (for [[key value] value]
           [:div {:class (stl/css :attr-row) :key key}
-           [:& attribute-value {:key key
-                                :attr (conj attr key)
-                                :value value
-                                :on-change on-change
-                                :on-delete on-delete}]])])]))
+           [:> attribute-value* {:key key
+                                 :attr (conj attr key)
+                                 :value value
+                                 :on-change on-change
+                                 :on-delete on-delete}]])])]))
 
-(mf/defc svg-attrs-menu [{:keys [ids values]}]
+(mf/defc svg-attrs-menu*
+  [{:keys [ids values]}]
   (let [state*          (mf/use-state true)
         open?           (deref state*)
         attrs           (:svg-attrs values)
@@ -103,8 +105,8 @@
        (when open?
          [:div {:class (stl/css :element-set-content)}
           (for [[attr-key attr-value] attrs]
-            [:& attribute-value {:key attr-key
-                                 :attr [attr-key]
-                                 :value attr-value
-                                 :on-change handle-change
-                                 :on-delete handle-delete}])])])))
+            [:> attribute-value* {:key attr-key
+                                  :attr [attr-key]
+                                  :value attr-value
+                                  :on-change handle-change
+                                  :on-delete handle-delete}])])])))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -38,7 +38,7 @@
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
-(mf/defc text-align-options
+(mf/defc text-align-options*
   [{:keys [values on-change on-blur] :as props}]
   (let [{:keys [text-align]} values
         handle-change
@@ -70,7 +70,7 @@
                         :title (tr "workspace.options.text-options.text-align-justify")
                         :icon i/text-justify}]]]))
 
-(mf/defc text-direction-options
+(mf/defc text-direction-options*
   [{:keys [values on-change on-blur] :as props}]
   (let [direction     (:text-direction values)
         handle-change
@@ -98,7 +98,7 @@
                         :title (tr "workspace.options.text-options.direction-rtl")
                         :icon i/text-rtl}]]]))
 
-(mf/defc vertical-align
+(mf/defc vertical-align*
   [{:keys [values on-change on-blur] :as props}]
   (let [{:keys [vertical-align]} values
         vertical-align (or vertical-align "top")
@@ -126,7 +126,7 @@
                         :title (tr "workspace.options.text-options.align-bottom")
                         :icon i/text-bottom}]]]))
 
-(mf/defc grow-options
+(mf/defc grow-options*
   [{:keys [ids values on-blur] :as props}]
   (let [grow-type (:grow-type values)
 
@@ -172,7 +172,7 @@
                         :title (tr "workspace.options.text-options.grow-auto-height")
                         :icon i/text-auto-height}]]]))
 
-(mf/defc text-decoration-options
+(mf/defc text-decoration-options*
   [{:keys [values on-change on-blur] :as props}]
   (let [text-decoration (or (:text-decoration values) "none")
         handle-change
@@ -199,7 +199,7 @@
                         :title (tr "workspace.options.text-options.strikethrough" (sc/get-tooltip :line-through))
                         :icon i/text-stroked}]]]))
 
-(mf/defc text-menu
+(mf/defc text-menu*
   {::mf/wrap [mf/memo]}
   [{:keys [ids type values] :as props}]
 
@@ -349,8 +349,8 @@
           [:> text-options opts])
 
         [:div {:class (stl/css :text-align-options)}
-         [:> text-align-options opts]
-         [:> grow-options opts]
+         [:> text-align-options* opts]
+         [:> grow-options* opts]
          [:> icon-button* {:variant "ghost"
                            :aria-label (tr "labels.options")
                            :data-testid "text-align-options-button"
@@ -359,6 +359,6 @@
 
         (when more-options-open?
           [:div  {:class (stl/css :text-decoration-options)}
-           [:> vertical-align opts]
-           [:> text-decoration-options opts]
-           [:> text-direction-options opts]])])]))
+           [:> vertical-align* opts]
+           [:> text-decoration-options* opts]
+           [:> text-direction-options* opts]])])]))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
@@ -9,8 +9,8 @@
    [app.common.data.macros :as dm]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -19,7 +19,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [rumext.v2 :as mf]))
 
 (mf/defc options*
@@ -118,8 +118,8 @@
          :shape shape}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu {:ids ids
-                             :values constraint-values}])
+       [:> constraints-menu* {:ids ids
+                              :values constraint-values}])
 
      [:> fill/fill-menu*
       {:ids ids
@@ -127,15 +127,15 @@
        :values shape
        :applied-tokens applied-tokens}]
 
-     [:& stroke-menu {:ids ids
-                      :type type
-                      :show-caps true
-                      :values stroke-values
-                      :applied-tokens applied-tokens}]
+     [:> stroke-menu* {:ids ids
+                       :type type
+                       :show-caps true
+                       :values stroke-values
+                       :applied-tokens applied-tokens}]
 
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
-     [:& blur-menu {:ids ids
-                    :values (select-keys shape [:blur])}]
+     [:> blur-menu* {:ids ids
+                     :values (select-keys shape [:blur])}]
 
      [:> exports-menu* {:type type
                         :ids ids

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu*]]
    [rumext.v2 :as mf]))
 
 (mf/defc options*
@@ -133,8 +133,8 @@
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
      [:> blur-menu* {:ids ids
                      :values (select-keys shape [:blur])}]
-     [:& svg-attrs-menu {:ids ids
-                         :values (select-keys shape [:svg-attrs])}]
+     [:> svg-attrs-menu* {:ids ids
+                          :values (select-keys shape [:svg-attrs])}]
      [:> exports-menu* {:type type
                         :ids ids
                         :shapes shapes

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
@@ -9,8 +9,8 @@
    [app.common.data.macros :as dm]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -19,7 +19,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
    [rumext.v2 :as mf]))
 
@@ -117,8 +117,8 @@
                              :shape shape}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu {:ids ids
-                             :values constraint-values}])
+       [:> constraints-menu* {:ids ids
+                              :values constraint-values}])
 
      [:> fill/fill-menu*
       {:ids ids
@@ -126,13 +126,13 @@
        :values shape
        :applied-tokens applied-tokens}]
 
-     [:& stroke-menu {:ids ids
-                      :type type
-                      :values stroke-values
-                      :applied-tokens applied-tokens}]
+     [:> stroke-menu* {:ids ids
+                       :type type
+                       :values stroke-values
+                       :applied-tokens applied-tokens}]
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
-     [:& blur-menu {:ids ids
-                    :values (select-keys shape [:blur])}]
+     [:> blur-menu* {:ids ids
+                     :values (select-keys shape [:blur])}]
      [:& svg-attrs-menu {:ids ids
                          :values (select-keys shape [:svg-attrs])}]
      [:> exports-menu* {:type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -16,7 +16,7 @@
    [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
-   [app.main.ui.workspace.sidebar.options.menus.frame-grid :refer [frame-grid]]
+   [app.main.ui.workspace.sidebar.options.menus.frame-grid :refer [frame-grid*]]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
    [app.main.ui.workspace.sidebar.options.menus.layer :refer [layer-attrs layer-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.layout-container :refer [layout-container-flex-attrs layout-container-menu]]
@@ -160,7 +160,7 @@
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
      [:> blur-menu* {:ids ids
                      :values (select-keys shape [:blur])}]
-     [:& frame-grid {:shape shape}]
+     [:> frame-grid* {:shape shape}]
      [:> exports-menu* {:type shape-type
                         :ids ids
                         :shapes shapes

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -10,10 +10,10 @@
    [app.common.types.component :as ctk]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu* component-variant-main*]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.frame-grid :refer [frame-grid]]
@@ -23,7 +23,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [select-measure-keys measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [rumext.v2 :as mf]))
 
 (mf/defc options*
@@ -140,8 +140,8 @@
          :shape shape}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu {:ids ids
-                             :values constraint-values}])
+       [:> constraints-menu* {:ids ids
+                              :values constraint-values}])
 
      [:> fill/fill-menu*
       {:ids ids
@@ -149,17 +149,17 @@
        :values shape
        :applied-tokens applied-tokens}]
 
-     [:& stroke-menu {:ids ids
-                      :type shape-type
-                      :values stroke-values
-                      :applied-tokens applied-tokens}]
+     [:> stroke-menu* {:ids ids
+                       :type shape-type
+                       :values stroke-values
+                       :applied-tokens applied-tokens}]
      [:> color-selection-menu* {:type shape-type
                                 :shapes shapes-with-children
                                 :file-id file-id
                                 :libraries libraries}]
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
-     [:& blur-menu {:ids ids
-                    :values (select-keys shape [:blur])}]
+     [:> blur-menu* {:ids ids
+                     :values (select-keys shape [:blur])}]
      [:& frame-grid {:shape shape}]
      [:> exports-menu* {:type shape-type
                         :ids ids

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -11,9 +11,9 @@
    [app.common.data.macros :as dm]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -22,7 +22,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
    [app.main.ui.workspace.sidebar.options.menus.text :as ot]
    [app.main.ui.workspace.sidebar.options.shapes.multiple :refer [get-attrs]]
@@ -143,7 +143,7 @@
          :values layout-item-values}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu {:ids constraint-ids :values constraint-values}])
+       [:> constraints-menu* {:ids constraint-ids :values constraint-values}])
 
      (when-not (empty? fill-ids)
        [:> fill/fill-menu*
@@ -153,10 +153,10 @@
          :applied-tokens fill-tokens}])
 
      (when-not (empty? stroke-ids)
-       [:& stroke-menu {:type type
-                        :ids stroke-ids
-                        :values stroke-values
-                        :applied-tokens stroke-tokens}])
+       [:> stroke-menu* {:type type
+                         :ids stroke-ids
+                         :values stroke-values
+                         :applied-tokens stroke-tokens}])
 
      [:> color-selection-menu*
       {:type type
@@ -168,7 +168,7 @@
        [:> shadow-menu* {:ids ids :values (get shape :shadow) :type type}])
 
      (when-not (empty? blur-ids)
-       [:& blur-menu {:type type :ids blur-ids :values blur-values}])
+       [:> blur-menu* {:type type :ids blur-ids :values blur-values}])
 
      (when-not (empty? text-ids)
        [:& ot/text-menu {:type type :ids text-ids :values text-values}])

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -171,7 +171,7 @@
        [:> blur-menu* {:type type :ids blur-ids :values blur-values}])
 
      (when-not (empty? text-ids)
-       [:& ot/text-menu {:type type :ids text-ids :values text-values}])
+       [:> ot/text-menu* {:type type :ids text-ids :values text-values}])
 
      (when-not (empty? svg-values)
        [:& svg-attrs-menu {:ids ids :values svg-values}])

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.text :as ot]
    [app.main.ui.workspace.sidebar.options.shapes.multiple :refer [get-attrs]]
    [rumext.v2 :as mf]))
@@ -174,7 +174,7 @@
        [:> ot/text-menu* {:type type :ids text-ids :values text-values}])
 
      (when-not (empty? svg-values)
-       [:& svg-attrs-menu {:ids ids :values svg-values}])
+       [:> svg-attrs-menu* {:ids ids :values svg-values}])
 
      [:> exports-menu* {:type type
                         :ids ids

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -20,10 +20,10 @@
    [app.common.types.token :as tt]
    [app.common.weak :as weak]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-attrs blur-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-attrs blur-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-attrs exports-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.layer :refer [layer-attrs layer-menu*]]
@@ -31,7 +31,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [select-measure-keys measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-attrs shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.text :as ot]
    [rumext.v2 :as mf]))
 
@@ -475,7 +475,7 @@
          :values layout-item-values}])
 
      (when-not (or (empty? constraint-ids) ^boolean is-layout-child?)
-       [:& constraints-menu {:ids constraint-ids :values constraint-values}])
+       [:> constraints-menu* {:ids constraint-ids :values constraint-values}])
 
      (when-not (empty? text-ids)
        [:& ot/text-menu {:type type :ids text-ids :values text-values}])
@@ -487,12 +487,12 @@
                             :applied-tokens fill-tokens}])
 
      (when-not (empty? stroke-ids)
-       [:& stroke-menu {:type type
-                        :ids stroke-ids
-                        :show-caps show-caps?
-                        :values stroke-values
-                        :disable-stroke-style has-text?
-                        :applied-tokens stroke-tokens}])
+       [:> stroke-menu* {:type type
+                         :ids stroke-ids
+                         :show-caps show-caps?
+                         :values stroke-values
+                         :disable-stroke-style has-text?
+                         :applied-tokens stroke-tokens}])
 
      (when-not (empty? shapes)
        [:> color-selection-menu*
@@ -507,7 +507,7 @@
                          :values (get shadow-values :shadow)}])
 
      (when-not (empty? blur-ids)
-       [:& blur-menu {:type type :ids blur-ids :values blur-values}])
+       [:> blur-menu* {:type type :ids blur-ids :values blur-values}])
 
      (when-not (empty? exports-ids)
        [:> exports-menu* {:type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -478,7 +478,7 @@
        [:> constraints-menu* {:ids constraint-ids :values constraint-values}])
 
      (when-not (empty? text-ids)
-       [:& ot/text-menu {:type type :ids text-ids :values text-values}])
+       [:> ot/text-menu* {:type type :ids text-ids :values text-values}])
 
      (when-not (empty? fill-ids)
        [:> fill/fill-menu* {:type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
@@ -9,8 +9,8 @@
    [app.common.data.macros :as dm]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -19,7 +19,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
    [rumext.v2 :as mf]))
 
@@ -117,8 +117,8 @@
                              :shape shape}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu {:ids ids
-                             :values constraint-values}])
+       [:> constraints-menu* {:ids ids
+                              :values constraint-values}])
 
      [:> fill/fill-menu*
       {:ids ids
@@ -126,14 +126,14 @@
        :values shape
        :applied-tokens applied-tokens}]
 
-     [:& stroke-menu {:ids ids
-                      :type type
-                      :show-caps true
-                      :values stroke-values
-                      :applied-tokens applied-tokens}]
+     [:> stroke-menu* {:ids ids
+                       :type type
+                       :show-caps true
+                       :values stroke-values
+                       :applied-tokens applied-tokens}]
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
-     [:& blur-menu {:ids ids
-                    :values (select-keys shape [:blur])}]
+     [:> blur-menu* {:ids ids
+                     :values (select-keys shape [:blur])}]
      [:& svg-attrs-menu {:ids ids
                          :values (select-keys shape [:svg-attrs])}]
      [:> exports-menu* {:type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu*]]
    [rumext.v2 :as mf]))
 
 (mf/defc options*
@@ -134,8 +134,8 @@
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
      [:> blur-menu* {:ids ids
                      :values (select-keys shape [:blur])}]
-     [:& svg-attrs-menu {:ids ids
-                         :values (select-keys shape [:svg-attrs])}]
+     [:> svg-attrs-menu* {:ids ids
+                          :values (select-keys shape [:svg-attrs])}]
      [:> exports-menu* {:type type
                         :ids ids
                         :shapes shapes

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
@@ -9,8 +9,8 @@
    [app.common.data.macros :as dm]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -19,7 +19,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
    [rumext.v2 :as mf]))
 
@@ -117,8 +117,8 @@
          :shape shape}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu {:ids ids
-                             :values constraint-values}])
+       [:> constraints-menu* {:ids ids
+                              :values constraint-values}])
 
      [:> fill/fill-menu*
       {:ids ids
@@ -126,15 +126,15 @@
        :values shape
        :applied-tokens applied-tokens}]
 
-     [:& stroke-menu {:ids ids
-                      :type type
-                      :values stroke-values
-                      :applied-tokens applied-tokens}]
+     [:> stroke-menu* {:ids ids
+                       :type type
+                       :values stroke-values
+                       :applied-tokens applied-tokens}]
 
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
 
-     [:& blur-menu {:ids ids
-                    :values (select-keys shape [:blur])}]
+     [:> blur-menu* {:ids ids
+                     :values (select-keys shape [:blur])}]
 
      [:& svg-attrs-menu {:ids ids
                          :values (select-keys shape [:svg-attrs])}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu*]]
    [rumext.v2 :as mf]))
 
 (mf/defc options*
@@ -136,8 +136,8 @@
      [:> blur-menu* {:ids ids
                      :values (select-keys shape [:blur])}]
 
-     [:& svg-attrs-menu {:ids ids
-                         :values (select-keys shape [:svg-attrs])}]
+     [:> svg-attrs-menu* {:ids ids
+                          :values (select-keys shape [:svg-attrs])}]
      [:> exports-menu* {:type type
                         :ids ids
                         :shapes shapes

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
@@ -21,7 +21,7 @@
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu*]]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -203,8 +203,8 @@
        [:> blur-menu* {:ids ids
                        :values (select-keys shape [:blur])}]
 
-       [:& svg-attrs-menu {:ids ids
-                           :values (select-keys shape [:svg-attrs])}]
+       [:> svg-attrs-menu* {:ids ids
+                            :values (select-keys shape [:svg-attrs])}]
        [:> exports-menu* {:type type
                           :ids ids
                           :shapes shapes

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
@@ -11,8 +11,8 @@
    [app.common.types.color :as cc]
    [app.common.types.shape.layout :as ctl]
    [app.main.refs :as refs]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -20,7 +20,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.svg-attrs :refer [svg-attrs-menu]]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
@@ -184,8 +184,8 @@
            :shape shape}])
 
        (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-         [:& constraints-menu {:ids ids
-                               :values constraint-values}])
+         [:> constraints-menu* {:ids ids
+                                :values constraint-values}])
 
        [:> fill/fill-menu*
         {:ids ids
@@ -193,15 +193,15 @@
          :values fill-values
          :applied-tokens applied-tokens}]
 
-       [:& stroke-menu {:ids ids
-                        :type type
-                        :values stroke-values
-                        :applied-tokens applied-tokens}]
+       [:> stroke-menu* {:ids ids
+                         :type type
+                         :values stroke-values
+                         :applied-tokens applied-tokens}]
 
        [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
 
-       [:& blur-menu {:ids ids
-                      :values (select-keys shape [:blur])}]
+       [:> blur-menu* {:ids ids
+                       :values (select-keys shape [:blur])}]
 
        [:& svg-attrs-menu {:ids ids
                            :values (select-keys shape [:svg-attrs])}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -26,7 +26,7 @@
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.text :refer [text-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.text :refer [text-menu*]]
    [rumext.v2 :as mf]))
 
 (mf/defc options*
@@ -176,7 +176,7 @@
         {:ids ids
          :values (select-keys shape constraint-attrs)}])
 
-     [:& text-menu
+     [:> text-menu*
       {:ids ids
        :type type
        :values text-values}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -14,9 +14,9 @@
    [app.main.features :as features]
    [app.main.refs :as refs]
    [app.main.store :as st]
-   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
@@ -25,7 +25,7 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-item :refer [layout-item-attrs layout-item-menu]]
    [app.main.ui.workspace.sidebar.options.menus.measures :refer [measure-attrs measures-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.shadow :refer [shadow-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.stroke :refer [stroke-attrs stroke-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.text :refer [text-menu]]
    [rumext.v2 :as mf]))
 
@@ -172,7 +172,7 @@
          :shape shape}])
 
      (when (or (not ^boolean is-layout-child?) ^boolean is-layout-child-absolute?)
-       [:& constraints-menu
+       [:> constraints-menu*
         {:ids ids
          :values (select-keys shape constraint-attrs)}])
 
@@ -187,11 +187,11 @@
        :values fill-values
        :applied-tokens applied-tokens}]
 
-     [:& stroke-menu {:ids ids
-                      :type type
-                      :values stroke-values
-                      :disable-stroke-style true
-                      :applied-tokens applied-tokens}]
+     [:> stroke-menu* {:ids ids
+                       :type type
+                       :values stroke-values
+                       :disable-stroke-style true
+                       :applied-tokens applied-tokens}]
 
      (when (= :multiple (:fills fill-values))
        [:> color-selection-menu*
@@ -202,7 +202,7 @@
 
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
 
-     [:& blur-menu
+     [:> blur-menu*
       {:ids ids
        :values (select-keys shape [:blur])}]
 

--- a/frontend/src/app/main/ui/workspace/text_palette_ctx_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/text_palette_ctx_menu.cljs
@@ -14,11 +14,11 @@
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(mf/defc text-palette-ctx-menu
-  [{:keys [show-menu? close-menu on-select-palette selected]}]
+(mf/defc text-palette-ctx-menu*
+  [{:keys [show-menu close-menu on-select-palette selected]}]
   (let [typographies (mf/deref refs/workspace-file-typography)
         libraries    (mf/deref refs/libraries)]
-    [:& dropdown {:show show-menu?
+    [:& dropdown {:show show-menu
                   :on-close close-menu}
      [:ul {:class (stl/css :text-context-menu)}
       (for [[idx cur-library] (map-indexed vector (vals libraries))]

--- a/frontend/src/app/main/ui/workspace/top_toolbar.cljs
+++ b/frontend/src/app/main/ui/workspace/top_toolbar.cljs
@@ -27,7 +27,7 @@
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
-(mf/defc image-upload
+(mf/defc image-upload*
   {::mf/wrap [mf/memo]}
   []
   (let [ref            (mf/use-ref nil)
@@ -181,7 +181,7 @@
             :data-tool "text"}
            deprecated-icon/text]]
 
-         [:& image-upload]
+         [:> image-upload*]
 
          [:li
           [:button

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -30,7 +30,7 @@
    [app.main.ui.workspace.shapes :as shapes]
    [app.main.ui.workspace.shapes.path.editor :refer [path-editor*]]
    [app.main.ui.workspace.shapes.text.editor :as editor-v1]
-   [app.main.ui.workspace.shapes.text.text-edition-outline :refer [text-edition-outline]]
+   [app.main.ui.workspace.shapes.text.text-edition-outline :refer [text-edition-outline*]]
    [app.main.ui.workspace.shapes.text.v2-editor :as editor-v2]
    [app.main.ui.workspace.shapes.text.viewport-texts-html :as stvh]
    [app.main.ui.workspace.top-toolbar :refer [top-toolbar*]]
@@ -487,7 +487,7 @@
            :on-context-menu on-menu-selected}])
 
        (when show-text-editor?
-         [:& text-edition-outline
+         [:> text-edition-outline*
           {:shape (get base-objects edition)
            :zoom zoom
            :modifiers modifiers}])

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -28,7 +28,7 @@
    [app.main.ui.measurements :as msr]
    [app.main.ui.workspace.shapes.path.editor :refer [path-editor*]]
    [app.main.ui.workspace.shapes.text.editor :as editor-v1]
-   [app.main.ui.workspace.shapes.text.text-edition-outline :refer [text-edition-outline]]
+   [app.main.ui.workspace.shapes.text.text-edition-outline :refer [text-edition-outline*]]
    [app.main.ui.workspace.shapes.text.v2-editor :as editor-v2]
    [app.main.ui.workspace.shapes.text.v3-editor :as editor-v3]
    [app.main.ui.workspace.top-toolbar :refer [top-toolbar*]]
@@ -566,7 +566,7 @@
            :on-context-menu on-menu-selected}])
 
        (when show-text-editor?
-         [:& text-edition-outline
+         [:> text-edition-outline*
           {:shape (get base-objects edition)
            :zoom zoom}])
 


### PR DESCRIPTION
### Summary

This PR is a 3nd part of a series of PR's that refactor the current components style (which implies performance and efficiency improvements because of removing the JS to CLJ props conversion on each render).

It is recommended to review by commit

**MERGE with REBASE**