### PR TITLE
:sparkles: Add nitrate endpoint to send renewal email

### DIFF
--- a/backend/resources/app/email/invite-to-org/en.subj
+++ b/backend/resources/app/email/invite-to-org/en.subj
@@ -1,1 +1,1 @@
-{{invited-by|abbreviate:25}} has invited you to join the organization “{{ organization-name|abbreviate:25 }}”
+{{invited-by|abbreviate:25}} has invited you to join the organization “{{ organization.name|abbreviate:25 }}”

--- a/backend/resources/app/email/invite-to-org/en.txt
+++ b/backend/resources/app/email/invite-to-org/en.txt
@@ -1,6 +1,6 @@
 Hello!
 
-{{invited-by|abbreviate:25}} has invited you to join the organization “{{ organization-name|abbreviate:25 }}”.
+{{invited-by|abbreviate:25}} has invited you to join the organization “{{ organization.name|abbreviate:25 }}”.
 
 Accept invitation using this link:
 

--- a/backend/resources/app/email/renewal-notice/en.html
+++ b/backend/resources/app/email/renewal-notice/en.html
@@ -187,46 +187,52 @@
                     <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
                         style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;">
-                        <b>{{invited-by|abbreviate:25}}</b> sent you an invitation to join the organization:
+                        Your Enterprise subscription is coming up for renewal. Here's a summary of what's included.
                       </div>
+                      <div style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;margin-top:20px">
+                        <b>Renewal date:</b> {{ renewal-date }}
+                      </div>
+                      <div style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;margin-top:10px">
+                        <b>Estimated amount:</b> {{ estimated-amount }}
+                      </div>
+                      <div style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;margin:10px 0">
+                        <b>Organizations covered:</b> {% if organizations|empty? %}No organizations yet.{% endif %}
+                      </div>
+
+                      {% for org in organizations %}
+                      <div
+                        style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;margin-bottom:5px">
+                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="20" height="20" style="display:inline-block;vertical-align:middle;">
+                          <tr>
+                            <td width="20" height="20" align="center" valign="middle"
+                                background="{% if org.logo %}{{org.logo}}{% else %}{{org.avatar-bg-url}}{% endif %}"
+                                style="width:20px;height:20px;text-align:center;font-weight:bold;font-size:9px;line-height:20px;color:#ffffff;background-size:cover;background-position:center;background-repeat:no-repeat;border-radius: 50%;color:black">
+                              {% if org.initials %}{{org.initials}}{% endif %}
+                            </td>
+                          </tr>
+                        </table>
+                        <span style="display:inline-block; vertical-align: middle;padding-left:5px;height:20px;line-height: 20px;">
+                        {{ org.name|abbreviate:50 }}
+                        </span>
+                      </div>
+                      {% endfor %}
                     </td>
                   </tr>
                   <tr>
                     <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
                         style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;">
-                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="20" height="20" style="display:inline-block;vertical-align:middle;">
-                          <tr>
-                            <td width="20" height="20" align="center" valign="middle"
-                                background="{% if organization.logo %}{{organization.logo}}{% else %}{{organization.avatar-bg-url}}{% endif %}"
-                                style="width:20px;height:20px;text-align:center;font-weight:bold;font-size:9px;line-height:20px;color:#ffffff;background-size:cover;background-position:center;background-repeat:no-repeat;border-radius: 50%;color:black">
-                              {% if organization.initials %}{{organization.initials}}{% endif %}
-                            </td>
-                          </tr>
-                        </table>
-                        <span style="display:inline-block; vertical-align: middle;padding-left:5px;height:20px;line-height: 20px;">
-                        {{ organization.name|abbreviate:50 }}
-                        </span>
-                      </div>
+                        This amount is based on current member counts across your organizations. You can adjust members from the <a href="{{ public-uri }}/admin-console/" target="_blank">Admin Console</a>.</div>
                     </td>
                   </tr>
                   <tr>
