### PR TITLE
:lipstick: Fix sucess typo in subscription dialog i18n keys

### DIFF
--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -343,14 +343,14 @@
 
        [:div {:class (stl/css :modal-end)}
         [:div {:class (stl/css :modal-title)}
-         (tr "subscription.settings.sucess.dialog.title" subscription-name)]
+         (tr "subscription.settings.success.dialog.title" subscription-name)]
         (when (not= subscription-name "professional")
           [:p {:class (stl/css :modal-text-large)}
            (tr "subscription.settings.success.dialog.thanks" subscription-name)])
         [:p {:class (stl/css :modal-text-large)}
          (tr "subscription.settings.success.dialog.description")]
         [:p {:class (stl/css :modal-text-large)}
-         (tr "subscription.settings.sucess.dialog.footer")]
+         (tr "subscription.settings.success.dialog.footer")]
 
         [:div {:class (stl/css :success-action-buttons)}
          [:input
@@ -381,7 +381,7 @@
         [:p {:class (stl/css :modal-text-large)}
          (tr "subscription.settings.success.dialog.description")]
         [:p {:class (stl/css :modal-text-large)}
-         (tr "subscription.settings.sucess.dialog.footer")]
+         (tr "subscription.settings.success.dialog.footer")]
 
         [:div {:class (stl/css :success-action-buttons)}
          [:input

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -4822,11 +4822,11 @@ msgid "subscription.settings.subscribe"
 msgstr "Abonnieren"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Viel Spaß mit Ihrem Abonnement!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Sie sind %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:558, src/app/main/ui/settings/subscription.cljs:574

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5309,11 +5309,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Thank your for chosing the Penpot %s plan!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Enjoy your plan!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "You are %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5254,11 +5254,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "¡Gracias por elegir el plan %s de Penpot!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "¡Disfruta de tu plan!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Eres %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -5010,11 +5010,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Merci d'avoir choisi l'abonnement Penpot %s !"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Profitez bien de votre abonnement !"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Vous êtes %s !"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/fr_CA.po
+++ b/frontend/translations/fr_CA.po
@@ -5025,11 +5025,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Merci d'avoir choisi le forfait Penpot %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Profite bien de ton forfait!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Tu es %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -4773,11 +4773,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "תודה על הבחירה בתוכנית %s של Penpot!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "מאחלים לך הנאה מהתוכנית שלך!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "התוכנית שלך היא %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/hi.po
+++ b/frontend/translations/hi.po
@@ -4904,11 +4904,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "पेनपोट %s योजना चुनने के लिए धन्यवाद!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "अपनी योजना का आनंद लें!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "आप %s हैं!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -5012,11 +5012,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Grazie per aver scelto il piano Penpot %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Goditi il tuo piano!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Sei %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -4622,11 +4622,11 @@ msgstr ""
 "\"Abonements\"."
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Izbaudi savu plānu!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Tu esi %s."
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -5036,11 +5036,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Bedankt voor het kiezen van het Penpot %s-abonnement!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Veel plezier met je abonnement!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Je bent %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -4747,11 +4747,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Mulțumim pentru că ai ales planul Penpot %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Bucură-te de abonament!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Ești %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -4827,11 +4827,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Tack för att du valt Penpot %s-abonnemanget!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Lycka till med ditt abonnemang!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Du är %!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -5002,11 +5002,11 @@ msgid "subscription.settings.success.dialog.thanks"
 msgstr "Penpot %s planını seçtiğiniz için teşekkür ederiz!"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Planınızın tadını çıkarın!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "%s oldunuz!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/ukr_UA.po
+++ b/frontend/translations/ukr_UA.po
@@ -4462,11 +4462,11 @@ msgstr ""
 "що у подробицях облікового запису."
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "Насолоджуйтесь планом!"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "Ви %s!"
 
 #: src/app/main/ui/settings/subscription.cljs:526

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -4318,11 +4318,11 @@ msgid "subscription.settings.subscribe"
 msgstr "订阅"
 
 #: src/app/main/ui/settings/subscription.cljs:347
-msgid "subscription.settings.sucess.dialog.footer"
+msgid "subscription.settings.success.dialog.footer"
 msgstr "享受您的计划！"
 
 #: src/app/main/ui/settings/subscription.cljs:340
-msgid "subscription.settings.sucess.dialog.title"
+msgid "subscription.settings.success.dialog.title"
 msgstr "你是 %s！"
 
 #: src/app/main/ui/settings/subscription.cljs:526


### PR DESCRIPTION
## Related Ticket

Closes #9203 

## Summary

Fixes a typo in the i18n keys for the subscription success dialog.
The keys were spelled `sucess` instead of `success`. Renamed in the English translation file and updated the three callsites in
`subscription.cljs`.

No behavioural change — same dialog, same text, just correctly-spelled keys under the hood.

## Steps to Reproduce (before)

1. `grep -n "sucess" frontend/translations/en.po` → returns 2 lines.
2. `grep -n "sucess" frontend/src/app/main/ui/settings/subscription.cljs` → returns 3 lines.

## Steps to Verify (after)

1. Same greps return zero results for `sucess`.
2. Subscription success dialog still renders correctly with title and footer text.
3. `./scripts/check-fmt` and `./scripts/lint` pass.

## Changes

- **`frontend/translations/en.po`** (lines 5312, 5316) — renamed keys `subscription.settings.sucess.dialog.{title,footer}` → `success`.
- **`frontend/src/app/main/ui/settings/subscription.cljs`** (lines 346, 353, 384) — updated three callsites to use the corrected key.

## Checklist

- [ ] Renamed keys in en.po
- [ ] Updated all callsites in subscription.cljs
- [ ] Subscription success dialog still renders the title and footer
- [ ] No regression in subscription settings flow
- [ ] `./scripts/check-fmt` passes
- [ ] `./scripts/lint` passes
