### PR TITLE
:bug: Translate layout panel header and add-layout options

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
@@ -1236,17 +1236,18 @@
         (mf/use-fn #(reset! show-dropdown* false))
 
         add-layout-dropdown
-        [:& dropdown {:show show-dropdown?
-                      :on-close on-hide-dropdown}
-         [:div {:class (stl/css :layout-options)}
-          [:button {:class (stl/css :layout-option)
-                    :data-type "flex"
-                    :on-click on-add-layout}
-           (tr "labels.flex-layout")]
-          [:button {:class (stl/css :layout-option)
-                    :data-type "grid"
-                    :on-click on-add-layout}
-           (tr "labels.grid-layout")]]]]
+        (mf/html
+         [:& dropdown {:show show-dropdown?
+                       :on-close on-hide-dropdown}
+          [:div {:class (stl/css :layout-options)}
+           [:button {:class (stl/css :layout-option)
+                     :data-type "flex"
+                     :on-click on-add-layout}
+            (tr "labels.flex-layout")]
+           [:button {:class (stl/css :layout-option)
+                     :data-type "grid"
+                     :on-click on-add-layout}
+            (tr "labels.grid-layout")]]])]
 
     [:div {:class (stl/css :element-set) :data-testid "inspect-layout"}
      [:div {:class (stl/css :element-title)}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
@@ -1233,7 +1233,20 @@
         (mf/use-fn #(swap! show-dropdown* not))
 
         on-hide-dropdown
-        (mf/use-fn #(reset! show-dropdown* false))]
+        (mf/use-fn #(reset! show-dropdown* false))
+
+        add-layout-dropdown
+        [:& dropdown {:show show-dropdown?
+                      :on-close on-hide-dropdown}
+         [:div {:class (stl/css :layout-options)}
+          [:button {:class (stl/css :layout-option)
+                    :data-type "flex"
+                    :on-click on-add-layout}
+           (tr "labels.flex-layout")]
+          [:button {:class (stl/css :layout-option)
+                    :data-type "grid"
+                    :on-click on-add-layout}
+           (tr "labels.grid-layout")]]]]
 
     [:div {:class (stl/css :element-set) :data-testid "inspect-layout"}
      [:div {:class (stl/css :element-title)}
@@ -1241,7 +1254,7 @@
        {:collapsable has-layout?
         :collapsed (not open?)
         :on-collapsed on-toggle-visibility
-        :title "Layout"
+        :title (tr "labels.layout")
         :class (stl/css-case :title-spacing-layout (not has-layout?))}
 
        (if (and (not multiple) (:layout values))
@@ -1251,17 +1264,7 @@
                             :on-click on-toggle-dropdown-visibility
                             :icon i/menu}]
 
-          [:& dropdown {:show show-dropdown?
-                        :on-close on-hide-dropdown}
-           [:div {:class (stl/css :layout-options)}
-            [:button {:class (stl/css :layout-option)
-                      :data-type "flex"
-                      :on-click on-add-layout}
-             "Flex layout"]
-            [:button {:class (stl/css :layout-option)
-                      :data-type "grid"
-                      :on-click on-add-layout}
-             "Grid layout"]]]
+          add-layout-dropdown
 
           (when has-layout?
             [:> icon-button* {:variant "ghost"
@@ -1275,17 +1278,7 @@
                             :on-click on-toggle-dropdown-visibility
                             :icon i/add}]
 
-          [:& dropdown {:show show-dropdown?
-                        :on-close on-hide-dropdown}
-           [:div {:class (stl/css :layout-options)}
-            [:button {:class (stl/css :layout-option)
-                      :data-type "flex"
-                      :on-click on-add-layout}
-             "Flex layout"]
-            [:button {:class (stl/css :layout-option)
-                      :data-type "grid"
-                      :on-click on-add-layout}
-             "Grid layout"]]]
+          add-layout-dropdown
 
           (when has-layout?
             [:> icon-button* {:variant "ghost"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2758,6 +2758,10 @@ msgstr "Figma"
 msgid "labels.fill"
 msgstr "Fill"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "labels.flex-layout"
+msgstr "Flex layout"
+
 #: src/app/main/ui/dashboard/fonts.cljs:432
 msgid "labels.font-family"
 msgstr "Font Family"
@@ -2799,6 +2803,10 @@ msgstr "Go back"
 #: src/app/main/ui/onboarding/questions.cljs:88
 msgid "labels.graphic-design"
 msgstr "Graphic design"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "labels.grid-layout"
+msgstr "Grid layout"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:887, src/app/main/ui/workspace/main_menu.cljs:136, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1317, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1345, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1533
 msgid "labels.help-center"


### PR DESCRIPTION
### Related Ticket

N/A

### Summary

The Layout panel header in the design sidebar bypassed i18n in three spots: the panel title "Layout", and the "Flex layout" / "Grid layout" buttons inside the add-layout dropdown (which appeared twice, once in the variant shown when a layout already exists and once in the variant shown before any layout is added).

The title now reads from the existing `labels.layout` key. Two new keys, `labels.flex-layout` and `labels.grid-layout`, back the dropdown options so the English wording stays the same while every other locale picks up a translatable string. The duplicated dropdown markup was extracted into a single local binding to keep the two branches in sync.

### Steps to reproduce

1. Switch the UI language to anything other than English (e.g. Spanish or French) from the user settings.
2. Open the design panel for a frame.
3. Click the add layout icon next to the "Layout" title.
4. Confirm the panel title and both dropdown options now render in the selected language.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
