### PR TITLE
:paperclip: Add license metadata for MCP package

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,6 +2,7 @@
   "name": "@penpot/mcp",
   "version": "2.16.0-rc.9.11",
   "description": "MCP server for Penpot integration",
+  "license": "MPL-2.0",
   "bin": {
     "penpot-mcp": "./bin/mcp-local.js"
   },


### PR DESCRIPTION
### Summary

Adds the repository license SPDX identifier to the `@penpot/mcp` package manifest so npm consumers and package-compliance tooling can read the package license directly from metadata.

### Verification

- Confirmed `mcp/package.json` parses as JSON.
- Confirmed the package manifest now includes `"license": "MPL-2.0"`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
