### PR TITLE
:bug: Fix guides pill on drag

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/guides.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/guides.cljs
@@ -681,7 +681,7 @@
         ;; only overlay the dotted extensions. Drag and edit hide the WASM line
         ;; and require the full SVG line.
         show-line?   (not= mode :hover)
-        show-pill?   (or (= mode :edit) (= mode :hover))
+        show-pill?   (or (= mode :edit) (= mode :hover) (= mode :drag))
         editing?     (= mode :edit)
 
         on-key-down


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10357

### Summary

Hotfix: missing on-drag check

[screen-recorder-mon-jun-22-2026-15-42-19.webm](https://github.com/user-attachments/assets/e6fd45b5-f16d-4222-a95a-a3cc6ca006cb)


### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
