### PR TITLE
:sparkles: On profile deletion, remove the user from nitrate too

### DIFF
--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -1,3 +1,9 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
 (ns app.nitrate
   "Module that make calls to the external nitrate aplication"
   (:require
@@ -286,6 +292,16 @@
                              "/remove-user")
                         nil params)))
 
+(defn- remove-profile-from-all-orgs-api
+  [cfg {:keys [profile-id] :as params}]
+  (let [baseuri (cf/get :nitrate-backend-uri)]
+    (request-to-nitrate cfg :post
+                        (str baseuri
+                             "/api/users/"
+                             profile-id
+                             "/remove-organizations")
+                        nil params)))
+
 (defn- remove-team-from-org-api
   [cfg {:keys [team-id organization-id] :as params}]
   (let [baseuri (cf/get :nitrate-backend-uri)
@@ -330,17 +346,18 @@
 (defmethod ig/init-key ::client
   [_ cfg]
   (when (contains? cf/flags :nitrate)
-    {:get-team-org               (partial get-team-org-api cfg)
-     :set-team-org               (partial set-team-org-api cfg)
-     :get-org-membership         (partial get-org-membership-api cfg)
-     :get-org-membership-by-team (partial get-org-membership-by-team-api cfg)
-     :get-org-summary            (partial get-org-summary-api cfg)
-     :add-profile-to-org         (partial add-profile-to-org-api cfg)
-     :remove-profile-from-org    (partial remove-profile-from-org-api cfg)
-     :delete-team                (partial delete-team-api cfg)
-     :remove-team-from-org       (partial remove-team-from-org-api cfg)
-     :get-subscription           (partial get-subscription-api cfg)
-     :connectivity               (partial get-connectivity-api cfg)}))
+    {:get-team-org                 (partial get-team-org-api cfg)
+     :set-team-org                 (partial set-team-org-api cfg)
+     :get-org-membership           (partial get-org-membership-api cfg)
+     :get-org-membership-by-team   (partial get-org-membership-by-team-api cfg)
+     :get-org-summary              (partial get-org-summary-api cfg)
+     :add-profile-to-org           (partial add-profile-to-org-api cfg)
+     :remove-profile-from-org      (partial remove-profile-from-org-api cfg)
+     :remove-profile-from-all-orgs (partial remove-profile-from-all-orgs-api cfg)
+     :delete-team                  (partial delete-team-api cfg)
+     :remove-team-from-org         (partial remove-team-from-org-api cfg)
+     :get-subscription             (partial get-subscription-api cfg)
+     :connectivity                 (partial get-connectivity-api cfg)}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; UTILS

--- a/backend/src/app/rpc/commands/nitrate.clj
+++ b/backend/src/app/rpc/commands/nitrate.clj
@@ -1,4 +1,12 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
 (ns app.rpc.commands.nitrate
+  "Nitrate API for Penpot. Provides nitrate-related endpoints to be called
+   from Penpot frontend."
   (:require
    [app.common.data :as d]
    [app.common.exceptions :as ex]
@@ -10,7 +18,6 @@
    [app.rpc.doc :as-alias doc]
    [app.rpc.notifications :as notifications]
    [app.util.services :as sv]))
-
 
 
 (defn assert-is-owner [cfg profile-id team-id]

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -462,6 +462,9 @@
                 {:deleted-at deleted-at}
                 {:id profile-id})
 
+    ;; Api call to nitrate
+    (nitrate/call cfg :remove-profile-from-all-orgs {:profile-id profile-id})
+
     ;; Schedule cascade deletion to a worker
     (wrk/submit! {::db/conn conn
                   ::wrk/task :delete-object


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/us/13346

### Summary

 On profile deletion, remove the user from nitrate too

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
