### PR TITLE
:sparkles: Add export-file-tokens RPC to push tokens via webhook

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -14,6 +14,7 @@
    [app.common.files.helpers :as cfh]
    [app.common.files.migrations :as fmg]
    [app.common.files.stats :as cfs]
+   [app.common.json :as json]
    [app.common.logging :as l]
    [app.common.schema :as sm]
    [app.common.schema.desc-js-like :as-alias smdj]
@@ -21,6 +22,7 @@
    [app.common.transit :as t]
    [app.common.types.components-list :as ctkl]
    [app.common.types.file :as ctf]
+   [app.common.types.tokens-lib :as ctob]
    [app.common.uri :as uri]
    [app.config :as cf]
    [app.db :as db]
@@ -680,6 +682,42 @@
   [cfg {:keys [::rpc/profile-id id]}]
   (check-read-permissions! cfg profile-id id)
   (get-file-stats cfg id))
+
+
+;; --- COMMAND: export-file-tokens
+
+(def ^:private schema:export-file-tokens
+  [:map {:title "export-file-tokens"}
+   [:id ::sm/uuid]])
+
+(sv/defmethod ::export-file-tokens
+  "Emit the file's design tokens, serialized as a W3C DTCG `tokens.json`
+   string, as a webhook event so an external integration (for example a
+   CI job) can commit them to a Git repository. The tokens are delivered
+   in the `tokens-json` event property and attributed to the requesting
+   profile's email. The team must have an active webhook for the event to
+   reach anywhere; the file must contain design tokens."
+  {::doc/added "2.17"
+   ::webhooks/event? true
+   ::sm/params schema:export-file-tokens
+   ::db/transaction true}
+  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id id]}]
+  (check-read-permissions! conn profile-id id)
+  (let [file       (bfc/get-file cfg id)
+        tokens-lib (get-in file [:data :tokens-lib])]
+    (when (nil? tokens-lib)
+      (ex/raise :type :validation
+                :code :no-tokens-in-file
+                :hint "the file has no design tokens to export"))
+    (let [profile     (db/get conn :profile {:id profile-id} {:columns [:email]})
+          tokens-json (json/encode (ctob/export-dtcg-json tokens-lib) :key-fn identity)]
+      (rph/with-meta
+        {:exported true}
+        {::audit/props {:file-id id
+                        :file-name (:name file)
+                        :project-id (:project-id file)
+                        :exported-by (:email profile)
+                        :tokens-json tokens-json}}))))
 
 
 ;; --- COMMAND QUERY: get-file-libraries

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -11,6 +11,7 @@
    [app.common.thumbnails :as thc]
    [app.common.time :as ct]
    [app.common.types.shape :as cts]
+   [app.common.types.tokens-lib :as ctob]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.db :as db]
@@ -2467,3 +2468,51 @@
         err   (:error out)]
     (t/is (th/ex-info? err))
     (t/is (th/ex-of-type? err :not-found))))
+(t/deftest export-file-tokens-without-tokens
+  (let [profile (th/create-profile* 1 {:is-active true})
+        file    (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared  false})
+        out     (th/command! {::th/type :export-file-tokens
+                              ::rpc/profile-id (:id profile)
+                              :id (:id file)})]
+
+    (t/is (some? (:error out)))
+    (let [edata (-> out :error ex-data)]
+      (t/is (= :validation (:type edata)))
+      (t/is (= :no-tokens-in-file (:code edata))))))
+
+(t/deftest export-file-tokens-with-tokens
+  (let [profile (th/create-profile* 1 {:is-active true})
+        file    (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared  false})]
+
+    (update-file!
+     :file-id (:id file)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :set-tokens-lib
+       :tokens-lib (ctob/make-tokens-lib)}])
+
+    (let [out (th/command! {::th/type :export-file-tokens
+                            ::rpc/profile-id (:id profile)
+                            :id (:id file)})]
+      (t/is (nil? (:error out)))
+      (t/is (= {:exported true} (:result out))))))
+
+(t/deftest export-file-tokens-forbidden
+  (let [owner (th/create-profile* 1 {:is-active true})
+        other (th/create-profile* 2 {:is-active true})
+        file  (th/create-file* 1 {:profile-id (:id owner)
+                                  :project-id (:default-project-id owner)
+                                  :is-shared  false})
+        out   (th/command! {::th/type :export-file-tokens
+                            ::rpc/profile-id (:id other)
+                            :id (:id file)})]
+
+    (t/is (some? (:error out)))
+    (let [edata (-> out :error ex-data)]
+      (t/is (= :not-found (:type edata))))))


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

## What & why

Issue #7091 requests exporting design tokens to a Git repository (with the designer as Git author). Rather than embedding a Git client and credential storage in Penpot, this takes the webhook route proposed in the issue discussion:

A new `export-file-tokens` RPC command serializes the file's design tokens to a W3C DTCG `tokens.json` and emits them as a **webhook event**. The team's existing webhook + its CI (GitLab CI, GitHub Actions, ...) receives the payload, commits `tokens.json`, and opens a PR attributing the designer.

## Design

- New `::export-file-tokens` command in `backend/src/app/rpc/commands/files.clj`: `check-read-permissions!`, read tokens via `bfc/get-file`, serialize with the existing `app.common.types.tokens-lib/export-dtcg-json` (same output as the manual export), raise `:validation`/`:no-tokens-in-file` when the file has no tokens.
- Marked `::webhooks/event? true`; the DTCG JSON and attribution (`file-id`, `file-name`, `project-id`, `exported-by`, `tokens-json`) ride in `::audit/props`, which the existing dispatcher (`app.loggers.webhooks`) delivers to the team's webhook.
- **The tokens are delivered as a pre-serialized JSON string**, on purpose: the webhook dispatcher camel-cases every payload key (`json-write-opts {:key-fn str/camel}`), which would otherwise corrupt DTCG token keys. Keeping `tokens.json` as an opaque string sidesteps that; the receiver does one `JSON.parse`.
- **No** new dependency, **no** credential storage, **no** DB migration, **no** `common/` change. Reuses the whole existing webhook stack.

## Scope / follow-up

This PR is the backend mechanism. The **frontend "Export to Git" tab** in the token export modal is a deliberate follow-up: it needs new UI strings, and Penpot's gettext `.po` translations are regenerated by the `pnpm run translations` extractor across ~30 locales, which I could not run in this environment. I did not want to hand-edit `.po` files blind and risk a broken i18n state. Happy to add the tab (and run the extractor) as a follow-up once the approach is confirmed.

## Related

Relates to #7091 (and the discussion comment there asking whether this webhook approach is preferred over a built-in Git client).

## Testing

- `clj-kondo` (repo config): 0 errors; `files.clj` is warning-clean (only the test file's pre-existing warnings remain).
- `cljfmt check`: formatted correctly.
- Added tests in `backend/test/backend_tests/rpc_file_test.clj`: no-tokens file -> `:validation`/`:no-tokens-in-file`; file with a tokens lib (seeded via a `:set-tokens-lib` change) -> `{:exported true}`; non-member -> `:not-found`.

I did not build the backend devenv (no test DB in this environment), so I did not execute the suite or a live webhook delivery here. Happy to run both once a maintainer confirms the direction.

## Risk

Moderate: one read-only-ish command reusing existing webhook/audit machinery. The webhook only fires when the team has an active webhook and the `:webhooks` flag is enabled; otherwise the command is a no-op beyond returning `{:exported true}`.
