### PR TITLE
:bug: Fix webgl thumbnail label

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2254,7 +2254,10 @@ impl RenderState {
         timestamp: i32,
     ) -> Result<()> {
         self.render_shape_tree_partial(base_object, tree, timestamp, false)?;
+        let saved_preview_mode = self.preview_mode;
+        self.preview_mode = true;
         self.present_frame(tree);
+        self.preview_mode = saved_preview_mode;
         Ok(())
     }
 

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -48,7 +48,7 @@ pub fn render_debug_cache_surface(render_state: &mut RenderState) {
 }
 
 pub fn render_wasm_label(render_state: &mut RenderState) {
-    if !render_state.options.show_wasm_info() {
+    if render_state.preview_mode || !render_state.options.show_wasm_info() {
         return;
     }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14295
Closes #10003

### Summary

We should not render the WebGL label on thumbnails (preview mode)

### Steps to reproduce 

- Create a new file
- Check in the dashboard if the label is present

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
