### PR TITLE
:bug: Fix number of days for deletion for nitrate

### DIFF
--- a/frontend/src/app/main/ui/dashboard/deleted.cljs
+++ b/frontend/src/app/main/ui/dashboard/deleted.cljs
@@ -12,10 +12,12 @@
    [app.main.data.common :as dcm]
    [app.main.data.dashboard :as dd]
    [app.main.data.modal :as modal]
+   [app.main.data.nitrate :as dnt]
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.context-menu-a11y :refer [context-menu*]]
    [app.main.ui.dashboard.grid :refer [grid*]]
+   [app.main.ui.dashboard.subscription :refer [get-subscription-type]]
    [app.main.ui.ds.buttons.button :refer [button*]]
    [app.main.ui.ds.product.empty-placeholder :refer [empty-placeholder*]]
    [app.main.ui.hooks :as hooks]
@@ -239,13 +241,15 @@
 
         ;; Calculate deletion days based on team subscription
         deletion-days
-        (let [subscription (get team :subscription)
-              sub-type     (get subscription :type)
-              sub-status   (get subscription :status)
-              canceled?    (contains? #{"canceled" "unpaid"} sub-status)]
+        (let [profile          (mf/deref refs/profile)
+              subscription-type (get-subscription-type (:subscription team))
+              nitrate-type      (get-in profile [:subscription :type])
+              nitrate-active?   (dnt/is-valid-license? profile)]
           (cond
-            (and (= "unlimited" sub-type) (not canceled?)) 30
-            (and (= "enterprise" sub-type) (not canceled?)) 90
+            (and nitrate-active?
+                 (contains? #{"enterprise" "nitrate"} nitrate-type)) 90
+            (= subscription-type "unlimited") 30
+            (= subscription-type "enterprise") 90
             :else 7))
 
         on-delete-all


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26542

### Summary

Deletion tab was showing 7 days instead of 90 when user is Enterprise (Nitrate).

### Steps to reproduce 

1. Delete a file.
2. Go to deleted tab.
3. Check the text is correctly displayed as 90 days.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
