### PR TITLE
:sparkles: Add minor changes to the mcp that simplifies its setup

### DIFF
--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -69,7 +69,7 @@ There are three key pieces:
 
 ![How the AI client, Penpot MCP server, plugin, and design file connect](/img/mcp/mcp-flow.webp)
 
-### Basic concepts 
+### Basic concepts
 
 Some important concepts for users:
 * **Integrations page**: MCP is configured under **Your account → Integrations → MCP Server**. Here you enable or disable MCP, get the server URL and manage the MCP key.
@@ -129,17 +129,18 @@ If you just want to try Penpot AI workflows quickly through the MCP, follow this
    ![MCP Server in Penpot Integrations, copy server url](/img/mcp/mcp-server-url.webp)
 
 4. #### Add the server to your MCP client
-   In your MCP-aware IDE/agent (Cursor, Claude Code, etc.), add a new server pointing to that URL.
-   **Example (generic JSON config):**
-   ```json
-   {
-     "mcpServers": {
-       "penpot": {
-         "url": "https://<your-penpot-domain>/mcp/stream?userToken=YOUR_MCP_KEY"
-       }
-     }
-   }
+   We recommend using the [add-mcp](https://github.com/neon-solutions/add-mcp) project for connecting your MCP client to the Penpot MCP server.
+   With `npx` available, call
+
+   ```shell
+   npx -y add-mcp -g -n penpot <URL>
    ```
+
+   and follow the interactive setup. Alternatively, follow your client's instructions for connecting
+   to a remote MCP server. For Claude Desktop, we recommend adding the Penpot MCP Server as a
+   custom [connector](http://claude.ai/customize/connectors).
+   See the section **Connect your MCP client** for more details on how to connect.
+
 5. #### Open a Penpot file and connect MCP
    In Penpot, open a design file and use **File → MCP Server → Connect** to connect the plugin to your current file.
 
@@ -187,9 +188,9 @@ When you are comfortable with the responses, you can move on to **light write op
 
 ### Model quality advice
 
-For best results, use a strong model and a high-quality inference setup. 
+For best results, use a strong model and a high-quality inference setup.
 
-Using a vision-language model (VLM) is required to enable image understanding; most commercially provided LLMs are VLMs. 
+Using a vision-language model (VLM) is required to enable image understanding; most commercially provided LLMs are VLMs.
 
 In any case, we recommend always using **frontier models**. The more complex the task is, the more the model will highly influence the quality of the results.
 
@@ -216,84 +217,26 @@ You can use Penpot MCP server in two main ways:
 
 ## Connect your MCP client
 
-Use the same client setup flow for both modes. What changes is the server URL and authentication method.
+Use the same client setup flow for both modes.
 
 ### Connection values by mode
 
 * **Remote MCP**
-  * URL: `https://<your-penpot-domain>/mcp/stream?userToken=YOUR_MCP_KEY`
-  * Auth: MCP key in `userToken`
+  * URL (copy from your penpot account overview): `https://<your-penpot-domain>/mcp/stream?userToken=YOUR_MCP_KEY`
+  * Connect with `npx -y add-mcp -g -n penpot <URL>` or by following your client's instructions for connecting to a remote MCP server.
 * **Local MCP**
-  * URL: `http://localhost:4401/mcp`
-  * Auth: none (uses your active Penpot browser session)
+  * Connect with `npx -y @penpot/mcp@latest add-mcp` which automatically uses the correct URL (by default `http://localhost:4401/mcp`)
 
