### PR TITLE
:bug: Fix Heroicons arrow paths broken after SVG import (#5283)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@
 ### :bug: Bugs fixed
 
 - Fix plugin API `fileVersion.restore()` promise hanging indefinitely on restore failure [Github #9092](https://github.com/penpot/penpot/issues/9092)
+- Fix imported stroke-only SVG paths losing their rounded join when authoring tools (e.g. Figma → Heroicons) split a continuous polyline into adjacent `M…L M…L` subpaths sharing an endpoint; on import these are now folded back into one chain so `stroke-linejoin` renders the elbow correctly in both editor and exports [Github #5283](https://github.com/penpot/penpot/issues/5283)
 - Fix plugin API `library.connectLibrary()` returning a non-Promise (or throwing synchronously) when the plugin lacks `library:write` permission — the method now always returns a `Promise` and rejects with a structured error message, matching the contract used by every other Promise-returning plugin method (`restore`, `remove`, `pin`, `saveVersion`, `findVersions`, …)
 - Fix LDAP provider params schema typo (`bind-passwor` → `bind-password`) introduced during the `clojure.spec` → `malli` migration; the schema slot now matches the runtime key actually read by `prepare-params` (`:password (:bind-password cfg)`) and `try-connectivity` (`(:bind-password cfg)`), so a wrong type for the password no longer slips through unvalidated
 - Fix `login-with-ldap` silently dropping its error message on the `ldap-not-initialized` restriction (typo `:hide` → `:hint`); the message `"ldap auth provider is not initialized"` now actually surfaces in logs and error responses instead of being discarded into an unread key

--- a/common/src/app/common/files/shapes_builder.cljc
+++ b/common/src/app/common/files/shapes_builder.cljc
@@ -340,12 +340,26 @@
       :svg-viewbox vbox
       :svg-defs defs})))
 
