### PR TITLE
:bug: Fix zh-CN boolean intersection label

### DIFF
--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -6616,7 +6616,7 @@ msgstr "显示/隐藏界面"
 
 #: src/app/main/ui/workspace/context_menu.cljs:466, src/app/main/ui/workspace/sidebar/options/menus/bool.cljs:95
 msgid "workspace.shape.menu.intersection"
-msgstr "差集"
+msgstr "交集"
 
 #: src/app/main/ui/workspace/context_menu.cljs:500, src/app/main/ui/workspace/sidebar/layer_item.cljs:198, src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:271, src/app/main/ui/workspace/sidebar/options/menus/layer.cljs:324
 msgid "workspace.shape.menu.lock"


### PR DESCRIPTION
## What
Fixes the Simplified Chinese label for the boolean Intersection action in the Path menu.

## Why
The Intersection action reused the Difference translation (`差集`), so both actions appeared as Difference in zh-CN.

## How
Updated `workspace.shape.menu.intersection` in `zh_CN.po` to `交集`.

Fixes #10346