### PR TITLE
:recycle: Migrate app.main.render components to modern syntax

### DIFF
--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -60,7 +60,7 @@
 (def ^:const viewbox-decimal-precision 3)
 (def ^:private default-color clr/canvas)
 
-(mf/defc background
+(mf/defc background*
   [{:keys [vbox color]}]
   [:rect
    {:x (:x vbox)
@@ -209,9 +209,9 @@
 
     (reduce updt-fn objects mod-ids)))
 
-(mf/defc page-svg
+(mf/defc page-svg*
   {::mf/wrap [mf/memo]}
-  [{:keys [data use-thumbnails embed include-metadata aspect-ratio] :as props
+  [{:keys [data use-thumbnails embed include-metadata aspect-ratio]
     :or {embed false include-metadata false}}]
   (let [objects (:objects data)
         shapes  (cfh/get-immediate-children objects)
@@ -250,8 +250,7 @@
           [:& shape-wrapper {:shape item
                              :key (:id item)}])]]]]))
 
-(mf/defc frame-imposter
-  {::mf/wrap-props false}
+(mf/defc frame-imposter*
   [{:keys [objects frame vbox x y width height background]}]
   (let [shape-wrapper (shape-wrapper-factory objects)]
     [:& (mf/provider muc/render-thumbnails) {:value false}
@@ -268,9 +267,9 @@
 
 ;; Component that serves for render frame thumbnails, mainly used in
 ;; the viewer and inspector
-(mf/defc frame-svg
+(mf/defc frame-svg*
   {::mf/wrap [mf/memo]}
-  [{:keys [objects frame zoom use-thumbnails aspect-ratio background-color] :or {zoom 1} :as props}]
+  [{:keys [objects frame zoom use-thumbnails aspect-ratio background-color] :or {zoom 1}}]
   (let [frame-id         (:id frame)
 
         bgcolor (d/nilv background-color default-color)
@@ -329,8 +328,7 @@
             :fill "none"}
       [:& shape-wrapper {:shape frame}]]]))
 
-(mf/defc empty-grids
-  {::mf/wrap-props false}
+(mf/defc empty-grids*
   [{:keys [root-shape-id objects]}]
   (let [empty-grids
         (->> (cons root-shape-id (cfh/get-children-ids objects root-shape-id))
@@ -342,9 +340,9 @@
 
 ;; Component for rendering a thumbnail of a single componenent. Mainly
 ;; used to render thumbnails on assets panel.
-(mf/defc component-svg
+(mf/defc component-svg*
   {::mf/wrap [mf/memo #(mf/deferred % ts/idle-then-raf)]}
-  [{:keys [objects root-shape show-grids? is-hidden zoom class] :or {zoom 1} :as props}]
+  [{:keys [objects root-shape show-grids? is-hidden zoom class] :or {zoom 1}}]
   (when root-shape
     (let [root-shape-id (:id root-shape)
           include-metadata (mf/use-ctx export/include-metadata-ctx)
@@ -394,12 +392,12 @@
             [:& root-shape-wrapper {:shape root-shape' :view-box vbox}]]]
 
           (when show-grids?
-            [:& empty-grids {:root-shape-id root-shape-id :objects objects}])])])))
+            [:> empty-grids* {:root-shape-id root-shape-id :objects objects}])])])))
 
-(mf/defc component-svg-thumbnail
+(mf/defc component-svg-thumbnail*
   {::mf/wrap [mf/memo #(mf/deferred % ts/idle-then-raf)]}
   [{:keys [thumbnail-uri on-error show-grids? class
-           objects root-shape zoom] :or {zoom 1} :as props}]
+           objects root-shape zoom] :or {zoom 1}}]
 
   (when root-shape
     (let [root-shape-id (:id root-shape)
@@ -444,13 +442,12 @@
                 :loading "lazy"
                 :decoding "async"}]
        (when show-grids?
-         [:& empty-grids {:root-shape-id root-shape-id :objects objects}])])))
+         [:> empty-grids* {:root-shape-id root-shape-id :objects objects}])])))
 
-(mf/defc object-svg
+(mf/defc object-svg*
   {::mf/wrap [mf/memo]}
   [{:keys [objects object-id embed skip-children]
-    :or {embed false}
-    :as props}]
+    :or {embed false}}]
   (let [object  (get objects object-id)
         object (cond-> object
                  (:hide-fill-on-export object)
@@ -484,9 +481,9 @@
        [:> ff/fontfaces-style* {:fonts fonts}]
        [:& shape-wrapper {:shape object}]]]]))
 
