### PR TITLE
:bug: Fix image loading callback

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -627,6 +627,7 @@
   (if (empty? fills)
     (h/call wasm/internal-module "_clear_shape_fills")
     (let [fills  (types.fills/coerce fills)
+          image-ids (types.fills/get-image-ids fills)
           offset (mem/alloc->offset-32 (types.fills/get-byte-size fills))
           heap   (mem/get-heap-u32)]
 
@@ -648,7 +649,7 @@
                 (when (zero? cached-image?)
                   (fetch-image shape-id id thumbnail?))))
 
-            (types.fills/get-image-ids fills)))))
+            image-ids))))
 
 (defn set-shape-strokes
   [shape-id strokes thumbnail?]
@@ -675,7 +676,8 @@
               (some? gradient)
               (do
                 (types.fills.impl/write-gradient-fill offset dview opacity gradient)
-                (h/call wasm/internal-module "_add_shape_stroke_fill"))
+                (h/call wasm/internal-module "_add_shape_stroke_fill")
+                nil)
 
               (some? image)
               (let [image-id      (get image :id)
@@ -692,7 +694,8 @@
               (some? color)
               (do
                 (types.fills.impl/write-solid-fill offset dview opacity color)
-                (h/call wasm/internal-module "_add_shape_stroke_fill")))))
+                (h/call wasm/internal-module "_add_shape_stroke_fill")
+                nil))))
         strokes))
 
 (defn set-shape-svg-attrs
@@ -1302,16 +1305,17 @@
                        (when (or (seq pending-thumbnails) (seq pending-full))
                          (->> (rx/concat
                                (->> (rx/from (vals pending-thumbnails))
-                                    (rx/merge-map (fn [callback] (callback)))
+                                    (rx/merge-map
+                                     (fn [callback]
+                                       (if (fn? callback) (callback) (rx/empty))))
                                     (rx/reduce conj []))
                                (->> (rx/from (vals pending-full))
-                                    (rx/mapcat (fn [callback] (callback)))
+                                    (rx/mapcat
+                                     (fn [callback]
+                                       (if (fn? callback) (callback) (rx/empty))))
                                     (rx/reduce conj [])))
                               (rx/subs!
                                (fn [_]
-                                 ;; Fonts are now loaded — recompute text
-                                 ;; layouts so Skia uses the real metrics
-                                 ;; instead of fallback-font estimates.
                                  (let [text-ids (into [] (comp (filter cfh/text-shape?) (map :id)) shapes)]
                                    (when (seq text-ids)
                                      (update-text-layouts text-ids)))

--- a/render-wasm/src/wasm/fills/image.rs
+++ b/render-wasm/src/wasm/fills/image.rs
@@ -1,10 +1,33 @@
 use crate::error::{Error, Result};
 use crate::mem;
+use crate::shapes::Fill;
+use crate::state::State;
 use crate::uuid::Uuid;
 use crate::with_state_mut;
 use crate::STATE;
 use crate::{shapes::ImageFill, utils::uuid_from_u32_quartet};
 use macros::wasm_error;
+
+fn touch_shapes_with_image(state: &mut State, image_id: Uuid) {
+    let ids: Vec<Uuid> = state
+        .shapes
+        .iter()
+        .filter(|shape| {
+            shape
+                .fills()
+                .any(|f| matches!(f, Fill::Image(i) if i.id() == image_id))
+                || shape
+                    .strokes
+                    .iter()
+                    .any(|s| matches!(&s.fill, Fill::Image(i) if i.id() == image_id))
+        })
+        .map(|shape| shape.id)
+        .collect();
+
+    for id in ids {
+        state.touch_shape(id);
+    }
+}
 
 const FLAG_KEEP_ASPECT_RATIO: u8 = 1 << 0;
 const IMAGE_IDS_SIZE: usize = 32;
@@ -90,7 +113,7 @@ pub extern "C" fn store_image() -> Result<()> {
         {
             eprintln!("{}", msg);
         }
-        state.touch_shape(ids.shape_id);
+        touch_shapes_with_image(state, ids.image_id);
     });
 
     mem::free_bytes()?;
@@ -167,7 +190,7 @@ pub extern "C" fn store_image_from_texture() -> Result<()> {
             // FIXME: Review if we should return a RecoverableError
             eprintln!("store_image_from_texture error: {}", msg);
         }
-        state.touch_shape(ids.shape_id);
+        touch_shapes_with_image(state, ids.image_id);
     });
 
     mem::free_bytes()?;


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14050

### Summary

Fixes image fills not always rendering. 
                                                                                                                                   
Root causes:

1. `set-shape-strokes` leaked numeric h/call return values into the pending-callbacks accumulator. When the async path (>100 shapes) invoked one as (callback), it threw and killed the whole rx stream, blocking every image load. Now it has explicit nil returns on gradient and solid-color.
2. `store_image` / `store_image_from_texture` only touched the single shape_id whose fetch callback won CLJS dedup. Other shapes sharing the same image (common with variants, duplicates, and components) stayed stuck with empty-fill tiles. 

### Steps to reproduce 

Load file samples attached to the ticket

<img width="1036" height="669" alt="image" src="https://github.com/user-attachments/assets/7c7e302e-6e49-427b-adf7-836594800ca2" />


### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
