### PR TITLE
:recycle: Migrate sidebar options syntax

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/drawing/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/drawing/frame.cljs
@@ -99,7 +99,7 @@
        (or selected-preset-name
            (tr "workspace.options.size-presets"))]
       [:span {:class (stl/css :collapsed-icon)} deprecated-icon/arrow]
-      [:& dropdown {:show show?
+      [:> dropdown {:show show?
                     :on-close on-close
                     :container container-ref}
        [:div {:class (stl/css :custom-select-dropdown)
@@ -137,15 +137,14 @@
                   (when preset-match
                     [:span {:class (stl/css :check-icon)} deprecated-icon/tick])]))))]]]]
 
-     [:& radio-buttons {:selected (or (d/name orientation) "")
+     [:> radio-buttons {:selected (or (d/name orientation) "")
                         :on-change on-orientation-change
                         :name "frame-orientation"
                         :wide true
                         :class (stl/css :radio-buttons)}
-      [:& radio-button {:icon i/size-vertical
+      [:> radio-button {:icon i/size-vertical
                         :value "vertical"
                         :id "size-vertical"}]
-      [:& radio-button {:icon i/size-horizontal
+      [:> radio-button {:icon i/size-horizontal
                         :value "horizontal"
                         :id "size-horizontal"}]]]))
-

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -129,7 +129,7 @@
                     :on-click toggle-more-options}
            deprecated-icon/menu]
           (if bg-blur?
-            [:& select {:class (stl/css :blur-type-select)
+            [:> select {:class (stl/css :blur-type-select)
                         :default-value (d/name (:type blur))
                         :options type-options
                         :disabled hidden?
@@ -157,3 +157,5 @@
              :min "0"
              :on-change handle-change
              :value (:value blur)}]])])]))
