### PR TITLE
:sparkles: Add organization logo to nitrate invitations emails

### DIFF
--- a/backend/resources/app/email/invite-to-org/en.html
+++ b/backend/resources/app/email/invite-to-org/en.html
@@ -198,9 +198,9 @@
                         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="20" height="20" style="display:inline-block;vertical-align:middle;">
                           <tr>
                             <td width="20" height="20" align="center" valign="middle"
-                                background="{{org-logo}}"
+                                background="{{organization-logo}}"
                                 style="width:20px;height:20px;text-align:center;font-weight:bold;font-size:9px;line-height:20px;color:#ffffff;background-size:cover;background-position:center;background-repeat:no-repeat;border-radius: 50%;color:black">
-                              {{org-initials}}
+                              {% if organization-initials %}{{organization-initials}}{% endif %}
                             </td>
                           </tr>
                         </table>

--- a/backend/src/app/email.clj
+++ b/backend/src/app/email.clj
@@ -416,8 +416,8 @@
   [:map
    [:invited-by ::sm/text]
    [:organization-name ::sm/text]
-   [:org-initials ::sm/text]
-   [:org-logo ::sm/uri]
+   [:organization-initials [:maybe :string]]
+   [:organization-logo ::sm/uri]
    [:user-name [:maybe ::sm/text]]
    [:token ::sm/text]])
 

--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -91,6 +91,7 @@
     [:map
      [:id ::sm/uuid]
      [:name :string]
+     [:initials [:maybe :string]]
      [:logo ::sm/uri]]]
    [:profile
     [:map
@@ -211,8 +212,8 @@
                             :invited-by (:fullname profile)
                             :user-name (:fullname member)
                             :organization-name (:name organization)
-                            :org-logo (:logo organization)
-                            :org-initials (d/get-initials (:name organization))
+                            :organization-logo (:logo organization)
+                            :organization-initials (:initials organization)
                             :token itoken
                             :extra-data ptoken}))
               (let [team (if (contains? cf/flags :nitrate)
@@ -231,11 +232,11 @@
           itoken)))))
 
 (defn create-org-invitation
-  [cfg {:keys [::rpc/profile-id id name logo] :as params}]
+  [cfg {:keys [::rpc/profile-id id name initials logo] :as params}]
   (let [profile  (db/get-by-id cfg :profile profile-id)]
     (create-invitation cfg
                        (assoc params
-                              :organization {:id id :name name :logo logo}
+                              :organization {:id id :name name :initials initials :logo logo}
                               :profile profile
                               :role :editor))))
 

--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -360,6 +360,7 @@ RETURNING id, name;")
                 [:email ::sm/email]
                 [:id ::sm/uuid]
                 [:name ::sm/text]
+                [:initials [:maybe :string]]
                 [:logo ::sm/uri]]}
   [cfg params]
   (db/tx-run! cfg ti/create-org-invitation params)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26256

### Summary

On the emails to invite an organization allways show the logo and the received initials (that can be empty)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
