### PR TITLE
:bug: Preserve target-positioned composite geometry when variant switch keeps size overrides

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix malformed component variants after Alt-drag duplication and variant switching
 - Fix plugin API `LibraryTypography.remove()` failing with a UUID assertion error [Github #8223](https://github.com/penpot/penpot/issues/8223)
 - Fix MCP SSE sessions leaking memory on zombie connections by adding inactivity timeout parity with Streamable HTTP sessions (by @bitloi) [Github #9432](https://github.com/penpot/penpot/issues/9432)
 - Fix missing `labels.open` translation (by @MilosM348) [Github #9320](https://github.com/penpot/penpot/pull/9320)

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2101,6 +2101,39 @@
            (grc/rect->center selrect)
            (or (:transform current-shape) (gmt/matrix)))))))
 
+
+(defn- switch-geom-change-value
+  [prev-shape current-shape attr]
+  ;; Composite geometry stores absolute coordinates. When preserving a size
+  ;; override across variants, keep the target variant's position and only carry
+  ;; the previous dimensions; otherwise :x/:y can disagree with :selrect/:points.
+  (let [prev-selrect (:selrect prev-shape)
+        current-selrect (:selrect current-shape)
+        final-width (:width prev-selrect)
+        final-height (:height prev-selrect)
+        x (:x current-selrect)
+        y (:y current-selrect)
+        selrect (assoc current-selrect
+                       :width final-width
+                       :height final-height
+                       :x x
+                       :y y
+                       :x1 x
+                       :y1 y
+                       :x2 (+ x final-width)
+                       :y2 (+ y final-height))]
+    (case attr
+      :selrect
+      selrect
+
+      :points
+      (-> selrect
+          (grc/rect->points)
+          (gsh/transform-points
+           (grc/rect->center selrect)
+           (or (:transform current-shape) (gmt/matrix)))))))
+
+
 (defn- equal-geometry?
   "Returns true when the value of `attr` in `shape` is considered equal
    to the corresponding value in `origin-shape`, ignoring positional
@@ -2269,6 +2302,10 @@
                            (= :fix (:layout-item-v-sizing previous-shape)))
                        (contains? #{:points :selrect :width :height} attr))
                   (switch-fixed-layout-geom-change-value previous-shape current-shape origin-ref-shape attr)
+
+                  (and (contains? #{:points :selrect} attr)
+                       (not path-change?))
+                  (switch-geom-change-value previous-shape current-shape attr)
 
                   :else
                   (get previous-shape attr)))

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2080,6 +2080,39 @@
            (grc/rect->center selrect)
            (or (:transform current-shape) (gmt/matrix)))))))
 
+
+(defn- switch-geom-change-value
+  [prev-shape current-shape attr]
+  ;; Composite geometry stores absolute coordinates. When preserving a size
+  ;; override across variants, keep the target variant's position and only carry
+  ;; the previous dimensions; otherwise :x/:y can disagree with :selrect/:points.
+  (let [prev-selrect (:selrect prev-shape)
+        current-selrect (:selrect current-shape)
+        final-width (:width prev-selrect)
+        final-height (:height prev-selrect)
+        x (:x current-selrect)
+        y (:y current-selrect)
+        selrect (assoc current-selrect
+                       :width final-width
+                       :height final-height
+                       :x x
+                       :y y
+                       :x1 x
+                       :y1 y
+                       :x2 (+ x final-width)
+                       :y2 (+ y final-height))]
+    (case attr
+      :selrect
+      selrect
+
+      :points
+      (-> selrect
+          (grc/rect->points)
+          (gsh/transform-points
+           (grc/rect->center selrect)
+           (or (:transform current-shape) (gmt/matrix)))))))
+
+
 (defn- equal-geometry?
   "Returns true when the value of `attr` in `shape` is considered equal
    to the corresponding value in `origin-shape`, ignoring positional
@@ -2237,6 +2270,10 @@
                            (= :fix (:layout-item-v-sizing previous-shape)))
                        (contains? #{:points :selrect :width :height} attr))
                   (switch-fixed-layout-geom-change-value previous-shape current-shape origin-ref-shape attr)
+
+                  (and (contains? #{:points :selrect} attr)
+                       (not path-change?))
+                  (switch-geom-change-value previous-shape current-shape attr)
 
                   :else
                   (get previous-shape attr)))

