### PR TITLE
:bug: Fix plugin API token application defects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Harden Nginx responses with standard security headers and hide upstream `X-Powered-By` headers
 - Expose Source Sans Pro semibold (weight 600) variants in the builtin fonts list, matching the bundled font assets and CSS @font-face declarations [Github #7378](https://github.com/penpot/penpot/issues/7378)
 - Fix plugin API `shape.fills` and `shape.strokes` arrays being read-only [Github #8357](https://github.com/penpot/penpot/issues/8357)
+- Fix plugin API `token.applyToShapes()` failing with "Doesn't support name: 0" and `shape.tokens` per-property assignment being silently discarded [Github #9561](https://github.com/penpot/penpot/issues/9561)
 - Fix `get-profile` masking transient DB errors as anonymous user (by @jack-stormentswe) [Github #9253](https://github.com/penpot/penpot/issues/9253)
 - Fix `Ctrl+'` "Show guides" shortcut on non-US keyboard layouts by matching the physical key location (by @RenzoMXD) [Github #8423](https://github.com/penpot/penpot/issues/8423)
 - Fix lost-update race on `team.features` during concurrent file creation (by @web-dev0521) [Github #9197](https://github.com/penpot/penpot/issues/9197)

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -31,6 +31,7 @@
    [app.common.types.shape.radius :as ctsr]
    [app.common.types.shape.shadow :as ctss]
    [app.common.types.text :as txt]
+   [app.common.types.tokens-lib :as ctob]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.exports.wasm :as wasm.exports]
@@ -1357,12 +1358,52 @@
               (let [applied-tokens
                     (-> (u/locate-shape file-id page-id id)
                         (get :applied-tokens)
-                        (applied-tokens-plugin->applied-tokens))]
-                (reduce
-                 (fn [acc [prop name]]
-                   (obj/set! acc (json/write-camel-key prop) name))
-                 #js {}
-                 applied-tokens)))}
+                        (applied-tokens-plugin->applied-tokens))
+
+                    target
+                    (reduce
+                     (fn [acc [prop name]]
+                       (obj/set! acc (json/write-camel-key prop) name))
+                     #js {}
+                     applied-tokens)]
+                ;; Wrap the plain object in a Proxy so that
+                ;; `shape.tokens.fill = "tokenName"` actually applies
+                ;; the token instead of silently failing (#9561).
+                ;; Reads continue to fall through to the underlying
+                ;; object built from the current shape state.
+                ;; The handler always returns `true` so strict-mode
+                ;; assignment from SES-sandboxed plugins doesn't throw
+                ;; a TypeError on invalid input. Validation failures are
+                ;; surfaced through the plugin's standard `u/not-valid`
+                ;; channel (console / throw-validation-errors flag).
+                (js/Proxy.
+                 target
+                 #js {:set
+                      (fn [target-obj prop value]
+                        (let [attr (token-attr-plugin->token-attr prop)
+                              tokens-lib (u/locate-tokens-lib file-id)
+                              token (when (and tokens-lib (string? value))
+                                      (-> (ctob/get-tokens-in-active-sets tokens-lib)
+                                          (get value)))]
+                          (cond
+                            (not (token-attr? prop))
+                            (u/not-valid plugin-id :tokens
+                                         (str "unknown token property: " prop))
+
+                            (nil? token)
+                            (u/not-valid plugin-id :tokens
+                                         (str "token not found in active sets: " value))
+
+                            :else
+                            (do
+                              (st/emit!
+                               (-> (dwta/toggle-token {:token token
+                                                       :attrs #{attr}
+                                                       :shape-ids [id]
+                                                       :expand-with-children false})
+                                   (se/add-event plugin-id)))
+                              (obj/set! target-obj prop value)))
+                          true))})))}
 
            :applyToken
            {:enumerable false

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -55,13 +55,16 @@
 
   Accepts either a Clojure keyword (the canonical form, e.g. `:r1`,
   `:fill`) or a string (the natural shape that arrives from a JS plugin
-  call such as `shape.applyToken(token, [\"fill\"])`). Converts strings
-  to keywords first, then maps verbose plugin-side aliases (e.g.
-  `:border-radius-top-left`) to their internal short form (e.g. `:r1`).
-  Inputs that are already in canonical form (`:r1`, `:fill`, `\"fill\"`,
-  …) pass through unchanged."
+  call such as `shape.applyToken(token, [\"fill\"])`). String input is
+  kebab-cased so that camelCase property names produced by the read
+  side of `shape.tokens` (e.g. `\"borderRadiusTopLeft\"` via
+  `json/write-camel-key`) round-trip correctly. After normalisation,
+  verbose plugin-side aliases (e.g. `:border-radius-top-left`) are
+  mapped to their internal short form (e.g. `:r1`). Inputs already in
+  canonical form (`:r1`, `:fill`, `\"fill\"`, …) pass through
+  unchanged."
   [k]
