### PR TITLE
:zap: Restore deleted team files in bulk instead of per file

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -1226,38 +1226,43 @@
       AND t.id = ?
       AND f.id = ANY(?::uuid[])")
 
+(def ^:private sql:restore-files
+  "UPDATE file SET deleted_at = null, has_media_trimmed = false
+    WHERE id = ANY(?::uuid[])")
+
+(def ^:private sql:restore-file-media-objects
+  "UPDATE file_media_object SET deleted_at = null
+    WHERE file_id = ANY(?::uuid[])")
+
+(def ^:private sql:restore-file-changes
+  "UPDATE file_change SET deleted_at = null
+    WHERE file_id = ANY(?::uuid[])")
+
+(def ^:private sql:restore-file-data
+  "UPDATE file_data SET deleted_at = null
+    WHERE file_id = ANY(?::uuid[])")
+
+(def ^:private sql:restore-file-thumbnails
+  "UPDATE file_thumbnail SET deleted_at = null
+    WHERE file_id = ANY(?::uuid[])")
+
+(def ^:private sql:restore-file-tagged-object-thumbnails
+  "UPDATE file_tagged_object_thumbnail SET deleted_at = null
+    WHERE file_id = ANY(?::uuid[])")
+
+(defn- restore-files
+  [conn file-ids]
+  (let [file-ids (db/create-array conn "uuid" file-ids)]
+    (db/exec-one! conn [sql:restore-files file-ids])
+    (db/exec-one! conn [sql:restore-file-media-objects file-ids])
+    (db/exec-one! conn [sql:restore-file-changes file-ids])
+    (db/exec-one! conn [sql:restore-file-data file-ids])
+    (db/exec-one! conn [sql:restore-file-thumbnails file-ids])
+    (db/exec-one! conn [sql:restore-file-tagged-object-thumbnails file-ids])))
+
 (defn- restore-file
   [conn file-id]
-  (db/update! conn :file
-              {:deleted-at nil
-               :has-media-trimmed false}
-              {:id file-id}
-              {::db/return-keys false})
-
-  (db/update! conn :file-media-object
-              {:deleted-at nil}
-              {:file-id file-id}
-              {::db/return-keys false})
-
-  (db/update! conn :file-change
-              {:deleted-at nil}
-              {:file-id file-id}
-              {::db/return-keys false})
-
-  (db/update! conn :file-data
-              {:deleted-at nil}
-              {:file-id file-id}
-              {::db/return-keys false})
-
-  (db/update! conn :file-thumbnail
-              {:deleted-at nil}
-              {:file-id file-id}
-              {::db/return-keys false})
-
-  (db/update! conn :file-tagged-object-thumbnail
-              {:deleted-at nil}
-              {:file-id file-id}
-              {::db/return-keys false}))
+  (restore-files conn [file-id]))
 
 (def ^:private sql:restore-projects
   "UPDATE project SET deleted_at = null WHERE id = ANY(?::uuid[])")
@@ -1278,17 +1283,18 @@
         (reduce (fn [result {:keys [id project-id]}]
                   (let [index (-> result :files count)]
                     (events/tap :progress {:file-id id :index (inc index) :total total-files})
-                    (restore-file conn id)
-
                     (-> result
                         (update :files conj id)
                         (update :projects conj project-id))))
-
                 {:files #{} :projects #{}}
                 (db/plan conn [sql:resolve-editable-files team-id
                                (db/create-array conn "uuid" ids)]))]
 
-    (restore-projects conn projects)
+    (when (seq files)
+      (restore-files conn files))
+
+    (when (seq projects)
+      (restore-projects conn projects))
 
     files))
 


### PR DESCRIPTION
### Related Ticket

Closes #9246 

### Summary

The `restore-deleted-team-files` RPC command was running a per-file helper that issued six single-row UPDATE statements (one per file table) inside a reduce over the resolved files. A team restore of N files therefore generated roughly 6 * N round trips to Postgres.

The helper now collects file ids up front and issues six bulk UPDATE statements filtered on `file_id = ANY(?::uuid[])`, matching the shape of the existing `restore-projects` helper right below it. Total statement count for the operation drops to a fixed 8 regardless of batch size: one SELECT to resolve editable files, six bulk file updates, and one bulk project update.

The reduce over the resolved rows still emits the per-file `events/tap :progress` events, so the SSE stream consumed by `dashboard.cljs` keeps advancing the restore-progress modal as before.

A small `restore-file` wrapper over the new `restore-files` bulk helper is kept on purpose: two srepl helpers in `app.srepl.main` (`restore-file!` and `restore-project*`) call the private function through a `#'var` reference.

### Steps to reproduce

1. Enable PostgreSQL statement logging (`log_statement = 'all'`) or attach a query counter to the connection pool used by the backend tests.
2. In a test team, mark N files (for example, N = 50) for deletion through `permanently-delete-team-files`.
3. Invoke `::restore-deleted-team-files` for that team and tally the UPDATE statements that hit Postgres.

Expected with this patch: 7 UPDATE statements regardless of N (6 on file tables, one on `project`). Before the patch the count grew linearly with N.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