--- a/common/test/common_tests/logic/variants_switch_test.cljc
+++ b/common/test/common_tests/logic/variants_switch_test.cljc
@@ -2689,18 +2689,14 @@
     (t/is (= (get-in rect02' [:selrect :width]) 150))))
 
 
-(t/deftest test-switch-when-source-master-child-has-touched-geometry
-  ;; Regression: when the previous-shape's geometry has sub-pixel drift
+(t/deftest test-switch-skips-composite-geometry-with-subpixel-drift
+  ;; Regression: when the previous-shape's geometry only has sub-pixel drift
   ;; relative to its source master (a state produced by interactive transform
   ;; modifiers, e.g. alt-drag duplicate of a variant whose children are
-  ;; component copies), the equal-geometry? guard in update-attrs-on-switch
-  ;; uses exact equality and fails. The :else branch then copies
-  ;; previous-shape's :selrect verbatim onto the freshly-instantiated target,
-  ;; leaving :y correct (the per-attr y skip catches that) but :selrect.y
-  ;; stale. The shape ends up internally inconsistent (:y disagrees with
-  ;; :selrect.y); the renderer reads :selrect, so the child appears at the
-  ;; source variant's position inside a parent that has resized to the
-  ;; target's dimensions — the visible "cut off" symptom.
+  ;; component copies), equal-geometry? must classify it as unchanged and skip
+  ;; copying composite geometry. Otherwise, :selrect/:points can carry stale
+  ;; absolute positions from the source variant onto the freshly-instantiated
+  ;; target, producing the visible "cut off" symptom.
   (let [;; ==== Setup
         ;; A self-contained Input/Button-like component, plus a variant
         ;; container whose two variants each instance that component
@@ -2734,8 +2730,8 @@
         ;; The copy carries an Input/Button instance (Frame1). Introduce
         ;; sub-pixel drift in its :width and :selrect.width — the kind of
         ;; floating-point error produced by the alt-drag modifier path in
-        ;; production. This drift is what defeats equal-geometry?'s
-        ;; exact-equality comparison and lets the bug surface.
+        ;; production. The drift is small enough to be treated as unchanged
+        ;; geometry by equal-geometry?.
         page          (thf/current-page file)
         copy01        (ths/get-shape file :copy01)
         copy-btn-id   (->> (cfh/get-children-ids-with-self (:objects page) (:id copy01))
@@ -2793,3 +2789,73 @@
     ;; its :selrect.y is internally inconsistent and renders incorrectly.
     (t/is (= post-btn-rel-y post-btn-selrect-rel-y)
           ":y and :selrect.y must agree after switch")))
+
+
+(t/deftest test-switch-preserves-size-override-at-target-position
+  (let [move-to   (fn [shape x y]
+                    (gsh/move shape (gpt/point (- x (:x shape))
+                                               (- y (:y shape)))))
+
+        ;; ==== Setup: each variant contains the same nested component instance.
+        ;; The nested instance has identical size in both variants, but a different
+        ;; position relative to the variant root.
+        file      (-> (thf/sample-file :file1)
+                      (tho/add-simple-component
+                       :nested-component :nested-main :nested-label
+                       :root-params {:width 100 :height 50}
+                       :child-params {:width 30 :height 10})
+                      (thv/add-variant-with-copy
+                       :v01 :c01 :m01 :c02 :m02 :r01 :r02 :nested-component))
+
+        page      (thf/current-page file)
+        r01       (ths/get-shape file :r01)
+        r02       (ths/get-shape file :r02)
+        changes   (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                              #{(:id r01) (:id r02)}
+                                              (fn [shape]
+                                                (cond
+                                                  (= (:id shape) (:id r01)) (move-to shape 20 100)
+                                                  (= (:id shape) (:id r02)) (move-to shape 20 70)
+                                                  :else shape))
+                                              (:objects page)
+                                              {})
+        file      (thf/apply-changes file changes)
+
+        file      (thc/instantiate-component file :c01
+                                             :copy01
+                                             :children-labels [:copy-r01])
+        page      (thf/current-page file)
+        copy01    (ths/get-shape file :copy01)
+        copy-r01  (get-in page [:objects (-> copy01 :shapes first)])
+
+        ;; This is a real geometry override, not float drift. The switch should
+        ;; preserve the overridden size while anchoring composite geometry to
+        ;; the target variant's position.
+        changes   (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                              #{(:id copy-r01)}
+                                              (fn [shape]
+                                                (let [new-width 150
+                                                      sr        (:selrect shape)
+                                                      new-sr    (-> sr
+                                                                    (assoc :width new-width)
+                                                                    (assoc :x2 (+ (:x1 sr) new-width)))]
+                                                  (-> shape
+                                                      (assoc :width new-width)
+                                                      (assoc :selrect new-sr)
+                                                      (assoc :touched #{:geometry-group}))))
+                                              (:objects page)
+                                              {})
+        file      (thf/apply-changes file changes)
+
+        ;; ==== Action
+        file'     (tho/swap-component-in-shape file :copy01 :c02 {:new-shape-label :copy02 :keep-touched? true})
+
+        page'     (thf/current-page file')
+        copy02'   (ths/get-shape file' :copy02)
+        rect02'   (get-in page' [:objects (-> copy02' :shapes first)])]
+
+    ;; The width override is preserved, but the target variant position remains
+    ;; authoritative for absolute composite geometry.
+    (t/is (= 150 (:width rect02')))
+    (t/is (= (+ (:y copy02') 70) (:y rect02')))
+    (t/is (= (:y rect02') (get-in rect02' [:selrect :y])))))

--- a/common/test/common_tests/logic/variants_switch_test.cljc
+++ b/common/test/common_tests/logic/variants_switch_test.cljc
@@ -2866,18 +2866,14 @@
     (t/is (= (get-in rect02' [:selrect :width]) 150))))
 
 
-(t/deftest test-switch-when-source-master-child-has-touched-geometry
-  ;; Regression: when the previous-shape's geometry has sub-pixel drift
+(t/deftest test-switch-skips-composite-geometry-with-subpixel-drift
+  ;; Regression: when the previous-shape's geometry only has sub-pixel drift
   ;; relative to its source master (a state produced by interactive transform
   ;; modifiers, e.g. alt-drag duplicate of a variant whose children are
-  ;; component copies), the equal-geometry? guard in update-attrs-on-switch
-  ;; uses exact equality and fails. The :else branch then copies
-  ;; previous-shape's :selrect verbatim onto the freshly-instantiated target,
-  ;; leaving :y correct (the per-attr y skip catches that) but :selrect.y
-  ;; stale. The shape ends up internally inconsistent (:y disagrees with
-  ;; :selrect.y); the renderer reads :selrect, so the child appears at the
-  ;; source variant's position inside a parent that has resized to the
-  ;; target's dimensions — the visible "cut off" symptom.
+  ;; component copies), equal-geometry? must classify it as unchanged and skip
+  ;; copying composite geometry. Otherwise, :selrect/:points can carry stale
+  ;; absolute positions from the source variant onto the freshly-instantiated
+  ;; target, producing the visible "cut off" symptom.
   (let [;; ==== Setup
         ;; A self-contained Input/Button-like component, plus a variant
         ;; container whose two variants each instance that component
@@ -2911,8 +2907,8 @@
         ;; The copy carries an Input/Button instance (Frame1). Introduce
         ;; sub-pixel drift in its :width and :selrect.width — the kind of
         ;; floating-point error produced by the alt-drag modifier path in
-        ;; production. This drift is what defeats equal-geometry?'s
-        ;; exact-equality comparison and lets the bug surface.
+        ;; production. The drift is small enough to be treated as unchanged
+        ;; geometry by equal-geometry?.
         page          (thf/current-page file)
         copy01        (ths/get-shape file :copy01)
         copy-btn-id   (->> (cfh/get-children-ids-with-self (:objects page) (:id copy01))
@@ -3035,3 +3031,73 @@
     (t/is (= target-rel-y actual-rel-y)
           (str "path :selrect.y should match target master layout (expected "
                target-rel-y " got " actual-rel-y ")"))))
+
+
+(t/deftest test-switch-preserves-size-override-at-target-position
+  (let [move-to   (fn [shape x y]
+                    (gsh/move shape (gpt/point (- x (:x shape))
+                                               (- y (:y shape)))))
+
+        ;; ==== Setup: each variant contains the same nested component instance.
+        ;; The nested instance has identical size in both variants, but a different
+        ;; position relative to the variant root.
+        file      (-> (thf/sample-file :file1)
+                      (tho/add-simple-component
+                       :nested-component :nested-main :nested-label
+                       :root-params {:width 100 :height 50}
+                       :child-params {:width 30 :height 10})
+                      (thv/add-variant-with-copy
+                       :v01 :c01 :m01 :c02 :m02 :r01 :r02 :nested-component))
+
+        page      (thf/current-page file)
+        r01       (ths/get-shape file :r01)
+        r02       (ths/get-shape file :r02)
+        changes   (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                              #{(:id r01) (:id r02)}
+                                              (fn [shape]
+                                                (cond
+                                                  (= (:id shape) (:id r01)) (move-to shape 20 100)
+                                                  (= (:id shape) (:id r02)) (move-to shape 20 70)
+                                                  :else shape))
+                                              (:objects page)
+                                              {})
+        file      (thf/apply-changes file changes)
+
+        file      (thc/instantiate-component file :c01
+                                             :copy01
+                                             :children-labels [:copy-r01])
+        page      (thf/current-page file)
+        copy01    (ths/get-shape file :copy01)
+        copy-r01  (get-in page [:objects (-> copy01 :shapes first)])
+
+        ;; This is a real geometry override, not float drift. The switch should
+        ;; preserve the overridden size while anchoring composite geometry to
+        ;; the target variant's position.
+        changes   (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                              #{(:id copy-r01)}
+                                              (fn [shape]
+                                                (let [new-width 150
+                                                      sr        (:selrect shape)
+                                                      new-sr    (-> sr
+                                                                    (assoc :width new-width)
+                                                                    (assoc :x2 (+ (:x1 sr) new-width)))]
+                                                  (-> shape
+                                                      (assoc :width new-width)
+                                                      (assoc :selrect new-sr)
+                                                      (assoc :touched #{:geometry-group}))))
+                                              (:objects page)
+                                              {})
+        file      (thf/apply-changes file changes)
+
+        ;; ==== Action
+        file'     (tho/swap-component-in-shape file :copy01 :c02 {:new-shape-label :copy02 :keep-touched? true})
+
+        page'     (thf/current-page file')
+        copy02'   (ths/get-shape file' :copy02)
+        rect02'   (get-in page' [:objects (-> copy02' :shapes first)])]
+
+    ;; The width override is preserved, but the target variant position remains
+    ;; authoritative for absolute composite geometry.
+    (t/is (= 150 (:width rect02')))
+    (t/is (= (+ (:y copy02') 70) (:y rect02')))
+    (t/is (= (:y rect02') (get-in rect02' [:selrect :y])))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14070
https://github.com/penpot/penpot/issues/9498

Related to the fix in #9434 and presents an alternative fix. The code was created by reverting the original fix and letting Codex find a solution. The result of this was the discovery of this additional failure path. The summary below is also mostly written by Codex.

The existing fix handles the drift-triggered reproduction, but variant switching still has an unsafe composite-geometry preservation path for real geometry overrides.

That is a bug because it can create invalid shape geometry under plausible user behavior, even if we do not currently have a confirmed UI reproduction beyond the synthetic common test.

### Summary
When switching variants, `update-attrs-on-switch` may preserve touched geometry from the previous instance. The existing float-tolerance fix prevents stale composite geometry from being copied when the previous shape only differs from its source master by sub-pixel drift.

There is a related but distinct case: the previous shape can have a real geometry override, such as a resized nested component instance. In that case the override should be preserved. However, :selrect and :points contain absolute coordinates, so copying them verbatim from the previous variant can also copy the previous variant’s absolute position.

Expected behavior:

Preserve the user’s real size override.
Keep the switched shape anchored at the target variant’s position.
Keep scalar geometry and composite geometry internally consistent, especially :x/:y vs :selrect.x/:selrect.y.

### Steps to reproduce 

1. Create two variants that contain the same nested component instance.
2. The nested instance has the same base size in both variants, but different relative positions.
3. Instantiate one variant.
4. Apply a real geometry override to the nested instance, e.g. resize width from 100 to 150.
5. Switch to the other variant with keep-touched? behavior.

Without anchoring preserved composite geometry to the target shape, the switch can preserve the width override while also carrying stale absolute :selrect / :points coordinates from the source variant. This risks a malformed shape where scalar :y follows the target variant, but :selrect.y still reflects the source variant.

### Additional Context

The previous fix solved that by making equal-geometry? tolerant, so the stale-copy path is skipped for drift-only changes.

I focused on the downstream invariant instead: if update-attrs-on-switch ever does preserve :selrect / :points, it should not copy old absolute position. That also fixes the reverted reproduction, because it makes the bad path safe rather than avoiding it.

So my fix addressed the same observed symptom because it was applied lower in the pipeline:

Previous fix: prevent entering the stale-copy branch for float drift.
My fix: make the stale-copy branch rebuild target-positioned composite geometry.
With the previous fix restored, my change is no longer necessary for the exact original Alt-drag reproduction, but it still protects the same invariant for real geometry overrides.

@pabloalba FYI


Closes #9749
