### PR TITLE
:zap: Add performance optimizations for `text.cljs` workspace panel

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -329,6 +329,31 @@ CSS modules pattern):
 - [ ] Selectors are flat (no deep nesting).
 
 
+### Translations (`tr`) and Memoization
+
+`(tr "some.key")` resolves the translation string from the **currently active
+locale at call time**. This has two consequences:
+
+- **Never call `(tr ...)` at namespace level** (inside a `def` or `defonce`).
+  Doing so would freeze the label to the locale active at module load time and
+  break runtime language switching.
+- **Always call `(tr ...)` at render time** — either directly in the component
+  body or inside a `mf/with-memo` / `mf/use-memo` block.
+
+When a component renders a **static list of options** whose labels come from
+`(tr ...)` (e.g. radio button options, select options), wrap the vector in
+`mf/with-memo []` with no dependencies. This ensures the vector and its
+`(tr ...)` calls are evaluated once per component mount instead of on every
+render, while still respecting the render-time requirement:
+
+```clojure
+(let [options (mf/with-memo []
+                [{:value "top"    :label (tr "some.key.top")}
+                 {:value "center" :label (tr "some.key.center")}
+                 {:value "bottom" :label (tr "some.key.bottom")}])]
+  ...)
+```
+
 ### Performance Macros (`app.common.data.macros`)
 
 Always prefer these macros over their `clojure.core` equivalents — they compile to faster JavaScript:

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -83,6 +83,17 @@
 (mf/defc text-direction-options*
   [{:keys [values on-change on-blur]}]
   (let [direction (:text-direction values)
+        options
+        (mf/with-memo []
+          [{:value "ltr"
+            :id    "ltr-text-direction"
+            :label (tr "workspace.options.text-options.direction-ltr")
+            :icon  i/text-ltr}
+           {:value "rtl"
+            :id    "rtl-text-direction"
+            :label (tr "workspace.options.text-options.direction-rtl")
+            :icon  i/text-rtl}])
+
         handle-change
         (mf/use-fn
          (mf/deps on-change on-blur direction)
@@ -94,14 +105,7 @@
      [:> radio-buttons* {:selected  direction
                          :on-change handle-change
                          :name      "text-direction-options"
-                         :options   [{:value "ltr"
-                                      :id    "ltr-text-direction"
-                                      :label (tr "workspace.options.text-options.direction-ltr")
-                                      :icon  i/text-ltr}
-                                     {:value "rtl"
-                                      :id    "rtl-text-direction"
-                                      :label (tr "workspace.options.text-options.direction-rtl")
-                                      :icon  i/text-rtl}]}]]))
+                         :options   options}]]))
 
 (mf/defc vertical-align*
   [{:keys [values on-change on-blur]}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -190,6 +190,19 @@
   [{:keys [values on-change on-blur token-applied]}]
   (let [token-row    (contains? cf/flags :token-typography-row)
         text-decoration (some-> (:text-decoration values) d/name)
+        options
+        (mf/with-memo [token-applied]
+          [{:value    "underline"
+            :id       "underline-text-decoration"
+            :disabled (and token-row (some? token-applied))
+            :label    (tr "workspace.options.text-options.underline" (sc/get-tooltip :underline))
+            :icon     i/text-underlined}
+           {:value    "line-through"
+            :id       "line-through-text-decoration"
+            :disabled (and token-row (some? token-applied))
+            :label    (tr "workspace.options.text-options.strikethrough" (sc/get-tooltip :line-through))
+            :icon     i/text-stroked}])
+
         handle-change
         (mf/use-fn
          (mf/deps on-change on-blur)
@@ -206,16 +219,7 @@
                          :name         "text-decoration-options"
                          :disabled     (and token-row (some? token-applied))
                          :allow-empty  true
-                         :options      [{:value "underline"
-                                         :id "underline-text-decoration"
-                                         :disabled (and token-row (some? token-applied))
-                                         :label (tr "workspace.options.text-options.underline" (sc/get-tooltip :underline))
-                                         :icon i/text-underlined}
-                                        {:value "line-through"
-                                         :id "line-through-text-decoration"
-                                         :disabled (and token-row (some? token-applied))
-                                         :label (tr "workspace.options.text-options.strikethrough" (sc/get-tooltip :line-through))
-                                         :icon i/text-stroked}]}]]))
+                         :options      options}]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helpers

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -348,12 +348,10 @@
         ;; --- Toggles
         toggle-main-menu
         (mf/use-fn
-         (mf/deps main-menu-open?)
          #(swap! menu-state* update :main-menu not))
 
         toggle-more-options
         (mf/use-fn
-         (mf/deps more-options-open?)
          #(swap! menu-state* update :more-options not))
 
         toggle-token-dropdown

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -48,7 +48,26 @@
 
 (mf/defc text-align-options*
   [{:keys [values on-change on-blur]}]
-  (let [handle-change
+  (let [options
+        (mf/with-memo []
+          [{:value "left"
+            :id    "text-align-left"
+            :label (tr "workspace.options.text-options.text-align-left")
+            :icon  i/text-align-left}
+           {:value "center"
+            :id    "text-align-center"
+            :label (tr "workspace.options.text-options.text-align-center")
+            :icon  i/text-align-center}
+           {:value "right"
+            :id    "text-align-right"
+            :label (tr "workspace.options.text-options.text-align-right")
+            :icon  i/text-align-right}
+           {:value "justify"
+            :id    "text-align-justify"
+            :label (tr "workspace.options.text-options.text-align-justify")
+            :icon  i/text-justify}])
+
+        handle-change
         (mf/use-fn
          (mf/deps on-change on-blur)
          (fn [value]
@@ -59,22 +78,7 @@
      [:> radio-buttons* {:selected  (:text-align values)
                          :on-change handle-change
                          :name      "align-text-options"
-                         :options   [{:value "left"
-                                      :id    "text-align-left"
-                                      :label (tr "workspace.options.text-options.text-align-left")
-                                      :icon  i/text-align-left}
-                                     {:value "center"
-                                      :id    "text-align-center"
-                                      :label (tr "workspace.options.text-options.text-align-center")
-                                      :icon  i/text-align-center}
-                                     {:value "right"
-                                      :id    "text-align-right"
-                                      :label (tr "workspace.options.text-options.text-align-right")
-                                      :icon  i/text-align-right}
-                                     {:value "justify"
-                                      :id    "text-align-justify"
-                                      :label (tr "workspace.options.text-options.text-align-justify")
-                                      :icon  i/text-justify}]}]]))
+                         :options   options}]]))
 
 (mf/defc text-direction-options*
   [{:keys [values on-change on-blur]}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -142,6 +142,20 @@
   [{:keys [ids values on-blur]}]
   (let [grow-type       (:grow-type values)
         editor-instance (mf/deref refs/workspace-editor)
+        options
+        (mf/with-memo []
+          [{:value "fixed"
+            :id    "text-fixed-grow"
+            :label (tr "workspace.options.text-options.grow-fixed")
+            :icon  i/text-fixed}
+           {:value "auto-width"
+            :id    "text-auto-width-grow"
+            :label (tr "workspace.options.text-options.grow-auto-width")
+            :icon  i/text-auto-width}
+           {:value "auto-height"
+            :id    "text-auto-height-grow"
+            :label (tr "workspace.options.text-options.grow-auto-height")
+            :icon  i/text-auto-height}])
 
         handle-change
         (mf/use-fn
@@ -170,18 +184,7 @@
      [:> radio-buttons* {:selected  (d/name grow-type)
                          :on-change handle-change
                          :name      "grow-text-options"
-                         :options   [{:value "fixed"
-                                      :id    "text-fixed-grow"
-                                      :label (tr "workspace.options.text-options.grow-fixed")
-                                      :icon  i/text-fixed}
-                                     {:value "auto-width"
-                                      :id    "text-auto-width-grow"
-                                      :label (tr "workspace.options.text-options.grow-auto-width")
-                                      :icon  i/text-auto-width}
-                                     {:value "auto-height"
-                                      :id    "text-auto-height-grow"
-                                      :label (tr "workspace.options.text-options.grow-auto-height")
-                                      :icon  i/text-auto-height}]}]]))
+                         :options   options}]]))
 
 (mf/defc text-decoration-options*
   [{:keys [values on-change on-blur token-applied]}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -500,13 +500,7 @@
                                  :values    values
                                  :on-change on-change
                                  :show-recent true
-                                 :on-blur
-                                 (fn []
-                                   (ts/schedule
-                                    100
-                                    (fn []
-                                      (when (not= "INPUT" (-> (dom/get-active) dom/get-tag-name))
-                                        (dom/focus! (txu/get-text-editor-content))))))}])
+                                 :on-blur   on-text-blur}])
 
         [:div {:class (stl/css :text-align-options)}
          [:> text-align-options* common-props]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -102,6 +102,21 @@
 (mf/defc vertical-align*
   [{:keys [values on-change on-blur]}]
   (let [vertical-align (or (:vertical-align values) "top")
+        options
+        (mf/with-memo []
+          [{:value "top"
+            :id    "vertical-text-align-top"
+            :label (tr "workspace.options.text-options.align-top")
+            :icon  i/text-top}
+           {:value "center"
+            :id    "vertical-text-align-center"
+            :label (tr "workspace.options.text-options.align-middle")
+            :icon  i/text-middle}
+           {:value "bottom"
+            :id    "vertical-text-align-bottom"
+            :label (tr "workspace.options.text-options.align-bottom")
+            :icon  i/text-bottom}])
+
         handle-change
         (mf/use-fn
          (mf/deps on-change on-blur)
@@ -113,18 +128,7 @@
      [:> radio-buttons* {:selected  vertical-align
                          :on-change handle-change
                          :name      "vertical-align-text-options"
-                         :options   [{:value "top"
-                                      :id    "vertical-text-align-top"
-                                      :label (tr "workspace.options.text-options.align-top")
-                                      :icon  i/text-top}
-                                     {:value "center"
-                                      :id    "vertical-text-align-center"
-                                      :label (tr "workspace.options.text-options.align-middle")
-                                      :icon  i/text-middle}
-                                     {:value "bottom"
-                                      :id    "vertical-text-align-bottom"
-                                      :label (tr "workspace.options.text-options.align-bottom")
-                                      :icon  i/text-bottom}]}]]))
+                         :options   options}]]))
 
 (mf/defc grow-options*
   [{:keys [ids values on-blur]}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -43,6 +43,15 @@
    [rumext.v2 :as mf]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def ^:private token-typography-row-enabled?
+  "True when the token-typography-row feature flag is enabled.
+  Evaluated once at module load time; cf/flags is immutable after startup."
+  (contains? cf/flags :token-typography-row))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Sub-components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -188,18 +197,17 @@
 
 (mf/defc text-decoration-options*
   [{:keys [values on-change on-blur token-applied]}]
-  (let [token-row    (contains? cf/flags :token-typography-row)
-        text-decoration (some-> (:text-decoration values) d/name)
+  (let [text-decoration (some-> (:text-decoration values) d/name)
         options
         (mf/with-memo [token-applied]
           [{:value    "underline"
             :id       "underline-text-decoration"
-            :disabled (and token-row (some? token-applied))
+            :disabled (and token-typography-row-enabled? (some? token-applied))
             :label    (tr "workspace.options.text-options.underline" (sc/get-tooltip :underline))
             :icon     i/text-underlined}
            {:value    "line-through"
             :id       "line-through-text-decoration"
-            :disabled (and token-row (some? token-applied))
+            :disabled (and token-typography-row-enabled? (some? token-applied))
             :label    (tr "workspace.options.text-options.strikethrough" (sc/get-tooltip :line-through))
             :icon     i/text-stroked}])
 
@@ -217,7 +225,7 @@
                                          text-decoration)
                          :on-change    handle-change
                          :name         "text-decoration-options"
-                         :disabled     (and token-row (some? token-applied))
+                         :disabled     (and token-typography-row-enabled? (some? token-applied))
                          :allow-empty  true
                          :options      options}]]))
 
