### PR TITLE
:bug: Fix go to your penpot on error page

### DIFF
--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -43,8 +43,15 @@
 
 (mf/defc error-container*
   [{:keys [children]}]
-  (let [profile-id  (:profile-id @st/state)
-        on-nav-root (mf/use-fn #(st/emit! (rt/nav-root)))]
+  (let [profile     (mf/deref refs/profile)
+        profile-id  (:id profile)
+        on-nav-root (mf/use-fn
+                     (mf/deps profile-id profile)
+                     (fn []
+                       (if (and profile-id (some? (:default-team-id profile)))
+                         (st/emit! (dcm/go-to-dashboard-recent
+                                    :team-id (:default-team-id profile)))
+                         (st/emit! (rt/nav-root)))))]
     [:section {:class (stl/css :exception-layout)}
      [:button
       {:class (stl/css :exception-header)


### PR DESCRIPTION
### Summary

If you go to a team with some problem, and reach the error page, "Go to your penpot" goes to /, that in turn go to `dashboard/recent` with the last team. But that team is the one with the problem, so you're stuck on the error page again.

This changes the behaviuor to go to 'Your penpot" (as the link say), not the most recet team.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.



Closes #10324
