### PR TITLE
:recycle: Migrate inspect attributes syntax

### DIFF
--- a/frontend/src/app/main/ui/inspect/attributes/blur.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/blur.cljs
@@ -22,7 +22,7 @@
     :backdrop-filter
     :filter))
 
-(mf/defc blur-panel
+(mf/defc blur-panel*
   [{:keys [objects shapes]}]
   (let [shapes (->> shapes (filter has-blur?))]
     (when (seq shapes)
@@ -47,3 +47,5 @@
               [:> copy-button* {:data (css/get-css-property objects shape prop)}
                [:div {:class (stl/css :button-children)}
                 (css/get-css-value objects shape prop)]]]]))]])))
+
+(def blur-panel blur-panel*)

--- a/frontend/src/app/main/ui/inspect/attributes/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/geometry.cljs
@@ -24,7 +24,7 @@
    :border-radius
    :transform])
 
-(mf/defc geometry-block
+(mf/defc geometry-block*
   [{:keys [objects shape]}]
   [:*
    (for [[idx property] (d/enumerate properties)]
@@ -39,7 +39,7 @@
             [:div {:class (stl/css :button-children)} value]]]])))])
 
 
-(mf/defc geometry-panel
+(mf/defc geometry-panel*
   [{:keys [objects shapes]}]
   [:div {:class (stl/css :attributes-block)}
    [:> inspect-title-bar*
@@ -52,6 +52,8 @@
                         :class (stl/css :copy-btn-title)}])]
 
    (for [shape shapes]
-     [:& geometry-block {:shape shape
-                         :objects objects
-                         :key (:id shape)}])])
+     [:> geometry-block* {:shape shape
+                          :objects objects
+                          :key (:id shape)}])])
+
+(def geometry-panel geometry-panel*)

--- a/frontend/src/app/main/ui/inspect/attributes/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/layout.cljs
@@ -34,7 +34,7 @@
    :padding-block-start
    :padding-block-end])
 
-(mf/defc layout-block
+(mf/defc layout-block*
   [{:keys [objects shape]}]
   (for [property properties]
     (when-let [value (css/get-css-value objects shape property)]
@@ -49,7 +49,7 @@
           [:> copy-button* {:data (css/get-css-property objects shape property)}
            [:div {:class (stl/css :button-children)} value]]]]))))
 
-(mf/defc layout-panel
+(mf/defc layout-panel*
   [{:keys [objects shapes]}]
   (let [shapes (->> shapes (filter ctl/any-layout?))]
 
@@ -65,6 +65,8 @@
                             :class (stl/css :copy-btn-title)}])]
 
        (for [shape shapes]
-         [:& layout-block {:shape shape
-                           :objects objects
-                           :key (:id shape)}])])))
+         [:> layout-block* {:shape shape
+                            :objects objects
+                            :key (:id shape)}])])))
+
+(def layout-panel layout-panel*)

--- a/frontend/src/app/main/ui/inspect/attributes/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/layout_element.cljs
@@ -31,7 +31,7 @@
    :grid-column
    :grid-row])
 
-(mf/defc layout-element-block
+(mf/defc layout-element-block*
   [{:keys [objects shape]}]
   (for [property properties]
     (when-let [value (css/get-css-value objects shape property)]
@@ -44,7 +44,7 @@
           [:> copy-button* {:data (css/get-css-property objects shape property)}
            [:div {:class (stl/css :button-children)} value]]]]))))
 
-(mf/defc layout-element-panel
+(mf/defc layout-element-panel*
   [{:keys [objects shapes]}]
   (let [shapes (->> shapes (filter #(ctl/any-layout-immediate-child? objects %)))
         only-flex? (every? #(ctl/flex-layout-immediate-child? objects %) shapes)
@@ -76,6 +76,8 @@
                             :class (stl/css :copy-btn-title)}])]
 
        (for [shape shapes]
-         [:& layout-element-block {:shape shape
-                                   :objects objects
-                                   :key (:id shape)}])])))
+         [:> layout-element-block* {:shape shape
+                                    :objects objects
+                                    :key (:id shape)}])])))
+
+(def layout-element-panel layout-element-panel*)

--- a/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
@@ -27,7 +27,7 @@
   [color format]
   (format-color-value color {:format format}))
 
-(mf/defc shadow-block [{:keys [shadow]}]
+(mf/defc shadow-block* [{:keys [shadow]}]
   (let [color-format (mf/use-state :hex)
         color-format* (deref color-format)
         label (cmm/get-css-rule-humanized (:style shadow))
@@ -51,12 +51,12 @@
          (str (:blur shadow) "px") " "
          (str (:spread shadow) "px")]]]]
 
-     [:& cmm/color-row {:color (:color shadow)
+     [:> cmm/color-row {:color (:color shadow)
                         :format @color-format
                         :copy-data (copy-color-data (:color shadow) color-format*)
                         :on-change-format on-change-format}]]))
 
-(mf/defc shadow-panel [{:keys [shapes]}]
+(mf/defc shadow-panel* [{:keys [shapes]}]
   (let [shapes (->> shapes (filter has-shadow?))]
 
     (when (and (seq shapes) (> (count shapes) 0))
@@ -69,6 +69,8 @@
        [:div {:class (stl/css :attributes-content)}
         (for [shape shapes]
           (for [shadow (:shadow shape)]
-            [:& shadow-block {:shape shape
-                              :key   (dm/str "block-" (:id shape) "-shadow")
-                              :shadow shadow}]))]])))
+            [:> shadow-block* {:shape shape
+                               :key   (dm/str "block-" (:id shape) "-shadow")
+                               :shadow shadow}]))]])))
+
+(def shadow-panel shadow-panel*)

