### PR TITLE
:bug: Fix del-page change constructed with nil id

### DIFF
--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -311,10 +311,12 @@
 
 (defn del-page
   [changes page]
-  (-> changes
-      (update :redo-changes conj {:type :del-page :id (:id page)})
-      (update :undo-changes conj {:type :add-page :id (:id page) :page page})
-      (apply-changes-local)))
+  (let [page-id (:id page)]
+    (assert (some? page-id) "page must have a valid :id")
+    (-> changes
+        (update :redo-changes conj {:type :del-page :id page-id})
+        (update :undo-changes conj {:type :add-page :id page-id :page page})
+        (apply-changes-local))))
 
 (defn move-page
   [changes page-id index prev-index]

--- a/frontend/src/app/main/data/workspace/pages.cljs
+++ b/frontend/src/app/main/data/workspace/pages.cljs
@@ -379,15 +379,18 @@
             pages   (:pages fdata)
 
             index   (d/index-of pages id)
-            page    (get pindex id)
-            page    (assoc page :index index)
-            pages   (filter #(not= % id) pages)
+            page    (get pindex id)]
 
-            changes (-> (pcb/empty-changes it)
-                        (pcb/with-library-data fdata)
-                        (delete-page-components page)
-                        (pcb/del-page page))]
+        (if (nil? page)
+          (rx/empty)
+          (let [page    (assoc page :index index)
+                pages   (filter #(not= % id) pages)
 
-        (rx/of (dch/commit-changes changes)
-               (when (= id (:current-page-id state))
-                 (dcm/go-to-workspace {:page-id (first pages)})))))))
+                changes (-> (pcb/empty-changes it)
+                            (pcb/with-library-data fdata)
+                            (delete-page-components page)
+                            (pcb/del-page page))]
+
+            (rx/of (dch/commit-changes changes)
+                   (when (= id (:current-page-id state))
+                     (dcm/go-to-workspace {:page-id (first pages)})))))))))


### PR DESCRIPTION
### Related Ticket

No issue.

### Summary

The `delete-page` function was constructing a `{:type :del-page :id nil}` change when the page id was nil or the page was no longer present in the pages-index. This caused a server-side validation error (400) when the frontend tried to commit the change.

This can happen due to a **race condition** where the UI triggers a delete on a page that has already been removed from state.

**Fix:**
- **Frontend** (`pages.cljs`): Guard in `delete-page` — if the page is not found in `pages-index`, return `(rx/empty)` instead of proceeding with a broken change.
- **Common** (`changes_builder.cljc`): Add assertion in `del-page` to catch a nil page id at construction time as defense-in-depth.

### Steps to reproduce

Difficult to reproduce deterministically — occurs under race conditions where the page is removed from state before the delete action is processed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief description of the changes.