### PR TITLE
:bug: Reflow synced component layouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix spacing token changes in main flex components leaving copied text children at stale padding offsets [Taiga #11766](https://tree.taiga.io/project/penpot/issue/11766)
 - Fix plugin API `fileVersion.restore()` promise hanging indefinitely on restore failure [Github #9092](https://github.com/penpot/penpot/issues/9092)
 - Fix LDAP provider params schema typo (`bind-passwor` → `bind-password`) introduced during the `clojure.spec` → `malli` migration; the schema slot now matches the runtime key actually read by `prepare-params` (`:password (:bind-password cfg)`) and `try-connectivity` (`(:bind-password cfg)`), so a wrong type for the password no longer slips through unvalidated
 - Fix `login-with-ldap` silently dropping its error message on the `ldap-not-initialized` restriction (typo `:hide` → `:hint`); the message `"ldap auth provider is not initialized"` now actually surfaces in logs and error responses instead of being discarded into an unread key

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix spacing token changes in main flex components leaving copied text children at stale padding offsets [Taiga #11766](https://tree.taiga.io/project/penpot/issue/11766)
 - Fix plugin API `LibraryTypography.remove()` failing with a UUID assertion error [Github #8223](https://github.com/penpot/penpot/issues/8223)
 - Fix MCP SSE sessions leaking memory on zombie connections by adding inactivity timeout parity with Streamable HTTP sessions (by @bitloi) [Github #9432](https://github.com/penpot/penpot/issues/9432)
 - Fix missing `labels.open` translation (by @MilosM348) [Github #9320](https://github.com/penpot/penpot/pull/9320)

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -25,6 +25,7 @@
    [app.common.types.container :as ctn]
    [app.common.types.file :as ctf]
    [app.common.types.library :as ctl]
+   [app.common.types.modifiers :as ctm]
    [app.common.types.shape.layout :as ctsl]
    [app.common.types.typography :as ctt]
    [app.common.uuid :as uuid]
@@ -38,6 +39,7 @@
    [app.main.data.notifications :as ntf]
    [app.main.data.workspace :as-alias dw]
    [app.main.data.workspace.groups :as dwg]
+   [app.main.data.workspace.modifiers :as dwm]
    [app.main.data.workspace.notifications :as-alias dwn]
    [app.main.data.workspace.pages :as-alias dwpg]
    [app.main.data.workspace.selection :as dws]
@@ -723,6 +725,23 @@
         (rx/of (when can-detach?
                  (dch/commit-changes changes)))))))
 
+(defn- reflow-synced-layout
+  [state page-id ids undo-group]
+  (let [page-id (or page-id (:current-page-id state))
+        objects (dsh/lookup-page-objects state page-id)
+        ids     (->> ids (remove uuid/zero?) (filter #(contains? objects %)))]
+    (when (d/not-empty? ids)
+      (let [modif-tree (dwm/create-modif-tree ids (ctm/reflow-modifiers))]
+        ;; Library sync already knows exactly which layout frames changed. Running
+        ;; the reflow in this event chain persists child geometry immediately;
+        ;; the generic :layout/update signal is buffered and can otherwise leave
+        ;; component copies with updated padding but stale flex child positions.
+        (dwm/apply-modifiers {:page-id page-id
+                              :modifiers modif-tree
+                              :stack-undo? true
+                              :ignore-touched true
+                              :undo-group undo-group})))))
+
 (defn go-to-component-file
   [file-id component update-layout?]
 
@@ -1209,14 +1228,10 @@
               (let [frames-by-page (->> updated-frames
                                         (group-by :page-id))]
                 (rx/merge
-                 ;; Emit one layout/update event for each page
                  (rx/from
-                  (map (fn [[page-id frames]]
-                         (ptk/data-event :layout/update
-                                         {:page-id page-id
-                                          :ids (map :id frames)
-                                          :undo-group undo-group}))
-                       frames-by-page))
+                  (keep (fn [[page-id frames]]
+                          (reflow-synced-layout state page-id (map :id frames) undo-group))
+                        frames-by-page))
                  (->> (rx/from updated-frames)
                       (rx/mapcat
                        (fn [shape]

--- a/frontend/test/frontend_tests/logic/components_and_tokens.cljs
+++ b/frontend/test/frontend_tests/logic/components_and_tokens.cljs
@@ -5,7 +5,9 @@
 ;; Copyright (c) KALEIDOS INC
 (ns frontend-tests.logic.components-and-tokens
   (:require
+   [app.common.files.changes-builder :as pcb]
    [app.common.geom.point :as geom]
+   [app.common.logic.shapes :as cls]
    [app.common.math :as mth]
    [app.common.test-helpers.components :as cthc]
    [app.common.test-helpers.compositions :as ctho]
@@ -70,6 +72,55 @@
   []
   (-> (setup-file-with-main)
       (cthc/instantiate-component :component1 :c-frame1)))
+
+(def flex-layout-attrs
+  {:layout                 :flex
+   :layout-flex-dir        :row
+   :layout-gap-type        :multiple
+   :layout-gap             {:row-gap 0 :column-gap 0}
+   :layout-align-items     :start
+   :layout-justify-content :start
+   :layout-align-content   :stretch
+   :layout-wrap-type       :nowrap
+   :layout-padding-type    :simple})
+
+(defn- setup-spacing-file-with-copy
+  []
+  (let [file       (-> (cthf/sample-file :file1)
+                       (ctht/add-tokens-lib)
+                       (ctht/update-tokens-lib #(-> %
+                                                    (ctob/add-set (ctob/make-token-set :id (cthi/new-id! :test-token-set)
+                                                                                       :name "test-token-set"))
+                                                    (ctob/add-theme (ctob/make-token-theme :name "test-theme"
+                                                                                           :sets #{"test-token-set"}))
+                                                    (ctob/set-active-themes #{"/test-theme"})
+                                                    (ctob/add-token (cthi/id :test-token-set)
+                                                                    (ctob/make-token :id (cthi/new-id! :space-s)
+                                                                                     :name "space.s"
+                                                                                     :type :spacing
+                                                                                     :value 12))
+                                                    (ctob/add-token (cthi/id :test-token-set)
+                                                                    (ctob/make-token :id (cthi/new-id! :space-m)
+                                                                                     :name "space.m"
+                                                                                     :type :spacing
+                                                                                     :value 36))))
+                       (ctho/add-frame-with-text :frame1
+                                                 :text1
+                                                 "Original text"
+                                                 :frame-params (merge flex-layout-attrs
+                                                                      {:layout-padding {:p1 12 :p2 12 :p3 12 :p4 12}})
+                                                 :child-params {:x 12 :y 12})
+                       (ctht/apply-token-to-shape :frame1 "space.s" [:p1 :p2 :p3 :p4] [:layout-padding] {:p1 12 :p2 12 :p3 12 :p4 12})
+                       (cthc/make-component :component1 :frame1)
+                       (cthc/instantiate-component :component1 :c-frame1 {:children-labels [:c-text1]}))
+        page       (cthf/current-page file)
+        copy-child (cths/get-shape file :c-text1)
+        changes    (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                               #{(:id copy-child)}
+                                               #(assoc-in % [:content :children 0 :children 0 :text] "Overridden text")
+                                               (:objects page)
+                                               {})]
+    (cthf/apply-changes file changes)))
 
 (t/deftest create-component-with-token
   (t/async
@@ -167,6 +218,41 @@
                          (t/is (= (get c-frame1' :r2) 50))
                          (t/is (= (get c-frame1' :r3) 50))
                          (t/is (= (get c-frame1' :r4) 50)))))))]
+
+      (tohs/run-store-async
+       store step2 events identity))))
+
+(t/deftest change-spacing-token-in-main-updates-copy-layout
+  (t/async
+    done
+    (let [;; ==== Setup
+          file     (setup-spacing-file-with-copy)
+          store    (ths/setup-store file)
+
+          ;; ==== Action
+          events [(dwta/apply-token {:shape-ids [(cthi/id :frame1)]
+                                     :attributes #{:p1 :p2 :p3 :p4}
+                                     :token (toht/get-token file "space.m")
+                                     :on-update-shape dwta/apply-spacing-token})]
+
+          step2 (fn [_]
+                  (let [events2 [(dwl/sync-file (:id file) (:id file))]]
+                    (ths/run-store
+                     store done events2
+                     (fn [new-state]
+                       (let [;; ==== Get
+                             file'     (ths/get-file-from-state new-state)
+                             c-frame1' (cths/get-shape file' :c-frame1)
+                             c-text1'  (cths/get-shape file' :c-text1)]
+
+                         ;; ==== Check
+                         (t/is (= (:applied-tokens c-frame1') {:p1 "space.m"
+                                                               :p2 "space.m"
+                                                               :p3 "space.m"
+                                                               :p4 "space.m"}))
+                         (t/is (= (:layout-padding c-frame1') {:p1 36 :p2 36 :p3 36 :p4 36}))
+                         (t/is (= 36 (- (:x c-text1') (:x c-frame1'))))
+                         (t/is (= 36 (- (:y c-text1') (:y c-frame1')))))))))]
 
       (tohs/run-store-async
        store step2 events identity))))

--- a/frontend/test/frontend_tests/logic/components_and_tokens.cljs
+++ b/frontend/test/frontend_tests/logic/components_and_tokens.cljs
@@ -5,7 +5,9 @@
 ;; Copyright (c) KALEIDOS INC Sucursal en España SL
 (ns frontend-tests.logic.components-and-tokens
   (:require
+   [app.common.files.changes-builder :as pcb]
    [app.common.geom.point :as geom]
+   [app.common.logic.shapes :as cls]
    [app.common.math :as mth]
    [app.common.test-helpers.components :as cthc]
    [app.common.test-helpers.compositions :as ctho]
@@ -70,6 +72,55 @@
   []
   (-> (setup-file-with-main)
       (cthc/instantiate-component :component1 :c-frame1)))
+
+(def flex-layout-attrs
+  {:layout                 :flex
+   :layout-flex-dir        :row
+   :layout-gap-type        :multiple
+   :layout-gap             {:row-gap 0 :column-gap 0}
+   :layout-align-items     :start
+   :layout-justify-content :start
+   :layout-align-content   :stretch
+   :layout-wrap-type       :nowrap
+   :layout-padding-type    :simple})
+
+(defn- setup-spacing-file-with-copy
+  []
+  (let [file       (-> (cthf/sample-file :file1)
+                       (ctht/add-tokens-lib)
+                       (ctht/update-tokens-lib #(-> %
+                                                    (ctob/add-set (ctob/make-token-set :id (cthi/new-id! :test-token-set)
+                                                                                       :name "test-token-set"))
+                                                    (ctob/add-theme (ctob/make-token-theme :name "test-theme"
+                                                                                           :sets #{"test-token-set"}))
+                                                    (ctob/set-active-themes #{"/test-theme"})
+                                                    (ctob/add-token (cthi/id :test-token-set)
+                                                                    (ctob/make-token :id (cthi/new-id! :space-s)
+                                                                                     :name "space.s"
+                                                                                     :type :spacing
+                                                                                     :value 12))
+                                                    (ctob/add-token (cthi/id :test-token-set)
+                                                                    (ctob/make-token :id (cthi/new-id! :space-m)
+                                                                                     :name "space.m"
+                                                                                     :type :spacing
+                                                                                     :value 36))))
+                       (ctho/add-frame-with-text :frame1
+                                                 :text1
+                                                 "Original text"
+                                                 :frame-params (merge flex-layout-attrs
+                                                                      {:layout-padding {:p1 12 :p2 12 :p3 12 :p4 12}})
+                                                 :child-params {:x 12 :y 12})
+                       (ctht/apply-token-to-shape :frame1 "space.s" [:p1 :p2 :p3 :p4] [:layout-padding] {:p1 12 :p2 12 :p3 12 :p4 12})
+                       (cthc/make-component :component1 :frame1)
+                       (cthc/instantiate-component :component1 :c-frame1 {:children-labels [:c-text1]}))
+        page       (cthf/current-page file)
+        copy-child (cths/get-shape file :c-text1)
+        changes    (cls/generate-update-shapes (pcb/empty-changes nil (:id page))
+                                               #{(:id copy-child)}
+                                               #(assoc-in % [:content :children 0 :children 0 :text] "Overridden text")
+                                               (:objects page)
+                                               {})]
+    (cthf/apply-changes file changes)))
 
 (t/deftest create-component-with-token
   (t/async
@@ -167,6 +218,41 @@
                          (t/is (= (get c-frame1' :r2) 50))
                          (t/is (= (get c-frame1' :r3) 50))
                          (t/is (= (get c-frame1' :r4) 50)))))))]
+
+      (tohs/run-store-async
+       store step2 events identity))))
+
+(t/deftest change-spacing-token-in-main-updates-copy-layout
+  (t/async
+    done
+    (let [;; ==== Setup
+          file     (setup-spacing-file-with-copy)
+          store    (ths/setup-store file)
+
+          ;; ==== Action
+          events [(dwta/apply-token {:shape-ids [(cthi/id :frame1)]
+                                     :attributes #{:p1 :p2 :p3 :p4}
+                                     :token (toht/get-token file "space.m")
+                                     :on-update-shape dwta/apply-spacing-token})]
+
+          step2 (fn [_]
+                  (let [events2 [(dwl/sync-file (:id file) (:id file))]]
+                    (ths/run-store
+                     store done events2
+                     (fn [new-state]
+                       (let [;; ==== Get
+                             file'     (ths/get-file-from-state new-state)
+                             c-frame1' (cths/get-shape file' :c-frame1)
+                             c-text1'  (cths/get-shape file' :c-text1)]
+
+                         ;; ==== Check
+                         (t/is (= (:applied-tokens c-frame1') {:p1 "space.m"
+                                                               :p2 "space.m"
+                                                               :p3 "space.m"
+                                                               :p4 "space.m"}))
+                         (t/is (= (:layout-padding c-frame1') {:p1 36 :p2 36 :p3 36 :p4 36}))
+                         (t/is (= 36 (- (:x c-text1') (:x c-frame1'))))
+                         (t/is (= 36 (- (:y c-text1') (:y c-frame1')))))))))]
 
       (tohs/run-store-async
        store step2 events identity))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11766

### Summary
Created by Codex in one-shot, part of the mcp-self-improvement umbrella. Summary by Codex:

The bug was not that spacing tokens failed to sync. They did sync: component copies received the new :applied-tokens and :layout-padding values from the main component. The stale visual result came from the flex layout children not being reflowed after that sync, so copied text children kept their old position, e.g. still offset by 12px even after padding changed to 36px.

I fixed it in frontend/src/app/main/data/workspace/libraries.cljs by making library/component sync run the layout reflow directly for frames it already knows were changed. Previously it emitted a buffered :layout/update signal, which could leave synced component copies with updated padding but stale child geometry. The new helper builds reflow modifiers for the affected frames and applies them in the sync chain with :ignore-touched true.

I also added a frontend regression test that creates a flex component with a spacing token, instantiates a copy, overrides the text child, changes the main component spacing token, syncs, and asserts both the copy padding and child offset update to the new token value.

### Steps to reproduce 
 See ticket



Closes #9892
