### PR TITLE
:bug: Fix first element on shared libraries list does not have border

### DIFF
--- a/frontend/src/app/main/ui/workspace/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/libraries.cljs
@@ -331,7 +331,7 @@
                       :class       (stl/css :title-spacing-lib)}]
       [:div {:class (stl/css :section-list)}
 
-       [:div {:class (stl/css :section-list-item)}
+       [:div {:class (stl/css :section-list-publish)}
         [:div {:class (stl/css :item-content)}
          [:div {:class (stl/css :item-title)} (tr "workspace.libraries.file-library")]
          [:ul {:class (stl/css :item-contents)}

--- a/frontend/src/app/main/ui/workspace/libraries.scss
+++ b/frontend/src/app/main/ui/workspace/libraries.scss
@@ -93,12 +93,14 @@
   border-radius: $br-8;
 }
 
-.section-list-item {
+.section-list-publish {
   @extend %section-list-item-placeholder;
 
-  &:first-child {
-    border: none;
-  }
+  border: none;
+}
+
+.section-list-item {
+  @extend %section-list-item-placeholder;
 }
 
 .section-list-item-double-icon {


### PR DESCRIPTION
### Related Ticket

Closes #9910 

### Summary

All the list items in the shared libraries & updates modal should have a border, except for the first item of the left column.