### PR TITLE
:recycle: Migrate workspace menu callsites syntax

### DIFF
--- a/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
@@ -335,7 +335,7 @@
                  :style {"--position" (dm/str (* offset 100) "%")}}]])]]
 
      [:div {:class (stl/css :gradient-options)}
-      [:& select
+      [:> select
        {:default-value type
         :options [{:value :linear-gradient :label "Linear"}
                   {:value :radial-gradient :label "Radial"}]

--- a/frontend/src/app/main/ui/workspace/shapes/text/viewport_texts_html.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/viewport_texts_html.cljs
@@ -191,7 +191,7 @@
 
     [:.text-changes-renderer
      (for [{:keys [id] :as shape} changed-texts]
-       [:& text-container {:key (dm/str "text-container-" id)
+       [:> text-container {:key (dm/str "text-container-" id)
                            :shape shape
                            :on-update handle-update-shape}])]))
 
@@ -223,7 +223,7 @@
 
     [:.text-changes-renderer
      (for [{:keys [id] :as shape} changed-texts]
-       [:& text-container {:key (dm/str "text-container-" id)
+       [:> text-container {:key (dm/str "text-container-" id)
                            :shape shape
                            :on-update handle-update-shape}])]))
 
@@ -271,7 +271,7 @@
      (fn []
        #(st/emit! (dwt/remove-text-modifier (:id shape)))))
 
-    [:& text-container {:shape shape
+    [:> text-container {:shape shape
                         :on-update handle-update-shape}]))
 
 (defn check-props
@@ -334,7 +334,7 @@
 
     [:*
      (when editing-shape
-       [:& viewport-text-editing {:shape editing-shape}])
+       [:> viewport-text-editing {:shape editing-shape}])
 
-     [:& text-modifiers-renderer {:text-shapes text-shapes-modifiers}]
-     [:& text-changes-renderer {:text-shapes text-shapes-changes}]]))
+     [:> text-modifiers-renderer {:text-shapes text-shapes-modifiers}]
+     [:> text-changes-renderer {:text-shapes text-shapes-changes}]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -787,20 +787,20 @@
                         :placeholder (str (tr "labels.search") " " (get-in libraries [current-library-id :name]))
                         :on-change on-search-term-change
                         :on-clear on-search-clear-click}]
-       [:& select {:default-value current-library-id
+       [:> select {:default-value current-library-id
                    :options libraries-options
                    :on-change on-library-change}]]
 
       [:div  {:class (stl/css :swap-library)}
        [:div {:class (stl/css :swap-library-title)}
         [:div {:class (stl/css :swap-library-name)} current-lib-name]
-        [:& radio-buttons {:selected (if (:listing-thumbs? filters) "grid" "list")
+        [:> radio-buttons {:selected (if (:listing-thumbs? filters) "grid" "list")
                            :on-change toggle-list-style
                            :name "swap-listing-style"}
-         [:& radio-button {:icon i/view-as-list
+         [:> radio-button {:icon i/view-as-list
                            :value "list"
                            :id "swap-opt-list"}]
-         [:& radio-button {:icon i/flex-grid
+         [:> radio-button {:icon i/flex-grid
                            :value "grid"
                            :id "swap-opt-grid"}]]]
 
@@ -902,7 +902,7 @@
                   :on-click on-menu-click}
          [:> icon* {:icon-id i/menu}]]
 
-        [:& dropdown {:show menu-open?
+        [:> dropdown {:show menu-open?
                       :on-close on-menu-close}
          [:ul {:class (stl/css-case :pill-actions-dropdown true
                                     :extended subtext)}

--- a/frontend/src/app/main/ui/workspace/sidebar/versions.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/versions.cljs
@@ -205,7 +205,7 @@
                      :on-blur-input on-name-input-blur
                      :on-key-down-input on-name-input-key-down}]
 
-     [:& dropdown {:show @show-menu?
+     [:> dropdown {:show @show-menu?
                    :on-close on-close-menu}
       (let [current-user-id  (:id current-profile)
             locked-by-id     (:locked-by entry)
@@ -297,7 +297,7 @@
        :snapshots (mapv :created-at (:snapshots entry))
        :on-menu-click on-open-snapshot-menu}]
 
-     [:& dropdown {:show (some? @open-menu*)
+     [:> dropdown {:show (some? @open-menu*)
                    :on-close #(reset! open-menu* nil)}
       [:ul {:class (stl/css :version-options-dropdown)
             :style {"--offset" (dm/str (:offset @open-menu*) "px")}}
@@ -402,7 +402,7 @@
       (st/emit! (dwv/init-versions-state)))
 
     [:div {:class (stl/css :version-toolbox)}
-     [:& select
+     [:> select
       {:default-value :all
        :aria-label (tr "workspace.versions.filter.label")
        :options options

--- a/frontend/src/app/main/ui/workspace/text_palette_ctx_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/text_palette_ctx_menu.cljs
@@ -18,7 +18,7 @@
   [{:keys [show-menu close-menu on-select-palette selected]}]
   (let [typographies (mf/deref refs/workspace-file-typography)
         libraries    (mf/deref refs/libraries)]
-    [:& dropdown {:show show-menu
+    [:> dropdown {:show show-menu
                   :on-close close-menu}
      [:ul {:class (stl/css :text-context-menu)}
       (for [[idx cur-library] (map-indexed vector (vals libraries))]

--- a/frontend/src/app/main/ui/workspace/tokens/management/node_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/node_context_menu.cljs
@@ -80,7 +80,7 @@
     (when is-open?
       (mf/portal
        (mf/html
-        [:& dropdown {:show is-open?
+        [:> dropdown {:show is-open?
                       :on-close #(st/emit! (dwtl/assign-token-node-context-menu nil))}
          [:div {:class (stl/css :token-node-context-menu)
                 :data-testid "tokens-context-menu-for-token-node"

--- a/frontend/src/app/main/ui/workspace/tokens/sets/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/context_menu.cljs
@@ -79,7 +79,7 @@
         on-close
         (mf/use-fn #(st/emit! (dwtl/assign-token-set-context-menu nil)))]
 
-    [:& dropdown {:show (some? position)
+    [:> dropdown {:show (some? position)
                   :on-close on-close}
      [:div {:class (stl/css :token-set-context-menu)
             :data-testid "tokens-context-menu-for-set"

--- a/frontend/src/app/main/ui/workspace/viewport/drawarea.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/drawarea.cljs
@@ -57,10 +57,10 @@
   [{:keys [shape zoom tool] :as props}]
   [:g.draw-area
    [:g {:style {:pointer-events "none"}}
-    [:& shapes/shape-wrapper {:shape shape}]]
+    [:> shapes/shape-wrapper {:shape shape}]]
 
    (case tool
      :path      [:> path-draw-area* props]
-     :curve     [:& path-shape {:shape shape :zoom zoom}]
+     :curve     [:> path-shape {:shape shape :zoom zoom}]
      #_:default [:> generic-draw-area* props])])
 


### PR DESCRIPTION
### Related Ticket

Part of https://github.com/penpot/penpot/issues/9260

### Summary

Migrates a workspace menus/text batch from legacy Rumext `[:& ...]` component call syntax to modern `[:> ...]` syntax.

- Updates component sidebar menu and versions dropdown/select callsites.
- Updates text palette and token context menu dropdown callsites.
- Updates gradient selector, viewport text renderers, and draw area shape callsites.
- Keeps the batch non-overlapping with currently open PR files.

### Steps to reproduce 

1. Open workspace component menu, version history menu, text palette menu, and token context menus.
2. Edit gradients, text shapes, and draw/create shapes in the viewport.
3. Verify the migrated dropdowns, selectors, text renderers, and draw areas still render and respond as before.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

Verification:

- `PATH=/tmp/penpot-tools/bin:$PATH cljfmt check src/app/main/ui/workspace/sidebar/options/menus/component.cljs src/app/main/ui/workspace/sidebar/versions.cljs src/app/main/ui/workspace/text_palette_ctx_menu.cljs src/app/main/ui/workspace/tokens/management/node_context_menu.cljs src/app/main/ui/workspace/tokens/sets/context_menu.cljs src/app/main/ui/workspace/colorpicker/gradients.cljs src/app/main/ui/workspace/shapes/text/viewport_texts_html.cljs src/app/main/ui/workspace/viewport/drawarea.cljs`
- `PATH=/tmp/penpot-tools/bin:$PATH clj-kondo --parallel --lint src/app/main/ui/workspace/sidebar/options/menus/component.cljs src/app/main/ui/workspace/sidebar/versions.cljs src/app/main/ui/workspace/text_palette_ctx_menu.cljs src/app/main/ui/workspace/tokens/management/node_context_menu.cljs src/app/main/ui/workspace/tokens/sets/context_menu.cljs src/app/main/ui/workspace/colorpicker/gradients.cljs src/app/main/ui/workspace/shapes/text/viewport_texts_html.cljs src/app/main/ui/workspace/viewport/drawarea.cljs`
- `git diff --check`