### PR TITLE
:bug: Fix wasm info label positioning

### DIFF
--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -53,7 +53,7 @@ pub fn render_wasm_label(render_state: &mut RenderState) {
     }
 
     let canvas = render_state.surfaces.canvas(SurfaceId::Target);
-    let skia::ISize { width, height } = canvas.base_layer_size();
+    let canvas_width = canvas.base_layer_size().width as f32;
     let mut paint = skia::Paint::default();
     paint.set_color(skia::Color::GRAY);
 
@@ -62,18 +62,19 @@ pub fn render_wasm_label(render_state: &mut RenderState) {
     } else {
         "WebGL rendering"
     };
+    let dpr = render_state.options.dpr;
     let (scalar, _) = render_state.fonts.debug_font().measure_str(str, None);
-    let mut p = skia::Point::new(width as f32 - 25.0 - scalar, height as f32 - 25.0);
+    let mut p = skia::Point::new(canvas_width - (20.0 * dpr) - scalar, 50.0 * dpr);
 
     let debug_font = render_state.fonts.debug_font();
     canvas.draw_str(str, p, debug_font, &paint);
 
     if render_state.options.is_text_editor_v3() {
-        str = "TEXT EDITOR / V3";
+        str = "Text Editor v3";
 
         let (scalar, _) = render_state.fonts.debug_font().measure_str(str, None);
-        p.x = width as f32 - 25.0 - scalar;
-        p.y -= 20.0;
+        p.x = canvas_width - (20.0 * dpr) - scalar;
+        p.y += 15.0 * dpr;
         canvas.draw_str(str, p, debug_font, &paint);
     }
 }

--- a/render-wasm/src/render/fonts.rs
+++ b/render-wasm/src/render/fonts.rs
@@ -39,7 +39,7 @@ impl FontStore {
                 "Failed to match default font".to_string(),
             ))?;
 
-        let debug_font = skia::Font::new(debug_typeface, 10.0);
+        let debug_font = skia::Font::new(debug_typeface, 12.0);
 
         Ok(Self {
             font_mgr,
@@ -51,7 +51,7 @@ impl FontStore {
     }
 
     pub fn set_scale_debug_font(&mut self, dpr: f32) {
-        let debug_font = skia::Font::new(self.debug_font.typeface(), 10.0 * dpr);
+        let debug_font = skia::Font::new(self.debug_font.typeface(), 12.0 * dpr);
         self.debug_font = debug_font;
     }
 


### PR DESCRIPTION
### Summary

This fixes wasm info label positioning and font size, so it does not get covered by the chat / help overlayed button.

<img width="189" height="73" alt="Screenshot" src="https://github.com/user-attachments/assets/f5b7848d-07f2-4b64-a903-6714e53c3017" />

With text editor v3 active: 
<img width="198" height="117" alt="Screenshot" src="https://github.com/user-attachments/assets/1075be5d-b8e2-4f1b-8965-6a816d910c2f" />
