### PR TITLE
:recycle: Migrate shared UI callsites syntax

### DIFF
--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -929,7 +929,7 @@
                           :aria-label (tr "labels.options")
                           :on-click on-toggle-options
                           :icon i/menu}])]
-     [:& dropdown {:show (= options uuid/zero)
+     [:> dropdown {:show (= options uuid/zero)
                    :on-close on-hide-options}
       [:ul {:class (stl/css :dropdown-menu)}
        [:li {:class (stl/css :dropdown-menu-option)
@@ -1003,7 +1003,7 @@
          [:span {:class (stl/css :text)}
           [:> comment-content* {:content (:content comment)}]])]]
 
-     [:& dropdown {:show (= options (:id comment))
+     [:> dropdown {:show (= options (:id comment))
                    :on-close on-hide-options}
       [:ul {:class (stl/css :dropdown-menu)}
        [:li {:class (stl/css :dropdown-menu-option)

--- a/frontend/src/app/main/ui/components/editable_select.cljs
+++ b/frontend/src/app/main/ui/components/editable_select.cljs
@@ -184,7 +184,7 @@
              :on-click toggle-dropdown}
       deprecated-icon/arrow]
 
-     [:& dropdown {:show (or is-open? false)
+     [:> dropdown {:show (or is-open? false)
                    :on-close close-dropdown}
       [:ul {:class (stl/css :custom-select-dropdown)
             :ref font-size-wrapper-ref}

--- a/frontend/src/app/main/ui/components/radio_buttons.cljs
+++ b/frontend/src/app/main/ui/components/radio_buttons.cljs
@@ -100,7 +100,7 @@
                            :encode-fn encode-fn
                            :decode-fn decode-fn})]
 
-    [:& (mf/provider context) {:value context-value}
+    [:> (mf/provider context) {:value context-value}
      [:div {:class (dm/str class " " (stl/css :radio-btn-wrapper))
             :style {:width  width}
             :key (dm/str name "-" selected)}

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -79,7 +79,7 @@
         [:h1 (tr "labels.drafts")]]
 
        (if (and (:edition @local) can-edit)
-         [:& inline-edition
+         [:> inline-edition
           {:content (:name project)
            :on-end (fn [name]
                      (let [name (str/trim name)]

--- a/frontend/src/app/main/ui/exports/assets.cljs
+++ b/frontend/src/app/main/ui/exports/assets.cljs
@@ -140,7 +140,7 @@
                              :style {:-webkit-print-color-adjust :exact}
                              :fill "none"}
 
-                       [:& shape-wrapper {:shape shape}]])]
+                       [:> shape-wrapper {:shape shape}]])]
 
                    [:div {:class (stl/css :selection-name)}
                     (cond-> (:name shape) suffix (str suffix))]
@@ -153,7 +153,7 @@
                      [:div {:class (stl/css :selection-extension)}
                       (-> export :type d/name str/upper)])]]))]]]
 
-          [:& no-selection])]
+          [:> no-selection])]
 
        (when (> (count all-exports) 0)
          [:div {:class (stl/css :modal-footer)}

--- a/frontend/src/app/main/ui/notifications.cljs
+++ b/frontend/src/app/main/ui/notifications.cljs
@@ -40,7 +40,7 @@
          content]
 
         inline?
-        [:& inline-notification
+        [:> inline-notification
          {:accept (:accept notification)
           :cancel (:cancel notification)
           :links (:links notification)
@@ -48,7 +48,7 @@
 
         ;; This should be substited with the actionable-notification* component
         actionable?
-        [:& context-notification
+        [:> context-notification
          {:level (or (:level notification) :info)
           :links (:links notification)
           :content (:content notification)}]

--- a/frontend/src/app/main/ui/viewer/login.cljs
+++ b/frontend/src/app/main/ui/viewer/login.cljs
@@ -113,7 +113,7 @@
              (tr "labels.go-back")]]]]
 
          :recovery-request
-         [:& recovery-request-page {:go-back-callback go-back-to-login
+         [:> recovery-request-page {:go-back-callback go-back-to-login
                                     :on-success-callback success-email-sent}]
          :email-sent
          [:div {:class (stl/css :form-container)}

--- a/frontend/src/app/main/ui/viewer/thumbnails.cljs
+++ b/frontend/src/app/main/ui/viewer/thumbnails.cljs
@@ -98,7 +98,7 @@
               :on-click #(on-click % index)}
      [:div {:class (stl/css-case :thumbnail-preview true
                                  :selected is-selected)}
-      [:& render/frame-svg {:frame (-> frame
+      [:> render/frame-svg {:frame (-> frame
                                        (assoc :thumbnail (get thumbnail-data (dm/str page-id (:id frame))))
                                        (assoc :children-bounds children-bounds))
                             :objects objects


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates a shared UI/viewer batch from legacy Rumext `[:& ...]` component call syntax to modern `[:> ...]` syntax.

- Updates comments and notification dropdown/context callsites.
- Updates editable select, radio buttons provider, dashboard files inline edition, export asset dialogs, and viewer auth/thumbnail callsites.
- Keeps the batch non-overlapping with currently open PR files.

### Steps to reproduce 

1. Open comments, notifications, dashboard file rename, export assets, viewer login recovery, and viewer thumbnails flows.
2. Verify the migrated dropdowns, inline edit input, selection dialogs, and thumbnails still render and behave as before.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/comments.cljs src/app/main/ui/components/editable_select.cljs src/app/main/ui/components/radio_buttons.cljs src/app/main/ui/dashboard/files.cljs src/app/main/ui/exports/assets.cljs src/app/main/ui/notifications.cljs src/app/main/ui/viewer/login.cljs src/app/main/ui/viewer/thumbnails.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/comments.cljs src/app/main/ui/components/editable_select.cljs src/app/main/ui/components/radio_buttons.cljs src/app/main/ui/dashboard/files.cljs src/app/main/ui/exports/assets.cljs src/app/main/ui/notifications.cljs src/app/main/ui/viewer/login.cljs src/app/main/ui/viewer/thumbnails.cljs`
- `git diff --check`