### PR TITLE
:bug: Fix render wasm generated component thumbnails for instant changes

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -960,6 +960,12 @@
       (dwt.wasm/render-thumbnail file-id page-id root-id)
       (dwt/update-thumbnail file-id page-id root-id tag "update-component-thumbnail-sync"))))
 
+(defn- render-component-thumbnail-event
+  [[component-id file-id]]
+  (let [file-id (or file-id (:current-file-id @st/state))]
+    (update-component-thumbnail-sync
+     @st/state component-id file-id "component")))
+
 (defn update-component-sync
   ([shape-id file-id] (update-component-sync shape-id file-id nil))
   ([shape-id file-id undo-group]
@@ -1358,15 +1364,14 @@
             (->> (rx/from-atom refs/workspace-data {:emit-current-value? true})
                  (rx/share))
 
+            ;; Pair every commit with the file data right before it
+            ;; (so deleted shapes still exist when we inspect the change).
             workspace-buffer-s
             (->> (rx/concat
                   (rx/take 1 workspace-data-s)
-                  (rx/take 1 workspace-data-s)
                   workspace-data-s)
-                 ;; Need to get the file data before the change, so deleted shapes
-                 ;; still exist, for example. We initialize the buffer with three
-                 ;; copies of the initial state
-                 (rx/buffer 3 1))
+                 (rx/buffer 2 1)
+                 (rx/map first))
 
             changes-s
             (->> stream
@@ -1376,7 +1381,7 @@
                  (rx/observe-on :async))
 
             check-changes
-            (fn [[event [old-data _mid_data _new-data]]]
+            (fn [[event old-data]]
               (if (nil? old-data)
                 (rx/empty)
                 (let [{:keys [file-id changes save-undo? undo-group]} event
@@ -1392,11 +1397,9 @@
                       (do (log/info :hint "detected component changes"
                                     :ids (map str changed-components)
                                     :undo-group undo-group)
-
                           (->> (rx/from changed-components)
                                (rx/map #(component-changed % (:id old-data) undo-group))))
-                      ;; even if save-undo? is false, we need to update the :modified-date of the component
-                      ;; (for example, for undos)
+                      ;; save-undo? false (undos): just bump :modified-at
                       (->> (rx/from changed-components)
                            (rx/map touch-component)))
 
@@ -1418,8 +1421,19 @@
           (->> (rx/merge
                 changes-s
 
-                ;; Persist thumbnails to the server in batches after user
-                ;; becomes inactive for 5 seconds.
+                ;; WASM only: render the thumbnail on every component
+                ;; change so single edits (fill, etc.) update instantly.
+                ;; Non-WASM persists on every render, so it stays on the
+                ;; debounced path below to avoid per-edit backend posts.
+                (if (features/active-feature? @st/state "render-wasm/v1")
+                  (->> changes-s
+                       (rx/filter (ptk/type? ::component-changed))
+                       (rx/map deref)
+                       (rx/map render-component-thumbnail-event))
+                  (rx/empty))
+
+                ;; Persist to the server in batches, 5s after the user
+                ;; goes idle.
                 (->> changes-s
                      (rx/filter (ptk/type? ::component-changed))
                      (rx/map deref)
@@ -1428,15 +1442,11 @@
                      (rx/map (fn [[component-id file-id]]
                                (update-component-thumbnail component-id file-id))))
 
-                ;; Immediately update the component thumbnail on undos,
-                ;; which emit touch-component instead of component-changed.
+                ;; Undo/redo emit touch-component instead.
                 (->> changes-s
                      (rx/filter (ptk/type? ::touch-component))
                      (rx/map deref)
-                     (rx/map (fn [[component-id file-id]]
-                               (let [file-id (or file-id (:current-file-id @st/state))]
-                                 (update-component-thumbnail-sync
-                                  @st/state component-id file-id "component"))))))
+                     (rx/map render-component-thumbnail-event)))
 
                (rx/take-until stopper-s)))))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14063

### Summary

Update a single component immediately when changing

### Steps to reproduce 

https://github.com/user-attachments/assets/783efab2-2017-439c-a13b-5989e975cb6b


What to test:

- Single component thumbnail update after creation (create shape -> create component -> change fill)
- Try undo/redo
- Check that after token propagation, update is still progressive

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
