### PR TITLE
:bug: Fix plugin API crash when setting text fills

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -411,7 +411,7 @@
         (rx/concat
          (rx/of (dwsh/update-shapes shape-ids update-fn))
          (if (features/active-feature? state "render-wasm/v1")
-           (dwwt/resize-wasm-text-debounce id)
+           (rx/of (dwwt/resize-wasm-text-debounce id))
            (rx/empty)))))))
 
 (defn update-root-attrs


### PR DESCRIPTION
## Problem

When a plugin sets text fills via the Plugin API, the application crashes with:

```
TypeError: You provided an invalid object where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.
```

## Root Cause

In `frontend/src/app/main/data/workspace/texts.cljs`, the `update-text-range` event's `watch` method was returning a bare potok event object directly inside `rx/concat`:

```clojure
(rx/concat
 (rx/of (dwsh/update-shapes shape-ids update-fn))
 (if (features/active-feature? state "render-wasm/v1")
   (dwwt/resize-wasm-text-debounce id)   ;; ← plain object, NOT an Observable
   (rx/empty)))
```

`dwwt/resize-wasm-text-debounce` returns a `ptk/reify` object (a plain ClojureScript map-like object). When `rx/concat` tried to subscribe to it, RxJS threw the error.

## Solution

Wrapped the event in `rx/of` so it becomes a proper Observable that emits the event to the potok store:

```clojure
(rx/concat
 (rx/of (dwsh/update-shapes shape-ids update-fn))
 (if (features/active-feature? state "render-wasm/v1")
   (rx/of (dwwt/resize-wasm-text-debounce id))   ;; ← now a valid Observable
   (rx/empty)))
```

This matches the correct pattern used elsewhere in the codebase (e.g., `clipboard.cljs` lines 1050/1082 and `texts.cljs` line 1232).

## Changes

- `frontend/src/app/main/data/workspace/texts.cljs`: Added `rx/of` wrapper around `(dwwt/resize-wasm-text-debounce id)` at line 414.


Closes #10053
