### PR TITLE
:bug: Fix double click not editing the guide

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/guides.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/guides.cljs
@@ -754,6 +754,7 @@
            on-guide-drag on-guide-hover get-hover-frame focus]}]
   (let [dragging-ref       (mf/use-ref false)
         moved-ref          (mf/use-ref false)
+        editing-ref        (mf/use-ref false)
         start-ref          (mf/use-ref nil)
         guide-ref          (mf/use-ref nil)
         pending-ref        (mf/use-ref nil)
@@ -813,6 +814,7 @@
         reset-state
         (fn []
           (clear-drag-refs)
+          (mf/set-ref-val! editing-ref false)
           (when (some? on-guide-drag)
             (on-guide-drag nil))
           (emit-hover-axis nil)
@@ -874,7 +876,7 @@
                     (reset! state pending)))))))
 
         editing?
-        (fn [] (= :edit (:mode @state)))
+        (fn [] (mf/ref-val editing-ref))
 
         guide-at-event
         (fn [event]
@@ -976,6 +978,7 @@
                 (when (some? on-guide-drag)
                   (on-guide-drag id))
                 (mf/set-ref-val! guide-ref guide)
+                (mf/set-ref-val! editing-ref true)
                 (let [frame  (some-> frame-id refs/object-by-id deref)
                       offset (if frame
                                (if (= :x axis) (:x frame) (:y frame))


### PR DESCRIPTION
### Related Ticket

#10213 

### Summary

<img width="684" height="487" alt="Double clicking guide" src="https://github.com/user-attachments/assets/8f6d268b-e372-4d59-af4c-d13d6321c30f" />

This fixes the guide disappearing (due to a re-render caused by a cleanup effect) on double clicking it

### Steps to reproduce 

See ticket #10213 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
