### PR TITLE
:books: Add MCP server block and setup videos to docs

### DIFF
--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -848,6 +848,9 @@ a[href].post-tag:visited {
 .illus-techguide {
   background-image: url(/img/home-technical-guide.webp);
 }
+.illus-mcp {
+  background-image: url(/img/home-mcp-server.webp);
+}
 .illus-plugins {
   background-image: url(/img/home-plugins.webp);
 }

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -18,22 +18,28 @@ eleventyNavigation:
       <p>Everything you need to know about how Penpot works.</p>
     </a>
   </li>
-  <li class="illus illus-contributing">
-    <a href="/contributing-guide/">
-      <h2>Contributing guide →</h2>
-      <p>How to report bugs, add translations and more.</p>
-    </a>
-  </li>
   <li class="illus illus-techguide">
     <a href="/technical-guide/">
       <h2>Technical guide →</h2>
       <p>Installation, configuration and architecture.</p>
     </a>
   </li>
+  <li class="illus illus-mcp">
+    <a href="/mcp/">
+      <h2>MCP server →</h2>
+      <p>Connect AI agents to your Penpot files for design and development workflows.</p>
+    </a>
+  </li>
   <li class="illus illus-plugins">
     <a href="/plugins/">
       <h2>Plugins →</h2>
       <p>All about Penpot plugins.</p>
+    </a>
+  </li>
+  <li class="illus illus-contributing">
+    <a href="/contributing-guide/">
+      <h2>Contributing guide →</h2>
+      <p>How to report bugs, add translations and more.</p>
     </a>
   </li>
   <li class="illus illus-faq">

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -309,6 +309,38 @@ For client-specific setup, use the shared section **Connect your MCP client**.
 
 For remote mode, use the URL shown in **Your account → Integrations → MCP Server**, which includes your `userToken`.
 
+### Setup videos
+
+<figure>
+  <iframe
+    width="672px"
+    height="378px"
+    src="https://www.youtube.com/embed/hBn1iutWSq4?rel=0"
+    title="Penpot MCP Server: Remote Setup in 5 Min | OpenCode + OpenRouter"
+    frameborder="0"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+  </iframe>
+  <figcaption>Penpot MCP Server – Remote setup with OpenCode and OpenRouter</figcaption>
+</figure>
+
+<figure>
+  <iframe
+    width="672px"
+    height="378px"
+    src="https://www.youtube.com/embed/QeSFO0h7GGY?rel=0"
+    title="Penpot MCP Server Remote Setup in 1 Minute | Cursor"
+    frameborder="0"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+  </iframe>
+  <figcaption>Penpot MCP Server – Remote setup with Cursor</figcaption>
+</figure>
+
 <a id="use-remote"></a>
 ### Use
 
@@ -390,6 +422,23 @@ Leave this terminal running while you use MCP.
 > Some Chromium-based browsers may block the connection from `https://design.penpot.app` to `http://localhost`. If that happens, explicitly allow local network access or use a browser like Firefox.
 
 For advanced or repository-based workflows, see the [MCP README](https://github.com/penpot/penpot/blob/main/mcp/README.md) in the Penpot repository.
+
+### Setup video
+
+<figure>
+  <iframe
+    width="672px"
+    height="378px"
+    src="https://www.youtube.com/embed/xfgf0kKGOoc?rel=0"
+    title="Penpot MCP Server Local Setup"
+    frameborder="0"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+  </iframe>
+  <figcaption>Penpot MCP Server – Local setup</figcaption>
+</figure>
 
 <a id="connect-local"></a>
 ### Connect


### PR DESCRIPTION
## Summary

- Add an **MCP server** card to the help center home page, linking to `/mcp/` and using `home-mcp-server.webp`.
- Reorder the home page sections to: User guide → Technical guide → MCP server → Plugins → Contributing guide → FAQs.
- Add YouTube setup walkthroughs to the MCP documentation:
  - **Remote setup**: OpenCode + OpenRouter, Cursor
  - **Local setup**: local MCP installation

## Test plan

- [ ] Open the help center home and confirm the MCP server card appears in the new position with the correct image and link.
- [ ] Verify the section order matches: User guide, Technical guide, MCP server, Plugins, Contributing guide, FAQs.
- [ ] Open `/mcp/` and confirm the three YouTube embeds load correctly in the Remote and Local setup sections.
- [ ] Check layout on a narrow viewport to ensure the video iframes and home cards still render properly.