### PR TITLE
:sparkles: Add modal to subscribe to nitrate from unlimited

### DIFF
--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -121,6 +121,8 @@
   {::mf/props :obj}
   [{:keys [profile teams]}]
   (let [nitrate? (dnt/is-valid-license? profile)
+        nitrate-license (:subscription profile)
+        subscription-type (if nitrate? (:type nitrate-license) (get-subscription-type (-> profile :props :subscription)))
         orgs (mf/with-memo [teams]
                (let [orgs (->> teams
                                vals
@@ -134,8 +136,11 @@
 
         handle-click
         (mf/use-fn
+         (mf/deps nitrate-license subscription-type)
          (fn []
-           (st/emit! (dnt/show-nitrate-popup :nitrate-form))))
+           (if (= subscription-type "unlimited")
+             (st/emit! (dnt/show-nitrate-popup :nitrate-dialog {:nitrate-license nitrate-license :show-contact-sales-option true}))
+             (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
 
         handle-go-to-cc
         (mf/use-fn dnt/go-to-nitrate-cc-create-org)]

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -468,8 +468,11 @@
 
         open-contact-sales-modal
         (mf/use-fn
-         (fn [subscription-type]
-           (st/emit! (modal/show :nitrate-contact-sales-dialog {:subscription-type subscription-type}))))]
+         (mf/deps nitrate-license)
+         (fn [current-subscription subscription-type]
+           (if (= current-subscription "unlimited")
+             (st/emit! (dnt/show-nitrate-popup :nitrate-dialog {:nitrate-license nitrate-license :show-contact-sales-option true}))
+             (st/emit! (modal/show :nitrate-contact-sales-dialog {:subscription-type subscription-type})))))]
 
     (mf/with-effect []
       (dom/set-html-title (tr "subscription.labels")))
@@ -623,7 +626,7 @@
                                     (tr "subscription.settings.unlimited.autosave-benefit"),
                                     (tr "subscription.settings.unlimited.bill")]
                          :cta-text (if (:type subscription) (tr "subscription.settings.subscribe") (tr "subscription.settings.try-it-free"))
-                         :cta-link (if (and (contains? cf/flags :nitrate) nitrate?) #(open-contact-sales-modal "Unlimited") #(open-subscription-modal "unlimited" subscription))
+                         :cta-link (if (and (contains? cf/flags :nitrate) nitrate?) #(open-contact-sales-modal subscription-type "Unlimited") #(open-subscription-modal "unlimited" subscription))
                          :cta-text-with-icon (tr "subscription.settings.more-information")
                          :cta-link-with-icon go-to-pricing-page
                          :recommended (= subscription-type "professional")
@@ -655,7 +658,7 @@
                                     "Acceso exclusivo al Control Center"
                                     "Lorem ipsum"]
                          :cta-text (if nitrate-license (tr "subscription.settings.subscribe") "Try 14 days for free")
-                         :cta-link #(open-subscription-modal "nitrate" subscription)
+                         :cta-link (if (= subscription-type "unlimited") #(open-contact-sales-modal subscription-type "Nitrate") #(open-subscription-modal "nitrate" subscription))
                          :cta-text-with-icon (tr "subscription.settings.more-information")
                          :cta-link-with-icon go-to-pricing-page
                          :show-button-cta (not nitrate-license)}])]]]))
@@ -668,7 +671,7 @@
 (mf/defc subscribe-nitrate-dialog
   {::mf/register modal/components
    ::mf/register-as :nitrate-dialog}
-  [{:keys [nitrate-license] :as connectivity}]
+  [{:keys [nitrate-license show-contact-sales-option] :as connectivity}]
   ;; TODO add translations for this texts when we have the definitive ones
   (let [online? (:licenses connectivity)
         initial (mf/with-memo []
@@ -701,7 +704,7 @@
       [:div {:class (stl/css :modal-title :subscription-title)}
        "Subcribe to the Business Nitrate plan"]
 
-      (if online?
+      (if (and online? (not show-contact-sales-option))
         [:div {:class (stl/css :modal-content)}
 
 


### PR DESCRIPTION
### Related Ticket

When you have an unlimited subscription and you want to subscribe to nitrate, it'll show the user a modal to contact to penpot.
This modal is triggered from `/settings/subscriptions` when user tries to subscribe to nitrate or from the banner in the left sidebar.

https://design.penpot.app/#/workspace?team-id=8fd8c29f-33f9-8038-8007-28bdc8c029f0&file-id=71bc4f81-468d-8163-8007-87dd424cbf26&page-id=24638977-c774-8055-8007-87ddd77ea15e&board-id=eaf6e70a-fca7-80b9-8007-8e6d77a1098f

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