-### Cursor
-
-1. Open Cursor MCP/tool configuration.
-2. Add a Penpot MCP server entry:
+For **Claude Desktop** we recommend to either add the Penpot Remote MCP server as custom connector, or to
+use the [mcp-remote](https://github.com/geelen/mcp-remote) wrapper for adding the Penpot MCP server
+(both remote or local works) as stdio server via
 
 ```json
 {
   "mcpServers": {
     "penpot": {
-      "url": "REMOTE_OR_LOCAL_URL",
-      "type": "http"
-    }
-  }
-}
-```
-
-Replace `REMOTE_OR_LOCAL_URL` with the URL for your mode.
-
-### Claude Code
-
-1. Open MCP configuration in Claude Code.
-2. Add a Penpot server with `http` transport and the URL for your mode.
-3. Restart Claude Code or reload tools.
-
-```json
-{
-  "mcpServers": {
-    "penpot": {
-      "transport": "http",
-      "url": "REMOTE_OR_LOCAL_URL"
-    }
-  }
-}
-```
-
-
-### VS Code / Copilot
-
-1. Open external MCP server configuration in your extension/settings.
-2. Add Penpot with the URL for your mode.
-3. Save and reload tools.
-
-```json
-{
-  "mcp.servers": {
-    "penpot": {
-      "transport": "http",
-      "url": "REMOTE_OR_LOCAL_URL"
-    }
-  }
-}
-```
-
-### Codex / OpenCode etc
-
-1. Use your client's "Add MCP server" flow.
-2. Set the URL for your mode.
-3. Reload tools and verify Penpot tools are available.
-
-```json
-{
-  "servers": {
-    "penpot": {
-      "url": "REMOTE_OR_LOCAL_URL",
-      "transport": {
-        "type": "http"
-      }
+      "command": "npx",
+      "args": ["mcp-remote", "<URL>"]
     }
   }
 }
@@ -326,9 +269,8 @@ Remote MCP is the easiest way to start using AI agents with Penpot. It's hosted 
 <a id="connect-remote"></a>
 ### Connect
 
-For client-specific setup, use the shared section **Connect your MCP client**.
-
 For remote mode, use the URL shown in **Your account → Integrations → MCP Server**, which includes your `userToken`.
+See the section **Connect your MCP client** for details on how to connect.
 
 ### Setup videos
 
@@ -464,9 +406,7 @@ For advanced or repository-based workflows, see the [MCP README](https://github.
 <a id="connect-local"></a>
 ### Connect
 
-For client-specific setup, use the shared section **Connect your MCP client**.
-
-For local mode, use `http://localhost:4401/mcp` with HTTP transport (no MCP key; authentication uses your active Penpot browser session).
+See the section **Connect your MCP client** for details on how to connect.
 
 <a id="use-local"></a>
 ### Use

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -180,11 +180,22 @@ By default, the server runs on port 4401 and provides:
 - **Modern Streamable HTTP endpoint**: `http://localhost:4401/mcp`
 - **Legacy SSE endpoint**: `http://localhost:4401/sse`
 
-These endpoints can be used directly by MCP clients that support them.
+You can change the port by setting the `PENPOT_MCP_SERVER_PORT` environment variable
+before starting the server. These endpoints can be used directly by MCP clients that support them.
 Simply configure the client to connect the MCP server by providing the respective URL.
 
-When using a client that only supports stdio transport,
-a proxy like `mcp-remote` is required.
+#### Configuring your client
+
+The `penpot/mcp` package comes with a pre-configured [add-mcp](https://github.com/neon-solutions/add-mcp)
+command to simplify client configuration.
+Simply call `npx -y @penpot/mcp@latest add-mcp` and follow the interactive dialogue to configure the clients
+of your choice.
+The default config entry name is `penpot` (override it with `-n <name>`) and the URL will post
+to the http endpoint (respecting the `PENPOT_MCP_SERVER_PORT`).
+
+When using a client that only supports stdio transport like **Claude Desktop**,
+a proxy like [mcp-remote](https://github.com/geelen/mcp-remote) is required. 
+More information on connecting your client follows below.
 
 #### Using a Proxy for stdio Transport
 
@@ -231,12 +242,6 @@ After updating the configuration file, restart Claude Desktop completely for the
 
 After the restart, you should see the MCP server listed when clicking on the "Search and tools" icon at the bottom
 of the prompt input area.
-
-#### Example: Claude Code
-
-To add the Penpot MCP server to a Claude Code project, issue the command
-
-    claude mcp add penpot -t http http://localhost:4401/mcp
 
 ## Repository Structure
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -14,6 +14,8 @@
     "start:multi-user": "pnpm -r --parallel run start:multi-user",
     "bootstrap": "pnpm -r install && pnpm run build && pnpm run start",
     "bootstrap:multi-user": "pnpm -r install && pnpm run build && pnpm run start:multi-user",
+    "add-mcp": "pnpm --filter ./packages/server run add-mcp --",
+    "add-mcp:dev": "pnpm --filter ./packages/server run add-mcp:dev --",
     "fmt": "prettier --write packages/",
     "fmt:check": "prettier --check packages/",
     "test": "pnpm -r run test"

--- a/mcp/packages/server/package.json
+++ b/mcp/packages/server/package.json
@@ -8,6 +8,8 @@
     "build:server": "esbuild src/index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.js --external:@modelcontextprotocol/* --external:ws --external:express --external:class-transformer --external:class-validator --external:reflect-metadata --external:pino --external:pino-pretty --external:pino-loki --external:js-yaml --external:sharp --external:nrepl-client --external:ioredis",
     "build": "pnpm run build:server && node scripts/copy-resources.js",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "add-mcp": "node dist/index.js add-mcp",
+    "add-mcp:dev": "tsx src/index.ts add-mcp",
     "start": "node dist/index.js",
     "start:multi-user": "node dist/index.js --multi-user",
     "start:dev": "node --import ts-node/register src/index.ts",
@@ -27,6 +29,7 @@
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "add-mcp": "1.11.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "express": "^5.1.0",

--- a/mcp/packages/server/src/index.ts
+++ b/mcp/packages/server/src/index.ts
@@ -1,8 +1,34 @@
 #!/usr/bin/env node
 
-import { PenpotMcpServer } from "./PenpotMcpServer";
 import { createLogger, logActiveTransports } from "./logger";
+import path from "node:path";
 
+import { spawn } from "node:child_process";
+import { BaseLogger } from "pino";
+import { fileURLToPath } from "url";
+
+async function runAddMcp(args: string[], logger: BaseLogger): Promise<never> {
+    const packageJsonUrl = import.meta.resolve("add-mcp/package.json");
+    const packageJsonPath = fileURLToPath(packageJsonUrl);
+    const packageRoot = path.dirname(packageJsonPath);
+
+    const addMcpBin = path.join(packageRoot, "dist", "index.js");
+
+    const child = spawn(process.execPath, [addMcpBin, ...args], {
+        stdio: "inherit",
+    });
+
+    child.on("error", (error) => {
+        logger.error(error, "Failed to run add-mcp");
+        process.exit(1);
+    });
+
+    child.on("exit", (code) => {
+        process.exit(code ?? 1);
+    });
+
+    return new Promise(() => {});
+}
 /**
  * Entry point for Penpot MCP Server
  *
@@ -14,11 +40,22 @@ import { createLogger, logActiveTransports } from "./logger";
 async function main(): Promise<void> {
     const logger = createLogger("main");
 
-    // announce active transports early so they appear before any potential errors
-    logActiveTransports(logger);
-
     try {
         const args = process.argv.slice(2);
+        if (args[0] === "add-mcp") {
+            let forwardedArgs = args.slice(1);
+            // We pass args with -- to avoid collisions with args that could be used by pnpm itself
+            if (forwardedArgs[0] === "--") {
+                forwardedArgs = forwardedArgs.slice(1);
+            }
+
+            const mcpPort = parseInt(process.env.PENPOT_MCP_SERVER_PORT ?? "4401");
+            const addMcpArgs = ["-g", "-n", "penpot", `http://localhost:${mcpPort}/mcp`];
+            await runAddMcp([...addMcpArgs, ...forwardedArgs], logger);
+        }
+
+        // announce active transports early so they appear before any potential errors
+        logActiveTransports(logger);
         let multiUser = false; // default to single-user mode
 
         // parse command line arguments
@@ -26,16 +63,32 @@ async function main(): Promise<void> {
             if (args[i] === "--multi-user") {
                 multiUser = true;
             } else if (args[i] === "--help" || args[i] === "-h") {
-                logger.info("Usage: node dist/index.js [options]");
+                logger.info("Usage:");
+                logger.info("  node dist/index.js [options]");
+                logger.info("  node dist/index.js add-mcp [add-mcp options]");
+                logger.info("");
                 logger.info("Options:");
                 logger.info("  --multi-user           Enable multi-user mode (default: single-user)");
                 logger.info("  --help, -h             Show this help message");
+                logger.info("");
+                logger.info("Commands:");
+                logger.info("  add-mcp                Run the add-mcp interactive setup CLI");
+                logger.info("");
+                logger.info("Examples:");
+                logger.info("  node dist/index.js");
+                logger.info("  node dist/index.js --multi-user");
+                logger.info("  node dist/index.js add-mcp");
+                logger.info("  node dist/index.js add-mcp --help");
+                logger.info("");
+                logger.info("Any arguments after 'add-mcp' are forwarded to the add-mcp CLI.");
                 logger.info("");
                 logger.info("Note that configuration is mostly handled through environment variables.");
                 logger.info("Refer to the README for more information.");
                 process.exit(0);
             }
         }
+        // Importing after handling add-mcp since import triggers logs which pollute the add-mcp TUI
+        const { PenpotMcpServer } = await import("./PenpotMcpServer.js");
 
         const server = new PenpotMcpServer(multiUser);
         await server.start();

--- a/mcp/packages/server/tsconfig.json
+++ b/mcp/packages/server/tsconfig.json
@@ -17,6 +17,9 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*",
+    "../plugin/src/index.d.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/mcp/pnpm-lock.yaml
+++ b/mcp/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      add-mcp:
+        specifier: 1.11.0
+        version: 1.11.0
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -123,6 +126,12 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@clack/core@0.4.1':
+    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+
+  '@clack/prompts@0.9.1':
+    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -301,6 +310,9 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -676,6 +688,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  add-mcp@1.11.0:
+    resolution: {integrity: sha512-pbFVg6UpbsFxsgVHLqu+wapKoNqPIZYxFRPU+5a67pGdddZcjvRDNZUlIA8vwbn72WGzzLFUSwrlWXJFOfPWDg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -744,6 +761,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   concurrently@10.0.3:
     resolution: {integrity: sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==}
@@ -989,6 +1010,10 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
   js-yaml@5.2.0:
     resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
     hasBin: true
@@ -998,6 +1023,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   libphonenumber-js@1.13.7:
     resolution: {integrity: sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==}
@@ -1309,6 +1337,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
@@ -1510,6 +1541,17 @@ packages:
 
 snapshots:
 
+  '@clack/core@0.4.1':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.9.1':
+    dependencies:
+      '@clack/core': 0.4.1
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -1613,6 +1655,8 @@ snapshots:
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
+
+  '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.1.0': {}
 
@@ -1896,6 +1940,15 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  add-mcp@1.11.0:
+    dependencies:
+      '@clack/prompts': 0.9.1
+      '@iarna/toml': 2.2.5
+      chalk: 5.6.2
+      commander: 13.1.0
+      js-yaml: 4.3.0
+      jsonc-parser: 3.3.1
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -1964,6 +2017,8 @@ snapshots:
   cluster-key-slot@1.1.1: {}
 
   colorette@2.0.20: {}
+
+  commander@13.1.0: {}
 
   concurrently@10.0.3:
     dependencies:
@@ -2223,6 +2278,10 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
   js-yaml@5.2.0:
     dependencies:
       argparse: 2.0.1
@@ -2230,6 +2289,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  jsonc-parser@3.3.1: {}
 
   libphonenumber-js@1.13.7: {}
 
@@ -2569,6 +2630,8 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  sisteransi@1.0.5: {}
 
   sonic-boom@4.2.0:
     dependencies:


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10355

### Summary

Added a wrapper around mcp-add to the penpot/mcp package, extended docs around that and
removed client-specific mcp config instructions (except for Claude Desktop).