--- a/frontend/src/app/main/ui/inspect/attributes/svg.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/svg.cljs
@@ -19,7 +19,7 @@
        (map (fn [[attr-key attr-value]] (str (d/name attr-key) ":" attr-value)))
        (str/join "; ")))
 
-(mf/defc svg-attr [{:keys [attr value]}]
+(mf/defc svg-attr* [{:keys [attr value]}]
   (if (map? value)
     [:*
      [:div {:class (stl/css :attributes-subtitle)}
@@ -27,7 +27,7 @@
       [:> copy-button* {:data (map->css value)}]]
 
      (for [[attr-key attr-value] value]
-       [:& svg-attr {:attr  attr-key :value attr-value :key (str/join "svg-key-" (d/name attr-key))}])]
+       [:> svg-attr* {:attr  attr-key :value attr-value :key (str/join "svg-key-" (d/name attr-key))}])]
 
     (let [attr-name (as-> attr $
                       (d/name $)
@@ -41,13 +41,13 @@
                           :class (stl/css :copy-btn-title)}
          [:div {:class (stl/css :button-children)} (str value)]]]])))
 
-(mf/defc svg-block
+(mf/defc svg-block*
   [{:keys [shape]}]
   [:*
    (for [[attr-key attr-value] (:svg-attrs shape)]
-     [:& svg-attr {:attr attr-key :value attr-value :key (str/join "svg-block-key-" (d/name attr-key))}])])
+     [:> svg-attr* {:attr attr-key :value attr-value :key (str/join "svg-block-key-" (d/name attr-key))}])])
 
-(mf/defc svg-panel
+(mf/defc svg-panel*
   [{:keys [shapes]}]
   (let [shape (first shapes)]
     (when (seq (:svg-attrs shape))
@@ -56,4 +56,6 @@
         {:title (tr "workspace.sidebar.options.svg-attrs.title")
          :class (stl/css :title-wrapper)
          :title-class (stl/css :svg-attr-title)}]
-       [:& svg-block {:shape shape}]])))
+       [:> svg-block* {:shape shape}]])))
+
+(def svg-panel svg-panel*)

--- a/frontend/src/app/main/ui/inspect/attributes/text.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/text.cljs
@@ -31,7 +31,7 @@
        (map #(dm/str (d/name %) ": " (get style %) ";"))
        (str/join "\n")))
 
-(mf/defc typography-block
+(mf/defc typography-block*
   [{:keys [text style]}]
   (let [color-format*       (mf/use-state :hex)
         color-format        (deref color-format*)
@@ -41,7 +41,7 @@
     [:div {:class (stl/css :attributes-content)}
      (when (:fills style)
        (for [[idx fill] (map-indexed vector (:fills style))]
-         [:& color-row {:key idx
+         [:> color-row {:key idx
                         :format color-format
                         :color (types.fills/fill->color fill)
                         :copy-data (copy-style-data fill :fill-color :fill-color-gradient)
@@ -139,19 +139,19 @@
        (str/trim text)]]]))
 
 
-(mf/defc text-block [{:keys [shape]}]
+(mf/defc text-block* [{:keys [shape]}]
   (let [style-text-blocks (->> (:content shape)
                                (txt/content->text+styles)
                                (remove (fn [[_ text]] (str/empty? (str/trim text))))
                                (mapv (fn [[style text]] (vector (merge (types.text/get-default-text-attrs) style) text))))]
 
     (for [[idx [full-style text]] (map-indexed vector style-text-blocks)]
-      [:& typography-block {:key idx
-                            :shape shape
-                            :style full-style
-                            :text text}])))
+      [:> typography-block* {:key idx
+                             :shape shape
+                             :style full-style
+                             :text text}])))
 
-(mf/defc text-panel
+(mf/defc text-panel*
   [{:keys [shapes]}]
   (when-let [shapes (seq (filter has-text? shapes))]
     [:div {:class (stl/css :attributes-block)}
@@ -161,5 +161,7 @@
        :title-class (stl/css :text-atrr-title)}]
 
      (for [shape shapes]
-       [:& text-block {:shape shape
-                       :key (dm/str "text-block" (:id shape))}])]))
+       [:> text-block* {:shape shape
+                        :key (dm/str "text-block" (:id shape))}])]))
+
+(def text-panel text-panel*)


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates the inspect attribute panels for blur, geometry, layout, layout element, shadow, SVG attributes, and text to the modern Rumext component syntax.

The panel implementations now use the `*` component suffix and internal component calls use `[:> ...]`. Existing non-star exports are kept as compatibility aliases so this PR does not need to touch the already-open inspect attributes aggregator PR.

### Steps to reproduce 

1. Open a file in the workspace and select shapes with blur, geometry, layout, layout element, shadow, SVG attributes, or text attributes.
2. Open the Inspect panel.
3. Verify those attribute sections render and their copy buttons still expose the same CSS values.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/inspect/attributes/blur.cljs src/app/main/ui/inspect/attributes/geometry.cljs src/app/main/ui/inspect/attributes/layout.cljs src/app/main/ui/inspect/attributes/layout_element.cljs src/app/main/ui/inspect/attributes/shadow.cljs src/app/main/ui/inspect/attributes/svg.cljs src/app/main/ui/inspect/attributes/text.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/inspect/attributes/blur.cljs src/app/main/ui/inspect/attributes/geometry.cljs src/app/main/ui/inspect/attributes/layout.cljs src/app/main/ui/inspect/attributes/layout_element.cljs src/app/main/ui/inspect/attributes/shadow.cljs src/app/main/ui/inspect/attributes/svg.cljs src/app/main/ui/inspect/attributes/text.cljs`
- `git diff --check`
