### PR TITLE
:bug: Fix default alignself behavior

### DIFF
--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -551,30 +551,27 @@ fn child_position(
     child_axis: &ChildAxis,
     track: &TrackData,
 ) -> Point {
+    let mid_point = (track.across_size - child_axis.across_size + child_axis.margin_across_start
+        - child_axis.margin_across_end)
+        / 2.0;
+    let end_point = track.across_size - child_axis.across_size - child_axis.margin_across_end;
+
     let across_position = match child.layout_item {
         Some(LayoutItem {
             align_self: Some(align_self),
             ..
         }) => match align_self {
-            AlignSelf::Center => {
-                (track.across_size - child_axis.across_size + child_axis.margin_across_start
-                    - child_axis.margin_across_end)
-                    / 2.0
-            }
-            AlignSelf::End => {
-                track.across_size - child_axis.across_size - child_axis.margin_across_end
-            }
-            _ => child_axis.margin_across_start,
+            AlignSelf::Center => mid_point,
+            AlignSelf::End => end_point,
+            _ => match layout_data.align_items {
+                AlignItems::Center => mid_point,
+                AlignItems::End => end_point,
+                _ => child_axis.margin_across_start,
+            },
         },
         _ => match layout_data.align_items {
-            AlignItems::Center => {
-                (track.across_size - child_axis.across_size + child_axis.margin_across_start
-                    - child_axis.margin_across_end)
-                    / 2.0
-            }
-            AlignItems::End => {
-                track.across_size - child_axis.across_size - child_axis.margin_across_end
-            }
+            AlignItems::Center => mid_point,
+            AlignItems::End => end_point,
             _ => child_axis.margin_across_start,
         },
     };


### PR DESCRIPTION
### Summary

Fixes a small problem with flex that wasn't using the correct behavior when the alignself has a default value.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
