### PR TITLE
:bug: Fix text editor swap when WebGL render is enabled/disabled

### DIFF
--- a/frontend/src/app/main/features.cljs
+++ b/frontend/src/app/main/features.cljs
@@ -63,7 +63,7 @@
     ;; Ensure it's always enabled whenever render-wasm/v1 is active.
     (if (contains? features "render-wasm/v1")
       (conj features "text-editor/v2")
-      (disj features "text-editor/v2"))))
+      (disj features "text-editor/v2" "text-editor-wasm/v1"))))
 
 (defn get-enabled-features
   "An explicit lookup of enabled features for the current team"

--- a/frontend/src/app/util/text/content.cljs
+++ b/frontend/src/app/util/text/content.cljs
@@ -14,7 +14,8 @@
 (defn dom->cljs
   "Gets the editor content from a DOM structure"
   [root]
-  (fd/create-root root))
+  (when (some? root)
+    (fd/create-root root)))
 
 (defn cljs->dom
   "Sets the editor content from a CLJS structure"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14298
https://github.com/penpot/penpot/issues/10015

### Summary

Enabling and disabling the WebGL render should also swap correctly between text editors

https://github.com/user-attachments/assets/db5f21e4-9841-490f-9538-87cb66615692

### Steps to reproduce 

Described in the issue

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