-  (let [k (cond-> k (string? k) keyword)]
+  (let [k (cond-> k (string? k) json/read-kebab-key)]
     (get map:token-attr-plugin->token-attr k k)))
 
 (defn applied-tokens-plugin->applied-tokens
@@ -203,11 +206,33 @@
 
     :applyToShapes
     {:enumerable false
-     :schema [:tuple
-              [:vector [:fn shape-proxy?]]
-              [:maybe [::sm/set [:and ::sm/keyword [:fn token-attr?]]]]]
+     ;; NOTE: We deliberately bypass the `:schema` coercion pipeline
+     ;; here. Validating shapes through `[:vector [:fn shape-proxy?]]`
+     ;; sent the JS array of hardened SES shape proxies through
+     ;; `json/->clj` and the malli json-transformer, which surfaced as a
+     ;; spurious validation failure. The error formatter then crashed
+     ;; with "Doesn't support name: 0" on the tuple-index path,
+     ;; obscuring the real cause and making the method completely
+     ;; unusable (#9561). Manual validation mirrors the pattern used by
+     ;; `penpot.selection` / `replaceColor` and works reliably for
+     ;; JS-array inputs.
      :fn (fn [shapes attrs]
-           (apply-token-to-shapes plugin-id file-id set-id id (map #(obj/get % "$id") shapes) attrs))}
+           (cond
+             (or (not (array? shapes)) (not (every? shape-proxy? shapes)))
+             (u/not-valid plugin-id :applyToShapes
+                          "shapes must be an array of shape proxies")
+
+             (and (some? attrs)
+                  (or (not (array? attrs))
+                      (not (every? token-attr? attrs))))
+             (u/not-valid plugin-id :applyToShapes
+                          "properties must be an array of token attribute names")
+
+             :else
+             (apply-token-to-shapes
+              plugin-id file-id set-id id
+              (map #(obj/get % "$id") shapes)
+              attrs)))}
 
     :applyToSelected
     {:enumerable false

--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -276,13 +276,29 @@
   (let [s (set values)]
     (if (= (count s) 1) (first s) "mixed")))
 
+(defn- format-field
+  "Render a schema error field path as a human-readable string.
+
+  Field comes from `interpret-schema-problem`. For map schemas it's a
+  keyword/string; for tuple/vector schemas it's an integer index (or a
+  vector of indices). Plain `(name x)` blows up on numbers with
+  \"Doesn't support name: 0\", masking the underlying validation
+  error — see #9561."
+  [field]
+  (cond
+    (keyword? field) (name field)
+    (string? field) field
+    (number? field) (str field)
+    (vector? field) (str/join "." (map format-field field))
+    :else (str field)))
+
 (defn error-messages
   [explain]
   (->> (:errors explain)
        (reduce csm/interpret-schema-problem {})
        #_(mapcat (comp seq val))     ;; FIXME: why is this for? it breaks the message
        (map (fn [[field {:keys [message]}]]
-              (tr "plugins.validation.message" (name field) message)))
+              (tr "plugins.validation.message" (format-field field) message)))
        (str/join ". ")))
 
 (defn handle-error

--- a/frontend/test/frontend_tests/plugins/tokens_test.cljs
+++ b/frontend/test/frontend_tests/plugins/tokens_test.cljs
@@ -6,10 +6,25 @@
 
 (ns frontend-tests.plugins.tokens-test
   (:require
+   [app.common.test-helpers.compositions :as ctho]
+   [app.common.test-helpers.files :as cthf]
+   [app.common.test-helpers.ids-map :as cthi]
+   [app.common.test-helpers.shapes :as cths]
+   [app.common.types.tokens-lib :as ctob]
+   [app.main.store :as st]
+   [app.plugins.shape :as pshape]
    [app.plugins.tokens :as ptok]
-   [cljs.test :as t :include-macros true]))
+   [app.plugins.utils :as putils]
+   [app.util.object :as obj]
+   [cljs.test :as t :include-macros true]
+   [frontend-tests.helpers.pages :as thp]
+   [frontend-tests.helpers.state :as ths]
+   [frontend-tests.helpers.wasm :as thw]
+   [frontend-tests.tokens.helpers.state :as tohs]
+   [potok.v2.core :as ptk]))
 
-;; Regression coverage for issue #9162.
+;; ---------------------------------------------------------------------
+;; Issue #9162 — `token-attr-plugin->token-attr` regression coverage.
 ;;
 ;; Plugin code calling `shape.applyToken(token, ["fill"])` or
 ;; `token.applyToShapes([rect], ["fill"])` from JavaScript supplies a JS
@@ -30,10 +45,6 @@
 ;;    a set of strings, after which the `[:and ::sm/keyword [:fn
 ;;    token-attr?]]` element schema coerces each string to a keyword and
 ;;    validates it.
-;;
-;; These helper-level tests pin the string-friendly conversion contract;
-;; the schema-level fix is covered by the existing plugin integration
-;; suite that exercises `applyToken` end-to-end.
 
 (t/deftest token-attr-plugin->token-attr-passes-canonical-form-through
   ;; Both already-canonical short names and unaliased names pass through
@@ -62,6 +73,14 @@
   (t/is (= :r1 (ptok/token-attr-plugin->token-attr "border-radius-top-left")))
   (t/is (= :m3 (ptok/token-attr-plugin->token-attr "margin-bottom-right"))))
 
+(t/deftest token-attr-plugin->token-attr-accepts-camelcase
+  ;; The read side of `shape.tokens` exposes property names as
+  ;; camelCase (via `json/write-camel-key`). For `shape.tokens.X = ...`
+  ;; to round-trip, the setter side must accept the same shape. (#9561)
+  (t/is (= :stroke-color (ptok/token-attr-plugin->token-attr "strokeColor")))
+  (t/is (= :r1 (ptok/token-attr-plugin->token-attr "borderRadiusTopLeft")))
+  (t/is (= :m3 (ptok/token-attr-plugin->token-attr "marginBottomRight"))))
+
 (t/deftest token-attr?-accepts-keyword-input
   (t/is (true? (boolean (ptok/token-attr? :fill))))
   (t/is (true? (boolean (ptok/token-attr? :stroke-color))))
@@ -80,3 +99,169 @@
   (t/is (false? (boolean (ptok/token-attr? :not-a-real-attr))))
   (t/is (false? (boolean (ptok/token-attr? "not-a-real-attr"))))
   (t/is (false? (boolean (ptok/token-attr? nil)))))
+
+;; ---------------------------------------------------------------------
+;; Issue #9561 — error formatter robustness.
+;;
+;; When a plugin schema validation fails at a positional path (tuple or
+;; vector), `interpret-schema-problem` builds a map keyed by integer
+;; indices. The legacy error formatter called `(name field)` on those
+;; integers and crashed with "Doesn't support name: 0". That secondary
+;; throw masked the real validation failure and was reported to plugin
+;; authors as the visible error.
+
+(t/deftest format-field-handles-keyword-string-number-and-path
+  ;; Direct coverage of the new `format-field` helper. Keywords/strings
+  ;; are unchanged; numbers stringify; vector paths are dotted.
+  (t/is (= "fill" (#'putils/format-field :fill)))
+  (t/is (= "color" (#'putils/format-field "color")))
+  (t/is (= "0" (#'putils/format-field 0)))
+  (t/is (= "1.2" (#'putils/format-field [1 2])))
+  (t/is (= "shapes.0" (#'putils/format-field [:shapes 0]))))
+
+(t/deftest error-messages-does-not-crash-on-integer-field
+  ;; Validation against `[:tuple ...]` produces errors with `:in [0]`.
+  ;; The old formatter called `(name 0)` on the field path and threw
+  ;; "Doesn't support name: 0" — the exact symptom users hit in #9561.
+  ;; We don't care about the exact message; we just want a string back.
+  (let [explain {:errors [{:schema [:tuple :keyword]
+                           :in [0]
+                           :value "bad"}]}]
+    (t/is (string? (putils/error-messages explain)))))
+
+;; ---------------------------------------------------------------------
+;; Issue #9561 — end-to-end coverage for `token.applyToShapes` and the
+;; `shape.tokens` setter.
+;;
+;; Async tests using `tohs/run-store-async` rely on the wasm mocks
+;; persisting until `done` fires; the synchronous `with-wasm-mocks*`
+;; helper would tear them down too early, so we install them via a
+;; fixture instead (see helpers/wasm.cljs).
+
+(t/use-fixtures :each
+  {:before (fn []
+             (thp/reset-idmap!)
+             (thw/setup-wasm-mocks!))
+   :after  thw/teardown-wasm-mocks!})
+
+(def color-token
+  {:name "colors.primary"
+   :value "#3525CD"
+   :type :color})
+
+(defn setup-tokens-file
+  []
+  (-> (cthf/sample-file :file1 :page-label :page1)
+      (ctho/add-rect :rect-1)
+      (assoc-in [:data :tokens-lib]
+                (-> (ctob/make-tokens-lib)
+                    (ctob/add-theme (ctob/make-token-theme :name "Theme A" :sets #{"Set A"}))
+                    (ctob/set-active-themes #{"/Theme A"})
+                    (ctob/add-set (ctob/make-token-set :id (cthi/new-id! :set-a)
+                                                       :name "Set A"))
+                    (ctob/add-token (cthi/id :set-a)
+                                    (ctob/make-token color-token))))))
+
+(defn rect-from-state
+  [state file rect-id]
+  (let [page-id (cthf/current-page-id file)]
+    (get-in state
+            [:files (:id file)
+             :data :pages-index page-id
+             :objects rect-id])))
+
+(defn- trigger
+  "Wrap a side-effecting plugin call as a ptk EffectEvent so it can be
+  fed through `run-store-async` and have its emitted events tracked."
+  [f]
+  (ptk/reify ::trigger
+    ptk/EffectEvent
+    (effect [_ _ _] (f))))
+
+(t/deftest test-apply-to-shapes-from-js-array
+  ;; Regression for #9561: calling
+  ;;   token.applyToShapes([shape], ["fill"])
+  ;; from JS code used to throw "Doesn't support name: 0". After the fix
+  ;; it must apply the token and update the shape's `:applied-tokens`.
+  (t/async
+   done
+   (let [file       (setup-tokens-file)
+         store      (ths/setup-store file)
+         _          (set! st/state store)
+         plugin-id  "00000000-0000-0000-0000-000000000000"
+
+         rect-1     (cths/get-shape file :rect-1)
+         page-id    (cthf/current-page-id file)
+         set-id     (cthi/id :set-a)
+         token      (-> (get-in file [:data :tokens-lib])
+                        (ctob/get-tokens-in-active-sets)
+                        (get "colors.primary"))
+
+         ^js shape  (pshape/shape-proxy plugin-id (:id file) page-id (:id rect-1))
+         ^js tok    (ptok/token-proxy plugin-id (:id file) set-id (:id token))]
+
+     (t/is (some? shape) "shape proxy should be obtained")
+     (t/is (some? tok)   "token proxy should be obtained")
+
+     (tohs/run-store-async
+      store done
+      ;; Pre-fix: this call would throw "Doesn't support name: 0".
+      [(trigger (fn [] (.applyToShapes tok #js [shape] #js ["fill"])))]
+      (fn [state]
+        (let [rect-1' (rect-from-state state file (:id rect-1))]
+          (t/is (= "colors.primary"
+                   (get-in rect-1' [:applied-tokens :fill]))
+                "token name should be recorded on the shape's :applied-tokens")))))))
+
+(t/deftest test-shape-tokens-setter-applies-token
+  ;; Regression for #9561 part 2: assigning to `shape.tokens.fill = "name"`
+  ;; used to silently fail because `:tokens` had no setter. After the fix
+  ;; the per-property assignment looks up the token in the active library
+  ;; and applies it via the existing `toggle-token` action.
+  (t/async
+   done
+   (let [file        (setup-tokens-file)
+         store       (ths/setup-store file)
+         _           (set! st/state store)
+         plugin-id   "00000000-0000-0000-0000-000000000000"
+
+         rect-1      (cths/get-shape file :rect-1)
+         page-id     (cthf/current-page-id file)
+         ^js shape   (pshape/shape-proxy plugin-id (:id file) page-id (:id rect-1))
+         ^js tokens  (. shape -tokens)]
+
+     (t/is (some? tokens) "shape.tokens should always return an object")
+
+     (tohs/run-store-async
+      store done
+      ;; Pre-fix: this assignment was silently discarded.
+      [(trigger (fn [] (obj/set! tokens "fill" "colors.primary")))]
+      (fn [state]
+        (let [rect-1' (rect-from-state state file (:id rect-1))]
+          (t/is (= "colors.primary"
+                   (get-in rect-1' [:applied-tokens :fill]))
+                "the token should be recorded on the shape's :applied-tokens")))))))
+
+(t/deftest test-shape-tokens-setter-rejects-unknown-token
+  ;; The Proxy reports invalid inputs through `u/not-valid` rather than
+  ;; silently swallowing them. We verify the underlying state is left
+  ;; untouched (no applied token).
+  (t/async
+   done
+   (let [file        (setup-tokens-file)
+         store       (ths/setup-store file)
+         _           (set! st/state store)
+         plugin-id   "00000000-0000-0000-0000-000000000000"
+
+         rect-1      (cths/get-shape file :rect-1)
+         page-id     (cthf/current-page-id file)
+         ^js shape   (pshape/shape-proxy plugin-id (:id file) page-id (:id rect-1))
+         ^js tokens  (. shape -tokens)]
+
+     (tohs/run-store-async
+      store done
+      [(trigger (fn [] (obj/set! tokens "fill" "colors.this-token-does-not-exist")))]
+      (fn [state]
+        (let [rect-1' (rect-from-state state file (:id rect-1))]
+          (t/is (nil? (get-in rect-1' [:applied-tokens :fill]))
+                "no token should be applied when the name doesn't resolve")))))))

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -3768,12 +3768,19 @@ export interface ShapeBase extends PluginData {
    * The design tokens applied to this shape.
    * It's a map property name -> token name.
    *
+   * Reading returns the currently applied tokens. Assigning to a property
+   * (e.g. `shape.tokens.fill = "colors.primary"`) looks up the named token
+   * across the file's active sets and applies it to the matching shape
+   * attribute. Assigning a name that does not resolve to an active token
+   * leaves the shape untouched and reports the failure via the plugin
+   * error channel.
+   *
    * NOTE that the tokens application is by name and not by id. If there exist
    * several tokens with the same name in different sets, the actual token applied
    * and the value set to the attributes will depend on which sets are active
    * (and will change if different sets or themes are activated later).
    */
-  readonly tokens: { [property in TokenProperty]: string };
+  tokens: { [property in TokenProperty]: string };
 
   /**
    * @return Returns true if the current shape is inside a component instance


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
Fixes [#9561](https://github.com/penpot/penpot/issues/9561) — Token Application API Defects (plugin API).

### Summary

Two coupled defects made the plugin design-token API effectively unusable from JavaScript:

1. `token.applyToShapes([shape], ["fill"])` threw `"Doesn't support name: 0"`.
The `[:vector [:fn shape-proxy?]]` schema failed for hardened SES shape proxies, and then `error-messages` crashed calling `(name 0)` on the resulting tuple-index path — masking the real validation error.

- `applyToShapes` now validates manually with `array?` + `shape-proxy?` (the same pattern `penpot.selection` and `replaceColor` already use).
- `error-messages` has a new `format-field` helper that renders integer / vector paths as strings instead of throwing.

2. `shape.tokens.fill = "colors.primary"` was silently discarded.
`:tokens` exposed only a getter that returned a fresh plain object on every access, so per-property assignments vanished.

- The getter now returns a `js/Proxy` whose `set` trap looks up the named token in the file's active token sets and dispatches the existing `toggle-token` action. The trap always returns `true` so strict-mode SES plugins don't get TypeErrors on invalid input — validation failures surface through `u/not-valid` like the rest of the plugin API.

Also:

Extended `token-attr-plugin->token-attr` to kebab-case string input so camelCase property names from the read side of `shape.tokens` (e.g. `"borderRadiusTopLeft"`) round-trip into a working setter call.
Dropped readonly from ShapeBase.tokens in the TypeScript plugin types and documented the new write semantics.
Added regression coverage in `frontend/test/frontend_tests/plugins/tokens_test.cljs`: unit tests for `format-field` and the camelCase normalisation, plus async end-to-end tests via `tohs/run-store-async` that exercise `applyToShapes`, the `shape.tokens` setter, and the unknown-token rejection path.

### Steps to reproduce 

Inside any plugin running against a file that has a color token `colors.primary` (value `#3525CD`) in an active set:

`const shape = penpot.selection[0];`
`const token = penpot.library.local.tokens`
`  .getSetById(setId)`
`  .getTokenById(tokenId);`

`// Before this PR: throws 'Doesn't support name: 0'.`
`// After this PR: token is applied to the shape's fill.`
`token.applyToShapes([shape], ["fill"]);`

`// Before this PR: silently discarded, shape.tokens.fill stays undefined.`
`// After this PR: the named token is resolved against the active sets`
`// and applied; reading shape.tokens.fill returns "colors.primary".`
`shape.tokens.fill = "colors.primary";`

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
