### PR TITLE
:bug: Fix inspect in View Mode displays shape size twice when selecting a shape

### DIFF
--- a/frontend/src/app/main/ui/measurements.cljs
+++ b/frontend/src/app/main/ui/measurements.cljs
@@ -281,7 +281,6 @@
                               :bounds bounds
                               :zoom zoom}]
        [:> size-display* {:selrect selected-selrect :zoom zoom}]
-       [:> selection-size-badge* {:selrect selected-selrect :zoom zoom}]
 
        (if (or (not hover-shape) (not hover-selected-shape?))
          (when (and frame (not= uuid/zero (:id frame)))


### PR DESCRIPTION
### Related Ticket

Closes #10306 