### PR TITLE
:bug: Let plugin addToken create tokens in an inactive set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix plugin API `addToken` refusing to create a token in a set that exists but isn't active, by forcing the target set active during resolution like the UI does (by @filipsajdak) [Github #10070](https://github.com/penpot/penpot/issues/10070)
 - Fix plugin API `fileVersion.restore()` promise hanging indefinitely on restore failure [Github #9092](https://github.com/penpot/penpot/issues/9092)
 - Fix LDAP provider params schema typo (`bind-passwor` → `bind-password`) introduced during the `clojure.spec` → `malli` migration; the schema slot now matches the runtime key actually read by `prepare-params` (`:password (:bind-password cfg)`) and `try-connectivity` (`(:bind-password cfg)`), so a wrong type for the password no longer slips through unvalidated
 - Fix `login-with-ldap` silently dropping its error message on the `ldap-not-initialized` restriction (typo `:hide` → `:hint`); the message `"ldap auth provider is not initialized"` now actually surfaces in logs and error responses instead of being discarded into an unread key

--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -328,7 +328,11 @@
       :fn (fn [attrs]
             (let [tokens-lib (u/locate-tokens-lib file-id)
                   token (ctob/make-token attrs)
-                  tokens-tree (-> (ctob/get-tokens-in-active-sets tokens-lib)
+                  ;; Force the target set active during resolution, mirroring the
+                  ;; UI (`get-tokens-in-active-sets-force` in sidebar.cljs), so a
+                  ;; token can be created in a set that exists but isn't currently
+                  ;; in the active themes (#10070).
+                  tokens-tree (-> (ctob/get-tokens-in-active-sets-force tokens-lib id)
                                   (assoc (:name token) token))
                   resolved-tokens (ts/resolve-tokens tokens-tree)
 

--- a/frontend/test/frontend_tests/plugins/tokens_test.cljs
+++ b/frontend/test/frontend_tests/plugins/tokens_test.cljs
@@ -6,6 +6,7 @@
 
 (ns frontend-tests.plugins.tokens-test
   (:require
+   [app.common.types.tokens-lib :as ctob]
    [app.plugins.tokens :as ptok]
    [cljs.test :as t :include-macros true]))
 
@@ -80,3 +81,33 @@
   (t/is (false? (boolean (ptok/token-attr? :not-a-real-attr))))
   (t/is (false? (boolean (ptok/token-attr? "not-a-real-attr"))))
   (t/is (false? (boolean (ptok/token-attr? nil)))))
+
+;; ---------------------------------------------------------------------
+;; Issue #10070 — creating a (reference) token must work when the target set
+;; exists but isn't active. `addToken` resolves the new token against the
+;; active-set tree; with no active theme the target set's own tokens are
+;; absent, so a same-set reference can't resolve and creation is refused.
+;; The fix forces the target set active during resolution
+;; (`get-tokens-in-active-sets-force`), mirroring the UI. These tests pin the
+;; resolution premise the fix relies on.
+
+(def ^:private inactive-set-id #uuid "00000000-0000-0000-0000-0000000000aa")
+
+(defn- lib-with-inactive-set
+  []
+  (-> (ctob/make-tokens-lib)
+      (ctob/add-set (ctob/make-token-set :id inactive-set-id :name "core"))
+      (ctob/add-token inactive-set-id
+                      (ctob/make-token {:name "color.gray.50" :type :color :value "#808080"}))))
+
+(t/deftest addtoken-target-set-absent-from-active-tree-without-force
+  ;; No active theme -> the inactive set's tokens are not in the active tree,
+  ;; so the old non-force resolution couldn't see them.
+  (let [lib (lib-with-inactive-set)]
+    (t/is (not (contains? (ctob/get-tokens-in-active-sets lib) "color.gray.50")))))
+
+(t/deftest addtoken-target-set-present-in-active-tree-with-force
+  ;; Forcing the target set active surfaces its tokens, so a reference into
+  ;; that set resolves and `addToken` can create the token (#10070).
+  (let [lib (lib-with-inactive-set)]
+    (t/is (contains? (ctob/get-tokens-in-active-sets-force lib inactive-set-id) "color.gray.50"))))


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

### Related Ticket

Fixes [#10070](https://github.com/penpot/penpot/issues/10070).

### Summary

The plugin `addToken` (`frontend/src/app/plugins/tokens.cljs`) resolved the new token against `ctob/get-tokens-in-active-sets`, then refused creation when `resolved-value` was nil. Creating a token into a set that exists but isn't in the active themes (or a reference to a token in that same set) therefore failed with a generic error — even though the product UI permits it: `sidebar.cljs` resolves with `get-tokens-in-active-sets-force` and the selected set id.

Fix: resolve against `ctob/get-tokens-in-active-sets-force tokens-lib id`, forcing the target set active during resolution, mirroring the UI.

Scope note: fully resolving references that point into *other* inactive sets ("allow unresolved-but-valid references") is a separate, feature-shaped change (deferred resolution) and is intentionally out of scope here.

### Steps to reproduce / verify

From a plugin, with a set that is not enabled in the active theme:
```js
const set = penpot.library.local.tokens.addSet({ name: "core" }); // inactive by default
set.addToken({ type: "color", name: "color.gray.50", value: "#808080" });
// before: rejected with a generic "Value not valid"; after: token created
```

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix.
- [x] Add or modify existing integration tests in case of bugs or new features.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue.

### Notes

- Added tests in `frontend/test/frontend_tests/plugins/tokens_test.cljs` pinning the resolution premise (forced active-set tree surfaces the target set's tokens; plain active-set tree does not).
- `clj-kondo` and `cljfmt` clean on the changed files.
- This touches the same file as open PR #9564 (different defects); flagging for coordination to avoid merge conflicts.
