### PR TITLE
:bug: Filter ignorable React removeChild errors at error boundary and fix HTML anti-pattern

### DIFF
--- a/frontend/src/app/main/ui/error_boundary.cljs
+++ b/frontend/src/app/main/ui/error_boundary.cljs
@@ -37,8 +37,20 @@
                           ;; If the error is a stale-asset error (cross-build
                           ;; module mismatch), force a hard page reload instead
                           ;; of showing the error page to the user.
-                          (if (errors/stale-asset-error? error)
+                          (cond
+                            (errors/stale-asset-error? error)
                             (cf/throttled-reload :reason (ex-message error))
+
+                            ;; If the error is known to be harmless (browser
+                            ;; extensions, React DOM conflicts, etc.), ignore it
+                            ;; silently — the global uncaught-error-handler
+                            ;; already does this, but react-error-boundary's
+                            ;; onError fires independently of the window.onerror
+                            ;; pipeline, so we must also filter here.
+                            (errors/is-ignorable-exception? error)
+                            nil
+
+                            :else
                             (do
                               (set! errors/last-exception error)
                               (ex/print-throwable error)

--- a/frontend/src/app/main/ui/notifications/context_notification.cljs
+++ b/frontend/src/app/main/ui/notifications/context_notification.cljs
@@ -54,16 +54,16 @@
    ;; The content can arrive in markdown format, in these cases
    ;;  we will use the prop is-html to true to indicate it and
    ;; that the html injection is performed and the necessary css classes are applied.
-   [:div {:class (stl/css :context-text)
-          :dangerouslySetInnerHTML (when is-html #js {:__html content})}
-    (when-not is-html
-      [:*
-       content
-       (when (some? links)
-         (for [[index link] (d/enumerate links)]
-           ;; TODO Review this component
-           [:& lb/link-button {:class (stl/css :link)
-                               :on-click (:callback link)
-                               :value (:label link)
-                               :key (dm/str "link-" index)}]))])]])
+   (if is-html
+     [:div {:class (stl/css :context-text)
+            :dangerouslySetInnerHTML #js {:__html content}}]
+     [:div {:class (stl/css :context-text)}
+      content
+      (when (some? links)
+        (for [[index link] (d/enumerate links)]
+          ;; TODO Review this component
+          [:& lb/link-button {:class (stl/css :link)
+                              :on-click (:callback link)
+                              :value (:label link)
+                              :key (dm/str "link-" index)}]))])])
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Fixes the continued reporting of harmless \"NotFoundError: removeChild\" React DOMExceptions in error tracking. The error boundary was catching these browser-extension-related errors and surfacing them to users even though the global handler already ignores them. Additionally, fixes a React anti-pattern in notification banners that can cause reconciliation mismatches.

## Why

Despite the global \"uncaught-error-handler\" in \"errors.cljs\" correctly filtering out \"NotFoundError/removeChild\" as an ignorable exception, \"react-error-boundary\"'s \"onError\" callback fires independently of the \"window.onerror\" pipeline. This meant the error boundary was still calling \"set! errors/last-exception\" and printing the throwable, causing the errors to keep appearing in reports. The \"dangerouslySetInnerHTML\" anti-pattern on a shared element with children could also trigger reconciliation mismatches.

## How

- Adds \"errors/is-ignorable-exception?\" check to the \"error-boundary*\" onError callback so harmless errors (browser extensions, analytics, React DOM conflicts) are silently ignored, matching the global handler behavior.
- Refactors \"context-notification\" to use two separate element branches (\"if is-html\" instead of \"dangerouslySetInnerHTML\" + children on the same element), eliminating the React anti-pattern.


Closes #10146
