### PR TITLE
:recycle: Migrate sidebar shape options syntax

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
@@ -94,7 +94,7 @@
                          :values measure-values
                          :shapes shapes}]
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type type
        :ids [(:id shape)]
        :values layout-container-values
@@ -102,12 +102,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when is-layout-child?
-       [:& layout-item-menu
+       [:> layout-item-menu
         {:ids ids
          :type type
          :values layout-item-values

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
@@ -93,7 +93,7 @@
                          :values measure-values
                          :shapes shapes}]
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type type
        :ids [(:id shape)]
        :values layout-container-values
@@ -101,12 +101,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when is-layout-child?
-       [:& layout-item-menu {:ids ids
+       [:> layout-item-menu {:ids ids
                              :type type
                              :values layout-item-values
                              :is-layout-child? true

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -113,7 +113,7 @@
      (when is-variant?
        [:> component-variant-main* {:shapes shapes}])
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type shape-type
        :ids ids
        :applied-tokens applied-tokens
@@ -121,12 +121,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when (or is-layout-child? is-layout-container?)
-       [:& layout-item-menu
+       [:> layout-item-menu
         {:ids ids
          :type shape-type
          :values layout-item-values

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -119,7 +119,7 @@
                          :values measure-values
                          :shapes shapes}]
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type type
        :ids [(:id shape)]
        :values layout-container-values
@@ -127,12 +127,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when is-layout-child?
-       [:& layout-item-menu
+       [:> layout-item-menu
         {:type type
          :ids layout-item-ids
          :is-layout-child? true

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
@@ -93,7 +93,7 @@
                          :values measure-values
                          :shapes shapes}]
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type type
        :ids [(:id shape)]
        :values layout-container-values
@@ -101,12 +101,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when is-layout-child?
-       [:& layout-item-menu {:ids ids
+       [:> layout-item-menu {:ids ids
                              :type type
                              :values layout-item-values
                              :is-layout-child? true

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
@@ -93,7 +93,7 @@
                          :applied-tokens applied-tokens
                          :shapes shapes}]
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type type
        :ids ids
        :values layout-container-values
@@ -101,12 +101,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when ^boolean is-layout-child?
-       [:& layout-item-menu
+       [:> layout-item-menu
         {:ids ids
          :type type
          :values layout-item-values

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
@@ -160,7 +160,7 @@
                            :values measure-values
                            :shapes shapes}]
 
-       [:& layout-container-menu
+       [:> layout-container-menu
         {:type type
          :ids [(:id shape)]
          :values layout-container-values
@@ -168,12 +168,12 @@
          :multiple false}]
 
        (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-         [:& grid-cell/options
+         [:> grid-cell/options
           {:shape (first parents)
            :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
        (when is-layout-child?
-         [:& layout-item-menu
+         [:> layout-item-menu
           {:ids ids
            :type type
            :values layout-item-values

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -148,7 +148,7 @@
        :applied-tokens applied-tokens
        :shapes shapes}]
 
-     [:& layout-container-menu
+     [:> layout-container-menu
       {:type type
        :ids ids
        :values layout-container-values
@@ -156,12 +156,12 @@
        :multiple false}]
 
      (when (and (= (count ids) 1) is-layout-child? is-grid-parent?)
-       [:& grid-cell/options
+       [:> grid-cell/options
         {:shape (first parents)
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when is-layout-child?
-       [:& layout-item-menu
+       [:> layout-item-menu
         {:ids ids
          :type type
          :values layout-item-values


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates the workspace sidebar shape option entry components to modern Rumext invocation syntax.

This PR covers bool, circle, frame, group, path, rect, raw SVG, and text shape option entry files. The files now call their option menu components through `[:> ...]`, while leaving the target menu implementation files untouched to avoid overlapping active PRs.

### Steps to reproduce 

1. Select bool, circle, frame, group, path, rect, raw SVG, and text shapes in the workspace.
2. Open the right sidebar options for each shape type.
3. Verify the layout, constraints, stroke, blur, SVG attributes, and shape-specific sections still render.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs src/app/main/ui/workspace/sidebar/options/shapes/group.cljs src/app/main/ui/workspace/sidebar/options/shapes/path.cljs src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs src/app/main/ui/workspace/sidebar/options/shapes/text.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs src/app/main/ui/workspace/sidebar/options/shapes/group.cljs src/app/main/ui/workspace/sidebar/options/shapes/path.cljs src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs src/app/main/ui/workspace/sidebar/options/shapes/text.cljs`
- `git diff --check`
