### PR TITLE
:bug: Fix long typography token name in tooltip in design tab

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/shared/token_option.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/token_option.scss
@@ -86,4 +86,5 @@
 
 .token-name-tooltip {
   color: var(--color-foreground-primary);
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
### Related Ticket

Closes #10295
