### PR TITLE
:bug: Ignore Safari browser extension errors in error handler

### DIFF
--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -436,7 +436,10 @@
   (let [stack (.-stack cause)]
     (and (string? stack)
          (or (str/includes? stack "chrome-extension://")
-             (str/includes? stack "moz-extension://")))))
+             (str/includes? stack "moz-extension://")
+             ;; Safari/WebKit masks extension and Web Inspector URLs
+             ;; with this internal scheme.
+             (str/includes? stack "webkit-masked-url://")))))
 
 (defn- from-posthog?
   "True when the error stack trace originates from PostHog analytics."
@@ -471,6 +474,14 @@
         ;; TypeError.  This is a known Zone.js / browser-extension
         ;; incompatibility and is NOT a Penpot bug.
         (str/starts-with? message "Cannot assign to read only property 'toString'")
+        ;; Safari TypeError: "Attempting to change value of a readonly
+        ;; property".  Raised when browser extensions or Web Inspector
+        ;; devtools (e.g., jsonPrune) try to mutate ClojureScript's
+        ;; immutable data structures via Object.defineProperty.
+        ;; ClojureScript defines getter-only properties on its maps
+        ;; and records, making them readonly.  This is NOT a Penpot bug.
+        (and (= (.-name ^js cause) "TypeError")
+             (= message "Attempting to change value of a readonly property"))
         ;; NotFoundError DOMException: "Failed to execute
         ;; 'removeChild' on 'Node'" — Thrown by React's commit
         ;; phase when the DOM tree has been modified externally


### PR DESCRIPTION
## Summary

Fix Safari browser extension errors being surfaced to users.

## Problem

Safari browser extensions and Web Inspector devtools inject code into the page that attempts to mutate ClojureScript's immutable data structures via `Object.defineProperty`. This throws a `TypeError: Attempting to change value of a readonly property` which was being reported as an application error.

The error trace showed:
- `jsonPrune` function (not part of Penpot codebase)
- `webkit-masked-url://` URLs (Safari's internal extension URL scheme)
- Dynamic code injection via `eval` + `appendChild`

## Solution

1. Added detection for Safari's `webkit-masked-url://` extension URLs in the `from-extension?` function
2. Added specific filter for the "Attempting to change value of a readonly property" TypeError as a safety net

These errors are now silently ignored like other browser extension errors (Chrome, Firefox).

## Changes

- `frontend/src/app/main/errors.cljs`: Extended `from-extension?` to recognize Safari extension URLs and added TypeError filter for readonly property mutation