### PR TITLE
:arrow_up: Updgrade base image  for devenv docker image to ubuntu 26.04

### DIFF
--- a/docker/devenv/Dockerfile
+++ b/docker/devenv/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS base
+FROM ubuntu:26.04 AS base
 
 ENV LANG='C.UTF-8' \
     LC_ALL='C.UTF-8' \
@@ -416,7 +416,7 @@ RUN set -ex; \
       libfreetype6 \
       libfontconfig1 \
       libglib2.0-0 \
-      libxml2 \
+      libxml2-16 \
       liblcms2-2 \
       libheif1 \
       libopenjp2-7 \
@@ -425,7 +425,7 @@ RUN set -ex; \
       libgomp1 \
       libwebpmux3 \
       libwebpdemux2 \
-      libzip4t64 \
+      libzip5 \
     ; \
     rm -rf /var/lib/apt/lists/*;
 
@@ -458,7 +458,7 @@ ENV LANG='C.UTF-8' \
     SERENA_CONTEXT="claude-code" \
     PATH="/opt/jdk/bin:/opt/gh/bin:/opt/utils/bin:/opt/clojure/bin:/opt/node/bin:/opt/imagick/bin:/opt/cargo/bin:$PATH"
 
-COPY --from=penpotapp/imagemagick:7.1.2-13 /opt/imagick /opt/imagick
+COPY --from=penpotapp/imagemagick:7.1.2-24 /opt/imagick /opt/imagick
 COPY --from=setup-jvm /opt/jdk /opt/jdk
 COPY --from=setup-jvm /opt/clojure /opt/clojure
 COPY --from=setup-node /opt/node /opt/node

--- a/docker/imagemagick/Dockerfile
+++ b/docker/imagemagick/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 LABEL maintainer="Penpot <docker@penpot.app>"
 
 ENV LANG='C.UTF-8' \
@@ -6,7 +6,7 @@ ENV LANG='C.UTF-8' \
     DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
-ARG IMAGEMAGICK_VERSION=7.1.2-13
+ARG IMAGEMAGICK_VERSION=7.1.2-24
 
 RUN set -e; \
     apt-get -qq update; \
@@ -79,13 +79,12 @@ RUN set -e; \
         libopenjp2-7 \
         libpng16-16 \
         librsvg2-2 \
-        libxml2 \
         libtiff6 \
         libwebp7 \
         libwebpdemux2 \
         libwebpmux3 \
-        libxml2 \
-        libzip4t64 \
+        libxml2-16 \
+        libzip5 \
         libzstd1 \
     ;\
     apt-get -qqy clean; \

--- a/manage.sh
+++ b/manage.sh
@@ -1281,16 +1281,17 @@ function usage {
     echo "- build-frontend-bundle            Build frontend bundle"
     echo "- build-backend-bundle             Build backend bundle."
     echo "- build-exporter-bundle            Build exporter bundle."
-    echo "- build-storybook-bundle           Build storybook bundle."
     echo "- build-mcp-bundle                 Build mcp bundle."
+    echo "- build-storybook-bundle           Build storybook bundle."
     echo "- build-docs-bundle                Build docs bundle."
     echo ""
-    echo "- build-docker-images              Build all docker images (frontend, backend and exporter)."
+    echo "- build-docker-images              Build all docker images (frontend, backend, exporter, mcp and storybook)."
     echo "- build-frontend-docker-image      Build frontend docker images."
     echo "- build-backend-docker-image       Build backend docker images."
     echo "- build-exporter-docker-image      Build exporter docker images."
     echo "- build-mcp-docker-image           Build exporter docker images."
     echo "- build-storybook-docker-image     Build storybook docker images."
+    echo "- build-imagemagick-docker-image   Build imagemagic docker images."
     echo ""
     echo "- version                          Show penpot's version."
 }
@@ -1369,11 +1370,6 @@ case $1 in
         build-docs-bundle;
         ;;
 
-    build-imagemagick-docker-image)
-        shift;
-        build-imagemagick-docker-image $@;
-        ;;
-
     build-docker-images)
         build-frontend-docker-image
         build-backend-docker-image
@@ -1400,6 +1396,11 @@ case $1 in
 
     build-storybook-docker-image)
         build-storybook-docker-image
+        ;;
+
+    build-imagemagick-docker-image)
+        shift;
+        build-imagemagick-docker-image $@;
         ;;
 
     *)

--- a/manage.sh
+++ b/manage.sh
@@ -59,7 +59,7 @@ PENPOT_PORT_BASE_MDTS=${MDTS_EXTERNAL_PORT:?missing in defaults.env}
 export CURRENT_USER_ID=$(id -u);
 export CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD);
 
-export IMAGEMAGICK_VERSION=7.1.2-13
+export IMAGEMAGICK_VERSION=7.1.2-24
 
 # Safe directory to avoid ownership errors with Git
 git config --global --add safe.directory /home/penpot/penpot || true


### PR DESCRIPTION
This PR:
- Upgrade ImageMagick to 7.1.2-24 (from 7.1.2-13)
- Updates the base image to Ubuntu 26.04 for ImageMagick and DevEnv. 
  There are two libraries that have changed their names:  `libxml2` -> `libxml2-16`  and  `libzip4t64` -> `libzip5`
- Fixes the help message in `manage.sh`.
  Adding commands that were missing and correcting typos.