@@ -255,8 +263,6 @@
   (let [file-id              (mf/use-ctx ctx/current-file-id)
         typographies         (mf/deref refs/workspace-file-typography)
         libraries            (mf/deref refs/files)
-        token-row            (contains? cf/flags :token-typography-row)
-
         ;; --- UI state
         menu-state*          (mf/use-state {:main-menu true
                                             :more-options false})
@@ -455,7 +461,7 @@
                       :title        label
                       :class        (stl/css :title-spacing-text)}
        [:*
-        (when (and token-row (some? (resolve-delay typography-tokens)) (not typography))
+        (when (and token-typography-row-enabled? (some? (resolve-delay typography-tokens)) (not typography))
           [:> icon-button* {:variant           "ghost"
                             :aria-label        (tr "ds.inputs.numeric-input.open-token-list-dropdown")
                             :on-click          toggle-token-dropdown
@@ -471,7 +477,7 @@
      (when main-menu-open?
        [:div {:class (stl/css :element-content)}
         (cond
-          (and token-row current-token-name)
+          (and token-typography-row-enabled? current-token-name)
           [:> token-typography-row* {:token-name    current-token-name
                                      :detach-token  detach-token
                                      :active-tokens (resolve-delay typography-tokens)}]
@@ -519,7 +525,7 @@
            [:> text-decoration-options* (mf/spread-props common-props {:token-applied current-token-name})]
            [:> text-direction-options* common-props]])])
 
-     (when (and token-row token-dropdown-open?)
+     (when (and token-typography-row-enabled? token-dropdown-open?)
        [:> searchable-options-dropdown* {:on-click     on-option-click
                                          :id           listbox-id
                                          :options      (resolve-delay dropdown-options)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -323,10 +323,12 @@
                                  :attributes        #{:typography}
                                  :token             token
                                  :on-update-shape   dwta/update-typography})))))
-        label          (case type
-                         :multiple (tr "workspace.options.text-options.title-selection")
-                         :group (tr "workspace.options.text-options.title-group")
-                         (tr "workspace.options.text-options.title"))
+        label
+        (mf/with-memo [type]
+          (case type
+            :multiple (tr "workspace.options.text-options.title-selection")
+            :group (tr "workspace.options.text-options.title-group")
+            (tr "workspace.options.text-options.title")))
         set-option-ref
         (mf/use-fn
          (fn [node]


### PR DESCRIPTION
### Summary

Targeted a set of render-time allocation issues in
`frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs`.

### Changes

#### Memoize static radio-button option vectors

Five components were building their options vectors (containing `(tr …)` calls)
on every render, allocating fresh maps and strings each time. 

#### Memoize dynamic label in `text-menu*`

The `(case type (tr …) …)` title expression was re-evaluated on every render.
Wrapped in `mf/with-memo [type]` so the translation is resolved only when `type`
changes.

#### Hoist feature-flag check to namespace level

`(contains? cf/flags :token-typography-row)` was evaluated inside component
render bodies. Because `cf/flags` is immutable after startup this is a constant;
it is now defined once at namespace level as `token-typography-row-enabled?`.

#### Remove spurious `mf/deps` from toggle callbacks in `text-menu*`

`toggle-main-menu` and `toggle-more-options` declared `(mf/deps
main-menu-open?)` / `(mf/deps more-options-open?)` even though neither value is
read inside the function body. This caused each callback to be reallocated on
every toggle — self-reinforcing churn. The unused deps were removed, making both
callbacks stable zero-dep references.

#### Replace duplicate `on-blur` lambda with stable `on-text-blur` reference

An anonymous `(fn [] (ts/schedule 100 …))` was passed inline as `:on-blur` to
the `text-options` call site. This was an exact copy of the `on-text-blur`
callback already defined via `mf/use-fn` earlier in the same `let` block. The
inline lambda was replaced with the existing stable reference, removing a fresh
allocation on every render and eliminating ~6 lines of duplicated code.
