### PR TITLE
:bug: Skip org membership lookup for anonymous invite recipients

### DIFF
--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -185,7 +185,10 @@
         registration-disabled? (not (contains? cf/flags :registration))
 
         org-invitation?        (and (contains? cf/flags :nitrate) organization-id)
-        membership             (when org-invitation?
+        ;; Membership only makes sense for a logged-in profile; querying it for
+        ;; an anonymous recipient would call nitrate with a nil profile-id and
+        ;; mask the clean :invalid-token response with a generic error.
+        membership             (when (and profile org-invitation?)
                                  (nitrate/call cfg :get-org-membership {:profile-id profile-id
                                                                         :organization-id organization-id}))]
 


### PR DESCRIPTION
When an organization invitation token is verified by a logged-out recipient (e.g. an unregistered invitee opening the emailed link), profile-id is nil. The team-invitation branch still evaluated get-org-membership eagerly, calling nitrate with that nil profile-id. That request fails and surfaces as a generic error, masking the clean :invalid-token response and dropping the user on the login screen instead of the dedicated "Invite invalid" page.

Only query membership when a logged-in profile is present, so a canceled or otherwise invalid org invite reaches the :invalid-token path as intended.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
