### PR TITLE
:bug: Fix rulers shown on thumbnails

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -890,7 +890,9 @@ impl RenderState {
         if self.options.is_debug_visible() {
             debug::render(self);
         }
-        ui::render(self, tree);
+        if !self.preview_mode {
+            ui::render(self, tree);
+        }
         debug::render_wasm_label(self);
         self.surfaces.flush_and_submit(SurfaceId::Target);
     }
@@ -2193,8 +2195,11 @@ impl RenderState {
             self.interactive_target_seeded = false;
             // Paint rulers/frame now so they survive the progressive frames
             // instead of blanking until the first full `present_frame`.
-            ui::render(self, tree);
-            self.flush_and_submit();
+            // Skip on sync renders (thumbnails/exports)
+            if !sync_render {
+                ui::render(self, tree);
+                self.flush_and_submit();
+            }
         }
 
         let surface_ids = SurfaceId::Strokes as u32


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10328

### Summary

Do not render UI elements on preview mode

### Steps to reproduce

1. Create a document with WebGL enabled
2. Go back to the dashboard page
3. Inspect the generated thumbnail image.
4. Observe that rulers are not visible in the thumbnail.