-                    <td align="center" vertical-align="middle"
-                      style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                      <table border="0" cellpadding="0" cellspacing="0" role="presentation"
-                        style="border-collapse:separate;line-height:100%;">
-                        <tr>
-                          <td align="center" bgcolor="#6911d4" role="presentation"
-                            style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
-                            valign="middle">
-                            <a href="{{ public-uri }}/#/auth/verify-token?token={{token}}"
-                              style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
-                              target="_blank"> ACCEPT INVITE </a>
-                          </td>
-                        </tr>
-                      </table>
+                    <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                      <div
+                        style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;">
+                        Check our <a href="https://penpot.app/terms" target="_blank">Terms and Conditions</a> and <a href="https://penpot.app/privacy" target="_blank">Privacy Policy.</a></div>
                     </td>
                   </tr>
+
                   <tr>
                     <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div

--- a/backend/resources/app/email/renewal-notice/en.subj
+++ b/backend/resources/app/email/renewal-notice/en.subj
@@ -1,0 +1,1 @@
+Your Enterprise subscription renews on {{ renewal-date }}

--- a/backend/resources/app/email/renewal-notice/en.txt
+++ b/backend/resources/app/email/renewal-notice/en.txt
@@ -1,0 +1,17 @@
+Hi {% if user-name %}{{ user-name }}{% endif %},
+
+Your Enterprise subscription is coming up for renewal. Here's a summary of what's included.
+
+Renewal date: {{ renewal-date }}
+Estimated amount: {{ estimated-amount }}
+
+Organizations covered: {% if organizations|empty? %}No organizations yet.{% endif %}
+{% for org in organizations %}
+- {{ org.name }}
+{% endfor %}
+This amount is based on current member counts across your organizations. You can adjust members from the Admin Console.
+
+Check our Terms and Conditions and Privacy Policy.
+
+Enjoy!
+The Penpot team.

--- a/backend/src/app/email.clj
+++ b/backend/src/app/email.clj
@@ -431,20 +431,40 @@
    :id ::invite-to-team
    :schema schema:invite-to-team))
 
+(def ^:private schema:organization-data
+  [:map
+   [:name ::sm/text]
+   [:initials [:maybe :string]]
+   [:logo [:maybe ::sm/uri]]
+   [:avatar-bg-url [:maybe ::sm/uri]]])
+
 (def ^:private schema:invite-to-org
   [:map
    [:invited-by ::sm/text]
-   [:organization-name ::sm/text]
-   [:organization-initials [:maybe :string]]
-   [:organization-logo ::sm/uri]
    [:user-name [:maybe ::sm/text]]
-   [:token ::sm/text]])
+   [:token ::sm/text]
+   [:organization schema:organization-data]])
 
 (def invite-to-org
   "Org member invitation email."
   (template-factory
    :id ::invite-to-org
    :schema schema:invite-to-org))
+
+
+
+(def ^:private schema:renewal-notice
+  [:map
+   [:user-name [:maybe ::sm/text]]
+   [:renewal-date ::sm/text]
+   [:estimated-amount ::sm/text]
+   [:organizations [:vector schema:organization-data]]])
+
+(def renewal-notice
+  "Enterprise subscription renewal notice email."
+  (template-factory
+   :id ::renewal-notice
+   :schema schema:renewal-notice))
 
 (def ^:private schema:join-team
   [:map

--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -237,9 +237,7 @@
                             :to email
                             :invited-by (:fullname profile)
                             :user-name (:fullname member)
-                            :organization-name (:name organization)
-                            :organization-logo (:logo organization)
-                            :organization-initials (:initials organization)
+                            :organization organization
                             :token itoken
                             :extra-data ptoken}))
               (eml/send! {::eml/conn conn
@@ -255,11 +253,10 @@
           itoken)))))
 
 (defn create-org-invitation
-  [cfg {:keys [::rpc/profile-id id name initials logo] :as params}]
+  [cfg {:keys [::rpc/profile-id] :as params}]
   (let [profile  (db/get-by-id cfg :profile profile-id)]
     (create-invitation cfg
                        (assoc params
-                              :organization {:id id :name name :initials initials :logo logo}
                               :profile profile
                               :role :editor))))
 

