### PR TITLE
:bug: Fix frame inner strokes ignoring focus mode in wasm renderer

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2584,8 +2584,11 @@ impl RenderState {
 
         // Strokes are drawn over children for clipped frames (all strokes), and for non-clipped
         // frames with inner strokes (inner strokes only — non-inner were rendered before children).
-        let needs_exit_strokes = element.clip()
-            || (matches!(element.shape_type, Type::Frame(_)) && element.has_inner_stroke());
+        // Skip when focus mode excludes this subtree (focus_mode.exit runs after this, so
+        // is_active() still reflects this element's focus state here).
+        let needs_exit_strokes = self.focus_mode.is_active()
+            && (element.clip()
+                || (matches!(element.shape_type, Type::Frame(_)) && element.has_inner_stroke()));
 
         if needs_exit_strokes {
             let mut element_strokes: Cow<Shape> = Cow::Borrowed(element);


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10061

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
