### PR TITLE
:bug: Fix get-comment-threads called with empty params due to race condition

### DIFF
--- a/frontend/src/app/main/data/workspace/comments.cljs
+++ b/frontend/src/app/main/data/workspace/comments.cljs
@@ -274,7 +274,8 @@
   (ptk/reify ::navigate-to-comment-id
     ptk/WatchEvent
     (watch [_ state _]
-      (let [file-id (:current-file-id state)]
+      (if-let [file-id (:current-file-id state)]
         (->> (rp/cmd! :get-comment-threads {:file-id file-id})
              (rx/map #(d/seek (fn [{:keys [id]}] (= thread-id id)) %))
-             (rx/map navigate-to-comment))))))
+             (rx/map navigate-to-comment))
+        (rx/empty)))))


### PR DESCRIPTION
## Root Cause

Race condition in `navigate-to-comment-id` (workspace/comments.cljs:274). During rapid workspace navigation, `finalize-workspace` clears `current-file-id` from state before the deferred `::workspace-initialized` observer dispatches `navigate-to-comment-id`. The function reads a nil file-id from state, passes `{:file-id nil}` which gets stripped to `{}` by `map->query-string`, and the backend validation fails.

## Fix

Changed `let` to `if-let` with `rx/empty` fallback when file-id is nil, gracefully handling the case where the workspace has been finalized before the deferred event runs.

## Error Before Fix

```
{:type :validation,
 :code :params-validation,
 :schema [:app.common.schema/contains-any #{:team-id :file-id}],
 :value {}}
```