### PR TITLE
:bug: Remove stray debug log in frame-preview load-ref callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@
 
 ### :bug: Bugs fixed
 
+- Remove stray `console.log` in frame-preview load-ref callback [Github #<issue-number>](https://github.com/penpot/penpot/issues/<issue-number>)
 - Fix layers-panel rename input opening with the type-based default (e.g. "Ellipse") instead of the user's saved name when re-entering edit mode on a previously renamed layer; the silent revert could overwrite the saved name on confirm. The `default-value` `mf/with-memo` was missing `shape-name` from its dependency list, so once the memo cached the original default it never refreshed. Adds `shape-name` to the deps and force-syncs the input's DOM value on every entry into edit mode [Github #9230](https://github.com/penpot/penpot/issues/9230)
 - Suppress the browser context menu when right-clicking empty space in the workspace sidebars while preserving it on text inputs so paste/select-all still work [Github #5127](https://github.com/penpot/penpot/issues/5127)
 - Fix release notes modal appearing behind the dashboard sidebar [Github #8296](https://github.com/penpot/penpot/issues/8296)

--- a/frontend/src/app/main/ui/frame_preview.cljs
+++ b/frontend/src/app/main/ui/frame_preview.cljs
@@ -37,7 +37,6 @@
         load-ref
         (mf/use-callback
          (fn [iframe-dom]
-           (.log js/console "load-ref" iframe-dom)
            (mf/set-ref-val! iframe-ref iframe-dom)
            (when (and iframe-dom @last-data*)
              (-> iframe-dom .-contentWindow .-document .open)


### PR DESCRIPTION
## Related Ticket

## Summary

`load-ref` in `frame-preview` had a stray
`(.log js/console "load-ref" iframe-dom)` call. Same defect class as the bug fixed in PR #9243 (stray `prn` in `color-row*`). The line fires on every ref invocation and pollutes the browser console.

## Steps to Reproduce (before)

1. Open DevTools → Console.
2. Trigger a path that mounts `frame-preview`.
3. Observe `load-ref <iframe>` lines in the console.

## Steps to Verify (after)

1. Same setup. Console stays clean.
2. Frame preview behaviour unchanged.

## Changes

- **`frontend/src/app/main/ui/frame_preview.cljs`** - removed the stray `(.log js/console "load-ref" iframe-dom)` line at line 40.

## Checklist

- [ ] Console clean on frame-preview mount/render
- [ ] Frame preview iframe still loads and displays correctly
- [ ] `./scripts/check-fmt` passes
- [ ] `./scripts/lint` passes
