### PR TITLE
:bug: Fix eyedropper not taking into account changes in dpr

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/pixel_overlay.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/pixel_overlay.cljs
@@ -261,10 +261,11 @@
   "Maps client (viewport) coordinates to device-pixel canvas coordinates."
   [viewport-node client-x client-y]
   (let [{brx :left bry :top} (dom/get-bounding-rect viewport-node)
+        dpr (wasm.api/get-dpr)
         x (mth/floor (- client-x brx))
         y (mth/floor (- client-y bry))]
-    [(mth/floor (* x wasm.api/dpr))
-     (mth/floor (* y wasm.api/dpr))]))
+    [(mth/floor (* x dpr))
+     (mth/floor (* y dpr))]))
 
 (defn process-pointer-move-wasm
   "Updates the magnifier loupe with the canvas region under the cursor. The


### PR DESCRIPTION
### Related Ticket

Fixes #10265 

### Summary

The color picker's eyedropper was using the stale DPR value, and therefore not taking into account changes in DPR (like when you use the browser's zoom)

https://github.com/user-attachments/assets/e437f608-1be6-42fc-a450-cb650505be6b

### Steps to reproduce 

1. Open a file in the workspace
2. Wait for the file to render.
3. Open the color picker and select the eyedropper tool

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
