### PR TITLE
:bug: Fix :heigth typo in clipboard frame-same-size?

### DIFF
--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -547,8 +547,8 @@
 (defn- frame-same-size?
   [paste-obj frame-obj]
   (and
-   (= (:heigth (:selrect (first (vals paste-obj))))
-      (:heigth (:selrect frame-obj)))
+   (= (:height (:selrect (first (vals paste-obj))))
+      (:height (:selrect frame-obj)))
    (= (:width (:selrect (first (vals paste-obj))))
       (:width (:selrect frame-obj)))))
 


### PR DESCRIPTION
### Related Ticket

<!-- Replace #NNNN with the issue you filed using the bug-report.yml form. -->
Closes #9249 

### Summary

The height comparison in `frame-same-size?` (`frontend/src/app/main/data/workspace/clipboard.cljs:547-553`) used the misspelled keyword `:heigth` on both sides. `(:heigth selrect)` returns `nil` for any real selrect, so `(= nil nil)` was always `true` and the function degenerated to a width-only comparison.

Result: the *Paste next to selected frame, if selected is itself or of the same size as the copied* branch in `clipboard.cljs` fired whenever the pasted content's width matched a target frame's width, even when the heights differed — content landed next to the frame instead of inside it.

The fix is `:heigth` → `:height` on both lines. `rg ':heigth\b'` across the whole repo confirms these were the only two occurrences.

Introduced in #9033 (`:sparkles: Add paste to replace (Cmd+Shift+V)`).

### Steps to reproduce

1. Open a workspace file.
2. Create **Frame A** with size `200 × 400`.
3. Create **Frame B** with size `200 × 100` (same width as A, different height).
4. Click into Frame B, select its content, copy (Ctrl+C / Cmd+C).
5. Click on Frame A to select it.
6. Paste (Ctrl+V / Cmd+V).

**Before:** content lands *next to* Frame A — the heuristic ignored the height mismatch.

**After:** content lands *inside* Frame A — the documented `Paste inside selected frame otherwise` branch fires.

The bug is also reproducible at the code level without the workspace UI:

```clojure
(defn- frame-same-size?
  [paste-obj frame-obj]
  (and
   (= (:heigth (:selrect (first (vals paste-obj))))
      (:heigth (:selrect frame-obj)))
   (= (:width (:selrect (first (vals paste-obj))))
      (:width (:selrect frame-obj)))))

(let [paste-obj {:some-id {:selrect {:width 200 :height 100}}}
      frame-obj          {:selrect {:width 200 :height 400}}]
  (assert (= false (frame-same-size? paste-obj frame-obj))
          "frame-same-size? wrongly reports same-size for 200x100 vs 200x400"))
```

The assertion fails on `develop` and passes once `:heigth` is replaced with `:height`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide. _(N/A — no SCSS changes)_
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