-(mf/defc objects-svg
+(mf/defc objects-svg*
   {::mf/wrap [mf/memo]}
-  [{:keys [objects object-ids embed] :or {embed false} :as props}]
+  [{:keys [objects object-ids embed] :or {embed false}}]
   (let [shapes
         (->> object-ids
              (keep #(get objects %))
@@ -550,9 +547,9 @@
         (js/console.error "Error initializing canvas context:" e)
         false))))
 
-(mf/defc object-wasm
+(mf/defc object-wasm*
   {::mf/wrap [mf/memo]}
-  [{:keys [objects object-id skip-children scale on-render] :as props}]
+  [{:keys [objects object-id skip-children scale on-render]}]
   (let [object  (get objects object-id)
         object (cond-> object
                  (:hide-fill-on-export object)
@@ -585,8 +582,8 @@
 ;; SPRITES (DEBUG)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(mf/defc component-symbol
-  [{:keys [component] :as props}]
+(mf/defc component-symbol*
+  [{:keys [component]}]
   (let [name       (:name component)
         path       (:path component)
         root-id    (or (:main-instance-id component)
@@ -635,8 +632,7 @@
           :group [:& group-wrapper {:shape root-shape :view-box vbox}]
           :frame [:& frame-wrapper {:shape root-shape :view-box vbox}])]])))
 
-(mf/defc components-svg
-  {::mf/wrap-props false}
+(mf/defc components-svg*
   [{:keys [data children embed include-metadata deleted?]}]
   (let [components (if (not deleted?)
                      (ctkl/components-seq data)
@@ -652,7 +648,7 @@
        [:defs
         (for [component components]
           (let [component (ctf/load-component-objects data component)]
-            [:& component-symbol {:key (dm/str (:id component)) :component component}]))]
+            [:> component-symbol* {:key (dm/str (:id component)) :component component}]))]
 
        children]]]))
 
@@ -705,7 +701,7 @@
    (->> (rx/of data)
         (rx/map
          (fn [data]
-           (let [elem (mf/element page-svg #js {:data data :embed true :include-metadata true})]
+           (let [elem (mf/element page-svg* #js {:data data :embed true :include-metadata true})]
              (rds/renderToStaticMarkup elem)))))))
 
 (defn render-components
@@ -727,7 +723,7 @@
      (->> (rx/of data)
           (rx/map
            (fn [data]
-             (let [elem (mf/element components-svg
+             (let [elem (mf/element components-svg*
                                     #js {:data data
                                          :embed true
                                          :include-metadata true
@@ -758,7 +754,7 @@
 
            data           (with-redefs [cfg/public-uri cfg/rasterizer-uri]
                             (rds/renderToStaticMarkup
-                             (mf/element frame-imposter
+                             (mf/element frame-imposter*
                                          #js {:objects objects
                                               :frame shape
                                               :vbox viewbox

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -174,8 +174,8 @@
               (let [root-id (:main-instance-id component)]
                 [:div {:class (stl/css :asset-list-item)
                        :key (str "assets-component-" (:id component))}
-                 [:& render/component-svg {:root-shape (get-in component [:objects root-id])
-                                           :objects (:objects component)}] ;; Components in the summary come loaded with objects, even in v2
+                 [:> render/component-svg* {:root-shape (get-in component [:objects root-id])
+                                            :objects (:objects component)}] ;; Components in the summary come loaded with objects, even in v2
                  [:div {:class (stl/css :name-block)}
                   [:span {:class (stl/css :item-name)
                           :title (:name component)}

--- a/frontend/src/app/main/ui/viewer/thumbnails.cljs
+++ b/frontend/src/app/main/ui/viewer/thumbnails.cljs
@@ -98,11 +98,11 @@
               :on-click #(on-click % index)}
      [:div {:class (stl/css-case :thumbnail-preview true
                                  :selected is-selected)}
-      [:& render/frame-svg {:frame (-> frame
-                                       (assoc :thumbnail (get thumbnail-data (dm/str page-id (:id frame))))
-                                       (assoc :children-bounds children-bounds))
-                            :objects objects
-                            :use-thumbnails true}]]
+      [:> render/frame-svg* {:frame (-> frame
+                                        (assoc :thumbnail (get thumbnail-data (dm/str page-id (:id frame))))
+                                        (assoc :children-bounds children-bounds))
+                             :objects objects
+                             :use-thumbnails true}]]
      [:div {:class (stl/css :thumbnail-info)
             :title (:name frame)}
       (:name frame)]]))

--- a/frontend/src/app/main/ui/workspace/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/libraries.cljs
@@ -25,7 +25,7 @@
    [app.main.data.workspace.colors :as mdc]
    [app.main.data.workspace.libraries :as dwl]
    [app.main.refs :as refs]
-   [app.main.render :refer [component-svg]]
+   [app.main.render :refer [component-svg*]]
    [app.main.store :as st]
    [app.main.ui.components.color-bullet :as cb]
    [app.main.ui.components.link-button :as lb]
@@ -555,9 +555,9 @@
                     (let [component (ctf/load-component-objects (:data library) component)
                           root-shape (ctf/get-component-root (:data library) component)]
                       [:*
-                       [:& component-svg {:root-shape root-shape
-                                          :class (stl/css :component-svg)
-                                          :objects (:objects component)}]
+                       [:> component-svg* {:root-shape root-shape
+                                           :class (stl/css :component-svg)
+                                           :objects (:objects component)}]
                        [:div {:class (stl/css :name-block)}
                         [:span {:class (stl/css :item-name)
                                 :title (:name component)}

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -27,7 +27,7 @@
    [app.main.data.workspace.variants :as dwv]
    [app.main.features :as features]
    [app.main.refs :as refs]
-   [app.main.render :refer [component-svg component-svg-thumbnail]]
+   [app.main.render :refer [component-svg* component-svg-thumbnail*]]
    [app.main.store :as st]
    [app.main.ui.components.context-menu-a11y :refer [context-menu*]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
@@ -356,7 +356,7 @@
     (if (and (some? thumbnail-uri)
              (or (contains? cf/flags :component-thumbnails)
                  wasm?))
-      [:& component-svg-thumbnail
+      [:> component-svg-thumbnail*
        {:thumbnail-uri thumbnail-uri
         :class class
         :on-error on-error
@@ -364,7 +364,7 @@
         :objects (:objects container)
         :show-grids? true}]
 
-      [:& component-svg
+      [:> component-svg*
        {:root-shape root-shape
         :class class
         :objects (:objects container)

--- a/frontend/src/app/render.cljs
+++ b/frontend/src/app/render.cljs
@@ -79,7 +79,7 @@
 
     (when objects
       (if wasm
-        [:& render/object-wasm
+        [:> render/object-wasm*
          {:objects objects
           :object-id object-id
           :embed embed
@@ -87,7 +87,7 @@
           :skip-children skip-children}]
 
         [:& (mf/provider ctx/is-render?) {:value true}
-         [:& render/object-svg
+         [:> render/object-svg*
           {:objects objects
            :object-id object-id
            :embed embed
@@ -108,7 +108,7 @@
       (for [object-id (take @limit object-ids)]
         (let [objects (render/adapt-objects-for-shape objects object-id)]
           (if wasm
-            [:& render/object-wasm
+            [:> render/object-wasm*
              {:objects objects
               :key (str object-id)
               :object-id object-id
@@ -118,7 +118,7 @@
               :on-render cb-fn}]
 
             [:& (mf/provider ctx/is-render?) {:value true}
-             [:& render/object-svg
+             [:> render/object-svg*
               {:objects objects
                :key (str object-id)
                :object-id object-id
@@ -247,7 +247,7 @@
              [:a {:on-click on-click} (:name data)]]))]
 
        [:main
-        [:& render/components-svg
+        [:> render/components-svg*
          {:data (:data file)
           :embed embed}
 

--- a/frontend/src/app/util/code_gen/markup_svg.cljs
+++ b/frontend/src/app/util/code_gen/markup_svg.cljs
@@ -15,7 +15,7 @@
   [objects shape]
   (rds/renderToStaticMarkup
    (mf/element
-    render/object-svg
+    render/object-svg*
     #js {:objects objects
          :object-id (-> shape :id)})))
 
@@ -23,7 +23,7 @@
   [objects shapes]
   (rds/renderToStaticMarkup
    (mf/element
-    render/objects-svg
+    render/objects-svg*
     #js {:objects objects
          :object-ids (mapv :id shapes)})))
 

--- a/frontend/src/app/worker/thumbnails.cljs
+++ b/frontend/src/app/worker/thumbnails.cljs
@@ -77,18 +77,18 @@
             frame    (some->> page :thumbnail-frame-id (get objects))
             background-color (:background page)
             element  (if frame
-                       (mf/element render/frame-svg #js
-                                                     {:objects objects
-                                                      :frame frame
-                                                      :use-thumbnails true
-                                                      :background-color background-color
-                                                      :aspect-ratio (/ 2 3)})
+                       (mf/element render/frame-svg* #js
+                                                      {:objects objects
+                                                       :frame frame
+                                                       :use-thumbnails true
+                                                       :background-color background-color
+                                                       :aspect-ratio (/ 2 3)})
 
-                       (mf/element render/page-svg #js
-                                                    {:data page
-                                                     :use-thumbnails true
-                                                     :embed true
-                                                     :aspect-ratio (/ 2 3)}))
+                       (mf/element render/page-svg* #js
+                                                     {:data page
+                                                      :use-thumbnails true
+                                                      :embed true
+                                                      :aspect-ratio (/ 2 3)}))
             data     (rds/renderToStaticMarkup element)]
         {:data data
          :fonts @fonts/loaded-hints


### PR DESCRIPTION
### Related Ticket

Refs #9260

### Summary

Migrates the 12 `mf/defc` components in `frontend/src/app/main/render.cljs`
— the central SVG rendering layer used by the workspace canvas, viewer, exporter, dashboard component thumbnails, libraries panel, and worker thumbnail generation — to the modern `mf/defc name*` syntax described in [`frontend/AGENTS.md`](https://github.com/penpot/penpot/blob/develop/frontend/AGENTS.md#ui-components-react--rumext-mfdefc).

This is one of the incremental refactors requested by #9260. Modern syntax avoids per-render JS→CLJS prop-conversion overhead, which matters in this hot path because these components run for every page, frame, and component thumbnail render.

**Components migrated (12):**

| Old name                     | New name                       |
|------------------------------|--------------------------------|
| `background`                 | `background*`                  |
| `page-svg`                   | `page-svg*`                    |
| `frame-imposter`             | `frame-imposter*`              |
| `frame-svg`                  | `frame-svg*`                   |
| `empty-grids`                | `empty-grids*`                 |
| `component-svg`              | `component-svg*`               |
| `component-svg-thumbnail`    | `component-svg-thumbnail*`     |
| `object-svg`                 | `object-svg*`                  |
| `objects-svg`                | `objects-svg*`                 |
| `object-wasm`                | `object-wasm*`                 |
| `component-symbol`           | `component-symbol*`            |
| `components-svg`             | `components-svg*`              |

**Other cleanups bundled with the rename:**

- Dropped `{::mf/wrap-props false}` from `frame-imposter*`, `empty-grids*`, and `components-svg*` (the marker is redundant once  the `*` suffix is applied).
- Dropped unused `:as props` destructure bindings from `page-svg*`, `frame-svg*`, `component-svg*`, `component-svg-thumbnail*`, `object-svg*`, `objects-svg*`, `object-wasm*`, and `component-symbol*`.

**Callsite updates (8 files total):**

- `frontend/src/app/main/render.cljs` — 3 internal hiccup callsites  (`empty-grids*` ×2, `component-symbol*`) and 3 `mf/element` calls  (`page-svg*`, `components-svg*`, `frame-imposter*`).
- `frontend/src/app/render.cljs` — 5 hiccup callsites in the exporter entry point.
- `frontend/src/app/main/ui/dashboard/grid.cljs` — 1 callsite  (`component-svg*` for asset-list thumbnails).
- `frontend/src/app/main/ui/workspace/libraries.cljs` — `:refer`  import + 1 callsite (`component-svg*`).
- `frontend/src/app/main/ui/viewer/thumbnails.cljs` — 1 callsite  (`frame-svg*`).
- `frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs` —  `:refer` import + 2 callsites (`component-svg*`,
  `component-svg-thumbnail*`).
- `frontend/src/app/util/code_gen/markup_svg.cljs` — 2 `mf/element`  references (`object-svg*`, `objects-svg*`).
- `frontend/src/app/worker/thumbnails.cljs` — 2 `mf/element`  references (`frame-svg*`, `page-svg*`).

**Preserved:** all `::mf/wrap [mf/memo]` and `::mf/wrap [mf/memo #(mf/deferred % ts/idle-then-raf)]` markers (they
control memoization, not props handling), the `set! wasm.api/shape-wrapper-factory shape-wrapper-factory` registration,
all factory functions (`shape-wrapper-factory`, `frame-wrapper-factory`, `group-wrapper-factory`, `bool-wrapper-factory`, `svg-raw-wrapper-factory`), and all helper functions.

### Steps to reproduce

To verify the migration:

1. **Workspace canvas** — open a file with a frame containing nested  shapes; confirm shapes render correctly and selection/hovering behaves as before.
2. **Viewer thumbnails** — open the viewer for a multi-frame file and confirm the frame-thumbnail strip renders and is clickable.
3. **Dashboard component thumbnails** — visit the project dashboard and confirm component thumbnails render in the asset-list summary.
4. **Libraries panel** — open Workspace > Libraries; confirm the "library updates available" panel renders component thumbnails.
5. **Assets sidebar** — open Workspace > Assets > Components; confirm both the WASM-rendered thumbnails (when the `:component-thumbnails` flag is on) and the SVG fallback render.
6. **Inspect tab — code generation** — select shapes and switch to the Inspect > Code tab; confirm SVG markup is generated correctly for single and multi-shape selections.
7. **Worker page-thumbnail generation** — trigger a page thumbnail refresh (e.g. by editing a frame) and confirm the resulting
   thumbnail renders without errors in the file's grid view.
8. **Exporter** — export a frame as SVG/PNG; confirm the exported markup matches the canvas.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. <!-- not applicable: no UI-visible change -->
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable. <!-- not applicable: pure refactor -->
- [ ] Refactor any modified SCSS files following the refactor guide. <!-- not applicable: no SCSS changes -->
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable. <!-- not applicable: no user-facing change -->
