### PR TITLE
:bug: Fix plugin API board.guides invalid-schema on set/clear

### DIFF
--- a/frontend/src/app/plugins/parser.cljs
+++ b/frontend/src/app/plugins/parser.cljs
@@ -336,17 +336,17 @@
     (d/without-nils
      {:type (-> (obj/get guide "type") parse-keyword)
       :display (obj/get guide "display")
-      :params (-> (obj/get guide "params") parse-frame-guide-column-params)})))
+      :params (-> (obj/get guide "params") parse-frame-guide-square-params)})))
 
 (defn parse-frame-guide
   [^js guide]
   (when (some? guide)
     (case (obj/get guide "type")
       "column"
-      parse-frame-guide-column
+      (parse-frame-guide-column guide)
 
       "row"
-      parse-frame-guide-row
+      (parse-frame-guide-row guide)
 
       "square"
       (parse-frame-guide-square guide))))

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -1562,7 +1562,7 @@
                         (let [id (obj/get self "$id")
                               value (parser/parse-frame-guides value)]
                           (cond
-                            (not (sm/validate [:vector ::ctg/grid] value))
+                            (not (sm/validate [:vector ctg/schema:grid] value))
                             (u/not-valid plugin-id :guides value)
 
                             (not (r/check-permission plugin-id "content:write"))

--- a/frontend/test/frontend_tests/plugins/parser_test.cljs
+++ b/frontend/test/frontend_tests/plugins/parser_test.cljs
@@ -7,6 +7,8 @@
 (ns frontend-tests.plugins.parser-test
   (:require
    [app.common.geom.point :as gpt]
+   [app.common.schema :as sm]
+   [app.common.types.grid :as ctg]
    [app.plugins.parser :as parser]
    [cljs.test :as t :include-macros true]))
 
@@ -31,3 +33,25 @@
       (t/is (gpt/point? result))
       (t/is (= 0 (:x result)))
       (t/is (= 0 (:y result))))))
+
+(t/deftest test-parse-frame-guides
+  ;; Regression test for issue #9773.
+  ;;
+  ;; `parse-frame-guide` returned the parser fns for column/row instead of
+  ;; calling them with the guide, and the `board.guides` setter validated
+  ;; against an unregistered `::ctg/grid` reference (now `ctg/schema:grid`).
+  ;; Parsed guides must be plain maps that validate against the same direct
+  ;; schema the setter uses, and clearing (empty input) must validate too.
+  (let [column #js {:type "column" :display true
+                    :params #js {:color #js {:color "#DE4762" :opacity 0.2}
+                                 :type "stretch" :size 12 :gutter 16 :margin 16}}
+        square #js {:type "square" :display true
+                    :params #js {:color #js {:color "#DE4762" :opacity 0.2} :size 8}}
+        parsed (parser/parse-frame-guides #js [column square])]
+    (t/is (= :column (-> parsed first :type)))
+    (t/is (= :square (-> parsed second :type)))
+    (t/is (map? (-> parsed first :params)))
+    (t/is (sm/validate [:vector ctg/schema:grid] parsed)))
+
+  (t/testing "clearing guides with an empty vector validates"
+    (t/is (sm/validate [:vector ctg/schema:grid] (parser/parse-frame-guides #js [])))))


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

### Related Ticket

Fixes [#9773](https://github.com/penpot/penpot/issues/9773).

### Summary

Setting or clearing `board.guides` from a plugin threw `:malli.core/invalid-schema` for every value (including `[]`). Three causes:

1. `frontend/src/app/plugins/shape.cljs` validated against `[:vector ::ctg/grid]`, but the `:app.common.types.grid/grid` reference is no longer registered (the namespaced-keyword registrations were replaced by direct schemas). malli then throws for any value. Fix: use the direct var `ctg/schema:grid` (already required as `ctg`), matching every other setter.
2. `frontend/src/app/plugins/parser.cljs` `parse-frame-guide` returned the `parse-frame-guide-column` / `parse-frame-guide-row` fns instead of calling them with `guide`, so column/row guides parsed to a vector containing a function — failing validation even after (1).
3. `parse-frame-guide-square` used `parse-frame-guide-column-params` instead of the dedicated `parse-frame-guide-square-params`.

### Steps to reproduce / verify

```js
const [board] = penpot.currentPage.findShapes({ type: "board" });
board.guides = [{ type: "square", display: true,
                  params: { color: { color: "#DE4762", opacity: 0.2 }, size: 8 } }];
board.guides = [];   // clearing
// before: "Value not valid" (invalid-schema thrown); after: both succeed
```

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix.
- [x] Add or modify existing integration tests in case of bugs or new features.

### Notes

- Per `CONTRIBUTING.md`, the changelog is generated at release time, so this PR intentionally does not modify `CHANGES.md`. No plugin-types surface changes, so no `plugins/CHANGELOG.md` entry either.

- Added a regression test in `frontend/test/frontend_tests/plugins/parser_test.cljs` that parses column/square guides and validates the result (and an empty vector) against `ctg/schema:grid`.
- `clj-kondo` and `cljfmt` clean on the changed files.
