### PR TITLE
:bug: Fix dashboard modal clipping behind sidebar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@
 - Adds a **Pixel grid color** picker in the viewport settings, next to the existing canvas color control [Github #7750](https://github.com/penpot/penpot/issues/7750)
 ### :bug: Bugs fixed
 
+- Fix release notes modal appearing behind the dashboard sidebar [Github #8296](https://github.com/penpot/penpot/issues/8296)
 - Fix plugin API `fileVersion.restore()` promise hanging indefinitely on restore failure [Github #9092](https://github.com/penpot/penpot/issues/9092)
 - Fix plugin API `library.connectLibrary()` returning a non-Promise (or throwing synchronously) when the plugin lacks `library:write` permission — the method now always returns a `Promise` and rejects with a structured error message, matching the contract used by every other Promise-returning plugin method (`restore`, `remove`, `pin`, `saveVersion`, `findVersions`, …)
 - Fix LDAP provider params schema typo (`bind-passwor` → `bind-password`) introduced during the `clojure.spec` → `malli` migration; the schema slot now matches the runtime key actually read by `prepare-params` (`:password (:bind-password cfg)`) and `try-connectivity` (`(:bind-password cfg)`), so a wrong type for the password no longer slips through unvalidated

--- a/frontend/src/app/main/ui/dashboard/sidebar.scss
+++ b/frontend/src/app/main/ui/dashboard/sidebar.scss
@@ -26,7 +26,7 @@
   margin: 0 var(--sp-l) 0 0;
   border-right: $b-1 solid var(--panel-border-color);
   background-color: var(--panel-background-color);
-  z-index: var(--z-index-dropdown);
+  z-index: var(--z-index-panels);
 }
 
 // SIDEBAR CONTENT COMPONENT


### PR DESCRIPTION
### Related Ticket

Closes #8296

### Summary

Fixes a dashboard layering issue where the release notes modal could appear behind the left sidebar. The sidebar now uses the panel z-index layer so modal overlays render above it.

### Steps to reproduce

1. Open the dashboard.
2. Open the profile menu in the left sidebar.
3. Open `About Penpot`.
4. Click the version notes item.
5. Verify the release notes modal appears above the sidebar.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

### Screenshots

Before:

<img width="1257" height="676" alt="reprodue0429_1" src="https://github.com/user-attachments/assets/eb4e7897-9428-4af8-b4cd-2a731816a964" />


After:

<img width="1345" height="684" alt="fix0429_2" src="https://github.com/user-attachments/assets/72a0dd04-cd8c-42d4-ad43-29e844b73e8a" />
