### PR TITLE
:bug: Fix text editor v2 min size

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -289,7 +289,9 @@
       :ref container-ref
       :data-testid "text-editor-container"
       :style {:width "var(--editor-container-width)"
-              :height "var(--editor-container-height)"}}
+              :height "var(--editor-container-height)"
+              :min-width "1px"
+              :min-height "1px"}}
      ;; We hide the editor when is blurred because otherwise the
      ;; selection won't let us see the underlying text. Use opacity
      ;; because display or visibility won't allow to recover focus


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #14098](https://tree.taiga.io/project/penpot/issue/14098)

### Summary

Playwright tests are failing due to textbox having width 0px, so Playwright can not assert element is visible: https://playwright.dev/docs/actionability#visible

### Steps to reproduce 

1. Create a textbox
2. Open Dev Console
3. Navigate to Computed tab
4. Observe: textbox widht is 0px

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
