### PR TITLE
:recycle: Migrate viewport grid layout editor components to modern syntax

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -720,7 +720,7 @@
 
        [:g.grid-layout-editor {:clipPath "url(#clip-handlers)"}
         (when (or show-grid-editor? hover-grid?)
-          [:& grid-layout/editor
+          [:> grid-layout/editor*
            {:zoom zoom
             :objects base-objects
             :modifiers modifiers
@@ -733,7 +733,7 @@
                      (empty? (:shapes frame))
                      (not= edition (:id frame))
                      (not= @hover-top-frame-id (:id frame)))
-            [:& grid-layout/editor
+            [:> grid-layout/editor*
              {:zoom zoom
               :key (dm/str "viewport-frame-" (:id frame))
               :objects base-objects

--- a/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
@@ -52,8 +52,7 @@
     :flex (dm/str (fmt/format-number value) "FR")
     :auto "AUTO"))
 
-(mf/defc grid-edition-actions
-  {::mf/wrap-props false}
+(mf/defc grid-edition-actions*
   [{:keys [shape]}]
   [:div {:class (stl/css :grid-actions)}
    [:div {:class (stl/css :grid-actions-container)}
@@ -66,15 +65,9 @@
               :on-click #(st/emit! (dw/clear-edition-mode))}
      (tr "workspace.layout-grid.editor.top-bar.done")]]])
 
-(mf/defc grid-editor-frame
-  {::mf/wrap-props false}
-  [props]
-
-  (let [bounds (unchecked-get props "bounds")
-        width (unchecked-get props "width")
-        height (unchecked-get props "height")
-        zoom (unchecked-get props "zoom")
-        hv     #(gpo/start-hv bounds %)
+(mf/defc grid-editor-frame*
+  [{:keys [bounds width height zoom]}]
+  (let [hv     #(gpo/start-hv bounds %)
         vv     #(gpo/start-vv bounds %)
         origin (gpo/origin bounds)
 
@@ -94,15 +87,9 @@
                    (map #(dm/fmt "%,%" (:x %) (:y %)))
                    (str/join " "))}]))
 
-(mf/defc plus-btn
-  {::mf/wrap-props false}
-  [props]
-  (let [start-p  (unchecked-get props "start-p")
-        zoom     (unchecked-get props "zoom")
-        type     (unchecked-get props "type")
-        on-click (unchecked-get props "on-click")
-
-        [rect-x rect-y icon-x icon-y]
+(mf/defc plus-btn*
+  [{:keys [start-p zoom type on-click]}]
+  (let [[rect-x rect-y icon-x icon-y]
         (if (= type :column)
           [(:x start-p)
            (- (:y start-p) (/ 40 zoom))
@@ -184,25 +171,11 @@
      :handle-lost-pointer-capture handle-lost-pointer-capture
      :handle-pointer-move handle-pointer-move}))
 
-(mf/defc resize-cell-handler
-  {::mf/wrap-props false}
-  [props]
-  (let [shape (unchecked-get props "shape")
-        x (unchecked-get props "x")
-        y (unchecked-get props "y")
-        width (unchecked-get props "width")
-        height (unchecked-get props "height")
-        handler (unchecked-get props "handler")
-
-        on-set-modifiers (unchecked-get props "on-set-modifiers")
-        on-clear-modifiers (unchecked-get props "on-clear-modifiers")
-
-        objects (mf/deref refs/workspace-page-objects)
-        {cell-id :id} (unchecked-get props "cell")
+(mf/defc resize-cell-handler*
+  [{:keys [shape x y width height handler on-set-modifiers on-clear-modifiers cell direction layout-data]}]
+  (let [objects (mf/deref refs/workspace-page-objects)
+        {cell-id :id} cell
         {:keys [row column row-span column-span]} (get-in shape [:layout-grid-cells cell-id])
-
-        direction (unchecked-get props "direction")
-        layout-data (unchecked-get props "layout-data")
 
         calculate-drag-modifiers
         (mf/use-fn
@@ -279,14 +252,10 @@
       :on-lost-pointer-capture handle-lost-pointer-capture
       :on-pointer-move handle-pointer-move}]))
 
-(mf/defc grid-cell-area-label
-  {::mf/wrap-props false}
-  [props]
-
-  (let [cell-origin (unchecked-get props "origin")
-        cell-width  (unchecked-get props "width")
-        zoom  (unchecked-get props "zoom")
-        text  (unchecked-get props "text")
+(mf/defc grid-cell-area-label*
+  [{:keys [origin width zoom text]}]
+  (let [cell-origin origin
+        cell-width  width
 
         area-width (/ (* 10 (count text)) zoom)
         area-height (/ 25 zoom)
@@ -408,10 +377,10 @@
        :on-pointer-down handle-pointer-down}]
 
      (when (:area-name cell)
-       [:& grid-cell-area-label {:origin cell-origin
-                                 :width cell-width
-                                 :zoom zoom
-                                 :text (:area-name cell)}])
+       [:> grid-cell-area-label* {:origin cell-origin
+                                  :width cell-width
+                                  :zoom zoom
+                                  :text (:area-name cell)}])
 
      (when selected?
        (let [handlers
@@ -422,18 +391,18 @@
               [:left (+ (:x cell-origin) (/ -10 zoom)) (:y cell-origin) (/ 20 zoom) cell-height :column]]]
          [:g {:transform (dm/str (gmt/transform-in cell-center (:transform shape)))}
           (for [[handler x y width height dir] handlers]
-            [:& resize-cell-handler {:key (dm/str "resize-" (d/name handler) "-" (:id cell))
-                                     :shape shape
-                                     :handler handler
-                                     :x x
-                                     :y y
-                                     :cell cell
-                                     :width width
-                                     :height height
-                                     :direction dir
-                                     :layout-data layout-data
-                                     :on-set-modifiers on-set-modifiers
-                                     :on-clear-modifiers on-clear-modifiers}])]))]))
+            [:> resize-cell-handler* {:key (dm/str "resize-" (d/name handler) "-" (:id cell))
+                                       :shape shape
+                                       :handler handler
+                                       :x x
+                                       :y y
+                                       :cell cell
+                                       :width width
+                                       :height height
+                                       :direction dir
+                                       :layout-data layout-data
+                                       :on-set-modifiers on-set-modifiers
+                                       :on-clear-modifiers on-clear-modifiers}])]))]))
 
 (defn use-resize-track
   [type shape index track-before track-after zoom snap-pixel? on-set-modifiers on-clear-modifiers]
@@ -518,27 +487,10 @@
                :on-drag-delta handle-drag-position
                :on-drag-end handle-drag-end})))
 
-(mf/defc resize-track-handler
-  {::mf/wrap-props false}
-  [props]
-
-  (let [shape (unchecked-get props "shape")
-        index (unchecked-get props "index")
-        last? (unchecked-get props "last?")
-        drop? (unchecked-get props "drop?")
-        track-before (unchecked-get props "track-before")
-        track-after (unchecked-get props "track-after")
-        snap-pixel? (unchecked-get props "snap-pixel?")
-
-        on-set-modifiers (unchecked-get props "on-set-modifiers")
-        on-clear-modifiers (unchecked-get props "on-clear-modifiers")
-
-        {:keys [column-total-size column-total-gap row-total-size row-total-gap] :as layout-data}
-        (unchecked-get props "layout-data")
-
-        start-p (unchecked-get props "start-p")
-        type (unchecked-get props "type")
-        zoom (unchecked-get props "zoom")
+(mf/defc resize-track-handler*
+  [{:keys [shape index is-last drop track-before track-after snap-pixel?
+           on-set-modifiers on-clear-modifiers layout-data start-p type zoom]}]
+  (let [{:keys [column-total-size column-total-gap row-total-size row-total-gap]} layout-data
 
         bounds (:points shape)
         hv #(gpo/start-hv bounds %)
@@ -565,11 +517,11 @@
           (and (= type :row) (= index 0))
           (gpt/subtract (vv (/ height 2)))
 
-          (and (= type :column) (not= index 0) (not last?))
+          (and (= type :column) (not= index 0) (not is-last))
           (-> (gpt/subtract (hv (/ layout-gap-col 2)))
               (gpt/subtract (hv (/ width 2))))
 
-          (and (= type :row) (not= index 0) (not last?))
+          (and (= type :row) (not= index 0) (not is-last))
           (-> (gpt/subtract (vv (/ layout-gap-row 2)))
               (gpt/subtract (vv (/ height 2)))))
 
@@ -581,21 +533,21 @@
           (and (= type :row) (= index 0))
           (gpt/subtract (vv (/ height 2)))
 
-          (and (= type :column) last?)
+          (and (= type :column) is-last)
           (gpt/add (hv (/ width 2)))
 
-          (and (= type :row) last?)
+          (and (= type :row) is-last)
           (gpt/add (vv (/ height 2)))
 
-          (and (= type :column) (not= index 0) (not last?))
+          (and (= type :column) (not= index 0) (not is-last))
           (-> (gpt/subtract (hv (/ layout-gap-col 2)))
               (gpt/subtract (hv (/ 5 zoom))))
 
-          (and (= type :row) (not= index 0) (not last?))
+          (and (= type :row) (not= index 0) (not is-last))
           (-> (gpt/subtract (vv (/ layout-gap-row 2)))
               (gpt/subtract (vv (/ 5 zoom)))))]
     [:*
-     (when drop?
+     (when drop
        [:rect.drop
         {:x (:x start-p-drop)
          :y (:y start-p-drop)
@@ -690,24 +642,10 @@
      (dm/fmt "L%,%" (:x a1) (:y a1))
      "Z")))
 
-(mf/defc track-marker
-  {::mf/wrap-props false}
-  [props]
-
-  (let [center (unchecked-get props "center")
-        value (unchecked-get props "value")
-        zoom (unchecked-get props "zoom")
-        shape (unchecked-get props "shape")
-        index (unchecked-get props "index")
-        type (unchecked-get props "type")
-        track-before (unchecked-get props "track-before")
-        track-after (unchecked-get props "track-after")
-        snap-pixel? (unchecked-get props "snap-pixel?")
-
-        on-set-modifiers (unchecked-get props "on-set-modifiers")
-        on-clear-modifiers (unchecked-get props "on-clear-modifiers")
-
-        text-x (:x center)
+(mf/defc track-marker*
+  [{:keys [center value zoom shape index type track-before track-after snap-pixel?
+           on-set-modifiers on-clear-modifiers]}]
+  (let [text-x (:x center)
         text-y (:y center)
 
         {:keys [handle-pointer-down handle-lost-pointer-capture handle-pointer-move]}
@@ -732,28 +670,12 @@
              :dominant-baseline "middle"}
       (dm/str value)]]))
 
-(mf/defc track
-  {::mf/wrap [mf/memo]
-   ::mf/wrap-props false}
-  [props]
-  (let [shape       (unchecked-get props "shape")
-        zoom        (unchecked-get props "zoom")
-        type        (unchecked-get props "type")
-        index       (unchecked-get props "index")
-        snap-pixel? (unchecked-get props "snap-pixel?")
-        track-data  (unchecked-get props "track-data")
-        layout-data (unchecked-get props "layout-data")
-        hovering?   (unchecked-get props "hovering?")
-        drop?       (unchecked-get props "drop?")
-
-        on-start-reorder-track   (unchecked-get props "on-start-reorder-track")
-        on-move-reorder-track   (unchecked-get props "on-move-reorder-track")
-        on-end-reorder-track   (unchecked-get props "on-end-reorder-track")
-
-        on-set-modifiers (unchecked-get props "on-set-modifiers")
-        on-clear-modifiers (unchecked-get props "on-clear-modifiers")
-
-        track-input-ref (mf/use-ref)
+(mf/defc track*
+  {::mf/wrap [mf/memo]}
+  [{:keys [shape zoom type index snap-pixel? track-data layout-data is-hovering drop
+           on-start-reorder-track on-move-reorder-track on-end-reorder-track
+           on-set-modifiers on-clear-modifiers]}]
+  (let [track-input-ref (mf/use-ref)
         [layout-gap-row layout-gap-col] (ctl/gaps shape)
 
         bounds (:points shape)
@@ -899,7 +821,7 @@
               :height (- text-height (/ 5 zoom))
               :rx (/ 3 zoom)
               :style {:cursor "pointer"}
-              :opacity (if (and hovering? (not small?)) 0.2 0)}]
+              :opacity (if (and is-hovering (not small?)) 0.2 0)}]
       (when (not small?)
         [:foreignObject {:x text-x :y text-y :width text-width :height text-height}
          [:div {:class (stl/css :grid-editor-wrapper)
@@ -916,12 +838,12 @@
             :data-default-value (format-size track-data)
             :on-key-down handle-keydown-track-input
             :on-blur handle-blur-track-input}]
-          (when (and hovering? (not medium?) (not small?))
+          (when (and is-hovering (not medium?) (not small?))
             [:button {:class (stl/css :grid-editor-button)
                       :on-click handle-show-track-menu} deprecated-icon/menu])]])]
 
      [:g {:transform (when (= type :row) (dm/fmt "rotate(-90 % %)" (:x marker-p) (:y marker-p)))}
-      [:& track-marker
+      [:> track-marker*
        {:center marker-p
         :index index
         :shape shape
@@ -934,12 +856,12 @@
         :on-set-modifiers on-set-modifiers
         :on-clear-modifiers on-clear-modifiers}]]
 
-     [:& resize-track-handler
+     [:> resize-track-handler*
       {:index index
        :layout-data layout-data
        :shape shape
        :snap-pixel? snap-pixel?
-       :drop? drop?
+       :drop drop
        :start-p start-p
        :track-after track-data
        :track-before track-before
@@ -948,16 +870,10 @@
        :on-set-modifiers on-set-modifiers
        :on-clear-modifiers on-clear-modifiers}]]))
 
-(mf/defc editor
-  {::mf/memo true
-   ::mf/props :obj}
-  [props]
-  (let [base-shape (unchecked-get props "shape")
-        objects    (unchecked-get props "objects")
-        modifiers  (unchecked-get props "modifiers")
-        zoom       (unchecked-get props "zoom")
-        view-only  (unchecked-get props "view-only")
-
+(mf/defc editor*
+  {::mf/memo true}
+  [{:keys [shape objects modifiers zoom view-only]}]
+  (let [base-shape shape
         st-modif   (mf/use-state nil)
 
         shape
@@ -1128,42 +1044,42 @@
 
        (when-not ^boolean view-only
          [:*
-          [:& grid-editor-frame {:zoom zoom
-                                 :bounds bounds
-                                 :width width
-                                 :height height}]
+          [:> grid-editor-frame* {:zoom zoom
+                                   :bounds bounds
+                                   :width width
+                                   :height height}]
           (let [start-p (-> origin (gpt/add (hv (+ width (/ 30 zoom)))))]
             [:g {:transform (dm/str (gmt/transform-in start-p (:transform shape)))}
-             [:& plus-btn {:start-p start-p
-                           :zoom zoom
-                           :type :column
-                           :on-click handle-add-column}]])
+             [:> plus-btn* {:start-p start-p
+                            :zoom zoom
+                            :type :column
+                            :on-click handle-add-column}]])
 
           (let [start-p (-> origin (gpt/add (vv (+ height (/ 30 zoom)))))]
             [:g {:transform (dm/str (gmt/transform-in start-p (:transform shape)))}
-             [:& plus-btn {:start-p start-p
-                           :zoom zoom
-                           :type :row
-                           :on-click handle-add-row}]])
+             [:> plus-btn* {:start-p start-p
+                            :zoom zoom
+                            :type :row
+                            :on-click handle-add-row}]])
 
           (for [[idx column-data] (d/enumerate column-tracks)]
-            (let [drop? (and (= :column @drop-track-type*)
-                             (= idx @drop-track-target*))]
-              [:& track {:key (dm/str "column-track-" idx)
-                         :shape shape
-                         :zoom zoom
-                         :type :column
-                         :index idx
-                         :layout-data layout-data
-                         :snap-pixel? snap-pixel?
-                         :drop? drop?
-                         :track-data column-data
-                         :hovering? (contains? hover-columns idx)
-                         :on-start-reorder-track handle-start-reorder-track
-                         :on-move-reorder-track handle-move-reorder-track
-                         :on-end-reorder-track handle-end-reorder-track
-                         :on-set-modifiers handle-set-modifiers
-                         :on-clear-modifiers handle-clear-modifiers}]))
+            (let [drop (and (= :column @drop-track-type*)
+                            (= idx @drop-track-target*))]
+              [:> track* {:key (dm/str "column-track-" idx)
+                          :shape shape
+                          :zoom zoom
+                          :type :column
+                          :index idx
+                          :layout-data layout-data
+                          :snap-pixel? snap-pixel?
+                          :drop drop
+                          :track-data column-data
+                          :is-hovering (contains? hover-columns idx)
+                          :on-start-reorder-track handle-start-reorder-track
+                          :on-move-reorder-track handle-move-reorder-track
+                          :on-end-reorder-track handle-end-reorder-track
+                          :on-set-modifiers handle-set-modifiers
+                          :on-clear-modifiers handle-clear-modifiers}]))
 
           ;; Last track resize handler
           (when-not (empty? column-tracks)
@@ -1173,22 +1089,22 @@
                   marker-p (-> (gpo/project-point bounds :h end-p)
                                (gpt/subtract (vv (/ 20 zoom))))]
               [:g.track
-               [:& track-marker {:center marker-p
-                                 :index (count column-tracks)
-                                 :shape shape
-                                 :snap-pixel? snap-pixel?
-                                 :track-before (last column-tracks)
-                                 :type :column
-                                 :value (dm/str (inc (count column-tracks)))
-                                 :zoom zoom
-                                 :on-set-modifiers handle-set-modifiers
-                                 :on-clear-modifiers handle-clear-modifiers}]
-               (let [drop? (and (= :column @drop-track-type*)
-                                (= (count column-tracks) @drop-track-target*))]
-                 [:& resize-track-handler
+               [:> track-marker* {:center marker-p
+                                   :index (count column-tracks)
+                                   :shape shape
+                                   :snap-pixel? snap-pixel?
+                                   :track-before (last column-tracks)
+                                   :type :column
+                                   :value (dm/str (inc (count column-tracks)))
+                                   :zoom zoom
+                                   :on-set-modifiers handle-set-modifiers
+                                   :on-clear-modifiers handle-clear-modifiers}]
+               (let [drop (and (= :column @drop-track-type*)
+                               (= (count column-tracks) @drop-track-target*))]
+                 [:> resize-track-handler*
                   {:index (count column-tracks)
-                   :last? true
-                   :drop? drop?
+                   :is-last true
+                   :drop drop
                    :shape shape
                    :layout-data layout-data
                    :snap-pixel? snap-pixel?
@@ -1200,23 +1116,23 @@
                    :on-clear-modifiers handle-clear-modifiers}])]))
 
           (for [[idx row-data] (d/enumerate row-tracks)]
-            (let [drop? (and (= :row @drop-track-type*)
-                             (= idx @drop-track-target*))]
-              [:& track {:index idx
-                         :key (dm/str "row-track-" idx)
-                         :layout-data layout-data
-                         :shape shape
-                         :snap-pixel? snap-pixel?
-                         :drop? drop?
-                         :track-data row-data
-                         :type :row
-                         :zoom zoom
-                         :hovering? (contains? hover-rows idx)
-                         :on-start-reorder-track handle-start-reorder-track
-                         :on-move-reorder-track handle-move-reorder-track
-                         :on-end-reorder-track handle-end-reorder-track
-                         :on-set-modifiers handle-set-modifiers
-                         :on-clear-modifiers handle-clear-modifiers}]))
+            (let [drop (and (= :row @drop-track-type*)
+                            (= idx @drop-track-target*))]
+              [:> track* {:index idx
+                          :key (dm/str "row-track-" idx)
+                          :layout-data layout-data
+                          :shape shape
+                          :snap-pixel? snap-pixel?
+                          :drop drop
+                          :track-data row-data
+                          :type :row
+                          :zoom zoom
+                          :is-hovering (contains? hover-rows idx)
+                          :on-start-reorder-track handle-start-reorder-track
+                          :on-move-reorder-track handle-move-reorder-track
+                          :on-end-reorder-track handle-end-reorder-track
+                          :on-set-modifiers handle-set-modifiers
+                          :on-clear-modifiers handle-clear-modifiers}]))
           (when-not (empty? row-tracks)
             (let [last-track (last row-tracks)
                   start-p (:start-p last-track)
@@ -1225,22 +1141,22 @@
                                (gpt/subtract (hv (/ 20 zoom))))]
               [:g.track
                [:g {:transform (dm/fmt "rotate(-90 % %)" (:x marker-p) (:y marker-p))}
-                [:& track-marker {:center marker-p
-                                  :index (count row-tracks)
-                                  :shape shape
-                                  :snap-pixel? snap-pixel?
-                                  :track-before (last row-tracks)
-                                  :type :row
-                                  :value (dm/str (inc (count row-tracks)))
-                                  :zoom zoom
-                                  :on-set-modifiers handle-set-modifiers
-                                  :on-clear-modifiers handle-clear-modifiers}]]
-               (let [drop? (and (= :row @drop-track-type*)
-                                (= (count row-tracks) @drop-track-target*))]
-                 [:& resize-track-handler
+                [:> track-marker* {:center marker-p
+                                    :index (count row-tracks)
+                                    :shape shape
+                                    :snap-pixel? snap-pixel?
+                                    :track-before (last row-tracks)
+                                    :type :row
+                                    :value (dm/str (inc (count row-tracks)))
+                                    :zoom zoom
+                                    :on-set-modifiers handle-set-modifiers
+                                    :on-clear-modifiers handle-clear-modifiers}]]
+               (let [drop (and (= :row @drop-track-type*)
+                               (= (count row-tracks) @drop-track-target*))]
+                 [:> resize-track-handler*
                   {:index (count row-tracks)
-                   :last? true
-                   :drop? drop?
+                   :is-last true
+                   :drop drop
                    :shape shape
                    :layout-data layout-data
                    :start-p end-p

--- a/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
@@ -488,7 +488,7 @@
                :on-drag-end handle-drag-end})))
 
 (mf/defc resize-track-handler*
-  [{:keys [shape index is-last drop track-before track-after snap-pixel?
+  [{:keys [shape index is-last drop track-before track-after is-snap-pixel
            on-set-modifiers on-clear-modifiers layout-data start-p type zoom]}]
   (let [{:keys [column-total-size column-total-gap row-total-size row-total-gap]} layout-data
 
@@ -499,7 +499,7 @@
         [layout-gap-row layout-gap-col] (ctl/gaps shape)
 
         {:keys [handle-pointer-down handle-lost-pointer-capture handle-pointer-move]}
-        (use-resize-track type shape index track-before track-after zoom snap-pixel? on-set-modifiers on-clear-modifiers)
+        (use-resize-track type shape index track-before track-after zoom is-snap-pixel on-set-modifiers on-clear-modifiers)
 
         [width height]
         (if (= type :column)
@@ -643,13 +643,13 @@
      "Z")))
 
 (mf/defc track-marker*
-  [{:keys [center value zoom shape index type track-before track-after snap-pixel?
+  [{:keys [center value zoom shape index type track-before track-after is-snap-pixel
            on-set-modifiers on-clear-modifiers]}]
   (let [text-x (:x center)
         text-y (:y center)
 
         {:keys [handle-pointer-down handle-lost-pointer-capture handle-pointer-move]}
-        (use-resize-track type shape index track-before track-after zoom snap-pixel? on-set-modifiers on-clear-modifiers)]
+        (use-resize-track type shape index track-before track-after zoom is-snap-pixel on-set-modifiers on-clear-modifiers)]
 
     [:g {:on-pointer-down handle-pointer-down
          :on-lost-pointer-capture handle-lost-pointer-capture
@@ -672,7 +672,7 @@
 
 (mf/defc track*
   {::mf/wrap [mf/memo]}
-  [{:keys [shape zoom type index snap-pixel? track-data layout-data is-hovering drop
+  [{:keys [shape zoom type index is-snap-pixel track-data layout-data is-hovering drop
            on-start-reorder-track on-move-reorder-track on-end-reorder-track
            on-set-modifiers on-clear-modifiers]}]
   (let [track-input-ref (mf/use-ref)
@@ -847,7 +847,7 @@
        {:center marker-p
         :index index
         :shape shape
-        :snap-pixel? snap-pixel?
+        :is-snap-pixel is-snap-pixel
         :track-after track-data
         :track-before track-before
         :type type
@@ -860,7 +860,7 @@
       {:index index
        :layout-data layout-data
        :shape shape
-       :snap-pixel? snap-pixel?
+       :is-snap-pixel is-snap-pixel
        :drop drop
        :start-p start-p
        :track-after track-data
@@ -1071,7 +1071,7 @@
                           :type :column
                           :index idx
                           :layout-data layout-data
-                          :snap-pixel? snap-pixel?
+                          :is-snap-pixel snap-pixel?
                           :drop drop
                           :track-data column-data
                           :is-hovering (contains? hover-columns idx)
@@ -1092,7 +1092,7 @@
                [:> track-marker* {:center marker-p
                                    :index (count column-tracks)
                                    :shape shape
-                                   :snap-pixel? snap-pixel?
+                                   :is-snap-pixel snap-pixel?
                                    :track-before (last column-tracks)
                                    :type :column
                                    :value (dm/str (inc (count column-tracks)))
@@ -1107,7 +1107,7 @@
                    :drop drop
                    :shape shape
                    :layout-data layout-data
-                   :snap-pixel? snap-pixel?
+                   :is-snap-pixel snap-pixel?
                    :start-p end-p
                    :type :column
                    :track-before (last column-tracks)
@@ -1122,7 +1122,7 @@
                           :key (dm/str "row-track-" idx)
                           :layout-data layout-data
                           :shape shape
-                          :snap-pixel? snap-pixel?
+                          :is-snap-pixel snap-pixel?
                           :drop drop
                           :track-data row-data
                           :type :row
@@ -1144,7 +1144,7 @@
                 [:> track-marker* {:center marker-p
                                     :index (count row-tracks)
                                     :shape shape
-                                    :snap-pixel? snap-pixel?
+                                    :is-snap-pixel snap-pixel?
                                     :track-before (last row-tracks)
                                     :type :row
                                     :value (dm/str (inc (count row-tracks)))
@@ -1162,7 +1162,7 @@
                    :start-p end-p
                    :type :row
                    :track-before (last row-tracks)
-                   :snap-pixel? snap-pixel?
+                   :is-snap-pixel snap-pixel?
                    :zoom zoom
                    :on-set-modifiers handle-set-modifiers
                    :on-clear-modifiers handle-clear-modifiers}])]))])])))

--- a/frontend/src/app/main/ui/workspace/viewport/top_bar.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/top_bar.cljs
@@ -10,7 +10,7 @@
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.common :as dwc]
    [app.main.store :as st]
-   [app.main.ui.workspace.viewport.grid-layout-editor :refer [grid-edition-actions]]
+   [app.main.ui.workspace.viewport.grid-layout-editor :refer [grid-edition-actions*]]
    [app.main.ui.workspace.viewport.path-actions :refer [path-actions*]]
    [app.util.i18n :as i18n :refer [tr]]
    [rumext.v2 :as mf]))
@@ -47,4 +47,4 @@
 
 (mf/defc grid-edition-bar*
   [{:keys [shape]}]
-  [:& grid-edition-actions {:shape shape}])
+  [:> grid-edition-actions* {:shape shape}])

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -861,7 +861,7 @@
 
        [:g.grid-layout-editor {:clipPath "url(#clip-handlers)"}
         (when show-grid-editor?
-          [:& grid-layout/editor
+          [:> grid-layout/editor*
            {:zoom zoom
             :objects objects-modified
             :shape (or (get objects-modified edition)


### PR DESCRIPTION
## Description

Migrate all legacy components in `viewport/grid_layout_editor.cljs` to modern
Rumext destructuring syntax, as part of #9260.

## Components migrated

| File | Components |
|------|-----------|
| `viewport/grid_layout_editor.cljs` | `grid-edition-actions*`, `grid-editor-frame*`, `plus-btn*`, `resize-cell-handler*`, `grid-cell-area-label*`, `resize-track-handler*`, `track-marker*`, `track*`, `editor*` |

## What changed

- Removed `{::mf/wrap-props false}` and `unchecked-get` from all 9 components
- Replaced with map destructuring; preserved `::mf/wrap [mf/memo]` hooks
- Added `*` suffix to all migrated component names
- Updated all internal callsites within the file
- Updated external callsites in `viewport.cljs`, `viewport_wasm.cljs`,
  and `viewport/top_bar.cljs`

## Testing

- [ ] Grid layout editor opens and renders correctly on a grid frame
- [ ] Track resize handles drag and resize rows/columns
- [ ] Cell area labels display and update
- [ ] Add-track (+) buttons work
- [ ] Grid edition action bar renders in `top_bar`
