### PR TITLE
:bug: Remove stray debug log in color-row component

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -352,10 +352,6 @@
                       :dnd-over-top (= (:over dprops) :top)
                       :dnd-over-bot (= (:over dprops) :bot))]
 
-    (when (= applied-token :multiple)
-      ;; (js/console.trace "color-row*")
-      (prn "color-row*" index color applied-token))
-
     (mf/with-effect [color prev-color disable-picker]
       (when (and (not disable-picker) (not= prev-color color))
         (modal/update-props! :colorpicker {:data (parse-color color)})))


### PR DESCRIPTION
### Related Ticket

Closes #9242 

### Summary

The `color-row*` component was emitting a `prn` line on every render where `applied-token` resolved to `:multiple`, alongside a commented out `js/console.trace`. Both look like leftover local debugging and add noise to the browser console. This change removes them so the workspace renders silently again.

### Steps to reproduce

1. Open Penpot in the browser with the developer console visible.
2. Open any file in the workspace and select two or more shapes whose color rows resolve to `applied-token` `:multiple` (for example, shapes with different applied color tokens).
3. Trigger any rerender of the color row (open the design panel, change selection, etc.).
4. Confirm that no `color-row*` line is printed to the console.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.