### PR TITLE
:bug: Fix crash when typography token value is an array

### DIFF
--- a/frontend/src/app/main/data/style_dictionary.cljs
+++ b/frontend/src/app/main/data/style_dictionary.cljs
@@ -302,36 +302,38 @@
       {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value-typography value)]}
 
       :else
-      (let [converted (js->clj value :keywordize-keys true)
-            add-keyed-errors (fn [typography-map k errors]
-                               (update typography-map :errors concat (map #(assoc % :typography-key k) errors)))
-            ;; Separate line-height to process in an extra step
-            without-line-height (dissoc converted :line-height)
-            valid-typography (reduce
-                              (fn [acc [k v]]
-                                (let [{:keys [errors value]} (parse-atomic-typography-value k v)]
-                                  (if (seq errors)
-                                    (add-keyed-errors acc k errors)
-                                    (assoc-in acc [:value k] (or value v)))))
-                              {:value {}}
-                              without-line-height)
+      (let [converted (js->clj value :keywordize-keys true)]
+        (if-not (map? converted)
+          {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value-typography value)]}
+          (let [add-keyed-errors (fn [typography-map k errors]
+                                   (update typography-map :errors concat (map #(assoc % :typography-key k) errors)))
+                ;; Separate line-height to process in an extra step
+                without-line-height (dissoc converted :line-height)
+                valid-typography (reduce
+                                  (fn [acc [k v]]
+                                    (let [{:keys [errors value]} (parse-atomic-typography-value k v)]
+                                      (if (seq errors)
+                                        (add-keyed-errors acc k errors)
+                                        (assoc-in acc [:value k] (or value v)))))
+                                  {:value {}}
+                                  without-line-height)
 
-            ;; Calculate line-height based on the resolved font-size and add it back to the map
-            line-height (when-let [line-height (:line-height converted)]
-                          (-> (parse-sd-token-typography-line-height
-                               line-height
-                               (get-in valid-typography [:value :font-size])
-                               (get-in valid-typography [:errors :font-size]))))
-            valid-typography (cond
-                               (:errors line-height)
-                               (add-keyed-errors valid-typography :line-height (:errors line-height))
+                ;; Calculate line-height based on the resolved font-size and add it back to the map
+                line-height (when-let [line-height (:line-height converted)]
+                              (-> (parse-sd-token-typography-line-height
+                                   line-height
+                                   (get-in valid-typography [:value :font-size])
+                                   (get-in valid-typography [:errors :font-size]))))
+                valid-typography (cond
+                                   (:errors line-height)
+                                   (add-keyed-errors valid-typography :line-height (:errors line-height))
 
-                               line-height
-                               (assoc-in valid-typography [:value :line-height] line-height)
+                                   line-height
+                                   (assoc-in valid-typography [:value :line-height] line-height)
 
-                               :else
-                               valid-typography)]
-        valid-typography))))
+                                   :else
+                                   valid-typography)]
+            valid-typography))))))
 
 (defn collect-typography-errors [token]
   (group-by :typography-key (:errors token)))

--- a/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
+++ b/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
@@ -97,6 +97,31 @@
                             (-> errors first :error/code)))))
                (done))))))))
 
+;; Regression: a composite typography token whose value is a plain
+;; array (e.g. ["Roboto"]) instead of a map must not crash with
+;; "No protocol method IMap.-dissoc defined for type object".
+;; It should return an invalid-token-value-typography error instead.
+(t/deftest resolve-tokens-typography-array-value-test
+  (t/async
+    done
+    (t/testing "typography token with array value produces error instead of crashing"
+      (let [tokens (-> (ctob/make-tokens-lib)
+                       (ctob/add-set (ctob/make-token-set :id (cthi/new-id! :core-set)
+                                                          :name "core"))
+                       (ctob/add-token (cthi/id :core-set)
+                                       (ctob/make-token {:name "typography.bad"
+                                                         :value ["Roboto"]
+                                                         :type :typography}))
+                       (ctob/get-all-tokens-map))]
+        (-> (sd/resolve-tokens tokens)
+            (rx/sub!
+             (fn [resolved-tokens]
+               (t/is (contains? resolved-tokens "typography.bad"))
+               (t/is (nil? (get-in resolved-tokens ["typography.bad" :resolved-value])))
+               (t/is (= :error.style-dictionary/invalid-token-value-typography
+                        (get-in resolved-tokens ["typography.bad" :errors 0 :error/code])))
+               (done))))))))
+
 (t/deftest resolve-tokens-interactive-test
   (t/async
     done


### PR DESCRIPTION
## Summary

Fixes a crash in the style dictionary resolver when a composite typography token has an array value (e.g. `["Roboto"]`) instead of the expected map structure.

## Problem

When `parse-composite-typography-value` receives a non-map value like `["Roboto"]`, `js->clj` converts it to a ClojureScript vector. The subsequent `(dissoc converted :line-height)` then crashes with:

```
Error: No protocol method IMap.-dissoc defined for type object: ["Roboto"]
```

This can happen when importing tokens from external sources or when token values are malformed.

## Solution

Added a `(map? converted)` guard after `js->clj` conversion in `parse-composite-typography-value`. If the result is not a map, the function now returns an `:error.style-dictionary/invalid-token-value-typography` error instead of crashing, allowing the UI to display the token as a broken pill.

## Changes

- **`frontend/src/app/main/data/style_dictionary.cljs`** — Added `map?` guard before `dissoc` call
- **`frontend/test/frontend_tests/tokens/style_dictionary_test.cljs`** — Added regression test `resolve-tokens-typography-array-value-test`

## Testing

All 4 style-dictionary tests pass (21 assertions, 0 failures), including the new regression test that verifies:
- The token is present in the resolved map
- No `resolved-value` is set
- The correct error code `:error.style-dictionary/invalid-token-value-typography` is returned