### PR TITLE
:sparkles: Add hard reload path for renderer menu A/B test

### DIFF
--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -30,6 +30,7 @@
    [app.main.data.workspace.versions :as dwv]
    [app.main.features :as features]
    [app.main.refs :as refs]
+   [app.main.repo :as rp]
    [app.main.store :as st]
    [app.main.ui.components.dropdown-menu :refer [dropdown-menu*
                                                  dropdown-menu-item*]]
@@ -938,15 +939,29 @@
          (fn [event]
            (dom/stop-propagation event)
            (let [renderer (or (-> profile :props :renderer) :svg)
-                 next-renderer (if (= renderer :wasm) :svg :wasm)]
-             (st/emit! (ev/event {::ev/name (if (= next-renderer :wasm)
-                                              "enable-webgl-rendering"
-                                              "disable-webgl-rendering")
-                                  ::ev/origin "workspace:menu"})
-                       (du/update-profile-props {:renderer next-renderer})
-                       (ntf/success (tr (if (= next-renderer :wasm)
-                                          "webgl.toast.webgl-render-enabled"
-                                          "webgl.toast.webgl-render-disabled")))))))
+                 next-renderer (if (= renderer :wasm) :svg :wasm)
+                 ev-name (if (= next-renderer :wasm)
+                           "enable-webgl-rendering"
+                           "disable-webgl-rendering")]
+             (if (cf/external-feature-flag "renderer-hard-reload" "test")
+               ;; Bare RPC + hard reload: skips `du/update-profile-props`, so
+               ;; `features/recompute-features` is not run here; bootstrap
+               ;; after reload resolves render-wasm/v1 from the saved profile.
+               (do
+                 (st/emit! (ev/event {::ev/name ev-name
+                                      ::ev/origin "workspace:menu"}))
+                 (->> (rp/cmd! :update-profile-props {:props {:renderer next-renderer}})
+                      (rx/subs! (fn [_] (dom/reload-current-window true))
+                                (fn [_]
+                                  (st/emit! (ntf/error (tr "errors.generic")))))))
+               ;; `update-profile-props` WatchEvent calls
+               ;; `features/recompute-features`.
+               (st/emit! (ev/event {::ev/name ev-name
+                                    ::ev/origin "workspace:menu"})
+                         (du/update-profile-props {:renderer next-renderer})
+                         (ntf/success (tr (if (= next-renderer :wasm)
+                                            "webgl.toast.webgl-render-enabled"
+                                            "webgl.toast.webgl-render-disabled"))))))))
 
         open-plugins-manager
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

### Summary

When the PostHog experiment "renderer-hard-reload" assigns the test
variant, persist the renderer preference via RPC and hard-reload the
page. The control path keeps hot-swapping through update-profile-props
and recompute-features.

How to test:
- Control (default in devenv): View menu → Enable/Disable WebGL
        hot-swaps renderer, shows toast, no page reload.
- Test variant: in DevTools before toggling:
        window.externalFeatureFlag = (f, v) => f === "renderer-hard-reload" && v === "test";
  then toggle WebGL: profile persists, page hard-reloads, no toast.

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
