### PR TITLE
:wrench: Define concurrency policy to cancel in progress build workflows

### DIFF
--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -37,6 +37,10 @@ on:
         required: false
         default: 'yes'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.gh_ref }}
+  cancel-in-progress: true
+
 jobs:
   build-bundle:
     name: Build and Upload Penpot Bundle

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -16,6 +16,10 @@ on:
         required: true
         default: 'develop'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.gh_ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     name: Build and Push Penpot Docker Images


### PR DESCRIPTION
This PR introduces **GitHub Actions concurrency control** in our reusable workflows (`build-bundle` and `build-docker`) using `inputs.gh_ref` as the run discriminator.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ inputs.gh_ref }}
  cancel-in-progress: true
```

With this configuration, when a new run starts for the same workflow and the same `gh_ref`, any older in-progress run is automatically canceled.

## Why this is better than not defining concurrency

- **Eliminates redundant builds**  
  Without concurrency, outdated runs keep consuming CI time even after a newer run has superseded them.

- **Improves feedback speed**  
  CI resources are focused on the latest relevant run, so developers get useful results faster.

- **Reduces infrastructure usage and cost**  
  Canceling obsolete runs lowers compute consumption and queue pressure.

- **Keeps pipelines cleaner**  
  Fewer overlapping executions means less noise and easier troubleshooting.

- **Applies cancellation safely by ref**  
  Using `gh_ref` ensures only equivalent runs are canceled; different refs can still run independently.

## Expected impact

We keep only the **latest meaningful build per workflow/ref** running, which improves CI efficiency, reduces waste, and shortens turnaround time.