### PR TITLE
fix: add profile avatar deletion flow with backend support #9067

### DIFF
--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -251,6 +251,7 @@
 
 (declare upload-photo)
 (declare update-profile-photo)
+(declare delete-profile-photo)
 
 (def ^:private
   schema:update-profile-photo
@@ -287,6 +288,26 @@
                          :file-size (:size file)
                          :file-path (str (:path file))
                          :file-mtype (:mtype file)}}))))
+
+(sv/defmethod ::delete-profile-photo
+  {::doc/added "2.15"
+   ::sm/params [:map]
+   ::sm/result :nil
+   ::db/transaction true}
+  [cfg {:keys [::rpc/profile-id] :as params}]
+  (delete-profile-photo cfg (assoc params :profile-id profile-id)))
+
+(defn delete-profile-photo
+  [{:keys [::db/conn ::sto/storage] :as cfg} {:keys [profile-id] :as _params}]
+  (let [profile (db/get-by-id conn :profile profile-id ::sql/for-update true)]
+    (when-let [id (:photo-id profile)]
+      (sto/touch-object! storage id))
+
+    (db/update! conn :profile
+                {:photo-id nil}
+                {:id profile-id}
+                {::db/return-keys false})
+    nil))
 
 (defn- generate-thumbnail
   [_ input]

--- a/backend/test/backend_tests/rpc_profile_test.clj
+++ b/backend/test/backend_tests/rpc_profile_test.clj
@@ -125,7 +125,19 @@
             out  (th/command! data)]
 
         ;; (th/print-result! out)
-        (t/is (nil? (:error out)))))))
+        (t/is (nil? (:error out)))))
+
+    (t/testing "delete photo"
+      (let [data {::th/type :delete-profile-photo
+                  ::rpc/profile-id (:id profile)}
+            out  (th/command! data)]
+        (t/is (nil? (:error out))))
+
+      (let [data {::th/type :get-profile
+                  ::rpc/profile-id (:id profile)}
+            out  (th/command! data)]
+        (t/is (nil? (:error out)))
+        (t/is (nil? (get-in out [:result :photo-id])))))))
 
 (t/deftest profile-deletion-1
   (let [prof (th/create-profile* 1)

--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -348,6 +348,19 @@
              (rx/map (constantly (refresh-profile)))
              (rx/catch on-error))))))
 
+(defn delete-photo
+  []
+  (ptk/reify ::delete-photo
+    ev/Event
+    (-data [_] {})
+
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (let [on-error di/process-error]
+        (->> (rp/cmd! :delete-profile-photo {})
+             (rx/map (constantly (refresh-profile)))
+             (rx/catch on-error))))))
+
 (defn fetch-file-comments-users
   [{:keys [team-id]}]
   (assert (uuid? team-id) "expected a valid uuid for `team-id`")

--- a/frontend/src/app/main/ui/settings/profile.cljs
+++ b/frontend/src/app/main/ui/settings/profile.cljs
@@ -16,6 +16,7 @@
    [app.main.store :as st]
    [app.main.ui.components.file-uploader :refer [file-uploader]]
    [app.main.ui.components.forms :as fm]
+   [app.main.ui.ds.foundations.assets.icon :as i :refer [icon*]]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [rumext.v2 :as mf]))
@@ -101,6 +102,13 @@
         (mf/use-fn
          #(dom/click (mf/ref-val input-ref)))
 
+        on-delete-click
+        (mf/use-fn
+         (fn [event]
+           (.preventDefault event)
+           (.stopPropagation event)
+           (st/emit! (du/delete-photo))))
+
         on-file-selected
         (fn [file]
           (st/emit! (du/update-photo file)))]
@@ -109,6 +117,14 @@
      [:div {:class (stl/css :image-change-field)}
       [:span {:class (stl/css :update-overlay)
               :on-click on-image-click} (tr "labels.update")]
+      (when (:photo-id profile)
+        [:button {:class (stl/css :delete-overlay)
+                  :type "button"
+                  :title (tr "labels.delete")
+                  :aria-label (tr "labels.delete")
+                  :on-click on-delete-click
+                  :data-testid "profile-image-delete"}
+         [:> icon* {:icon-id i/delete}]])
       [:img {:src photo}]
       [:& file-uploader {:accept "image/jpeg,image/png"
                          :multi false

--- a/frontend/src/app/main/ui/settings/profile.scss
+++ b/frontend/src/app/main/ui/settings/profile.scss
@@ -280,6 +280,25 @@ form.avatar-form {
     z-index: $z-index-modal;
   }
 
+  .delete-overlay {
+    opacity: 0;
+    position: absolute;
+    top: $s-8;
+    inset-inline-end: $s-8;
+    z-index: calc(#{$z-index-modal} + 1);
+    width: $s-24;
+    height: $s-24;
+    border: none;
+    border-radius: 50%;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    background: var(--color-background-primary);
+    color: var(--color-foreground-primary);
+  }
+
   input[type="file"] {
     width: 100%;
     height: 100%;
@@ -293,6 +312,10 @@ form.avatar-form {
   &:hover {
     .update-overlay {
       opacity: 0.8;
+    }
+
+    .delete-overlay {
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
## Summary
Closes #9067
- Add end-to-end support for deleting a profile avatar after upload.
- Implement backend RPC command `delete-profile-photo` to clear `photo-id` and schedule old media cleanup.
- Update settings profile UI to show a delete control on avatar hover (only when a custom avatar exists), and wire it to the new frontend event.
- Add backend regression coverage for upload + delete avatar behavior.

## Problem

Users could upload a profile avatar but had no way to delete it afterward from **Your Account**. The hover action only exposed update behavior, and there was no delete RPC/event path.

## Solution

- **Backend**
  - Add `::delete-profile-photo` in `backend/src/app/rpc/commands/profile.clj`.
  - Lock profile row, touch old object for cleanup, set `photo-id` to `nil`.
- **Frontend data**
  - Add `delete-photo` event in `frontend/src/app/main/data/profile.cljs` to call `:delete-profile-photo` and refresh profile state.
- **Frontend UI**
  - In `frontend/src/app/main/ui/settings/profile.cljs`, add a hover delete button/icon on avatar and emit `du/delete-photo`.
  - Render delete action only when `:photo-id` exists.
- **Styles**
  - In `frontend/src/app/main/ui/settings/profile.scss`, add `.delete-overlay` styles and hover visibility.
- **Tests**
  - Extend `backend/test/backend_tests/rpc_profile_test.clj` with a delete-photo scenario that verifies `photo-id` is `nil` after deletion.

## Test Plan

- [ ] Go to **Settings → Your Account**.
- [ ] Upload a profile avatar image.
- [ ] Hover avatar and verify delete control is visible.
- [ ] Click delete and verify avatar reverts to generated default.
- [ ] Refresh page and verify avatar remains deleted.
- [ ] Run backend profile RPC tests to confirm upload/delete regression coverage.

## Notes

- This change preserves existing media lifecycle behavior by marking old avatar objects for cleanup instead of hard-deleting synchronously