### PR TITLE
:bug: Fix text editor v2 with 0 width

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -425,8 +425,8 @@
 
           (not render-wasm?)
           (obj/merge!
-           #js {"--editor-container-width" (dm/str width "px")
-                "--editor-container-height" (dm/str height "px")})
+           #js {"--editor-container-width" (dm/str (max 1 width) "px")
+                "--editor-container-height" (dm/str (max 1 height) "px")})
 
           ;; Transform is necessary when there is a text overflow and the vertical
           ;; aligment is center or bottom.


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #14098](https://tree.taiga.io/project/penpot/issue/14098)

### Summary

Playwright tests are failing due to textbox having width 0px, so Playwright can not assert element is visible: https://playwright.dev/docs/actionability#visible

### Steps to reproduce 

1. Create a textbox
2. Open Dev Console
3. Navigate to Computed tab
4. Observe: textbox widht is 0px

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