+
+(def blur-menu blur-menu*)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/bool.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/bool.cljs
@@ -75,26 +75,26 @@
     (when (not (and disabled-bool-btns disabled-flatten))
       [:div {:class (stl/css :boolean-options)}
        [:div {:class (stl/css :bool-group)}
-        [:& radio-buttons {:selected (d/name head-bool-type)
+        [:> radio-buttons {:selected (d/name head-bool-type)
                            :class (stl/css :boolean-radio-btn)
                            :on-change on-change
                            :name "bool-options"}
-         [:& radio-button {:icon i/boolean-union
+         [:> radio-button {:icon i/boolean-union
                            :value "union"
                            :disabled disabled-bool-btns
                            :title (str (tr "workspace.shape.menu.union") " (" (sc/get-tooltip :bool-union) ")")
                            :id "bool-opt-union"}]
-         [:& radio-button {:icon i/boolean-difference
+         [:> radio-button {:icon i/boolean-difference
                            :value "difference"
                            :disabled disabled-bool-btns
                            :title (str (tr "workspace.shape.menu.difference") " (" (sc/get-tooltip :bool-difference) ")")
                            :id "bool-opt-differente"}]
-         [:& radio-button {:icon i/boolean-intersection
+         [:> radio-button {:icon i/boolean-intersection
                            :value "intersection"
                            :disabled disabled-bool-btns
                            :title (str (tr "workspace.shape.menu.intersection") " (" (sc/get-tooltip :bool-intersection) ")")
                            :id "bool-opt-intersection"}]
-         [:& radio-button {:icon i/boolean-exclude
+         [:> radio-button {:icon i/boolean-exclude
                            :value "exclude"
                            :disabled disabled-bool-btns
                            :title (str (tr "workspace.shape.menu.exclude") " (" (sc/get-tooltip :bool-exclude) ")")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs
@@ -208,12 +208,12 @@
              [:span {:class (stl/css :resalted-area)}]]]]
           [:div {:class (stl/css :constraints-selects)}
            [:div {:class (stl/css :horizontal-select) :data-testid "constraint-h-select"}
-            [:& select
+            [:> select
              {:default-value (if (not= constraints-h :multiple) (d/nilv (d/name constraints-h) "scale") "")
               :options options-h
               :on-change on-constraint-h-select-changed}]]
            [:div {:class (stl/css :vertical-select) :data-testid "constraint-v-select"}
-            [:& select
+            [:> select
              {:default-value (if (not= constraints-v :multiple) (d/nilv (d/name constraints-v) "scale") "")
               :options options-v
               :on-change on-constraint-v-select-changed}]]
@@ -231,3 +231,5 @@
                         :id "fixed-on-scroll"
                         :checked (:fixed-scroll values)
                         :on-change on-fixed-scroll-clicked}]]])]])])))
+
+(def constraints-menu constraints-menu*)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -153,7 +153,7 @@
                  :on-click toggle-advanced-options}
         deprecated-icon/menu]
        [:div {:class (stl/css :type-select-wrapper)}
-        [:& select
+        [:> select
          {:class (stl/css :grid-type-select)
           :default-value type
           :options [{:value :square :label (tr "workspace.options.grid.square")}
@@ -170,7 +170,7 @@
                               :on-change (handle-change :params :size)}]]
 
          [:div {:class (stl/css :editable-select-wrapper)}
-          [:& editable-select {:value (:size params)
+          [:> editable-select {:value (:size params)
                                :type  "number"
                                :class (stl/css :column-select)
                                :input-class (stl/css :numeric-input)
@@ -225,7 +225,7 @@
           [:div {:class (stl/css :column-row)}
            [:div {:class (stl/css :advanced-row)}
             [:div {:class (stl/css :orientation-select-wrapper)}
-             [:& select {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+             [:> select {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
                          :default-value (:type params)
                          :class (stl/css :orientation-select)
                          :options [{:value :stretch :label (tr "workspace.options.grid.params.type.stretch")}
@@ -339,4 +339,5 @@
                              :frame-height (:height shape)
                              :default-grid-params default-grid-params}])])]))
 
+(def frame-grid frame-grid*)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/grid_cell.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/grid_cell.cljs
@@ -36,7 +36,7 @@
                  :justify-self
                  :area-name])
 
-(mf/defc set-self-alignment
+(mf/defc set-self-alignment*
   [{:keys [is-col? alignment set-alignment] :as props}]
   (let [alignment (or alignment :auto)
         type (if is-col? "col" "row")
@@ -48,32 +48,32 @@
            (set-alignment (-> value keyword))))]
 
     [:div {:class (stl/css :self-align-menu)}
-     [:& radio-buttons {:selected (d/name alignment)
+     [:> radio-buttons {:selected (d/name alignment)
                         :on-change handle-set-alignment
                         :allow-empty true
                         :name (dm/str "flex-align-items-" type)}
-      [:& radio-button {:value "start"
+      [:> radio-button {:value "start"
                         :icon  (if is-col?
                                  i/align-self-row-left
                                  i/align-self-column-top)
                         :title "Align self start"
                         :id     (dm/str "align-self-start-" type)}]
 
-      [:& radio-button {:value "center"
+      [:> radio-button {:value "center"
                         :icon  (if is-col?
                                  i/align-self-row-center
                                  i/align-self-column-center)
                         :title "Align self center"
                         :id     (dm/str "align-self-center-" type)}]
 
-      [:& radio-button {:value "end"
+      [:> radio-button {:value "end"
                         :icon  (if is-col?
                                  i/align-self-row-right
                                  i/align-self-column-bottom)
                         :title "Align self end"
                         :id     (dm/str "align-self-end-" type)}]
 
-      [:& radio-button {:value "stretch"
+      [:> radio-button {:value "stretch"
                         :icon  (if is-col?
                                  i/align-self-row-stretch
                                  i/align-self-column-stretch)
@@ -81,7 +81,7 @@
                         :id     (dm/str "align-self-stretch-" type)}]]]))
 
 
-(mf/defc options
+(mf/defc options*
   {::mf/wrap [mf/memo]}
   [{:keys [shape cell cells] :as props}]
 
@@ -187,13 +187,13 @@
      (when open?
        [:div {:class (stl/css :grid-cell-menu-container)}
         [:div {:class (stl/css :cell-mode :row)}
-         [:& radio-buttons {:selected (d/name cell-mode)
+         [:> radio-buttons {:selected (d/name cell-mode)
                             :on-change set-cell-mode
                             :name "cell-mode"
                             :wide true}
-          [:& radio-button {:value "auto" :id :auto}]
-          [:& radio-button {:value "manual" :id :manual}]
-          [:& radio-button {:value "area"
+          [:> radio-button {:value "auto" :id :auto}]
+          [:> radio-button {:value "manual" :id :manual}]
+          [:> radio-button {:value "area"
                             :id :area
                             :disabled (not valid-area-cells?)}]]]
 
@@ -271,12 +271,12 @@
                :value row-end}]]]])
 
         [:div {:class (stl/css :row)}
-         [:& set-self-alignment {:is-col? false
-                                 :alignment align-self
-                                 :set-alignment set-alignment}]
-         [:& set-self-alignment {:is-col? true
-                                 :alignment justify-self
-                                 :set-alignment set-justify-self}]]
+         [:> set-self-alignment* {:is-col? false
+                                  :alignment align-self
+                                  :set-alignment set-alignment}]
+         [:> set-self-alignment* {:is-col? true
+                                  :alignment justify-self
+                                  :set-alignment set-justify-self}]]
 
         [:div {:class (stl/css :row)}
          [:button
@@ -284,3 +284,5 @@
            :alt    (tr "workspace.layout-grid.editor.options.edit-grid")
            :on-click toggle-edit-mode}
           (tr "workspace.layout-grid.editor.options.edit-grid")]]])]))
+
+(def options options*)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -415,7 +415,7 @@
                :on-click on-type-change'}
       deprecated-icon/margin]]))
 
-(mf/defc element-behaviour-horizontal
+(mf/defc element-behaviour-horizontal*
   {::mf/props :obj
    ::mf/private true}
   [{:keys [^boolean is-auto ^boolean has-fill value on-change]}]
@@ -424,32 +424,32 @@
                  :one-element (and (not has-fill) (not is-auto))
                  :two-element (or has-fill is-auto)
                  :three-element (and has-fill is-auto))}
-   [:& radio-buttons
+   [:> radio-buttons
     {:selected  (d/name value)
      :decode-fn keyword
      :on-change on-change
      :name      "flex-behaviour-h"}
 
-    [:& radio-button
+    [:> radio-button
      {:value "fix"
       :icon  i/fixed-width
       :title "Fix width"
       :id    "behaviour-h-fix"}]
 
     (when has-fill
-      [:& radio-button
+      [:> radio-button
        {:value "fill"
         :icon  i/fill-content
         :title "Width 100%"
         :id    "behaviour-h-fill"}])
     (when is-auto
-      [:& radio-button
+      [:> radio-button
        {:value "auto"
         :icon  i/hug-content
         :title "Fit content (Horizontal)"
         :id    "behaviour-h-auto"}])]])
 
-(mf/defc element-behaviour-vertical
+(mf/defc element-behaviour-vertical*
   {::mf/props :obj
    ::mf/private true}
   [{:keys [^boolean is-auto ^boolean has-fill value on-change]}]
@@ -458,12 +458,12 @@
                  :one-element (and (not has-fill) (not is-auto))
                  :two-element (or has-fill is-auto)
                  :three-element (and has-fill is-auto))}
-   [:& radio-buttons
+   [:> radio-buttons
     {:selected  (d/name value)
      :decode-fn keyword
      :on-change on-change
      :name      "flex-behaviour-v"}
-    [:& radio-button
+    [:> radio-button
      {:value      "fix"
       :icon       i/fixed-width
       :icon-class (stl/css :rotated)
@@ -471,37 +471,37 @@
       :id         "behaviour-v-fix"}]
 
     (when has-fill
-      [:& radio-button
+      [:> radio-button
        {:value      "fill"
         :icon       i/fill-content
         :icon-class (stl/css :rotated)
         :title      "Height 100%"
         :id         "behaviour-v-fill"}])
     (when is-auto
-      [:& radio-button
+      [:> radio-button
        {:value      "auto"
         :icon       i/hug-content
         :icon-class (stl/css :rotated)
         :title      "Fit content (Vertical)"
         :id         "behaviour-v-auto"}])]])
 
-(mf/defc align-self-row
+(mf/defc align-self-row*
   {::mf/props :obj}
   [{:keys [^boolean is-col value on-change]}]
-  [:& radio-buttons {:selected (d/name value)
+  [:> radio-buttons {:selected (d/name value)
                      :decode-fn keyword
                      :on-change on-change
                      :name "flex-align-self"
                      :allow-empty true}
-   [:& radio-button {:value "start"
+   [:> radio-button {:value "start"
                      :icon  (get-layout-flex-icon :align-self :start is-col)
                      :title "Align self start"
                      :id     "align-self-start"}]
-   [:& radio-button {:value "center"
+   [:> radio-button {:value "center"
                      :icon  (get-layout-flex-icon :align-self :center is-col)
                      :title "Align self center"
                      :id    "align-self-center"}]
-   [:& radio-button {:value "end"
+   [:> radio-button {:value "end"
                      :icon  (get-layout-flex-icon :align-self :end is-col)
                      :title "Align self end"
                      :id    "align-self-end"}]])
@@ -715,7 +715,7 @@
              :value (get values :layout-item-max-h)
              :nillable true}]])])]))
 
-(mf/defc layout-item-menu
+(mf/defc layout-item-menu*
   {::mf/memo #{:ids :values :type :is-layout-child? :is-grid-parent :is-flex-parent? :is-grid-layout? :is-flex-layout? :applied-tokens}
    ::mf/props :obj}
   [{:keys [ids values
@@ -850,14 +850,14 @@
         (when (or is-layout-child? is-absolute?)
           [:div {:class (stl/css :position-row)}
            [:div {:class (stl/css :position-options)}
-            [:& radio-buttons {:selected (if is-absolute? "absolute" "static")
+            [:> radio-buttons {:selected (if is-absolute? "absolute" "static")
                                :decode-fn keyword
                                :on-change on-change-position
                                :name "layout-style"
                                :wide true}
-             [:& radio-button {:value "static"
+             [:> radio-button {:value "static"
                                :id :static-position}]
-             [:& radio-button {:value "absolute"
+             [:> radio-button {:value "absolute"
                                :id :absolute-position}]]]
 
            [:div {:class (stl/css :z-index-wrapper)
@@ -877,12 +877,12 @@
                         :behaviour-menu true
                         :wrap (and ^boolean is-layout-child?
                                    ^boolean is-layout-container?))}
-          [:& element-behaviour-horizontal
+          [:> element-behaviour-horizontal*
            {:is-auto is-layout-container?
             :has-fill is-layout-child?
             :value (:layout-item-h-sizing values)
             :on-change on-behaviour-h-change}]
-          [:& element-behaviour-vertical
+          [:> element-behaviour-vertical*
            {:is-auto is-layout-container?
             :has-fill is-layout-child?
             :value (:layout-item-v-sizing values)
@@ -890,9 +890,9 @@
 
         (when (and is-layout-child? is-flex-parent?)
           [:div {:class (stl/css :align-row)}
-           [:& align-self-row {:is-col is-col?
-                               :value align-self
-                               :on-change on-align-self-change}]])
+           [:> align-self-row* {:is-col is-col?
+                                :value align-self
+                                :on-change on-align-self-change}]])
 
         (when is-layout-child?
           [:> margin-section* {:value (:layout-item-margin values)
@@ -907,3 +907,5 @@
           [:> layout-size-constraints* {:ids ids
                                         :values values
                                         :applied-tokens applied-tokens}])])]))
+
+(def layout-item-menu layout-item-menu*)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/shadow_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/shadow_row.cljs
@@ -145,7 +145,7 @@
                           :aria-label "open more options"
                           :disabled hidden?
                           :on-click on-toggle-open}]
-        [:& select {:class (stl/css :shadow-basic-select)
+        [:> select {:class (stl/css :shadow-basic-select)
                     :default-value (d/name shadow-style)
                     :options type-options
                     :disabled hidden?


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates a workspace sidebar options batch to modern Rumext component invocation syntax.

This PR covers frame drawing presets, blur/bool/constraints/frame-grid/grid-cell/layout-item/SVG-attrs option menus, and the shadow row select. Local menu components now use the `*` suffix where needed, internal local calls use `[:> ...*]`, and compatibility aliases keep existing parent imports working without touching files owned by other open PRs.

### Steps to reproduce 

1. Select shapes that expose blur, boolean, constraints, frame grid, grid cell, layout item, SVG attributes, or shadow options in the workspace sidebar.
2. Open the corresponding sidebar option sections.
3. Verify radio buttons, dropdowns/selects, grid options, and menu toggles render and respond as before.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/workspace/sidebar/options/drawing/frame.cljs src/app/main/ui/workspace/sidebar/options/menus/blur.cljs src/app/main/ui/workspace/sidebar/options/menus/bool.cljs src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs src/app/main/ui/workspace/sidebar/options/menus/grid_cell.cljs src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs src/app/main/ui/workspace/sidebar/options/menus/svg_attrs.cljs src/app/main/ui/workspace/sidebar/options/rows/shadow_row.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/workspace/sidebar/options/drawing/frame.cljs src/app/main/ui/workspace/sidebar/options/menus/blur.cljs src/app/main/ui/workspace/sidebar/options/menus/bool.cljs src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs src/app/main/ui/workspace/sidebar/options/menus/grid_cell.cljs src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs src/app/main/ui/workspace/sidebar/options/menus/svg_attrs.cljs src/app/main/ui/workspace/sidebar/options/rows/shadow_row.cljs`
- `git diff --check`
