### PR TITLE
:bug: Make set-file-shared idempotent to fix race condition with optimistic updates

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -974,6 +974,12 @@
                              {:id id})
                  file)
 
+               (= (:is-shared file) (:is-shared params))
+               ;; File is already in the desired state (idempotent);
+               ;; this can happen when the frontend sends a duplicate
+               ;; request due to optimistic updates or race conditions.
+               file
+
                :else
                (ex/raise :type :validation
                          :code :invalid-shared-state

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -830,6 +830,49 @@
     (t/is (th/ex-info? error))
     (t/is (th/ex-of-type? error :not-found))))
 
+(t/deftest set-file-shared-idempotent
+  (let [profile (th/create-profile* 1)
+        file    (th/create-file* 1 {:project-id (:default-project-id profile)
+                                    :profile-id (:id profile)})]
+
+    ;; Share the file
+    (let [data {::th/type :set-file-shared
+                ::rpc/profile-id (:id profile)
+                :id (:id file)
+                :is-shared true}
+          out  (th/command! data)]
+      (t/is (nil? (:error out)))
+      (t/is (true? (-> out :result :is-shared))))
+
+    ;; Calling set-file-shared with is-shared=true again should be a
+    ;; no-op success (idempotent), not an error.
+    (let [data {::th/type :set-file-shared
+                ::rpc/profile-id (:id profile)
+                :id (:id file)
+                :is-shared true}
+          out  (th/command! data)]
+      (t/is (nil? (:error out)))
+      (t/is (true? (-> out :result :is-shared))))
+
+    ;; Unshare the file
+    (let [data {::th/type :set-file-shared
+                ::rpc/profile-id (:id profile)
+                :id (:id file)
+                :is-shared false}
+          out  (th/command! data)]
+      (t/is (nil? (:error out)))
+      (t/is (false? (-> out :result :is-shared))))
+
+    ;; Calling set-file-shared with is-shared=false again should also
+    ;; be a no-op success (idempotent).
+    (let [data {::th/type :set-file-shared
+                ::rpc/profile-id (:id profile)
+                :id (:id file)
+                :is-shared false}
+          out  (th/command! data)]
+      (t/is (nil? (:error out)))
+      (t/is (false? (-> out :result :is-shared))))))
+
 (t/deftest permissions-checks-link-to-library-1
   (let [profile1 (th/create-profile* 1)
         profile2 (th/create-profile* 2)


### PR DESCRIPTION
## Description

Fixes the `:invalid-shared-state` ("unexpected state found") error that occurs when toggling a file's shared status.

## Root Cause

The frontend performs an **optimistic local state update** before the RPC call resolves (`frontend/src/app/main/data/workspace/libraries.cljs:1500-1501`):

```clojure
(update [_ state]
  (update-in state [:files id] assoc :is-shared is-shared))  ;; immediate
```

This creates a race window where a duplicate `set-file-shared` RPC (from double-click, stale UI, or another tab having already shared the file) arrives at the backend after the first one already committed `is-shared: true` to the DB.

The backend `cond` only handled two transitions (`true→false` and `false→true`), so `true→true` or `false→false` fell through to the `:else` branch which raised the error.

## Fix

Added a third `cond` branch in `set-file-shared` that checks `(= (:is-shared file) (:is-shared params))` — when the file is already in the desired state, it returns the file as-is (no-op), making the operation **idempotent**.

## Files Changed

- `backend/src/app/rpc/commands/files.clj` — Added idempotent no-op branch
- `backend/test/backend_tests/rpc_file_test.clj` — Added `set-file-shared-idempotent` test covering both directions (share→share, unshare→unshare)

## Verification

- `pnpm run lint` — 0 errors, 0 warnings
- `pnpm run check-fmt` — all files formatted correctly


Closes #10094
