### PR TITLE
:sparkles: Dismiss workspace search panel with the Escape key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### :sparkles: New features & Enhancements
 
+- Dismiss the workspace layers search panel with the Escape key while the search field is focused (by @dhgoal) [Github #9540](https://github.com/penpot/penpot/issues/9540)
 - Show a read-only W × H size badge below the bounding box of the current selection (by @bittoby) [Github #9205](https://github.com/penpot/penpot/issues/9205)
 - Expose `variants` retrieval on `LibraryComponent` via `isVariant()` type guard in plugin API [Github #9185](https://github.com/penpot/penpot/issues/9185)
 

--- a/frontend/src/app/main/ui/components/search_bar.cljs
+++ b/frontend/src/app/main/ui/components/search_bar.cljs
@@ -13,7 +13,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc search-bar*
-  [{:keys [id class value placeholder icon-id auto-focus on-change on-clear on-submit children]}]
+  [{:keys [id class value placeholder icon-id auto-focus on-change on-clear on-submit on-escape children]}]
   (let [handle-change
         (mf/use-fn
          (mf/deps on-change)
@@ -31,7 +31,7 @@
 
         handle-key-down
         (mf/use-fn
-         (mf/deps on-submit)
+         (mf/deps on-submit on-escape)
          (fn [event]
            (let [enter? (kbd/enter? event)
                  esc?   (kbd/esc? event)
@@ -42,7 +42,10 @@
                  (let [value (dom/get-target-val event)]
                    (on-submit value event))))
 
-             (when ^boolean esc? (dom/blur! node)))))]
+             (when ^boolean esc?
+               (dom/blur! node)
+               (when (fn? on-escape)
+                 (on-escape event))))))]
 
     [:span {:class (stl/css-case :search-box true
                                  :has-children (some? children))}

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -313,6 +313,20 @@
                                  (assoc :search-scope :layers :num-items 100 :current-match-idx 0)
                                  (update :show-search not)))))))
 
+        close-search
+        (mf/use-fn
+         (fn [_event]
+           ;; Progressive Escape: when the filter menu is open, leave the
+           ;; existing document keydown handler to close just the menu;
+           ;; only dismiss the whole search panel once the menu is closed.
+           (when-not (:show-menu @state*)
+             (swap! state* (fn [state]
+                             (-> state
+                                 (assoc :search-text "" :replace-text "" :filters #{})
+                                 (assoc :show-menu false :find-replace-mode? false)
+                                 (assoc :search-scope :layers :num-items 100 :current-match-idx 0)
+                                 (assoc :show-search false)))))))
+
         remove-filter
         (mf/use-fn
          (fn [event]
@@ -443,6 +457,7 @@
            [:> search-bar* {:on-change update-search-text
                             :value current-search
                             :on-clear clear-search-text
+                            :on-escape close-search
                             :placeholder (tr "workspace.sidebar.layers.search")}
             [:button {:on-click on-toggle-filters-click
                       :class (stl/css-case :filter-button true :opened show-menu? :active active?)}


### PR DESCRIPTION
This PR closes the workspace **Search layers / Search on canvas** panel when the user presses <kbd>Escape</kbd> while the search field is focused, returning keyboard control to the canvas.

## References

Resolves https://github.com/penpot/penpot/issues/9540

## Code changes

- `search-bar*` gains an optional `on-escape` callback. The component already swallowed <kbd>Escape</kbd> to blur its input; it now also invokes `on-escape` when provided. All existing `search-bar*` callers are unaffected (the prop is optional and `fn?`-guarded).
- The layers search panel passes a `close-search` handler that resets search state and hides the panel.

## Behaviour / design notes

- **Focus scoping** — because the handler fires from the search field’s own `keydown`, Escape only dismisses the panel when focus is inside it. If focus has moved elsewhere (e.g. back to the layers list), the search input never receives the event, so the panel is left open — matching the issue’s requirement.
- **Progressive Escape** — when the filter dropdown is open, the existing document-level handler closes just the menu; `close-search` is suppressed in that case, so the panel is dismissed on the next Escape press rather than both at once.
- **Return focus to canvas** — the search field is blurred (existing behaviour); with no element retaining focus, the workspace’s document-level shortcut handlers regain control, which is how the canvas “has focus” in this codebase.

## How to verify

Open the workspace, open search with its shortcut, place the cursor in the search input, and press <kbd>Escape</kbd> — the panel dismisses. Confirm that pressing <kbd>Escape</kbd> while focus is outside the panel (e.g. in the layers list) does not affect it, and that with the filter menu open the first <kbd>Escape</kbd> closes only the menu.

## Backwards-incompatible changes

None.