### PR TITLE
♻ Migrate shared ancillary components to modern syntax

### DIFF
--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -23,10 +23,7 @@
 (mf/defc numeric-input*
   {::mf/forward-ref true}
   [{:keys [value min max step data-wrap on-change on-blur on-focus title default
-           select-on-focus class class-name]
-    disabled? :disabled
-    nillable? :nillable
-    integer? :integer
+           select-on-focus class class-name disabled nillable integer]
     :rest props} external-ref]
   (let [value-str   value
         min-value   min
@@ -38,7 +35,7 @@
         min-value   (d/parse-double min-value)
         max-value   (d/parse-double max-value)
         step-value  (d/parse-double step-value 1)
-        default     (d/parse-double default (when-not nillable? 0))
+        default     (d/parse-double default (when-not nillable 0))
 
         select-on-focus? (d/nilv select-on-focus true)
 
@@ -65,7 +62,7 @@
 
         parse-value
         (mf/use-fn
-         (mf/deps min-value max-value value nillable? default integer?)
+         (mf/deps min-value max-value value nillable default integer)
          (fn []
            (when-let [node (mf/ref-val ref)]
              (let [new-value (-> (dom/get-value node)
@@ -74,7 +71,7 @@
                (cond
                  (d/num? new-value)
                  (-> new-value
-                     (cond-> integer? mth/round)
+                     (cond-> integer mth/round)
                      (d/max (/ sm/min-safe-int 2))
                      (d/min (/ sm/max-safe-int 2))
                      (cond-> (d/num? min-value)
@@ -82,7 +79,7 @@
                      (cond-> (d/num? max-value)
                        (d/min max-value)))
 
-                 nillable?
+                 nillable
                  default
 
                  :else value)))))
@@ -150,7 +147,7 @@
                                  max-value
 
                                  :else new-value)
-                     new-value (if integer? (mth/round new-value) new-value)]
+                     new-value (if integer (mth/round new-value) new-value)]
 
                  (apply-value event new-value))))))
 
