### PR TITLE
:sparkles: Add get-file-plugin-data RPC to read file plugin data

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -21,6 +21,7 @@
    [app.common.transit :as t]
    [app.common.types.components-list :as ctkl]
    [app.common.types.file :as ctf]
+   [app.common.types.plugins :as ctpg]
    [app.common.uri :as uri]
    [app.config :as cf]
    [app.db :as db]
@@ -680,6 +681,31 @@
   [cfg {:keys [::rpc/profile-id id]}]
   (check-read-permissions! cfg profile-id id)
   (get-file-stats cfg id))
+
+
+;; --- COMMAND QUERY: get-file-plugin-data
+
+(def ^:private schema:get-file-plugin-data
+  [:map {:title "get-file-plugin-data"}
+   [:id ::sm/uuid]
+   [:namespace {:optional true} :keyword]])
+
+(sv/defmethod ::get-file-plugin-data
+  "Return the file-level plugin data: the arbitrary key/value metadata
+   stored on the file root through the Plugin API. Optionally narrowed
+   to a single `namespace`. Lets external tooling read metadata such as
+   issue or commit references without downloading the whole file."
+  {::doc/added "2.17"
+   ::sm/params schema:get-file-plugin-data
+   ::sm/result ctpg/schema:plugin-data
+   ::db/transaction true}
+  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id id namespace]}]
+  (check-read-permissions! conn profile-id id)
+  (let [plugin-data (-> (bfc/get-file cfg id)
+                        (get-in [:data :plugin-data]))]
+    (if namespace
+      (select-keys plugin-data [namespace])
+      (or plugin-data {}))))
 
 
 ;; --- COMMAND QUERY: get-file-libraries

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -2467,3 +2467,65 @@
         err   (:error out)]
     (t/is (th/ex-info? err))
     (t/is (th/ex-of-type? err :not-found))))
+(t/deftest get-file-plugin-data
+  (let [profile (th/create-profile* 1 {:is-active true})
+        file    (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared  false})]
+
+    ;; A file without plugin data returns an empty map
+    (let [out (th/command! {::th/type :get-file-plugin-data
+                            ::rpc/profile-id (:id profile)
+                            :id (:id file)})]
+      (t/is (nil? (:error out)))
+      (t/is (= {} (:result out))))
+
+    ;; Set file-level plugin data through a change
+    (update-file!
+     :file-id (:id file)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :set-plugin-data
+       :object-type :file
+       :namespace :shared/traceability
+       :key "req-id"
+       :value "REQ-123"}])
+
+    ;; The full plugin-data map is returned
+    (let [out (th/command! {::th/type :get-file-plugin-data
+                            ::rpc/profile-id (:id profile)
+                            :id (:id file)})]
+      (t/is (nil? (:error out)))
+      (t/is (= {:shared/traceability {"req-id" "REQ-123"}} (:result out))))
+
+    ;; A namespace filter narrows the result
+    (let [out (th/command! {::th/type :get-file-plugin-data
+                            ::rpc/profile-id (:id profile)
+                            :id (:id file)
+                            :namespace :shared/traceability})]
+      (t/is (nil? (:error out)))
+      (t/is (= {:shared/traceability {"req-id" "REQ-123"}} (:result out))))
+
+    ;; A filter on an absent namespace returns an empty map
+    (let [out (th/command! {::th/type :get-file-plugin-data
+                            ::rpc/profile-id (:id profile)
+                            :id (:id file)
+                            :namespace :plugin/absent})]
+      (t/is (nil? (:error out)))
+      (t/is (= {} (:result out))))))
+
+(t/deftest get-file-plugin-data-forbidden
+  (let [owner (th/create-profile* 1 {:is-active true})
+        other (th/create-profile* 2 {:is-active true})
+        file  (th/create-file* 1 {:profile-id (:id owner)
+                                  :project-id (:default-project-id owner)
+                                  :is-shared  false})
+        out   (th/command! {::th/type :get-file-plugin-data
+                            ::rpc/profile-id (:id other)
+                            :id (:id file)})]
+
+    (t/is (not (nil? (:error out))))
+    (let [edata (-> out :error ex-data)]
+      (t/is (= :not-found (:type edata))))))


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

## What & why

The Plugin API can write arbitrary key/value **plugin data** onto the file root (`setPluginData` / `setSharedPluginData`), and it is persisted inside the file data. But there was no way to read it back over RPC without downloading and decoding the whole file.

This adds a `get-file-plugin-data` read command that returns the file-level plugin data map, optionally narrowed to a single `namespace`. It lets external tooling (CI, an MCP/agent) cheaply fetch metadata such as issue/commit/requirement references attached to a file. This is the read counterpart to the existing write API and the primitive behind the traceability use case in #10169.

## Design

- New `::get-file-plugin-data` command in `backend/src/app/rpc/commands/files.clj`, modelled on `::get-file-stats`: `check-read-permissions!`, `bfc/get-file`, return a minimal map.
- Result schema reuses `app.common.types.plugins/schema:plugin-data`.
- Read-only: **no** data-model change, **no** new change type, **no** migration, **no** new dependency. `files` is already in `resolve-methods`, so no `rpc.clj` change.

## Scope

File-root plugin data only, kept deliberately small. Object/page/color/etc. level reads are a natural follow-up.

While scoping the page case I noticed an inconsistency that I asked about in #10169: `process-change` writes page plugin data to `[:pages-index id :plugin-data ns key]`, whereas `changes-builder/set-plugin-data` reads the previous value from `[:pages-index id :options :plugin-data ns key]` (extra `:options`). Confirming the canonical page path is a prerequisite for an object/page-level read, so I left it out here.

## Related

Relates to #10169 (and the discussion there).

## Testing

- `clj-kondo` (repo config): 0 errors; the command file is warning-clean (the test file's pre-existing warnings are untouched).
- `cljfmt check`: formatted correctly.
- Added `get-file-plugin-data` and `get-file-plugin-data-forbidden` tests in `backend/test/backend_tests/rpc_file_test.clj` (empty file -> `{}`; set file-level data via a `:set-plugin-data` change -> full map; namespace filter; absent namespace -> `{}`; non-member -> `:not-found`), mirroring the existing `get-file-stats` tests.

I did not build the backend devenv (no test DB in this environment), so I did not execute the suite here. Happy to run it / adjust once a maintainer confirms the direction.

## Risk

Low: a single read-only command reusing existing helpers and an existing schema.
