### PR TITLE
:bug: Fix trailing whitespace behavior in v2 editor

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -367,6 +367,9 @@
         (when (cf/check-browser? :safari)
           (mf/deref refs/selected-zoom))
 
+        vbox
+        (mf/deref refs/vbox)
+
         shape (cond-> shape
                 (some? text-modifier)
                 (dwt/apply-text-modifier text-modifier)
@@ -385,13 +388,20 @@
                 selrect-width (:width selrect)
                 max-width (max width selrect-width)
                 max-height (max height selrect-height)
+                ;; During auto-width editing we keep the shape width trimmed, but the caret
+                ;; must be able to move after trailing spaces. Expand only the editor
+                ;; overlay up to one viewport width to avoid clipping caret rendering.
+                viewport-width (or (:width vbox) 0)
+                overlay-width (if (= (:grow-type shape) :auto-width)
+                                (+ max-width viewport-width)
+                                max-width)
                 valign (-> shape :content :vertical-align)
                 y (:y selrect)
                 y (case valign
                     "bottom" (+ y (- selrect-height height))
                     "center" (+ y (/ (- selrect-height height) 2))
                     y)]
-            [(assoc selrect :y y :width max-width :height max-height) transform])
+            [(assoc selrect :y y :width overlay-width :height max-height) transform])
 
           (let [bounds (gst/shape->rect shape)
                 x      (mth/min (dm/get-prop bounds :x)

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.scss
@@ -53,7 +53,10 @@
     font-size: 0px;
   }
 
-  [data-itype="inline"] {
+  // Text spans emitted by @penpot/text-editor use `data-itype="span"`.
+  // Keep whitespace rules attached to the real node type so trailing spaces
+  // are handled consistently while editing.
+  [data-itype="span"] {
     box-sizing: content-box;
     display: inline;
     line-height: inherit;
@@ -75,11 +78,11 @@
 .grow-type-auto-width {
   [data-itype="span"],
   [data-itype="paragraph"] {
-    white-space: nowrap;
-  }
-
-  [data-itype="span"] {
-    white-space-collapse: preserve;
+    // Keep auto-width editing on a single preformatted line so trailing
+    // spaces are part of caret geometry and browser selection math.
+    white-space: pre;
+    overflow-wrap: normal;
+    word-break: keep-all;
   }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13971

### Summary

This PR handles trailing whitespace like Figma does, which is advancing the caret without growing the shape (until a non-whitespace character is typed).

https://github.com/user-attachments/assets/dd723cf2-caa9-4d2f-a408-19dda7d69699


### Steps to reproduce 

1. Create a new text shape with autowidth.
2. Type something. Then add spaces. 
3. Type a non-whitespace character.

Expected behavior: While typing whitespace at the end, the caret should advance. When a non-whitespace character is typed, the shape width must grow to acomodate that.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
