### PR TITLE
Fix integration modal z-index to appear above Recent/Deleted tabs

### DIFF
--- a/frontend/src/app/main/ui/settings/integrations.scss
+++ b/frontend/src/app/main/ui/settings/integrations.scss
@@ -10,6 +10,7 @@
 @use "ds/mixins.scss" as *;
 @use "ds/spacing.scss" as *;
 @use "ds/typography.scss" as t;
+@use "ds/z-index.scss" as *;
 
 .color-primary {
   color: var(--color-foreground-primary);
@@ -44,6 +45,7 @@
 
 .modal-overlay {
   @extend %modal-overlay-base;
+  z-index: $z-index-100;
 }
 
 .modal-container {


### PR DESCRIPTION
The modal was appearing below the Recent/Deleted tabs due to z-index mismatch:
- Modal had z-index: 30 (from %modal-overlay-base)
- Tabs had z-index: 100

This caused the tabs to overlap the modal incorrectly.

Fix: Explicitly set z-index: -index-100 on the modal overlay to ensure it appears above the dashboard tabs.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
