### PR TITLE
:zap: Skip component-sync on pure-translation drag commits

### DIFF
--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -67,6 +67,12 @@
     (some? undo-group)
     (assoc :undo-group undo-group)))
 
+(defn set-translation?
+  [changes translation?]
+  (cond-> changes
+    translation?
+    (assoc :translation? true)))
+
 (defn with-page
   [changes page]
   (vary-meta changes assoc

--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -122,7 +122,8 @@
 (defn commit
   "Create a commit event instance"
   [{:keys [commit-id redo-changes undo-changes origin save-undo? features
-           file-id file-revn file-vern undo-group tags stack-undo? source ignore-wasm?]}]
+           file-id file-revn file-vern undo-group tags stack-undo? source ignore-wasm?
+           translation?]}]
 
   (assert (cpc/check-changes redo-changes)
           "expect valid vector of changes for redo-changes")
@@ -148,7 +149,8 @@
                    :undo-group undo-group
                    :tags tags
                    :stack-undo? stack-undo?
-                   :ignore-wasm? ignore-wasm?}]
+                   :ignore-wasm? ignore-wasm?
+                   :translation? translation?}]
 
     (ptk/reify ::commit
       cljs.core/IDeref
@@ -186,7 +188,8 @@
    - undo-group: if some consecutive changes (or even transactions) share the same
                  undo-group, they will be undone or redone in a single step
    "
-  [{:keys [redo-changes undo-changes save-undo? undo-group tags stack-undo? file-id]
+  [{:keys [redo-changes undo-changes save-undo? undo-group tags stack-undo? file-id
+           translation?]
     :or {save-undo? true
          stack-undo? false
          undo-group (uuid/next)
@@ -216,4 +219,5 @@
                      (assoc :file-vern (resolve-file-vern state file-id))
                      (assoc :undo-changes uchg)
                      (assoc :redo-changes rchg)
+                     (assoc :translation? translation?)
                      (commit))))))))

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -1382,8 +1382,14 @@
 
             check-changes
             (fn [[event old-data]]
-              (if (nil? old-data)
+              (cond
+                (nil? old-data)
                 (rx/empty)
+
+                (:translation? event)
+                (rx/empty)
+
+                :else
                 (let [{:keys [file-id changes save-undo? undo-group]} event
 
                       changed-components

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -659,15 +659,14 @@
             snap-pixel?
             (and (not ignore-snap-pixel) (contains? (:workspace-layout state) :snap-pixel-grid))]
         (set-wasm-props! objects prev-wasm-props wasm-props)
-        (let [structure-entries (parse-structure-modifiers modif-tree)]
-          (wasm.api/set-structure-modifiers structure-entries)
-          (let [geometry-entries (parse-geometry-modifiers modif-tree)
-                modifiers        (wasm.api/propagate-modifiers geometry-entries snap-pixel?)]
-            (wasm.api/set-modifiers modifiers)
-            (let [ids     (into [] xf:map-key geometry-entries)
-                  selrect (wasm.api/get-selection-rect ids)]
-              (rx/of (set-temporary-selrect selrect)
-                     (set-temporary-modifiers modifiers)))))))))
+        (wasm.api/set-structure-modifiers (parse-structure-modifiers modif-tree))
+        (let [geometry-entries (parse-geometry-modifiers modif-tree)
+              modifiers        (wasm.api/propagate-modifiers geometry-entries snap-pixel?)]
+          (wasm.api/set-modifiers modifiers)
+          (let [ids     (into [] xf:map-key geometry-entries)
+                selrect (wasm.api/get-selection-rect ids)]
+            (rx/of (set-temporary-selrect selrect)
+                   (set-temporary-modifiers modifiers))))))))
 
 (defn propagate-structure-modifiers
   [modif-tree objects]
@@ -701,8 +700,7 @@
     ptk/WatchEvent
     (watch [_ state _]
       (wasm.api/clean-modifiers)
-      (let [structure-entries (parse-structure-modifiers modif-tree)]
-        (wasm.api/set-structure-modifiers structure-entries))
+      (wasm.api/set-structure-modifiers (parse-structure-modifiers modif-tree))
 
       ;; Apply property changes (e.g. grow-type) to WASM shapes before
       ;; propagating geometry, so propagate_modifiers sees the updated state.
@@ -722,6 +720,12 @@
             transforms
             (into {} (wasm.api/propagate-modifiers geometry-entries snap-pixel?))
 
+            ;; Pure-translation gesture: every shape's modifier only
+            ;; contains `:move` operations (no resize/rotate/scale and
+            ;; no structural mutation)
+            translation?
+            (every? #(ctm/only-move? (:modifiers %)) (vals modif-tree))
+
             ignore-tree
             (calculate-ignore-tree-wasm transforms objects)
 
@@ -729,6 +733,7 @@
             (-> params
                 (assoc :reg-objects? true)
                 (assoc :ignore-tree ignore-tree)
+                (assoc :translation? translation?)
                 ;; Attributes that can change in the transform. This
                 ;; way we don't have to check all the attributes
                 (assoc :attrs transform-attrs))

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -50,7 +50,7 @@
   ([ids update-fn] (update-shapes ids update-fn nil))
   ([ids update-fn
     {:keys [reg-objects? save-undo? stack-undo? attrs ignore-tree page-id
-            ignore-touched undo-group with-objects? changed-sub-attr]
+            ignore-touched undo-group with-objects? changed-sub-attr translation?]
      :or {reg-objects? false
           save-undo? true
           stack-undo? false
@@ -90,7 +90,8 @@
                                               :ignore-touched ignore-touched
                                               :with-objects? with-objects?})
                  (cond-> undo-group
-                   (pcb/set-undo-group undo-group)))
+                   (pcb/set-undo-group undo-group))
+                 (pcb/set-translation? translation?))
 
              changes
              (add-undo-group changes state)]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/14099

### Summary

Component thumbnails were re-rendering on every drag-end. When dragging a frame containing many component instances, each instance's :mod-obj change triggered ::component-changed → 100s of immediate thumbnail renders + a multi-second setInterval block, even though instance positions are independent of their master and a translate doesn't change the master's contents

Note: I added the `new render` because the `:translation?` flag only applies for `apply-wasm-modifiers` 

### Steps to reproduce

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
