### PR TITLE
fix: close workspace search panel with Escape key (#9540)

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -307,9 +307,12 @@
 
         on-key-down
         (mf/use-fn
+         (mf/deps show-search?)
          (fn [event]
            (when (kbd/esc? event)
-             (hide-menu))))
+             (hide-menu)
+             (when show-search?
+               (st/emit! dw/close-layers-search)))))
 
         update-search-text
         (mf/use-fn


### PR DESCRIPTION
## Description
Pressing Escape now dismisses the layers search panel, matching standard keyboard conventions for closing overlays and panels.

## Changes
- Modified the document-level `keydown` handler in the layers sidebar to also close the search panel when Escape is pressed
- Added `show-search?` as a dependency to the memoized handler

## Fixes
Closes #9540

## Testing
1. Open a workspace file
2. Press Ctrl+F to open the search panel
3. Press Escape — search panel should close
4. Verify the filter menu also closes on Escape (existing behavior preserved)