### PR TITLE
:sparkles: Remove non-recoverable mcp key warning from regenerated modal

### DIFF
--- a/frontend/src/app/main/ui/settings/integrations.cljs
+++ b/frontend/src/app/main/ui/settings/integrations.cljs
@@ -93,14 +93,13 @@
                 :class (stl/css :color-primary)}
       title]
 
-     [:> notification-pill* {:level :info
-                             :type :context}
-      [:> text* {:as "div"
-                 :typography t/body-small
-                 :class (stl/css :color-primary)}
-       (if is-mcp
-         (tr "integrations.mcp-key.info.non-recuperable")
-         (tr "integrations.token.info.non-recuperable"))]]
+     (when-not is-mcp
+       [:> notification-pill* {:level :info
+                               :type :context}
+        [:> text* {:as "div"
+                   :typography t/body-small
+                   :class (stl/css :color-primary)}
+         (tr "integrations.token.info.non-recuperable")]])
 
      [:div {:class (stl/css :modal-content)}
       [:> input-copy* {:value (:token token-created "")

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2536,12 +2536,6 @@ msgstr ""
 "The Penpot MCP Server enables MCP clients to interact directly with Penpot "
 "design files."
 
-#: src/app/main/ui/settings/integrations.cljs:101
-msgid "integrations.mcp-key.info.non-recuperable"
-msgstr ""
-"This unique MCP key is non-recoverable. If you lose it, you will need to "
-"create a new one."
-
 #: src/app/main/ui/settings/integrations.cljs:113
 msgid "integrations.mcp-key.will-expire"
 msgstr "The MCP key will expire on %s"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2466,12 +2466,6 @@ msgstr ""
 "El servidor MCP de Penpot permite a los clientes MCP interactuar "
 "directamente con los archivos de diseño de Penpot."
 
-#: src/app/main/ui/settings/integrations.cljs:101
-msgid "integrations.mcp-key.info.non-recuperable"
-msgstr ""
-"Esta clave MCP única no es recuperable. Si la pierdes, tendrás que crear "
-"una nueva."
-
 #: src/app/main/ui/settings/integrations.cljs:113
 msgid "integrations.mcp-key.will-expire"
 msgstr "La clave MCP expirará el %s"


### PR DESCRIPTION
## What

Removes the "non-recoverable" warning notification from the MCP key generated/regenerated success modal. The warning is preserved for personal access tokens, which remain one-time-disclosure.

## Why

The MCP key is now accessible from the Integrations page after generation (see #10290), so the one-time disclosure warning is no longer accurate. Showing it alongside the key on Integrations sends conflicting signals to users.

## How

The non-recoverable notification in the key generation modal is now conditionally rendered based on whether the key is a personal access token or an MCP key. The MCP-specific translation strings for this message were removed.

Closes #10290.
