### PR TITLE
:bug: Fix transparent tile holes in viewer WASM render

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -968,7 +968,8 @@ impl RenderState {
 
         // Viewer masked passes render a partial scene. Reusing the tile texture cache would
         // SrcOver-blend onto textures from the previous pass and leak pixels into the blob.
-        if self.viewer_masked_pass() {
+        // `render_sync_shape` (viewer/thumbnails) uses the same direct backbuffer path.
+        if self.viewer_masked_pass() || self.viewer_render_root.is_some() {
             // Use viewbox-aligned bounds (not grid-snapped) to match interactive-transform
             // compositing and avoid a visible offset vs the DOM canvas.
             let tile_rect = self.get_current_tile_bounds()?;


### PR DESCRIPTION
### Related Ticket

Use direct backbuffer tile compositing for render_sync_shape (viewer/thumbnails) instead of the tile texture atlas cache, which left 512×512 transparent holes.

https://github.com/penpot/penpot/issues/10188

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
