### PR TITLE
:bug: Fix swapped tooltip messages for token deletion states

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/token_typography_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/token_typography_row.cljs
@@ -39,9 +39,9 @@
 
         tooltip-content (cond
                           not-active
-                          (tr "not-active-token.no-name")
-                          has-errors
                           (tr "options.deleted-token")
+                          has-errors
+                          (tr "not-active-token.no-name")
                           :else
                           (mf/html [:> to/resolved-value-tooltip* {:token-name token-name
                                                                    :resolved-value resolved-value}]))]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -98,16 +98,16 @@
         token-name-ref (mf/use-ref nil)
         swatch-tooltip-content (cond
                                  not-active
-                                 (tr "not-active-token.no-name")
-                                 has-errors
                                  (tr "options.deleted-token")
+                                 has-errors
+                                 (tr "not-active-token.no-name")
                                  :else
                                  (tr "workspace.tokens.resolved-value" resolved))
         name-tooltip-content (cond
                                not-active
-                               (tr "not-active-token.no-name")
-                               has-errors
                                (tr "options.deleted-token")
+                               has-errors
+                               (tr "not-active-token.no-name")
                                :else
                                #(mf/html
                                  [:div


### PR DESCRIPTION
## Summary

Fixes the swapped tooltip messages for design token deletion states in both the typography row and color row components.

## Problem

The tooltip messages for the `not-active` (deleted token) and `has-errors` (referenced token with errors) conditions were swapped in two files:

1. **`token_typography_row.cljs`** — typography token tooltips
2. **`color_row.cljs`** — color token tooltips (both swatch and name tooltips)

This caused:
- **Deleted tokens** (`not-active`) to show: *"This token is not in any active set or has an invalid value"* (wrong)
- **Referenced tokens with errors** (`has-errors`) to show: *"This token does not exist or has been deleted"* (wrong)

## Fix

Swapped the translation keys in the `cond` expressions so each condition maps to the correct tooltip:

| Condition | Before (wrong) | After (correct) |
|-----------|----------------|-----------------|
| `not-active` (deleted) | `"not-active-token.no-name"` | `"options.deleted-token"` |
| `has-errors` (referenced) | `"options.deleted-token"` | `"not-active-token.no-name"` |

### Files changed
- `frontend/src/app/main/ui/workspace/sidebar/options/menus/token_typography_row.cljs` (1 swap)
- `frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs` (2 swaps: swatch-tooltip + name-tooltip)

## Related Issues
Fixes #10296
Fixes #10299