### PR TITLE
:zap: Fix slow zoom/edit on Firefox+NVIDIA WebGL renderer

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -2187,7 +2187,6 @@ impl RenderState {
             // quality pass completes.
             self.surfaces
                 .reset_interactive_transform(self.background_color);
-            self.surfaces.seed_backbuffer_from_target();
             self.interactive_target_seeded = false;
         } else {
             self.reset_canvas();

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -907,17 +907,6 @@ impl Surfaces {
         self.tile_atlas.canvas().clear(skia::Color::TRANSPARENT);
     }
 
-    /// Seed `Backbuffer` from `Target` (last presented frame).
-    pub fn seed_backbuffer_from_target(&mut self) {
-        let sampling_options = self.sampling_options;
-        self.target.draw(
-            self.backbuffer.canvas(),
-            (0.0, 0.0),
-            sampling_options,
-            Some(&skia::Paint::default()),
-        );
-    }
-
     fn reset_from_target(&mut self, target: skia::Surface) -> Result<()> {
         let dim = (target.width(), target.height());
         self.target = target;


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10370

### Summary

start_render_loop's preserve-target / zoom branch seeds Backbuffer from Target every frame.  By checking the trace, it seems that Skia resolves the Target surface with a full-viewport glCopyTexImage2D each frame. 

Moreover,  it seems that `seed_backbuffer_from_target` is not necessary 

### Steps to reproduce 

Check in the issue

[screen-recorder-mon-jun-22-2026-23-02-01.webm](https://github.com/user-attachments/assets/3760ba53-ccc2-470b-bbdb-50d3b480eb6b)


### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
