### PR TITLE
:recycle: Extract wait-for-persistence into shared helper

### DIFF
--- a/frontend/src/app/main/data/exports/assets.cljs
+++ b/frontend/src/app/main/data/exports/assets.cljs
@@ -15,7 +15,6 @@
    [app.main.data.modal :as modal]
    [app.main.data.persistence :as dwp]
    [app.main.features :as features]
-   [app.main.refs :as refs]
    [app.main.repo :as rp]
    [app.main.store :as st]
    [app.util.dom :as dom]
@@ -204,13 +203,7 @@
                           :wait true
                           :is-wasm (wasm-export-enabled? state)}]
           (rx/concat
-           (rx/of ::dwp/force-persist)
-
-           ;; Wait the persist to be succesfull
-           (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
-                (rx/filter #(or (nil? %) (= :saved %)))
-                (rx/first)
-                (rx/timeout 400 (rx/empty)))
+           (dwp/force-persist-and-wait 400)
 
            (->> (rp/cmd! :export params)
                 (rx/map (fn [{:keys [filename mtype uri]}]

--- a/frontend/src/app/main/data/persistence.cljs
+++ b/frontend/src/app/main/data/persistence.cljs
@@ -12,6 +12,7 @@
    [app.common.uuid :as uuid]
    [app.main.data.changes :as dch]
    [app.main.data.helpers :as dsh]
+   [app.main.refs :as refs]
    [app.main.repo :as rp]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
@@ -25,6 +26,26 @@
 (def queue-conj (fnil conj #queue []))
 
 (def force-persist? #(= % ::force-persist))
+
+(defn wait-persisted
+  "Returns an observable that emits the first terminal persistence status
+   (nil | :saved) and completes. With a timeout-ms, if persistence doesn't
+   settle in time the observable completes silently without emitting."
+  ([] (wait-persisted nil))
+  ([timeout-ms]
+   (let [base (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
+                   (rx/filter #(or (nil? %) (= :saved %)))
+                   (rx/take 1))]
+     (if timeout-ms
+       (->> base (rx/timeout timeout-ms (rx/empty)))
+       base))))
+
+(defn force-persist-and-wait
+  "Convenience that emits the force-persist event and then waits for
+   persistence to settle. Returns the combined observable."
+  ([] (force-persist-and-wait nil))
+  ([timeout-ms]
+   (rx/concat (rx/of ::force-persist) (wait-persisted timeout-ms))))
 
 (defn- update-status
   [status]

--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -37,7 +37,7 @@
    [app.main.data.exports.wasm :as wasm.exports]
    [app.main.data.helpers :as dsh]
    [app.main.data.notifications :as ntf]
-   [app.main.data.persistence :as-alias dps]
+   [app.main.data.persistence :as dps]
    [app.main.data.workspace.media :as dwm]
    [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.shapes :as dwsh]
@@ -1166,11 +1166,7 @@
 
         (rx/concat
          ;; Ensure current state persisted before exporting.
-         (rx/of ::dps/force-persist)
-         (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
-              (rx/filter #(or (nil? %) (= :saved %)))
-              (rx/first)
-              (rx/timeout 400 (rx/empty)))
+         (dps/force-persist-and-wait 400)
 
          ;; Exporting itself can take its time, better to notify that we are busy.
          (rx/of (ntf/info (tr "workspace.clipboard.copying")))

--- a/frontend/src/app/main/data/workspace/versions.cljs
+++ b/frontend/src/app/main/data/workspace/versions.cljs
@@ -19,7 +19,6 @@
    [app.main.data.workspace.pages :as dwpg]
    [app.main.data.workspace.thumbnails :as th]
    [app.main.features :as features]
-   [app.main.refs :as refs]
    [app.main.repo :as rp]
    [app.util.i18n :refer [tr]]
    [beicon.v2.core :as rx]
@@ -73,9 +72,7 @@
          (rx/of ::dwp/force-persist
                 (ev/event {::ev/name "create-version"}))
 
-         (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
-              (rx/filter #(or (nil? %) (= :saved %)))
-              (rx/take 1)
+         (->> (dwp/wait-persisted)
               (rx/mapcat #(rp/cmd! :create-file-snapshot {:file-id file-id :label label}))
               (rx/mapcat
                (fn [{:keys [id]}]
@@ -119,13 +116,6 @@
     ptk/EffectEvent
     (effect [_ _ _]
       (th/clear-queue!))))
-
-(defn- wait-for-persistence
-  [file-id snapshot-id]
-  (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
-       (rx/filter #(or (nil? %) (= :saved %)))
-       (rx/take 1)
-       (rx/mapcat #(rp/cmd! :restore-file-snapshot {:file-id file-id :id snapshot-id}))))
 
 (defn delete-version
   [id]
@@ -223,7 +213,8 @@
          (rx/of ::dwp/force-persist
                 (dw/remove-layout-flag :document-history))
 
-         (->> (wait-for-persistence file-id id)
+         (->> (dwp/wait-persisted)
+              (rx/mapcat #(rp/cmd! :restore-file-snapshot {:file-id file-id :id id}))
               (rx/map #(initialize-version))))))))
 
 (defn enter-restore
@@ -349,12 +340,6 @@
 ;; PLUGINS SPECIFIC EVENTS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- wait-persisted-status
-  []
-  (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
-       (rx/filter #(or (nil? %) (= :saved %)))
-       (rx/take 1)))
-
 (defn create-version-from-plugins
   [file-id label resolve reject]
 
@@ -371,7 +356,7 @@
                 (rx/of ::dwp/force-persist))
 
               (->> (if (= file-id current-file-id)
-                     (wait-persisted-status)
+                     (dwp/wait-persisted)
                      (rx/of :nothing))
                    (rx/mapcat
                     (fn [_]
@@ -401,7 +386,8 @@
                               ::ev/origin "plugins"})
                    ::dwp/force-persist)
 
-            (->> (wait-for-persistence file-id id)
+            (->> (dwp/wait-persisted)
+                 (rx/mapcat #(rp/cmd! :restore-file-snapshot {:file-id file-id :id id}))
                  (rx/map #(initialize-version)))
 
             (->> (rx/of 1)

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -48,7 +48,6 @@
    [app.main.data.workspace.texts :as dwt]
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.variants :as dwv]
-   [app.main.refs :as refs]
    [app.main.repo :as rp]
    [app.main.store :as st]
    [app.plugins.fills :as fills]
@@ -1304,10 +1303,7 @@
                         ;; renders locally and does not need this.)
                         (st/emit! ::dwp/force-persist)
                         (->> (rx/concat
-                              (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
-                                   (rx/filter #(or (nil? %) (= :saved %)))
-                                   (rx/first)
-                                   (rx/timeout 5000 (rx/empty))
+                              (->> (dwp/wait-persisted 5000)
                                    (rx/ignore))
                               (rp/cmd! :export payload))
                              (rx/mapcat (fn [{:keys [uri]}]


### PR DESCRIPTION
## What

Extract the duplicated "wait for persistence to settle before proceeding" pattern into two shared helpers in `app.main.data.persistence`, replacing 5 inline copies and 2 private helper functions.

## Why

The same RX chain (`rx/from-atom refs/persistence-state` → filter for terminal states → take 1) was duplicated across 6 call sites with minor variations (timeout values, chaining style). This creates maintenance burden and inconsistency risk. Centralizing it into a single helper ensures uniform behavior and makes the persistence wait semantics clearer.

## How

- Added `wait-persisted` — returns an observable that emits `nil` or `:saved` when persistence settles, with optional timeout that silently completes on expiry.
- Added `force-persist-and-wait` — convenience combining `::force-persist` emission + wait.
- Replaced all 6 occurrences: 3 in `versions.cljs`, 1 in `assets.cljs`, 1 in `clipboard.cljs`, 1 in `shape.cljs`.
- Removed 2 private helper functions (`wait-for-persistence`, `wait-persisted-status`) from `versions.cljs`.
- Dropped unused `app.main.refs` imports from 3 files where `refs/persistence-state` was only used through the inline pattern.
