### PR TITLE
:recycle: Migrate layout inspector callsites syntax

### DIFF
--- a/frontend/src/app/main/ui/flex_controls/gap.cljs
+++ b/frontend/src/app/main/ui/flex_controls/gap.cljs
@@ -320,7 +320,7 @@
     [:g.gaps {:pointer-events "visible"}
      (for [[index display-item] (d/enumerate (concat display-blocks display-children))]
        (let [gap-type (:gap-type display-item)]
-         [:& gap-display
+         [:> gap-display
           {:key (str frame-id index)
            :frame-id frame-id
            :zoom zoom
@@ -338,7 +338,7 @@
            :hover-value hover-value}]))
 
      (when @hover
-       [:& fcc/flex-display-pill
+       [:> fcc/flex-display-pill
         {:height pill-height
          :width pill-width
          :font-size (/ fcc/font-size zoom)
@@ -354,7 +354,7 @@
   (when frame
     [:g.measurement-gaps {:pointer-events "none"}
      [:g.hover-shapes
-      [:& gap-rects
+      [:> gap-rects
        {:frame frame
         :zoom zoom
         :on-move-selected on-move-selected

--- a/frontend/src/app/main/ui/flex_controls/margin.cljs
+++ b/frontend/src/app/main/ui/flex_controls/margin.cljs
@@ -202,7 +202,7 @@
 
     [:g.margins {:pointer-events "visible"}
      (for [[margin-num rect-data] margin-display-data]
-       [:& margin-display
+       [:> margin-display
         {:key (:key rect-data)
          :shape-id shape-id
          :zoom zoom
@@ -221,7 +221,7 @@
          :hover-value hover-value}])
 
      (when @hover
-       [:& fcc/flex-display-pill
+       [:> fcc/flex-display-pill
         {:height pill-height
          :width pill-width
          :font-size (/ fcc/font-size zoom)
@@ -236,7 +236,7 @@
   (when shape
     [:g.measurement-gaps {:pointer-events "none"}
      [:g.hover-shapes
-      [:& margin-rects
+      [:> margin-rects
        {:shape shape
         :frame parent
         :zoom zoom

--- a/frontend/src/app/main/ui/flex_controls/padding.cljs
+++ b/frontend/src/app/main/ui/flex_controls/padding.cljs
@@ -243,7 +243,7 @@
 
     [:g.paddings {:pointer-events "visible"}
      (for [[padding-num rect-data] padding-rect-data]
-       [:& padding-display
+       [:> padding-display
         {:key (:key rect-data)
          :frame-id frame-id
          :zoom zoom
@@ -264,7 +264,7 @@
          :rect-data rect-data}])
 
      (when @hover
-       [:& fcc/flex-display-pill
+       [:> fcc/flex-display-pill
         {:height pill-height
          :width pill-width
          :font-size (/ fcc/font-size zoom)
@@ -279,7 +279,7 @@
   (when frame
     [:g.measurement-gaps {:pointer-events "none"}
      [:g.hover-shapes
-      [:& padding-rects
+      [:> padding-rects
        {:frame frame
         :zoom zoom
         :alt? alt?

--- a/frontend/src/app/main/ui/inspect/selection_feedback.cljs
+++ b/frontend/src/app/main/ui/inspect/selection_feedback.cljs
@@ -63,7 +63,7 @@
     (when (d/not-empty? selected-shapes)
       [:g.selection-feedback {:pointer-events "none"}
        [:g.selected-shapes
-        [:& selection-rect {:selrect selrect :zoom zoom}]
+        [:> selection-rect {:selrect selrect :zoom zoom}]
         [:> size-display* {:selrect selrect :zoom zoom}]]
 
        [:> measurement* {:bounds (assoc size :x 0 :y 0)

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -274,7 +274,7 @@
            [:> style-box* {:panel panel}
             [:div color-space]])])]
      [:div {:class (stl/css :exports-wrapper)}
-      [:& exports/exports
+      [:> exports/exports
        {:shapes shapes
         :type type
         :page-id page-id

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -356,7 +356,7 @@
     (if (and (some? thumbnail-uri)
              (or (contains? cf/flags :component-thumbnails)
                  wasm?))
-      [:& component-svg-thumbnail
+      [:> component-svg-thumbnail
        {:thumbnail-uri thumbnail-uri
         :class class
         :on-error on-error
@@ -364,7 +364,7 @@
         :objects (:objects container)
         :show-grids? true}]
 
-      [:& component-svg
+      [:> component-svg
        {:root-shape root-shape
         :class class
         :objects (:objects container)

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs
@@ -163,8 +163,8 @@
                  :on-click modal/hide!} deprecated-icon/close]]
 
       [:div {:class (stl/css :modal-content)}
-       [:& fm/form {:form form :on-submit on-accept}
-        [:& fm/input {:name :name
+       [:> fm/form {:form form :on-submit on-accept}
+        [:> fm/input {:name :name
                       :class (stl/css :input-wrapper)
                       :auto-focus? true
                       :label (tr "workspace.assets.group-name")

--- a/frontend/src/app/main/ui/workspace/sidebar/debug_shape_info.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/debug_shape_info.cljs
@@ -87,19 +87,19 @@
       [:div {:class (stl/css :cell-shape)}
        (if (empty? (:shapes cell))
          [:div "<empty>"]
-         [:& shape-link {:id (first (:shapes cell)) :objects objects}])]])])
+         [:> shape-link {:id (first (:shapes cell)) :objects objects}])]])])
 
 (mf/defc debug-shape-attr
   [{:keys [attr value objects]}]
 
   (case (get custom-renderer attr)
     :shape-link
-    [:& shape-link {:id value :objects objects}]
+    [:> shape-link {:id value :objects objects}]
 
     :shape-list
     [:div {:class (stl/css :shape-list)}
      (for [id value]
-       [:& shape-link {:key (dm/str "child-" id)
+       [:> shape-link {:key (dm/str "child-" id)
                        :id id :objects objects}])]
 
     :matrix-render
@@ -114,7 +114,7 @@
        [:div {:key (dm/str "point-" idx)} (dm/fmt "(%, %)" (:x point) (:y point))])]
 
     :cells-render
-    [:& cells-render {:cells value :objects objects}]
+    [:> cells-render {:cells value :objects objects}]
 
     [:div {:class (stl/css :attrs-container-value)} (str value)]))
 
@@ -147,4 +147,4 @@
                         :key (dm/str "att-" idx "-" attr)}
                   [:div {:class (stl/css :attrs-container-name)} (d/name attr)]
 
-                  [:& debug-shape-attr {:attr attr :value value :objects objects}]])))]]))]))
+                  [:> debug-shape-attr {:attr attr :value value :objects objects}]])))]]))]))


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates a layout, inspect, and workspace-sidebar batch from legacy Rumext `[:& ...]` component call syntax to modern `[:> ...]` syntax.

- Updates flex gap, margin, and padding overlay callsites.
- Updates inspect selection feedback/styles callsites.
- Updates workspace sidebar assets and debug shape info callsites.
- Keeps the batch non-overlapping with currently open PR files.

### Steps to reproduce 

1. Open workspace flex gap/margin/padding controls and inspect panel style exports.
2. Open sidebar asset sections, asset group rename, and debug shape info panels.
3. Verify the migrated controls and nested components still render and respond as before.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/flex_controls/gap.cljs src/app/main/ui/flex_controls/margin.cljs src/app/main/ui/flex_controls/padding.cljs src/app/main/ui/inspect/selection_feedback.cljs src/app/main/ui/inspect/styles.cljs src/app/main/ui/workspace/sidebar/assets/common.cljs src/app/main/ui/workspace/sidebar/assets/groups.cljs src/app/main/ui/workspace/sidebar/debug_shape_info.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/flex_controls/gap.cljs src/app/main/ui/flex_controls/margin.cljs src/app/main/ui/flex_controls/padding.cljs src/app/main/ui/inspect/selection_feedback.cljs src/app/main/ui/inspect/styles.cljs src/app/main/ui/workspace/sidebar/assets/common.cljs src/app/main/ui/workspace/sidebar/assets/groups.cljs src/app/main/ui/workspace/sidebar/debug_shape_info.cljs`
- `git diff --check`