### PR TITLE
:sparkles: Enable viewer WASM when render-wasm/v1 is active

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -201,7 +201,8 @@
    :enable-feature-render-wasm
    :enable-token-import-from-library
    :enable-render-switch
-   :enable-render-wasm-info])
+   :enable-render-wasm-info
+   :enable-available-viewer-wasm])
 
 (defn parse
   [& flags]


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10037

### Summary

Remove the :available-viewer-wasm admin flag and gate viewer WASM
rendering solely on the render-wasm/v1 feature flag.

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
