### PR TITLE
:recycle: Migrate early release notes syntax

### DIFF
--- a/frontend/src/app/main/ui/releases/common.cljs
+++ b/frontend/src/app/main/ui/releases/common.cljs
@@ -18,3 +18,5 @@
      [:li {:class (stl/css-case :dot true
                                 :current (= slide i))
            :on-click #(navigate i)}])])
+
+(def navigation-bullets navigation-bullets*)


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates the shared release-note navigation bullets component and early v1 release-note screens to modern Rumext component invocation syntax.

The shared component is now defined with the `*` suffix, early release note files call it with `[:> c/navigation-bullets* ...]`, and the old export remains as a compatibility alias for release-note files that will be migrated separately.

### Steps to reproduce 

1. Trigger the release notes/onboarding modal for v1.4 through v1.13 release entries.
2. Move between slides.
3. Verify the navigation bullets render, highlight the active slide, and still navigate to the selected slide.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/releases/common.cljs src/app/main/ui/releases/v1_4.cljs src/app/main/ui/releases/v1_5.cljs src/app/main/ui/releases/v1_6.cljs src/app/main/ui/releases/v1_7.cljs src/app/main/ui/releases/v1_8.cljs src/app/main/ui/releases/v1_9.cljs src/app/main/ui/releases/v1_11.cljs src/app/main/ui/releases/v1_12.cljs src/app/main/ui/releases/v1_13.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/releases/common.cljs src/app/main/ui/releases/v1_4.cljs src/app/main/ui/releases/v1_5.cljs src/app/main/ui/releases/v1_6.cljs src/app/main/ui/releases/v1_7.cljs src/app/main/ui/releases/v1_8.cljs src/app/main/ui/releases/v1_9.cljs src/app/main/ui/releases/v1_11.cljs src/app/main/ui/releases/v1_12.cljs src/app/main/ui/releases/v1_13.cljs`
- `git diff --check`