+(defn- stroke-only-svg-path?
+  "Returns true when the SVG element renders only a stroke (fill=none).
+  Stroke-only paths can have their consecutive touching subpaths safely
+  merged into a continuous polyline so that `stroke-linejoin` applies at
+  shared endpoints, without affecting any fill-rule semantics."
+  [attrs]
+  (let [attr-fill  (some-> (:fill attrs) str/trim)
+        style-fill (some-> (get-in attrs [:style :fill]) str/trim)]
+    (= "none" (or attr-fill style-fill))))
+
 (defn create-path-shape [name frame-id svg-data {:keys [attrs] :as data}]
   (when (and (contains? attrs :d) (seq (:d attrs)))
-    (let [transform (csvg/parse-transform (:transform attrs))
-          content   (cond-> (path/from-string (:d attrs))
-                      (some? transform)
-                      (path.segm/transform-content transform))
+    (let [transform    (csvg/parse-transform (:transform attrs))
+          stroke-only? (stroke-only-svg-path? attrs)
+          content      (cond-> (path/from-string (:d attrs))
+                         stroke-only?
+                         (path/merge-touching-subpaths)
+
+                         (some? transform)
+                         (path.segm/transform-content transform))
 
           selrect    (path.segm/content->selrect content)
           points     (grc/rect->points selrect)

--- a/common/src/app/common/types/path.cljc
+++ b/common/src/app/common/types/path.cljc
@@ -84,6 +84,19 @@
   (-> (subpath/close-subpaths content)
       (impl/from-plain)))
 
+(defn merge-touching-subpaths
+  "Given a content, fold consecutive subpaths whose endpoints coincide
+  into a single continuous subpath, returning a PathData instance.
+
+  Conservative counterpart of `close-subpaths`: only adjacent subpaths
+  are merged and none are reversed, so fill rules and stroke-dasharray
+  semantics are preserved. Used at SVG-import time on stroke-only paths
+  to recover the `stroke-linejoin` rendering when authoring tools split
+  a continuous polyline into adjacent `M..L M..L` subpaths."
+  [content]
+  (-> (subpath/merge-touching-subpaths content)
+      (impl/from-plain)))
+
 (defn apply-content-modifiers
   "Apply delta modifiers over the path content"
   [content modifiers]

--- a/common/src/app/common/types/path/subpath.cljc
+++ b/common/src/app/common/types/path/subpath.cljc
@@ -128,6 +128,36 @@
 (def ^:private xf-mapcat-data
   (mapcat :data))
 
+(defn- join-adjacent
+  "Fold neighbouring subpaths into the accumulator only when the
+  current accumulator's end-point matches the next subpath's start-point.
+  Unlike `merge-paths` this does not reverse subpaths nor reorder them;
+  the original draw order is preserved so stroke-dasharray and animation
+  semantics stay intact."
+  [acc subpath]
+  (if-let [prev (peek acc)]
+    (if (and (not (is-closed? prev))
+             (not (is-closed? subpath))
+             (pt= (:to prev) (:from subpath)))
+      (conj (pop acc) (subpaths-join prev subpath))
+      (conj acc subpath))
+    (conj acc subpath)))
+
+(defn merge-touching-subpaths
+  "Merge consecutive subpaths whose endpoints coincide into a single
+  continuous subpath, preserving the original drawing order.
+
+  This is a conservative variant of `close-subpaths`: it never reverses
+  a subpath and only merges immediate neighbours, so closed regions and
+  fill semantics are left untouched. The intent is to recover the
+  `stroke-linejoin` rendering for SVG paths whose authoring tools split
+  a continuous polyline into adjacent `M..L M..L` subpaths (e.g. the
+  `m0 0` markers Figma emits when exporting Heroicons-like icons)."
+  [content]
+  (let [subpaths (get-subpaths content)
+        merged   (reduce join-adjacent [] subpaths)]
+    (into [] xf-mapcat-data merged)))
+
 (defn close-subpaths
   "Searches a path for possible subpaths that can create closed loops and merge them"
   [content]

--- a/common/test/common_tests/types/path_data_test.cljc
+++ b/common/test/common_tests/types/path_data_test.cljc
@@ -667,6 +667,41 @@
           result (path.subpath/close-subpaths content)]
       (t/is (seq result)))))
 
+(t/deftest subpath-merge-touching-subpaths
+  (t/testing "adjacent subpaths sharing an endpoint collapse into one chain"
+    ;; Heroicons-style fragment: continuous polyline split as M-L M-L M-L
+    ;; with the second/third subpath starting at the first's endpoint.
+    (let [content [{:command :move-to :params {:x 0.0  :y 10.0}}
+                   {:command :line-to :params {:x 10.0 :y 10.0}}
+                   {:command :move-to :params {:x 10.0 :y 10.0}}
+                   {:command :line-to :params {:x 5.0  :y 0.0}}
+                   {:command :move-to :params {:x 10.0 :y 10.0}}
+                   {:command :line-to :params {:x 5.0  :y 20.0}}]
+          result  (path.subpath/merge-touching-subpaths content)
+          moves   (filter #(= :move-to (:command %)) result)]
+      ;; Subpaths 1+2 share (10,10) → merged. Subpath 3 also starts at (10,10),
+      ;; but the merged chain now ends at (5,0), so it does NOT match and
+      ;; is preserved as its own subpath. Two move-tos in the final result.
+      (t/is (= 2 (count moves)))
+      (t/is (= 5 (count result)))))
+  (t/testing "non-touching subpaths are left untouched"
+    (let [content [{:command :move-to :params {:x 0.0  :y 0.0}}
+                   {:command :line-to :params {:x 5.0  :y 0.0}}
+                   {:command :move-to :params {:x 50.0 :y 50.0}}
+                   {:command :line-to :params {:x 60.0 :y 60.0}}]
+          result  (path.subpath/merge-touching-subpaths content)]
+      (t/is (= content (vec result)))))
+  (t/testing "closed subpath is not absorbed into a neighbour"
+    (let [content [{:command :move-to   :params {:x 0.0 :y 0.0}}
+                   {:command :line-to   :params {:x 5.0 :y 0.0}}
+                   {:command :line-to   :params {:x 5.0 :y 5.0}}
+                   {:command :line-to   :params {:x 0.0 :y 0.0}}
+                   {:command :move-to   :params {:x 0.0 :y 0.0}}
+                   {:command :line-to   :params {:x 1.0 :y 1.0}}]
+          result  (path.subpath/merge-touching-subpaths content)
+          moves   (filter #(= :move-to (:command %)) result)]
+      (t/is (= 2 (count moves))))))
+
 (t/deftest subpath-reverse-content
   (let [result (path.subpath/reverse-content simple-open-content)]
     (t/is (= (count simple-open-content) (count result)))
@@ -1099,6 +1134,24 @@
         result  (path/close-subpaths content)]
     (t/is (path/content? result))
     (t/is (seq (vec result)))))
+
+(t/deftest path-merge-touching-subpaths
+  (t/testing "regression for #5283 — heroicons arrow path serialises as a single chain"
+    ;; SVG `d` originally split a continuous polyline by inserting a
+    ;; redundant moveto at the elbow. Importing it must collapse the
+    ;; first two subpaths so that stroke-linejoin renders the rounded tip.
+    (let [content (path/from-string
+                   (str "M350.5,1846 L365.5,1846"
+                        " M365.5,1846 L358.75,1839.25"
+                        " M365.5,1846 L358.75,1852.75"))
+          merged   (path/merge-touching-subpaths content)
+          rendered (str merged)]
+      (t/is (path/content? merged))
+      ;; First two subpaths fold into M ... L ... L ... ; third stays
+      ;; separate (its start point matches the original M, not the merged
+      ;; chain's tail), so exactly two M commands remain.
+      (t/is (= 2 (count (re-seq #"M" rendered))))
+      (t/is (= 3 (count (re-seq #"L" rendered)))))))
 
 (t/deftest path-move-content
   (let [content  (path/content sample-content-square)


### PR DESCRIPTION
### Related Ticket

Closes #5283

### Summary

When an SVG is imported whose authoring tool split a continuous polyline into adjacent `M…L M…L` subpaths sharing an endpoint — common with Heroicons (Figma exports a redundant `m0 0` between segments) — Penpot was storing each segment as its own subpath, so `stroke-linejoin="round"` could not round the elbow. Arrow tips rendered with butt caps in the editor and in PNG/SVG exports; entering and leaving path-edit mode would temporarily fix the visible state because that flow runs `subpath/close-subpaths` on save, but reload reverted to the broken state because import never ran any merge step.

This PR adds a conservative merge pass at SVG-import time, gated on `fill="none"`, that folds consecutive endpoint-sharing subpaths into a single chain — restoring the rounded join in the renderer and in exports.

```
input  d="M3 12 h13.5 m0 0 L9 5.25 M16.5 12 L9 18.75"
before "M3,12 L16.5,12 M16.5,12 L9,5.25 M16.5,12 L9,18.75"   ← 3 M's, broken tip
after  "M3,12 L16.5,12 L9,5.25 M16.5,12 L9,18.75"            ← 2 M's, rounded tip
```

**Implementation**

- New `merge-touching-subpaths` in `common/src/app/common/types/path/subpath.cljc` — conservative variant of `close-subpaths`: it **never reverses or reorders** subpaths and only merges immediate neighbours, so closed regions and stroke-dasharray intent are preserved.
- New `PathData`-returning wrapper in `common/src/app/common/types/path.cljc`.
- New `stroke-only-svg-path?` predicate in `shapes_builder.cljc`; `create-path-shape` invokes the merge only when `fill="none"`, so fill-rule semantics on filled paths are untouched.
- No new dependencies. No CI/build changes.

### Steps to reproduce

**Reproduce the bug on `develop`:**
1. Import the [Heroicons template](https://penpot.app/penpothub/libraries-templates/heroicons) into a project, search for any arrow icon, and drop it on the canvas.
2. Zoom in on the arrow tip. Tip is a flat T-shape (three butt-capped line ends) instead of a smooth chevron.
3. Right-click → Edit path → exit. Tip becomes rounded. Reload the page → tip is broken again.
4. Right-click → Export as PNG → exported PNG also shows the broken tip.

**Smaller standalone repro** — paste this SVG via File → Import (or drag-drop):

```svg
<svg width="48" height="48" viewBox="0 0 24 24" fill="none"
     stroke="black" stroke-width="1.5"
     stroke-linecap="round" stroke-linejoin="round">
  <path d="M3 12h13.5m0 0L9 5.25M16.5 12L9 18.75" />
</svg>
```

**Verify the fix on this branch:**
1. Repeat the standalone repro — tip is rounded on first import, stays rounded after reload.
2. Right-click → Copy as SVG. The pasted `d` should contain `… L 16.5,12 L 9,5.25 …` (two consecutive `L`s after the elbow), not `… L 16.5,12 M 16.5,12 L 9,5.25 …`.
3. Negative regressions:
   - Import an X-mark icon (`d="M6 18 18 6M6 6l12 12"`) — both diagonals must remain separate `M-L` strokes.
   - Import a filled multi-subpath SVG (`d="M10,10 L90,10 L50,90 Z M30,30 L70,30 L50,70 Z"` with `fill="black"`) — both `Z`-closed triangles must remain as separate subpaths.

I verified all of the above end-to-end through Playwright drag-drop into the running editor, reading the resulting shape's `:content` straight out of the workspace store:

| Imported SVG | Stored `d` | M / L / Z | Verdict |
|---|---|---|---|
| Heroicons arrow (fragmented, fill=none) | `M…L…L M…L` | **2** / 3 / 0 | merged ✅ |
| X-mark (disjoint, fill=none) | `M…L M…L` | 2 / 2 / 0 | untouched ✅ |
| Two filled triangles | `M…L…L…Z M…L…L…Z` | 2 / 4 / 2 | untouched ✅ |

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable. _Before/after side-by-side rendered with the same `stroke-linejoin="round"`

- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
  - `subpath-merge-touching-subpaths` and `path-merge-touching-subpaths` in `common/test/common_tests/types/path_data_test.cljc`
  - Full common JVM suite green: `clojure -M:dev:test` → 992 tests, 24077 assertions, 0 failures
  - `cljfmt check` + `clj-kondo` clean on changed files
- [ ] Refactor any modified SCSS files following the refactor guide. _N/A — no SCSS touched._
- [ ] Check CI passes successfully. _Pending CI run._
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

### Screenshots

<img width="544" height="626" alt="heroicons-arrow-before" src="https://github.com/user-attachments/assets/cf6f8049-9bb7-4fe6-b7b4-69814657e3d8" />

<img width="544" height="626" alt="heroicons-arrow-after" src="https://github.com/user-attachments/assets/c1773c45-58b9-4893-b9f3-c667459c3d76" />
