### PR TITLE
:bug: Fix float precision in typography line-height/letter-spacing string conversion

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -957,10 +957,10 @@
                                           txt/text-transform-attrs)))
              values    (cond-> values
                          (number? (:line-height values))
-                         (update :line-height str)
+                         (update :line-height #(str (mth/precision % 2)))
 
                          (number? (:letter-spacing values))
-                         (update :letter-spacing str))
+                         (update :letter-spacing #(str (mth/precision % 2))))
 
              typ-id    (uuid/next)
              typ       (-> (if multiple?

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -384,7 +384,7 @@
         letter-spacing (or letter-spacing "0")
         handle-change
         (fn [value attr]
-          (on-change {attr (str value)}))]
+          (on-change {attr (ust/format-precision value 2)}))]
 
     [:div {:class (stl/css :spacing-options)}
      [:div {:class (stl/css :line-height)

--- a/frontend/test/frontend_tests/data/workspace_texts_test.cljs
+++ b/frontend/test/frontend_tests/data/workspace_texts_test.cljs
@@ -7,9 +7,13 @@
 (ns frontend-tests.data.workspace-texts-test
   (:require
    [app.common.geom.rect :as grc]
+   [app.common.test-helpers.files :as cthf]
+   [app.common.test-helpers.shapes :as cths]
    [app.common.types.shape :as cts]
+   [app.common.types.text :as txt]
    [app.main.data.workspace.texts :as dwt]
-   [cljs.test :as t :include-macros true]))
+   [cljs.test :as t :include-macros true]
+   [frontend-tests.helpers.state :as ths]))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -272,3 +276,101 @@
           result (dwt/apply-text-modifier shape {:width 200 :position-data pd})]
       (t/is (some? result))
       (t/is (some? (:selrect result))))))
+
+;; ---------------------------------------------------------------------------
+;; Tests: add-typography event normalises float line-height / letter-spacing
+;;
+;; These tests exercise the full add-typography event path in texts.cljs:
+;; a text shape whose content nodes carry float line-height / letter-spacing
+;; values (as produced by JS float arithmetic) must yield a typography entry
+;; in the file with properly-rounded *string* values, not the raw floats.
+;;
+;; Root cause reproduced here: JS float arithmetic (e.g. 1.3 - 0.1) can
+;; produce 1.2000000000000002 instead of 1.2.  Without the fix, that number
+;; survives through add-typography unchanged, and (ctt/check-typography)
+;; would throw because :line-height must be a :string.
+;; With the fix (mth/precision + str), it is normalised to "1.2" before the
+;; schema check runs.
+;; ---------------------------------------------------------------------------
+
+(t/deftest add-typography-normalises-float-line-height
+  (t/async
+    done
+    (let [;; Exact value reproduced from the issue: 1.3 - 0.1 in JS
+          float-lh  1.2000000000000002
+          content   (txt/change-text nil "hello" :line-height float-lh)
+          file      (-> (cthf/sample-file :file1)
+                        (cths/add-sample-shape :text1
+                                               :type    :text
+                                               :x 0 :y 0
+                                               :content content))
+          shape-id  (:id (cths/get-shape file :text1))
+          file-id   (:id file)
+          store     (ths/setup-store file)
+          events    [;; Pre-select the text shape so add-typography can find it
+                     (fn [state] (assoc-in state [:workspace-local :selected] #{shape-id}))
+                     (dwt/add-typography file-id)]]
+
+      (ths/run-store
+       store done events
+       (fn [new-state]
+         (let [file'        (ths/get-file-from-state new-state)
+               typographies (vals (get-in file' [:data :typographies]))]
+           (t/is (= 1 (count typographies))
+                 "exactly one typography was added")
+           (t/is (= "1.2" (:line-height (first typographies)))
+                 "float line-height is normalised to 2-decimal string")))))))
+
+(t/deftest add-typography-truncates-line-height-to-two-decimals
+  (t/async
+    done
+    (let [;; A value with more than 2 decimal places: 1.234234234 → "1.23"
+          long-lh   1.234234234
+          content   (txt/change-text nil "hello" :line-height long-lh)
+          file      (-> (cthf/sample-file :file1)
+                        (cths/add-sample-shape :text1
+                                               :type    :text
+                                               :x 0 :y 0
+                                               :content content))
+          shape-id  (:id (cths/get-shape file :text1))
+          file-id   (:id file)
+          store     (ths/setup-store file)
+          events    [(fn [state] (assoc-in state [:workspace-local :selected] #{shape-id}))
+                     (dwt/add-typography file-id)]]
+
+      (ths/run-store
+       store done events
+       (fn [new-state]
+         (let [file'        (ths/get-file-from-state new-state)
+               typographies (vals (get-in file' [:data :typographies]))]
+           (t/is (= 1 (count typographies))
+                 "exactly one typography was added")
+           (t/is (= "1.23" (:line-height (first typographies)))
+                 "line-height with more than 2 decimals is truncated to 2")))))))
+
+(t/deftest add-typography-normalises-float-letter-spacing
+  (t/async
+    done
+    (let [;; Analogous imprecision for letter-spacing
+          float-ls  0.10000000000000001
+          content   (txt/change-text nil "hello" :letter-spacing float-ls)
+          file      (-> (cthf/sample-file :file1)
+                        (cths/add-sample-shape :text1
+                                               :type    :text
+                                               :x 0 :y 0
+                                               :content content))
+          shape-id  (:id (cths/get-shape file :text1))
+          file-id   (:id file)
+          store     (ths/setup-store file)
+          events    [(fn [state] (assoc-in state [:workspace-local :selected] #{shape-id}))
+                     (dwt/add-typography file-id)]]
+
+      (ths/run-store
+       store done events
+       (fn [new-state]
+         (let [file'        (ths/get-file-from-state new-state)
+               typographies (vals (get-in file' [:data :typographies]))]
+           (t/is (= 1 (count typographies))
+                 "exactly one typography was added")
+           (t/is (= "0.1" (:letter-spacing (first typographies)))
+                 "float letter-spacing is normalised to 2-decimal string")))))))


### PR DESCRIPTION
### Related Ticket

Closes #3658 

Now the frontend stores the rounded value with two decimals. We haven't done a migration because seems overkill for this case.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
