### PR TITLE
:bug: Surface real plugin errors instead of bare "Value not valid"

### DIFF
--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -304,12 +304,16 @@
 
 (defn error-messages
   [explain]
-  (->> (:errors explain)
-       (reduce csm/interpret-schema-problem {})
-       (flatten-error-map)
-       (map (fn [[field message]]
-              (tr "plugins.validation.message" field message)))
-       (str/join ". ")))
+  (let [msg (->> (:errors explain)
+                 (reduce csm/interpret-schema-problem {})
+                 (flatten-error-map)
+                 (map (fn [[field message]]
+                        (tr "plugins.validation.message" field message)))
+                 (str/join ". "))]
+    ;; Return nil (not "") when the explain has no mappable errors, so
+    ;; `handle-error` can fall back to a non-empty message instead of
+    ;; surfacing a bare "Value not valid. Code: :error" (#9692).
+    (when-not (str/blank? msg) msg)))
 
 (defn handle-error
   "Function to be used in plugin proxies methods to handle errors and print a readable
@@ -320,8 +324,13 @@
           (if-let [explain (-> cause ex-data ::sm/explain)]
             (do
               (js/console.error (sm/humanize-explain explain))
-              (error-messages explain))
-            (ex-data cause))]
+              ;; A well-formed explain renders a message; an empty or
+              ;; unmappable one falls back to the raw explain so we never
+              ;; surface a bare "Value not valid" (#9692).
+              (or (error-messages explain) (pr-str explain)))
+            ;; Non-malli throwables (plain js/Error, TypeError, …) carry no
+            ;; ::sm/explain, so surface their own message instead of nil (#9692).
+            (or (ex-data cause) (ex-message cause) (str cause)))]
       (js/console.log (.-stack cause))
       (not-valid plugin-id :error message))))
 

--- a/frontend/test/frontend_tests/plugins/utils_test.cljs
+++ b/frontend/test/frontend_tests/plugins/utils_test.cljs
@@ -54,3 +54,36 @@
   ;; No validation errors -> no output (callers join with ". " and would
   ;; otherwise emit an empty string, which is fine).
   (t/is (empty? (flatten-error-map {}))))
+
+;; ---------------------------------------------------------------------
+;; Issue #9692 — `handle-error` must surface a useful message instead of a
+;; bare "Value not valid. Code: :error".
+;;
+;; `not-valid` is redefined to capture the rendered message directly, so the
+;; assertions don't depend on `st/state` or the console.
+
+(t/deftest test-handle-error-plain-js-error
+  ;; A plain JS error has no `::sm/explain` and CLJS `ex-data` returns nil, so
+  ;; the handler must fall back to the error's own message rather than nil.
+  (let [captured (atom ::none)]
+    (with-redefs [plugins.utils/not-valid (fn [_plugin-id _code value]
+                                            (reset! captured value) nil)]
+      ((plugins.utils/handle-error #uuid "00000000-0000-0000-0000-000000000000")
+       (js/Error. "boom: not a function")))
+    (t/is (= "boom: not a function" @captured))))
+
+(t/deftest test-handle-error-empty-explain
+  ;; An explain whose errors don't render any message must not produce an
+  ;; empty string; the handler falls back to the raw explain.
+  (let [captured (atom ::none)
+        cause    (ex-info "invalid" {:app.common.schema/explain {:errors [] :value 1}})]
+    (with-redefs [plugins.utils/not-valid (fn [_plugin-id _code value]
+                                            (reset! captured value) nil)]
+      ((plugins.utils/handle-error #uuid "00000000-0000-0000-0000-000000000000") cause))
+    (t/is (string? @captured))
+    (t/is (not= "" @captured))))
+
+(t/deftest test-error-messages-empty-returns-nil
+  ;; `error-messages` returns nil (not "") on an explain with no mappable
+  ;; errors, so `handle-error` can distinguish "no message" from a real one.
+  (t/is (nil? (plugins.utils/error-messages {:errors []}))))


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

### Related Ticket

Fixes [#9692](https://github.com/penpot/penpot/issues/9692).

### Summary

The plugin proxy error handler (`obj/reify` `:on-error` -> `handle-error` in `frontend/src/app/plugins/utils.cljs`) only produced a useful message for malli `ExceptionInfo` carrying `::sm/explain`. Two paths fell through to the bare `"[PENPOT PLUGIN] Value not valid. Code: :error"`, hiding the real cause:

1. **Plain JS errors** (e.g. a `TypeError` thrown inside a proxy method) are not `ExceptionInfo`, so `(ex-data cause)` is `nil`; the message bound to `nil` and the real `.-message` only reached the host-page console (invisible to the plugin sandbox / MCP `execute_code`).
2. **Empty/unmappable malli explains** made `error-messages` return `""`, which rendered as `"Value not valid: . Code: :error"`.

Changes (frontend-only, two adjacent fns):
- `error-messages` returns `nil` instead of `""` when there is nothing to render, so the caller can fall back.
- `handle-error` adds fallback chains: explain branch `(or (error-messages explain) (pr-str explain))`; non-explain branch `(or (ex-data cause) (ex-message cause) (str cause))`.

Working cases (well-formed explain producing a non-empty message) are unchanged; this only improves the previously-bare path. It complements #9486/#9632, which fixed the *content* of well-formed explains, not the empty/missing-cause path.

### Steps to reproduce / verify

From a plugin:
```js
// Before: "[PENPOT PLUGIN] Value not valid. Code: :error"
// After:  the real error message, e.g. "first is not a function"
penpot.createBoard().nonExistentMethodThatThrows();
```
Any proxy method that throws a plain JS error, or fails malli validation with an explain that doesn't map to a field message, now surfaces a useful message.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix.
- [x] Add or modify existing integration tests in case of bugs or new features.

### Notes

- Per `CONTRIBUTING.md`, the changelog is generated at release time, so this PR intentionally does not modify `CHANGES.md`. No plugin-types surface changes, so no `plugins/CHANGELOG.md` entry either.

- Tests added to `frontend/test/frontend_tests/plugins/utils_test.cljs` (plain-JS-error path, empty-explain path, `error-messages` nil contract).
- `clj-kondo` and `cljfmt` are clean on the changed files.
