### PR TITLE
:sparkles: Copy stable deep link to selected boards from context menu

### DIFF
--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -1132,11 +1132,35 @@
         (rx/of (dwm/upload-media-workspace params))))))
 
 (defn copy-link-to-clipboard
+  "Copy a link to the clipboard. When one or more boards are part of the
+  current selection, the link deep-links to those boards through their
+  ids (`board-id` route param), which are stable across renames and
+  reordering. Otherwise it falls back to the current location."
   []
   (ptk/reify ::copy-link-to-clipboard
     ptk/WatchEvent
-    (watch [_ _ _]
-      (clipboard/to-clipboard (rt/get-current-href)))))
+    (watch [_ state _]
+      (let [objects   (dsh/lookup-page-objects state)
+            board-ids (into (d/ordered-set)
+                            (keep (fn [id]
+                                    (let [shape (get objects id)]
+                                      (cond
+                                        (cfh/frame-shape? shape) id
+                                        (some? shape)            (:frame-id shape)))))
+                            (dsh/lookup-selected state))
+            board-ids (disj board-ids uuid/zero)
+
+            link      (if (seq board-ids)
+                        (let [router (:router state)
+                              route  (rt/lookup-name state)
+                              params (-> (rt/get-params state)
+                                         (assoc :board-id (mapv str board-ids)))
+                              href   (rt/resolve router route params)]
+                          (if href
+                            (dm/str (assoc cf/public-uri :fragment href))
+                            (rt/get-current-href)))
+                        (rt/get-current-href))]
+        (clipboard/to-clipboard link)))))
 
 (defn copy-as-image
   []


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

## What & why

The workspace **Copy link** context-menu action (and its `copy-link` shortcut) copied the raw current location, which only carries `file-id` and `page-id`. The resulting link did not point at any specific board, so it could not be used to reference "this board" from an issue/MR.

This builds the link from the current route plus a `board-id` query param derived from the current selection:

- a selected board contributes its own id;
- a selected shape contributes the id of the board it belongs to.

`board-id` is an existing workspace route param (`zoom-to-frame` already selects and zooms to it on navigation), and board ids are stable across renames and reordering, so the link keeps resolving to the same board. When the selection contains no board, it falls back to the previous behavior (current location).

## Scope

Editor-side deep links only, kept deliberately minimal. Making the **viewer** share link frame-precise (so shared/public links can target a specific board) is a natural follow-up; noted on the issue.

## Related

Relates to #4584 (and the discussion comment there).

## Testing

- `clj-kondo` lint of the changed namespace: 0 errors, 0 warnings.
- `cljfmt check`: formatted correctly.
- Behavior verified by code-path inspection: `app.main.data.workspace/zoom-to-frame` already consumes the `board-id` query param (string or vector), maps it through `uuid/uuid`, and runs `select-shapes` + `zoom-to-selected-shape`, so a generated `board-id` link resolves to the board on load.

I have not built the full devenv in this environment, so I did not exercise it end-to-end in a running instance. Happy to add a Playwright case and/or run the devenv verification if you'd like.

## Risk

Low: single function, no API/DB/schema change, no new dependencies, reuses an existing route param.
