### PR TITLE
:bug: Improve export shape diagnostics

### DIFF
--- a/mcp/packages/plugin/src/PenpotUtils.ts
+++ b/mcp/packages/plugin/src/PenpotUtils.ts
@@ -419,7 +419,12 @@ export class PenpotUtils {
      *   - For mode="shape", it will be PNG or SVG data depending on the value of `asSVG`.
      *   - For mode="fill", it will be whatever format the fill image is stored in.
      */
-    public static async exportImage(shape: Shape, mode: "shape" | "fill", asSVG: boolean): Promise<Uint8Array> {
+    public static async exportImage(
+        shape: Shape,
+        mode: "shape" | "fill",
+        asSVG: boolean,
+        options: { scale?: number } = {}
+    ): Promise<Uint8Array> {
         // Updates are asynchronous in Penpot, so wait a tick to ensure any pending updates are applied before export.
         // The constant wait time is a temporary workardound until a better solution for penpot/penpot-mcp#27
         // is implemented.
@@ -427,7 +432,7 @@ export class PenpotUtils {
         // Perform export
         switch (mode) {
             case "shape":
-                return shape.export({ type: asSVG ? "svg" : "png" });
+                return shape.export({ type: asSVG ? "svg" : "png", scale: options.scale ?? 1 });
             case "fill":
                 if (asSVG) {
                     throw new Error("Image fills cannot be exported as SVG");

--- a/mcp/packages/server/src/tools/ExportShapeTool.ts
+++ b/mcp/packages/server/src/tools/ExportShapeTool.ts
@@ -29,6 +29,12 @@ export class ExportShapeArgs {
                 "The export mode: either 'shape' (full shape as it appears in the design, including descendants; the default) or " +
                     "'fill' (export the raw image that is used as a fill for the shape; PNG format only)"
             ),
+        scale: z
+            .number()
+            .min(0.1)
+            .max(8)
+            .optional()
+            .describe("Optional export scale for shape PNG/SVG export. Defaults to 1. Ignored for fill mode."),
         filePath: z
             .string()
             .optional()
@@ -44,7 +50,45 @@ export class ExportShapeArgs {
 
     mode: "shape" | "fill" = "shape";
 
+    scale?: number;
+
     filePath?: string;
+}
+
+export function normalizeExportScale(scale: number | undefined): number {
+    if (scale === undefined) {
+        return 1;
+    }
+    if (!Number.isFinite(scale) || scale < 0.1 || scale > 8) {
+        throw new Error("export_shape scale must be a number between 0.1 and 8");
+    }
+    return scale;
+}
+
+export function buildExportImageCode(
+    shapeId: string,
+    mode: "shape" | "fill",
+    asSvg: boolean,
+    scale: number | undefined
+): string {
+    let shapeCode: string;
+    if (shapeId === "selection") {
+        shapeCode = `penpot.selection[0]`;
+    } else if (shapeId === "page") {
+        shapeCode = `penpot.root`;
+    } else {
+        shapeCode = `penpotUtils.findShapeById(${JSON.stringify(shapeId)})`;
+    }
+    return `return penpotUtils.exportImage(${shapeCode}, ${JSON.stringify(mode)}, ${asSvg}, { scale: ${normalizeExportScale(scale)} });`;
+}
+
+export function getInvalidImagePayloadHint(bytes: Uint8Array): string | null {
+    const prefix = Buffer.from(bytes.slice(0, 512)).toString("utf8").replace(/\s+/g, " ").trim();
+    const lower = prefix.toLowerCase();
+    if (lower.startsWith("<!doctype html") || lower.startsWith("<html")) {
+        return `Penpot export returned HTML instead of image bytes. This usually means the exported asset URL resolved to an error page rather than PNG/JPEG data. Body prefix: ${prefix.slice(0, 240)}`;
+    }
+    return null;
 }
 
 /**
@@ -137,17 +181,8 @@ export class ExportShapeTool extends Tool<ExportShapeArgs> {
             FileUtils.checkPathIsAbsolute(args.filePath);
         }
 
-        // create code for exporting the shape
-        let shapeCode: string;
-        if (args.shapeId === "selection") {
-            shapeCode = `penpot.selection[0]`;
-        } else if (args.shapeId === "page") {
-            shapeCode = `penpot.root`;
-        } else {
-            shapeCode = `penpotUtils.findShapeById("${args.shapeId}")`;
-        }
         const asSvg = args.format === "svg";
-        const code = `return penpotUtils.exportImage(${shapeCode}, "${args.mode}", ${asSvg});`;
+        const code = buildExportImageCode(args.shapeId, args.mode, asSvg, args.scale);
 
         // execute the code and obtain the image data
         const task = new ExecuteCodePluginTask({ code: code });
@@ -185,6 +220,11 @@ export class ExportShapeTool extends Tool<ExportShapeArgs> {
      */
     private async toPngImageBytes(data: Uint8Array | object): Promise<Uint8Array> {
         const originalBytes = ImageContent.byteData(data);
+
+        const invalidPayloadHint = getInvalidImagePayloadHint(originalBytes);
+        if (invalidPayloadHint) {
+            throw new Error(invalidPayloadHint);
+        }
 
         // use sharp to detect format and convert to PNG if necessary
         const image = sharp(originalBytes);


### PR DESCRIPTION
## Summary

Improve the MCP `export_shape` tool when Penpot returns an error page instead of image bytes.

This patch:

- adds an optional `scale` argument to `export_shape`
- forwards the scale option through the Penpot plugin `exportImage` helper for shape exports
- detects HTML payloads before passing bytes to `sharp`
- returns a targeted diagnostic message when the export result is an HTML error page instead of PNG/JPEG/WebP/SVG data
- escapes generated plugin code arguments with `JSON.stringify`

## Why

When a self-hosted Penpot instance has a broken `/assets/by-id/...` or `/assets/by-file-media-id/...` route, `shape.export()` can return an HTML error page. Previously the MCP server passed those bytes to `sharp`, which surfaced a generic error such as `Input buffer contains unsupported image format`. That hides the actionable cause.

With this patch, users see a direct message that Penpot returned HTML instead of image bytes, including a short body prefix for diagnosis.

## Verification

- `pnpm run types:check` in `mcp/packages/server`
- `git diff --check`
- static secret-literal scan on the diff
- independent code review of the patch

Note: I also drafted a local diagnostic script, but did not include it because this local environment cannot load the `sharp` optional native dependency for `darwin-arm64`, so the script is not a reliable regression test here.
