### PR TITLE
:bug: Board stroke disappears when a layer is placed inside 

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -217,20 +217,20 @@ impl NodeRenderState {
 #[derive(Clone)]
 pub struct FocusMode {
     shapes: Vec<Uuid>,
-    active: bool,
+    depth: u32,
 }
 
 impl FocusMode {
     pub fn new() -> Self {
         FocusMode {
             shapes: Vec::new(),
-            active: false,
+            depth: 0,
         }
     }
 
     pub fn clear(&mut self) {
         self.shapes.clear();
-        self.active = false;
+        self.depth = 0;
     }
 
     pub fn set_shapes(&mut self, shapes: Vec<Uuid>) {
@@ -244,23 +244,23 @@ impl FocusMode {
     }
 
     pub fn enter(&mut self, id: &Uuid) {
-        if !self.active && self.should_focus(id) {
-            self.active = true;
+        if self.should_focus(id) {
+            self.depth += 1;
         }
     }
 
     pub fn exit(&mut self, id: &Uuid) {
-        if self.active && self.should_focus(id) {
-            self.active = false;
+        if self.should_focus(id) && self.depth > 0 {
+            self.depth -= 1;
         }
     }
 
     pub fn is_active(&self) -> bool {
-        self.active
+        self.depth > 0
     }
 
     pub fn reset(&mut self) {
-        self.active = false;
+        self.depth = 0;
     }
 }
 
@@ -2521,8 +2521,6 @@ impl RenderState {
             let layer_rec = skia::canvas::SaveLayerRec::default().paint(&paint);
             self.surfaces.canvas(target_surface).save_layer(&layer_rec);
         }
-
-        self.focus_mode.enter(&element.id);
     }
 
     #[inline]


### PR DESCRIPTION
### Related Ticket

[GitHub Issue #10175](https://github.com/penpot/penpot/issues/10175)
[GitHub Issue #10131](https://github.com/penpot/penpot/issues/10131)

<img width="640" height="360" alt="board" src="https://github.com/user-attachments/assets/5f15402d-abc6-42bc-bcdb-ec441f8e4670" />


### Steps to reproduce 

1. Open a file on PRO (https://design.penpot.app) with the WebGL renderer enabled.
2. Create a board.
3. Apply a stroke to the board.
4. Place a layer inside the board.
5. Observe the board stroke rendering.
6. Switch to the SVG renderer and repeat steps 2–5 for comparison.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