@@ -197,7 +194,7 @@
          (fn [event]
            (when (mf/ref-val dirty-ref)
              (let [new-value (or @last-value* default)]
-               (if (or nillable? new-value)
+               (if (or nillable new-value)
                  (apply-value event new-value)
                  (update-input new-value)))
              (when (fn? on-blur)
@@ -235,7 +232,7 @@
          (fn [event]
            (let [node      (mf/ref-val ref)
                  is-focused (and (some? node) (dom/active? node))]
-             (when-not (or disabled? is-focused (= :multiple value-str))
+             (when-not (or disabled is-focused (= :multiple value-str))
                (let [client-x  (.-clientX event)
                      start-val (or value default 0)]
                  (mf/set-ref-val! drag-state* :maybe-dragging)

--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -14,7 +14,6 @@
    [app.util.dom :as dom]
    [app.util.globals :as globals]
    [app.util.keyboard :as kbd]
-   [app.util.object :as obj]
    [app.util.simple-math :as smt]
    [cljs.core :as c]
    [cuerdas.core :as str]
@@ -23,28 +22,25 @@
 
 (mf/defc numeric-input*
   {::mf/forward-ref true}
-  [props external-ref]
-  (let [value-str   (unchecked-get props "value")
-        min-value   (unchecked-get props "min")
-        max-value   (unchecked-get props "max")
-        step-value  (unchecked-get props "step")
-        wrap-value? (unchecked-get props "data-wrap")
-        on-change   (unchecked-get props "onChange")
-        on-blur     (unchecked-get props "onBlur")
-        on-focus    (unchecked-get props "onFocus")
-
-        title       (unchecked-get props "title")
-        default     (unchecked-get props "default")
-        nillable?   (unchecked-get props "nillable")
-        class       (d/nilv (unchecked-get props "className") "")
+  [{:keys [value min max step data-wrap on-change on-blur on-focus title default
+           select-on-focus class class-name]
+    disabled? :disabled
+    nillable? :nillable
+    integer? :integer
+    :rest props} external-ref]
+  (let [value-str   value
+        min-value   min
+        max-value   max
+        step-value  step
+        wrap-value? data-wrap
+        class       (d/nilv (or class class-name) "")
 
         min-value   (d/parse-double min-value)
         max-value   (d/parse-double max-value)
         step-value  (d/parse-double step-value 1)
         default     (d/parse-double default (when-not nillable? 0))
 
-        integer?         (unchecked-get props "integer")
-        select-on-focus? (d/nilv (unchecked-get props "selectOnFocus") true)
+        select-on-focus? (d/nilv select-on-focus true)
 
         ;; We need a ref pointing to the input dom element, but the user
         ;; of this component may provide one (that is forwarded here).
@@ -237,8 +233,7 @@
         (mf/use-fn
          (mf/deps value value-str min-value max-value default)
          (fn [event]
-           (let [disabled? (unchecked-get props "disabled")
-                 node      (mf/ref-val ref)
+           (let [node      (mf/ref-val ref)
                  is-focused (and (some? node) (dom/active? node))]
              (when-not (or disabled? is-focused (= :multiple value-str))
                (let [client-x  (.-clientX event)
@@ -296,24 +291,21 @@
            (mf/set-ref-val! drag-state* :idle)
            (dom/remove-class! (dom/get-body) "cursor-drag-scrub")))
 
-        props (-> (obj/clone props)
-                  (obj/unset! "selectOnFocus")
-                  (obj/unset! "nillable")
-                  (obj/unset! "integer")
-                  (obj/set! "value" mf/undefined)
-                  (obj/set! "onChange" handle-change)
-                  (obj/set! "className" class)
-                  (obj/set! "type" "text")
-                  (obj/set! "ref" ref)
-                  (obj/set! "defaultValue" (fmt/format-number value))
-                  (obj/set! "title" title)
-                  (obj/set! "onKeyDown" handle-key-down)
-                  (obj/set! "onBlur" handle-blur)
-                  (obj/set! "onFocus" handle-focus)
-                  (obj/set! "onPointerDown" on-scrub-pointer-down)
-                  (obj/set! "onPointerMove" on-scrub-pointer-move)
-                  (obj/set! "onPointerUp" on-scrub-pointer-up)
-                  (obj/set! "onLostPointerCapture" on-scrub-lost-pointer-capture))]
+        props (mf/spread-props props
+                               {:value mf/undefined
+                                :on-change handle-change
+                                :class class
+                                :type "text"
+                                :ref ref
+                                :default-value (fmt/format-number value)
+                                :title title
+                                :on-key-down handle-key-down
+                                :on-blur handle-blur
+                                :on-focus handle-focus
+                                :on-pointer-down on-scrub-pointer-down
+                                :on-pointer-move on-scrub-pointer-move
+                                :on-pointer-up on-scrub-pointer-up
+                                :on-lost-pointer-capture on-scrub-lost-pointer-capture})]
 
     (mf/with-effect [value]
       (when-let [input-node (mf/ref-val ref)]

--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -22,8 +22,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc numeric-input*
-  {::mf/wrap-props false
-   ::mf/forward-ref true}
+  {::mf/forward-ref true}
   [props external-ref]
   (let [value-str   (unchecked-get props "value")
         min-value   (unchecked-get props "min")

--- a/frontend/src/app/main/ui/components/org_avatar.cljs
+++ b/frontend/src/app/main/ui/components/org_avatar.cljs
@@ -11,7 +11,6 @@
    [rumext.v2 :as mf]))
 
 (mf/defc org-avatar*
-  {::mf/props :obj}
   [{:keys [org size]}]
   (let [name         (:name org)
         custom-photo (:custom-photo org)

--- a/frontend/src/app/main/ui/components/tab_container.cljs
+++ b/frontend/src/app/main/ui/components/tab_container.cljs
@@ -18,13 +18,11 @@
 
 (set! *warn-on-infer* false)
 
-(mf/defc tab-element
-  {::mf/wrap-props false}
+(mf/defc tab-element*
   [{:keys [children]}]
   children)
 
-(mf/defc tab-container
-  {::mf/wrap-props false}
+(mf/defc tab-container*
   [{:keys [children selected on-change-tab collapsable handle-collapse header-class content-class]}]
   (let [children  (-> (array/normalize-to-array children)
                       (array/without-nils))

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -147,9 +147,10 @@
    [:emails [::sm/set {:min 1} ::sm/email]]
    [:team-id ::sm/uuid]])
 
-(mf/defc invite-members-modal*
+(mf/defc invite-members-modal
   {::mf/register modal/components
-   ::mf/register-as :invite-members}
+   ::mf/register-as :invite-members
+   ::mf/props :obj}
   [{:keys [team origin invite-email]}]
   (let [members     (get team :members)
         perms       (get team :permissions)
@@ -1546,4 +1547,3 @@
 
        (when (contains? cfg/flags :subscriptions)
          [:> team* {:is-owner (:is-owner permissions) :team team}])]]]))
-

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -70,9 +70,8 @@
 (def ^:private group-icon
   (deprecated-icon/icon-xref :group (stl/css :group-icon)))
 
-(mf/defc header
-  {::mf/wrap [mf/memo]
-   ::mf/props :obj}
+(mf/defc header*
+  {::mf/wrap [mf/memo]}
   [{:keys [section team]}]
   (let [on-nav-members       (mf/use-fn #(st/emit! (dcm/go-to-dashboard-members)))
         on-nav-settings      (mf/use-fn #(st/emit! (dcm/go-to-dashboard-settings)))
@@ -148,10 +147,9 @@
    [:emails [::sm/set {:min 1} ::sm/email]]
    [:team-id ::sm/uuid]])
 
-(mf/defc invite-members-modal
+(mf/defc invite-members-modal*
   {::mf/register modal/components
-   ::mf/register-as :invite-members
-   ::mf/props :obj}
+   ::mf/register-as :invite-members}
   [{:keys [team origin invite-email]}]
   (let [members     (get team :members)
         perms       (get team :permissions)
@@ -268,8 +266,7 @@
 ;; MEMBERS SECTION
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(mf/defc member-info
-  {::mf/props :obj}
+(mf/defc member-info*
   [{:keys [member profile]}]
   (let [is-you? (= (:id profile) (:id member))]
     [:*
@@ -481,7 +478,7 @@
 
     [:div {:class (stl/css :table-row)}
      [:div {:class (stl/css :table-field :field-name)}
-      [:& member-info {:member member :profile profile}]]
+      [:> member-info* {:member member :profile profile}]]
 
      [:div {:class (stl/css :table-field :field-roles)}
       [:> rol-info*  {:member member
@@ -551,7 +548,7 @@
     (st/emit! (dtm/fetch-members)))
 
   [:*
-   [:& header {:section :dashboard-team-members :team team}]
+   [:> header* {:section :dashboard-team-members :team team}]
    [:section {:class (stl/css :dashboard-container :dashboard-team-members)}
 
     [:> team-members*
@@ -1074,8 +1071,8 @@
     (st/emit! (dtm/fetch-invitations)))
 
   [:*
-   [:& header {:section :dashboard-team-invitations
-               :team team}]
+   [:> header* {:section :dashboard-team-invitations
+                :team team}]
    [:section {:class (stl/css :dashboard-team-invitations)}
 
     [:> invitation-section* {:team team}]
@@ -1337,7 +1334,7 @@
       (st/emit! (dtm/fetch-webhooks)))
 
     [:*
-     [:& header {:team team :section :dashboard-team-webhooks}]
+     [:> header* {:team team :section :dashboard-team-webhooks}]
      [:section {:class (stl/css :dashboard-container :dashboard-team-webhooks)}
       [:*
        [:> webhooks-hero* {}]
@@ -1459,7 +1456,7 @@
                 (dtm/fetch-stats)))
 
     [:*
-     [:& header {:section :dashboard-team-settings :team team}]
+     [:> header* {:section :dashboard-team-settings :team team}]
      [:section {:class (stl/css :dashboard-team-settings)}
       [:div {:class (stl/css :settings-container)}
        [:div {:class (stl/css :block :info-block)}

--- a/frontend/src/app/main/ui/ds/buttons/icon_button.cljs
+++ b/frontend/src/app/main/ui/ds/buttons/icon_button.cljs
@@ -30,7 +30,7 @@
 
 (mf/defc icon-button*
   {::mf/schema schema:icon-button
-   ::mf/memo true}
+   ::mf/wrap [mf/memo]}
   [{:keys [class icon icon-class icon-size variant aria-label children tooltip-placement tooltip-class type] :rest props}]
   (let [variant
         (d/nilv variant "primary")

--- a/frontend/src/app/main/ui/ds/layout/tab_switcher.cljs
+++ b/frontend/src/app/main/ui/ds/layout/tab_switcher.cljs
@@ -48,7 +48,7 @@
 
 (mf/defc tab-nav*
   {::mf/private true
-   ::mf/memo true}
+   ::mf/wrap [mf/memo]}
   [{:keys [ref tabs selected on-click button-position action-button] :rest props}]
   (let [nav-class
         (stl/css-case :tab-nav true

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -64,9 +64,10 @@
     [:div {:class (stl/css :file-name-label)}
      (:name file)]]])
 
-(mf/defc export-dialog*
+(mf/defc export-dialog
   {::mf/register modal/components
-   ::mf/register-as ::fexp/export-files}
+   ::mf/register-as ::fexp/export-files
+   ::mf/props :obj}
   [{:keys [team-id files]}]
   (let [state*       (mf/use-state (partial initialize-state files))
         has-libs?    (some :has-libraries files)

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -64,10 +64,9 @@
     [:div {:class (stl/css :file-name-label)}
      (:name file)]]])
 
-(mf/defc export-dialog
+(mf/defc export-dialog*
   {::mf/register modal/components
-   ::mf/register-as ::fexp/export-files
-   ::mf/props :obj}
+   ::mf/register-as ::fexp/export-files}
   [{:keys [team-id files]}]
   (let [state*       (mf/use-state (partial initialize-state files))
         has-libs?    (some :has-libraries files)

--- a/frontend/src/app/main/ui/onboarding/questions.cljs
+++ b/frontend/src/app/main/ui/onboarding/questions.cljs
@@ -21,8 +21,7 @@
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
-(mf/defc step-container
-  {::mf/props :obj}
+(mf/defc step-container*
   [{:keys [form step on-next on-prev children class label]}]
 
   (let [on-next*
@@ -70,8 +69,7 @@
           (and (= role "other")
                (not (str/blank? role-other)))))]])
 
-(mf/defc step-1
-  {::mf/props :obj}
+(mf/defc step-1*
   [{:keys [on-next form show-step-3]}]
   (let [use-options
         (mf/with-memo []
@@ -95,11 +93,11 @@
         (dm/get-in @form [:data :role])]
 
 
-    [:& step-container {:form form
-                        :step 1
-                        :label "questions:about-you"
-                        :on-next on-next
-                        :class (stl/css :step-1)}
+    [:> step-container* {:form form
+                         :step 1
+                         :label "questions:about-you"
+                         :on-next on-next
+                         :class (stl/css :step-1)}
 
      [:div {:class (stl/css :paginator)} (str/ffmt "1/%" (if @show-step-3 4 3))]
 
@@ -148,8 +146,7 @@
             (and (= experience "other")
                  (not (str/blank? experience-other))))))]])
 
-(mf/defc step-2
-  {::mf/props :obj}
+(mf/defc step-2*
   [{:keys [on-next on-prev form show-step-3]}]
   (let [design-tool-options
         (mf/with-memo []
@@ -176,12 +173,12 @@
              (swap! form d/dissoc-in [:data :experience-design-tool-other])
              (swap! form d/dissoc-in [:errors :experience-design-tool-other]))))]
 
-    [:& step-container {:form form
-                        :step 2
-                        :label "questions:experience-design-tool"
-                        :on-next on-next
-                        :on-prev on-prev
-                        :class (stl/css :step-2)}
+    [:> step-container* {:form form
+                         :step 2
+                         :label "questions:experience-design-tool"
+                         :on-next on-next
+                         :on-prev on-prev
+                         :class (stl/css :step-2)}
 
      [:div {:class (stl/css :paginator)} (str/ffmt "2/%" (if @show-step-3 4 3))]
 
@@ -222,8 +219,7 @@
           (and (= planning "other")
                (not (str/blank? planning-other)))))]])
 
-(mf/defc step-3
-  {::mf/props :obj}
+(mf/defc step-3*
   [{:keys [on-next on-prev form show-step-3]}]
   (let [team-size-options
         (mf/with-memo []
@@ -257,12 +253,12 @@
         current-planning
         (dm/get-in @form [:data :planning])]
 
-    [:& step-container {:form form
-                        :step 3
-                        :label "questions:about-your-job"
-                        :on-next on-next
-                        :on-prev on-prev
-                        :class (stl/css :step-3)}
+    [:> step-container* {:form form
+                         :step 3
+                         :label "questions:about-your-job"
+                         :on-next on-next
+                         :on-prev on-prev
+                         :class (stl/css :step-3)}
 
      [:div {:class (stl/css :paginator)} (str/ffmt "3/%" (if @show-step-3 4 3))]
 
@@ -306,8 +302,7 @@
           (and (= start-with "other")
                (not (str/blank? start-with-other)))))]])
 
-(mf/defc step-4
-  {::mf/props :obj}
+(mf/defc step-4*
   [{:keys [on-next on-prev form show-step-3]}]
   (let [start-options
         (mf/with-memo []
@@ -333,12 +328,12 @@
              (swap! form d/dissoc-in [:data :start-with-other])
              (swap! form d/dissoc-in [:errors :start-with-other]))))]
 
-    [:& step-container {:form form
-                        :step 4
-                        :label "questions:how-start"
-                        :on-next on-next
-                        :on-prev on-prev
-                        :class (stl/css :step-4)}
+    [:> step-container* {:form form
+                         :step 4
+                         :label "questions:how-start"
+                         :on-next on-next
+                         :on-prev on-prev
+                         :class (stl/css :step-4)}
 
      [:div {:class (stl/css :paginator)} (str/ffmt "%/%" (if @show-step-3 4 3) (if @show-step-3 4 3))]
 
@@ -413,10 +408,10 @@
             :ref container}
 
       (case @step
-        1 [:& step-1 {:on-next on-next :on-prev on-prev :form step-1-form :show-step-3 show-step-3}]
-        2 [:& step-2 {:on-next on-next :on-prev on-prev :form step-2-form :show-step-3 show-step-3}]
+        1 [:> step-1* {:on-next on-next :on-prev on-prev :form step-1-form :show-step-3 show-step-3}]
+        2 [:> step-2* {:on-next on-next :on-prev on-prev :form step-2-form :show-step-3 show-step-3}]
         3 (if @show-step-3
-            [:& step-3 {:on-next on-next :on-prev on-prev :form step-3-form :show-step-3 show-step-3}]
-            [:& step-4 {:on-next on-submit :on-prev on-prev :form step-4-form :show-step-3 show-step-3}])
+            [:> step-3* {:on-next on-next :on-prev on-prev :form step-3-form :show-step-3 show-step-3}]
+            [:> step-4* {:on-next on-submit :on-prev on-prev :form step-4-form :show-step-3 show-step-3}])
         (when @show-step-3
-          4 [:& step-4 {:on-next on-submit :on-prev on-prev :form step-4-form :show-step-3 show-step-3}]))]]))
+          4 [:> step-4* {:on-next on-submit :on-prev on-prev :form step-4-form :show-step-3 show-step-3}]))]]))

--- a/frontend/src/app/main/ui/shapes/svg_raw.cljs
+++ b/frontend/src/app/main/ui/shapes/svg_raw.cljs
@@ -22,8 +22,7 @@
 ;; Context to store a re-mapping of the ids
 (def svg-ids-ctx (mf/create-context nil))
 
-(mf/defc svg-root
-  {::mf/wrap-props false}
+(mf/defc svg-root*
   [props]
 
   (let [shape       (unchecked-get props "shape")
@@ -53,8 +52,7 @@
      [:g.svg-raw {:transform (gsh/transform-str shape)}
       [:> "svg" props children]]]))
 
-(mf/defc svg-element
-  {::mf/wrap-props false}
+(mf/defc svg-element*
   [props]
   (let [shape       (unchecked-get props "shape")
         children    (unchecked-get props "children")
@@ -119,13 +117,13 @@
         [:style style-content]
 
         ^boolean svg-root?
-        [:& svg-root {:shape shape}
+        [:> svg-root* {:shape shape}
          (for [item childs]
            [:& shape-wrapper {:shape item :key (dm/str (:id item))}])]
 
         (and ^boolean svg-tag?
              ^boolean valid-tag?)
-        [:& svg-element {:shape shape}
+        [:> svg-element* {:shape shape}
          (for [item childs]
            [:& shape-wrapper {:shape item :key (dm/str (:id item))}])]
 

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -234,10 +234,9 @@
         (get-contrast-color background-color)))
     (get-contrast-color background-color)))
 
-(mf/defc text-editor-html
+(mf/defc text-editor-html*
   "Text editor (HTML)"
-  {::mf/wrap [mf/memo]
-   ::mf/props :obj}
+  {::mf/wrap [mf/memo]}
   [{:keys [shape canvas-ref render-wasm?] :or {render-wasm? false}}]
   (let [content          (:content shape)
         shape-id         (dm/get-prop shape :id)
@@ -468,7 +467,7 @@
 
      [:foreignObject {:x x :y y :width width :height height}
       [:div {:style style}
-       [:& text-editor-html {:shape shape
-                             :canvas-ref canvas-ref
-                             :render-wasm? render-wasm?
-                             :key (dm/str shape-id)}]]]]))
+       [:> text-editor-html* {:shape shape
+                              :canvas-ref canvas-ref
+                              :render-wasm? render-wasm?
+                              :key (dm/str shape-id)}]]]]))

--- a/frontend/src/app/main/ui/workspace/viewport/presence.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/presence.cljs
@@ -23,9 +23,8 @@
           "11.78,1.82,11.05L11.58,1.30ZL11.58,1.30ZM1.37,12.15L2.90,"
           "13.68L1.67,13.89L1.165,13.39L1.37,12.15ZL1.37,12.15Z"))
 
-(mf/defc session-cursor
-  {::mf/props :obj
-   ::mf/memo true}
+(mf/defc session-cursor*
+  {::mf/wrap [mf/memo]}
   [{:keys [session profile zoom]}]
   (let [point     (:point session)
         bg-color  (:color session)
@@ -70,7 +69,7 @@
         (fn [] (rx/dispose! sem))))
 
     (for [session sessions]
-      [:& session-cursor
+      [:> session-cursor*
        {:session session
         :zoom zoom
         :profile (get profiles (:profile-id session))


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates a second larger frontend slice to modern Rumext component syntax.

- Updates selected shared, dashboard team, export, onboarding, SVG, text editor, and viewport presence components.
- Renames scoped legacy components with the modern `*` suffix and updates matching local call sites to `[:> ...*]`.
- Converts memo metadata to `::mf/wrap [mf/memo]` and removes legacy props/wrap-props metadata where the component was migrated.

### Steps to reproduce 

Syntax-only refactor. Manually verify numeric inputs, organization avatars, tab containers, dashboard team pages, design-system icon/tab controls, export dialog, onboarding questions, raw SVG rendering, v2 text editor HTML wrapper, and active cursor rendering.

Verification run locally:

```sh
PATH=/tmp/penpot-tools/bin:$PATH pnpm run fmt:clj
PATH=/tmp/penpot-tools/bin:$PATH pnpm run lint:clj
git diff --check
```

Current open PR files were rechecked before opening this PR; none of the touched files overlap an open PR.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
