### PR TITLE
:bug: Fix duplicate modal title

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
@@ -55,7 +55,9 @@
      [:> heading* {:level 2
                    :typography "headline-medium"
                    :class (stl/css :form-modal-title)}
-      (tr "workspace.tokens.rename-group")]
+      (if (= variant "rename")
+        (tr "workspace.tokens.rename-group")
+        (tr "workspace.tokens.duplicate-group"))]
      [:> fc/form-input* {:id "rename-node"
                          :name :name
                          :label (tr "workspace.tokens.token-name")

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_tree.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_tree.scss
@@ -12,7 +12,6 @@
   padding-block-end: var(--sp-s);
   display: flex;
   flex-wrap: wrap;
-  gap: var(--sp-s);
   padding-inline-start: calc(var(--node-spacing));
 
   & .node-parent {

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -4289,6 +4289,10 @@ msgid "workspace.tokens.rename-group"
 msgstr "Canviar nom del grup de tokens"
 
 #: src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
+msgid "workspace.tokens.duplicate-group"
+msgstr "Duplicar grup de tokens"
+
+#: src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
 msgid "workspace.tokens.rename-group-name-hint"
 msgstr "Els teus tokens es renomenaran automàticament a %s.(sufix).(token)"
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -8783,6 +8783,10 @@ msgid "workspace.tokens.rename-group"
 msgstr "Rename Tokens Group"
 
 #: src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
+msgid "workspace.tokens.duplicate-group"
+msgstr "Duplicate Tokens Group"
+
+#: src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
 msgid "workspace.tokens.rename-group-name-hint"
 msgstr "Your tokens will automatically be renamed to %s.(suffix).(tokenName)"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -8575,6 +8575,10 @@ msgid "workspace.tokens.rename-group"
 msgstr "Renombrar grupo de tokens"
 
 #: src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
+msgid "workspace.tokens.duplicate-group"
+msgstr "Duplicar grupo de tokens"
+
+#: src/app/main/ui/workspace/tokens/management/forms/rename_node_modal.cljs
 msgid "workspace.tokens.rename-group-name-hint"
 msgstr "Tus tokens serán automáticamente renombrados a %s.(sufijo).(token)"
 


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/task/13998

### Summary

- Fixes duplicate token modal title
- Removes gap in token tree

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
