### PR TITLE
:sparkles: Allow customising the OIDC login button label

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 - Persist asset search query and section filter when switching sidebar tabs (by @eureka0928) [Github #2913](https://github.com/penpot/penpot/issues/2913)
 - Add delete and duplicate buttons to typography dialog (by @eureka0928) [Github #5270](https://github.com/penpot/penpot/issues/5270)
 - Edit ruler guide position by double-clicking the guide pill (by @eureka0928) [Github #2311](https://github.com/penpot/penpot/issues/2311)
-
+- Allow customising the OIDC login button label (by @wdeveloper16) [Github #7027](https://github.com/penpot/penpot/issues/7027)
 
 ### :bug: Bugs fixed
 

--- a/docker/images/files/config.js
+++ b/docker/images/files/config.js
@@ -1,2 +1,3 @@
 // Frontend configuration
 //var penpotFlags = "";
+//var penpotOIDCName = "";

--- a/docker/images/files/nginx-entrypoint.sh
+++ b/docker/images/files/nginx-entrypoint.sh
@@ -21,7 +21,16 @@ update_flags() {
   fi
 }
 
+update_oidc_name() {
+  if [ -n "$PENPOT_OIDC_NAME" ]; then
+    echo "$(sed \
+      -e "s|^//var penpotOIDCName = .*;|var penpotOIDCName = \"$PENPOT_OIDC_NAME\";|g" \
+      "$1")" > "$1"
+  fi
+}
+
 update_flags /var/www/app/js/config.js
+update_oidc_name /var/www/app/js/config.js
 
 #########################################
 ## Nginx Config

--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -242,6 +242,16 @@ register with another method.
 PENPOT_FLAGS: [...] enable-oidc-registration
 ```
 
+__Since version 2.16.0__
+
+Allows customising the label shown on the OIDC login button (defaults to "OpenID").
+
+```bash
+# Frontend
+PENPOT_OIDC_NAME: <provider-name>
+```
+<br />
+
 #### Azure Active Directory using OpenID Connect
 
 Allows integrating with Azure Active Directory as authentication provider:

--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -154,6 +154,7 @@
         true))))
 
 (def terms-of-service-uri (obj/get global "penpotTermsOfServiceURI"))
+(def oidc-name            (obj/get global "penpotOIDCName"))
 (def privacy-policy-uri   (obj/get global "penpotPrivacyPolicyURI"))
 (def flex-help-uri        (obj/get global "penpotGridHelpURI" "https://help.penpot.app/user-guide/flexible-layouts/"))
 (def grid-help-uri        (obj/get global "penpotGridHelpURI" "https://help.penpot.app/user-guide/flexible-layouts/"))

--- a/frontend/src/app/main/ui/auth/login.cljs
+++ b/frontend/src/app/main/ui/auth/login.cljs
@@ -239,7 +239,7 @@
      (when (contains? cf/flags :login-with-oidc)
        [:& bl/button-link {:on-click login-with-oidc
                            :icon deprecated-icon/brand-openid
-                           :label (tr "auth.login-with-oidc-submit")
+                           :label (or (not-empty cf/oidc-name) (tr "auth.login-with-oidc-submit"))
                            :class (stl/css :login-btn :btn-oidc-auth)}])]))
 
 (mf/defc login-dialog*


### PR DESCRIPTION
Closes #7027

Self-hosted operators can now set `PENPOT_OIDC_NAME` in the frontend
container environment to replace the generic "OpenID" button label with a
recognisable provider name.

## How it works

`nginx-entrypoint.sh` reads `PENPOT_OIDC_NAME` at container startup and
injects it into `config.js` as `var penpotOIDCName = "…"`. The frontend
reads this global at boot time (`cf/oidc-name`) and uses it as the OIDC
button label, falling back to the existing i18n string ("OpenID") when
the variable is not set.

## Usage

docker-compose.yaml (frontend service):
  environment:
    PENPOT_OIDC_NAME: "Acme SSO"

## Changes
- `docker/images/files/config.js` — add `penpotOIDCName` template line
- `docker/images/files/nginx-entrypoint.sh` — inject `PENPOT_OIDC_NAME`
- `frontend/src/app/config.cljs` — expose `cf/oidc-name`
- `frontend/src/app/main/ui/auth/login.cljs` — use custom label on OIDC button
