### PR TITLE
:sparkles: Add WebSocket proxy configuration for MCP in Nginx example

### DIFF
--- a/docs/technical-guide/getting-started/docker.md
+++ b/docs/technical-guide/getting-started/docker.md
@@ -206,6 +206,12 @@ server {
     proxy_pass http://localhost:9001/ws/notifications;
   }
 
+  location /mcp/ws {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_pass http://localhost:9001/mcp/ws;
+  }
+
   # Proxy pass
   location / {
     proxy_set_header Host $http_host;


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

The current Nginx example doesn't include the required Websocket settings to correctly proxy /mcp/ws, and leads to WebSocket connection error when trying to connect in a design.

The same configuration as /ws/notifications in the original file is added for /mcp/ws

### Steps to reproduce 

1. Use the original Nginx configuration to proxy Penpot
2. Enable MCP
3. Open a design file, click MCP -> Connect
4. Open developer console, and see WebSocket connection failed

Verify the fix:

1. Apply the new configuration
2. Open a design file, click MCP -> connect
3. Connected successfully

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Closes #10153
