### PR TITLE
:bug: Follow 302 redirects when downloading templates

### DIFF
--- a/backend/resources/app/onboarding.edn
+++ b/backend/resources/app/onboarding.edn
@@ -1,45 +1,45 @@
 [{:id "tokens-starter-kit"
   :name "Design tokens starter kit"
-  :file-uri "https://github.com/penpot/penpot-files/raw/refs/heads/main/Tokens%20starter%20kit.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/refs/heads/main/Tokens%20starter%20kit.penpot"}
  {:id "penpot-design-system"
   :name "Penpot Design System | Pencil"
-  :file-uri "https://github.com/penpot/penpot-files/raw/refs/heads/main/Pencil-Penpot-Design-System.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/refs/heads/main/Pencil-Penpot-Design-System.penpot"}
  {:id "wireframing-kit"
   :name "Wireframe library"
-  :file-uri "https://github.com/penpot/penpot-files/raw/refs/heads/main/Wireframing%20kit%20v1.1.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/refs/heads/main/Wireframing%20kit%20v1.1.penpot"}
  {:id "prototype-examples"
   :name "Prototype template"
-  :file-uri "https://github.com/penpot/penpot-files/raw/refs/heads/main/Prototype%20examples%20v1.1.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/refs/heads/main/Prototype%20examples%20v1.1.penpot"}
  {:id "plants-app"
   :name "UI mockup example"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/Plants-app.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/Plants-app.penpot"}
  {:id "tutorial-for-beginners"
   :name "Tutorial for beginners"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/tutorial-for-beginners.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/tutorial-for-beginners.penpot"}
  {:id "lucide-icons"
   :name "Lucide Icons"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/Lucide-icons.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/Lucide-icons.penpot"}
  {:id "font-awesome"
   :name "Font Awesome"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/FontAwesome.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/FontAwesome.penpot"}
  {:id "black-white-mobile-templates"
   :name "Black & White Mobile Templates"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/Black-&-White-Mobile-Templates.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/Black-&-White-Mobile-Templates.penpot"}
  {:id "avataaars"
   :name "Avataaars"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/Avataaars-by-Pablo-Stanley.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/Avataaars-by-Pablo-Stanley.penpot"}
  {:id "ux-notes"
   :name "UX Notes"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/UX-Notes.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/UX-Notes.penpot"}
  {:id "whiteboarding-kit"
   :name "Whiteboarding Kit"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/Whiteboarding-mapping-kit.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/Whiteboarding-mapping-kit.penpot"}
  {:id "open-color-scheme"
   :name "Open Color Scheme"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/Open%20Color%20Scheme%20(v1.9.1).penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/Open%20Color%20Scheme%20(v1.9.1).penpot"}
  {:id "flex-layout-playground"
   :name "Flex Layout Playground"
-  :file-uri "https://github.com/penpot/penpot-files/raw/refs/heads/main/Flex%20Layout%20Playground%20v2.0.penpot"}
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/refs/heads/main/Flex%20Layout%20Playground%20v2.0.penpot"}
  {:id "welcome"
   :name "Welcome"
-  :file-uri "https://github.com/penpot/penpot-files/raw/main/welcome.penpot"}]
+  :file-uri "https://raw.githubusercontent.com/penpot/penpot-files/main/welcome.penpot"}]

--- a/backend/src/app/setup/templates.clj
+++ b/backend/src/app/setup/templates.clj
@@ -57,9 +57,9 @@
 
       (if (fs/exists? path)
         (io/input-stream path)
-        (let [resp (http/req cfg
-                             {:method :get :uri (:file-uri template)}
-                             {:response-type :input-stream :sync? true})]
+        (let [resp (http/req-with-redirects cfg
+                                            {:method :get :uri (:file-uri template)}
+                                            {:response-type :input-stream :sync? true})]
           (when-not (= 200 (:status resp))
             (ex/raise :type :internal
                       :code :unexpected-status-code


### PR DESCRIPTION
GitHub has moved the default location for raw files. This PR 

* allows the backend to follow the 302 redirect
* updates the URIs for the download of penpot template files to their new locations, to avoid the redirect entirely.

Without this change, trying to import an example file from the interface fails because `app.setup.get-template-stream` in the backend does not handle 302s.

### Steps to reproduce 

From the dashboard, try to copy a template file into a project. You'll see an error, and the console shows the culprit is a 302.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Closes #10317
