### PR TITLE
:bug: Fix error when sending user feedback form

### DIFF
--- a/backend/src/app/rpc/commands/feedback.clj
+++ b/backend/src/app/rpc/commands/feedback.clj
@@ -54,7 +54,6 @@
 
     (eml/send! {::eml/conn pool
                 ::eml/factory eml/user-feedback
-                :from     (cf/get :smtp-default-from)
                 :to       destination
                 :reply-to (:email profile)
                 :email    (:email profile)


### PR DESCRIPTION
### Related Ticket

Closes https://github.com/penpot/penpot/issues/10178

### Summary

If the smtp-default-from is something like "Penpot <no-reply@penpot.app>", the schema validation fails because it expects a simple email without < >

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