--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -12,11 +12,12 @@
    [app.common.exceptions :as ex]
    [app.common.schema :as sm]
    [app.common.time :as ct]
-   [app.common.types.organization :refer [schema:team-with-organization]]
+   [app.common.types.organization :refer [schema:team-with-organization schema:organization-with-avatar]]
    [app.common.types.profile :refer [schema:profile, schema:basic-profile]]
    [app.common.types.team :refer [schema:team]]
    [app.config :as cf]
    [app.db :as db]
+   [app.email :as eml]
    [app.media :as media]
    [app.nitrate :as nitrate]
    [app.rpc :as-alias rpc]
@@ -29,7 +30,8 @@
    [app.rpc.notifications :as notifications]
    [app.storage :as sto]
    [app.util.services :as sv]
-   [app.worker :as wrk]))
+   [app.worker :as wrk]
+   [cuerdas.core :as str]))
 
 
 (defn- profile-to-map [profile]
@@ -472,10 +474,7 @@ RETURNING id, deleted_at;")
   {::doc/added "2.15"
    ::sm/params [:map
                 [:email ::sm/email]
-                [:id ::sm/uuid]
-                [:name ::sm/text]
-                [:initials [:maybe :string]]
-                [:logo ::sm/uri]]}
+                [:organization schema:organization-with-avatar]]}
   [cfg params]
   (db/tx-run! cfg ti/create-org-invitation params)
   nil)
@@ -676,6 +675,38 @@ LEFT JOIN profile AS p
                                 valid-teams-to-delete-ids
                                 (count valid-teams-to-transfer)
                                 (count valid-teams-to-exit))))
+
+;; API: send-renewal-email
+
+(def ^:private schema:send-renewal-email-params
+  [:map
+   [:profile-id ::sm/uuid]
+   [:user-email ::sm/email]
+   [:user-name [:maybe ::sm/text]]
+   [:renewal-date :string]
+   [:estimated-amount :double]
+   [:organizations [:vector schema:organization-with-avatar]]])
+
+(sv/defmethod ::send-renewal-email
+  "Send an Enterprise subscription renewal notice email to a user."
+  {::doc/added "2.17"
+   ::sm/params schema:send-renewal-email-params
+   ::rpc/auth false}
+  [cfg {:keys [profile-id user-email user-name renewal-date estimated-amount organizations]}]
+  (let [amount-str (format "$%.2f" estimated-amount)
+        user-name  (if (str/empty? user-name)
+                     (:fullname (profile/get-profile cfg profile-id))
+                     user-name)]
+    (db/tx-run! cfg (fn [{:keys [::db/conn]}]
+                      (eml/send! {::eml/conn    conn
+                                  ::eml/factory eml/renewal-notice
+                                  :public-uri   (cf/get :public-uri)
+                                  :to           user-email
+                                  :user-name    user-name
+                                  :renewal-date renewal-date
+                                  :estimated-amount amount-str
+                                  :organizations organizations}))))
+  nil)
 
 ;; API: cleanup-org-team-invitations
 

--- a/common/src/app/common/types/organization.cljc
+++ b/common/src/app/common/types/organization.cljc
@@ -52,3 +52,12 @@
                      (or (:organization team) {})
                      organization->team-keys))
       (dissoc team :organization))))
+
+
+(def schema:organization-with-avatar
+  [:map
+   [:id ::sm/uuid]
+   [:name ::sm/text]
+   [:initials [:maybe :string]]
+   [:logo [:maybe ::sm/uri]]
+   [:avatar-bg-url [:maybe ::sm/uri]]])


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26461

### Summary

* Add nitrate endpoint to send renewal email
* Change send-invitation-to-org endpoint to use the same parameters structure


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
