### PR TITLE
:books: Fix Angular plugin usage doc link

### DIFF
--- a/plugins/docs/create-angular-plugin.md
+++ b/plugins/docs/create-angular-plugin.md
@@ -156,4 +156,4 @@ pnpm --filter example-plugin build
 
 For more detailed information on plugin development, check out our guides:
 
-- [Plugin Usage Documentation](,/plugin-usage.md)
+- [Using plugins in Penpot](https://help.penpot.app/user-guide/plugins-integrations/)


### PR DESCRIPTION
## Summary
- replace the malformed `,/plugin-usage.md` link at the end of the Angular plugin guide
- point contributors to Penpot's existing plugin-usage help page instead of a nonexistent repo doc

## Verification
- targeted markdown relative-link check on `plugins/docs/create-angular-plugin.md`
- `git diff --check`
