### PR TITLE
:zap: Drain GPU queue during pan/zoom to avoid render_from_cache hitch

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1815,16 +1815,20 @@ impl RenderState {
             }
 
             // In a pure viewport interaction (pan/zoom), render_from_cache
-            // owns the Target surface — skip flush so we don't present
-            // stale tile positions.  The rAF still populates the Cache
-            // surface and tile HashMap so render_from_cache progressively
-            // shows more complete content.
+            // owns the Target surface — don't flush Target so we don't
+            // present stale tile positions. We still drain the GPU command
+            // queue with a non-Target `flush_and_submit` so the backlog
+            // of tile-render commands executes incrementally instead of
+            // piling up for hundreds of milliseconds and blowing up the
+            // next `render_from_cache` call into a multi-frame hitch.
             //
             // During interactive shape transforms (drag/resize/rotate) we
             // still need to flush every rAF so the user sees the updated
             // shape position — render_from_cache is not in the loop here.
             if !self.options.is_viewport_interaction() {
                 self.flush_and_submit();
+            } else {
+                self.gpu_state.context.flush_and_submit();
             }
 
             if self.render_in_progress {


### PR DESCRIPTION
### Related Ticket



### Summary

During pan/zoom gestures, process_animation_frame deliberately skipped flush_and_submit to avoid presenting stale tile positions on the Target surface. Tile-render commands still queued up though, and over a few-second gesture the Skia command buffer  accumulated hundreds of pending GPU operations.

In process_animation_frame, during viewport interaction, call the non-Target gpu_state.context.flush_and_submit() instead of skipping the flush entirely. This drains the command buffer incrementally without touching the Target framebuffer, so the canvas still shows whatever render_from_cache drew last and no intermediate tile positions are presented.

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
