### PR TITLE
:bug: Fix org options space should be hidden when there are no options

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -779,9 +779,8 @@
              [:span {:class (stl/css :team-text)}
               (:name current-org)]])]
          arrow-icon]
-        (if (or default-org?
-                (= (:id profile) (:owner-id current-org)))
-          [:div {:class (stl/css :org-options)}]
+        (when-not (or default-org?
+                      (= (:id profile) (:owner-id current-org)))
           [:> button* {:variant "ghost"
                        :type "button"
                        :class (stl/css :org-options-btn)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26289

### Summary

When an organization doesn't have options, the arrow should be on the right, and not keep the space for the missing options icon


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
