### PR TITLE
:bug: Fix license not loading in theme change

### DIFF
--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -89,6 +89,12 @@
                 email)]
     email))
 
+(defn- with-nitrate-licence
+  [profile cfg]
+  (if (contains? cf/flags :nitrate)
+    (nitrate/add-nitrate-licence-to-profile cfg profile)
+    profile))
+
 ;; --- QUERY: Get profile (own)
 
 
@@ -106,9 +112,7 @@
     (let [profile (-> (get-profile pool profile-id)
                       (strip-private-attrs)
                       (update :props filter-props))]
-      (if (contains? cf/flags :nitrate)
-        (nitrate/add-nitrate-licence-to-profile cfg profile)
-        profile))
+      (with-nitrate-licence profile cfg))
 
     (catch Throwable cause
       (if (= :not-found (-> cause ex-data :type))
@@ -137,7 +141,7 @@
    ::sm/params schema:update-profile
    ::sm/result schema:profile
    ::db/transaction true}
-  [{:keys [::db/conn]} {:keys [::rpc/profile-id fullname lang theme] :as params}]
+  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id fullname lang theme] :as params}]
   ;; NOTE: we need to retrieve the profile independently if we use
   ;; it or not for explicit locking and avoid concurrent updates of
   ;; the same row/object.
@@ -158,6 +162,7 @@
     (-> profile
         (strip-private-attrs)
         (d/without-nils)
+        (with-nitrate-licence cfg)
         (rph/with-meta {::audit/props (audit/profile->props profile)}))))
 
 

--- a/backend/test/backend_tests/rpc_profile_test.clj
+++ b/backend/test/backend_tests/rpc_profile_test.clj
@@ -12,6 +12,7 @@
    [app.db :as db]
    [app.email.blacklist :as email.blacklist]
    [app.email.whitelist :as email.whitelist]
+   [app.nitrate :as nitrate]
    [app.rpc :as-alias rpc]
    [app.rpc.commands.profile :as profile]
    [app.tokens :as tokens]
@@ -90,17 +91,26 @@
           (t/is (not (contains? result :password))))))
 
     (t/testing "update profile"
-      (let [data (assoc profile
-                        ::th/type :update-profile
-                        ::rpc/profile-id (:id profile)
-                        :fullname "Full Name"
-                        :lang "en"
-                        :theme "dark")
-            out  (th/command! data)]
+      (with-redefs [app.config/flags #{:nitrate}]
+        (with-redefs [nitrate/add-nitrate-licence-to-profile
+                      (fn [_ profile]
+                        (assoc profile :subscription {:plan :pro}))]
+          (let [data (assoc profile
+                            ::th/type :update-profile
+                            ::rpc/profile-id (:id profile)
+                            :fullname "Full Name"
+                            :lang "en"
+                            :theme "dark")
+                out  (th/command! data)]
 
-        ;; (th/print-result! out)
-        (t/is (nil? (:error out)))
-        (t/is (map? (:result out)))))
+            ;; (th/print-result! out)
+            (t/is (nil? (:error out)))
+            (t/is (map? (:result out)))
+            (t/is (= "Full Name" (get-in out [:result :fullname])))
+            (t/is (= "en" (get-in out [:result :lang])))
+            (t/is (= "dark" (get-in out [:result :theme])))
+            (t/is (= {:plan :pro}
+                     (:subscription (:result out))))))))
 
     (t/testing "query profile after update"
       (let [data {::th/type :get-profile

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -1298,6 +1298,11 @@
            (st/emit! (ev/event {::ev/name "explore-pricing-click" ::ev/origin "dashboard" :section "sidebar"}))
            (dom/open-new-window "https://penpot.app/pricing")))]
 
+    (mf/with-effect [teams]
+      (when (and (contains? cf/flags :nitrate)
+                 (empty? teams))
+        (st/emit! (dtm/fetch-teams))))
+
     (mf/with-effect [show-profile-menu?]
       (when-not show-profile-menu?
         (reset! sub-menu* nil)))

--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -136,10 +136,12 @@
                                         (some? days-until-expiry)
                                         (some? expiration-date-text))
         subscription-type (if nitrate? (:type nitrate-license) (get-subscription-type (-> profile :props :subscription)))
+        teams-loaded? (seq teams)
         no-orgs-created? (mf/with-memo [teams]
-                           (->> teams
-                                vals
-                                (not-any? :organization)))
+                           (and (seq teams)
+                                (->> teams
+                                     vals
+                                     (not-any? :organization))))
 
         handle-click
         (mf/use-fn
@@ -163,7 +165,7 @@
 
     [:*
      ;; TODO add translations for this texts when we have the definitive ones
-     (if (and nitrate? no-orgs-created? (not show-subscription-warning?))
+     (if (and nitrate? teams-loaded? no-orgs-created? (not show-subscription-warning?))
        ;; Banner for users with active nitrate license but no organizations created
        [:div {:class (stl/css :nitrate-banner :highlighted)}
         [:div {:class (stl/css :nitrate-content)}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26551

### Summary

Fixed inconsistent nitrate subscription enrichment across profile mutations and direct settings page entry. The subscription data was being dropped in 3 scenarios: theme changes, profile updates (name/lang), and direct navigation to /settings/profile. Root causes were in both backend (missing enrichment in mutations) and frontend (teams not loaded before org-dependent UI evaluation).

### Steps to reproduce 

1. User with nitrate license changes theme → subscription disappears from client state
2. User changes username → subscription disappears from client state
3. User navigates directly to /settings/profile → sidebar shows Enteprise banner incorrectly (treats missing teams as no organizations)

Now the subscription stays and no incorrect banner shows up.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
