### PR TITLE
:bug: Fix pixel grid shown on top of rulers

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -603,7 +603,8 @@
 
        (when show-pixel-grid?
          [:> widgets/pixel-grid* {:vbox vbox
-                                  :zoom zoom}])
+                                  :zoom zoom
+                                  :clip-rulers false}])
 
        (when show-snap-points?
          [:> snap-points/snap-points*

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -603,8 +603,7 @@
 
        (when show-pixel-grid?
          [:> widgets/pixel-grid* {:vbox vbox
-                                  :zoom zoom
-                                  :clip-rulers false}])
+                                  :zoom zoom}])
 
        (when show-snap-points?
          [:> snap-points/snap-points*

--- a/frontend/src/app/main/ui/workspace/viewport/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/frame_grid.cljs
@@ -15,6 +15,7 @@
    [app.common.types.shape-tree :as ctst]
    [app.common.uuid :as uuid]
    [app.main.refs :as refs]
+   [app.main.ui.workspace.viewport.rulers :as rulers]
    [rumext.v2 :as mf]))
 
 (mf/defc square-grid* [{:keys [frame zoom grid]}]
@@ -165,12 +166,15 @@
 
 (mf/defc frame-grid*
   {::mf/wrap [mf/memo]}
-  [{:keys [zoom transform selected focus]}]
+  [{:keys [zoom transform selected focus vbox clip-rulers] :or {clip-rulers false}}]
   (let [frames        (->> (mf/deref refs/workspace-frames)
                            (filter has-grid?))
         transforming  (when (some? transform) selected)]
 
-    [:g.grid-display {:style {:pointer-events "none"}}
+    [:g.grid-display {:style {:pointer-events "none"}
+                      :clip-path (when clip-rulers "url(#clip-frame-grid)")}
+     (when clip-rulers
+       [:> rulers/rulers-clip-path* {:id "clip-frame-grid" :vbox vbox :zoom zoom}])
      (for [frame frames]
        (when (and #_(not (is-transform? frame))
               (not (ctst/rotated-frame? frame))

--- a/frontend/src/app/main/ui/workspace/viewport/rulers.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/rulers.cljs
@@ -35,6 +35,19 @@
 ;;   RULERS
 ;; ----------------
 
+(mf/defc rulers-clip-path*
+  "Defines a clip path (referenced by `id`) that excludes the ruler bars from the
+   given `vbox`. Used to keep SVG overlays from painting over the rulers that are
+   drawn by the wasm render engine on the canvas."
+  [{:keys [id vbox zoom]}]
+  (let [ruler-size (/ ruler-area-size zoom)]
+    [:defs
+     [:clipPath {:id id}
+      [:rect {:x (+ (:x vbox) ruler-size)
+              :y (+ (:y vbox) ruler-size)
+              :width (max 0 (- (:width vbox) ruler-size))
+              :height (max 0 (- (:height vbox) ruler-size))}]]]))
+
 (defn- calculate-step-size
   [zoom]
   (cond

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -23,6 +23,7 @@
    [app.main.ui.context :as ctx]
    [app.main.ui.ds.foundations.assets.icon :as i :refer [icon*]]
    [app.main.ui.hooks :as hooks]
+   [app.main.ui.workspace.viewport.rulers :as rulers]
    [app.main.ui.workspace.viewport.utils :as vwu]
    [app.util.debug :as dbg]
    [app.util.dom :as dom]
@@ -32,7 +33,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc pixel-grid*
-  [{:keys [vbox zoom]}]
+  [{:keys [vbox zoom clip-rulers]}]
   (let [page         (mf/deref refs/workspace-page)
         custom-color (:pixel-grid-color page)
         custom-alpha (:pixel-grid-opacity page)
@@ -44,7 +45,9 @@
         opacity      (cond
                        debug?              1
                        (some? custom-alpha) custom-alpha
-                       :else               0.2)]
+                       :else               0.2)
+        ;; Width of the ruler bars in document coordinates.
+        ruler-size   (/ rulers/ruler-area-size zoom)]
     [:g.pixel-grid
      [:defs
       [:pattern {:id "pixel-grid"
@@ -56,12 +59,21 @@
                :style {:fill "none"
                        :stroke stroke
                        :stroke-opacity opacity
-                       :stroke-width (str (/ 1 zoom))}}]]]
+                       :stroke-width (str (/ 1 zoom))}}]]
+      ;; In the wasm render, rulers are drawn on the canvas, so we need to clip
+      ;; this grid overlay
+      (when clip-rulers
+        [:clipPath {:id "clip-pixel-grid"}
+         [:rect {:x (+ (:x vbox) ruler-size)
+                 :y (+ (:y vbox) ruler-size)
+                 :width (max 0 (- (:width vbox) ruler-size))
+                 :height (max 0 (- (:height vbox) ruler-size))}]])]
      [:rect {:x (:x vbox)
              :y (:y vbox)
              :width (:width vbox)
              :height (:height vbox)
              :fill (str "url(#pixel-grid)")
+             :clip-path (when clip-rulers "url(#clip-pixel-grid)")
              :style {:pointer-events "none"}}]]))
 
 (mf/defc cursor-tooltip*

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -33,7 +33,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc pixel-grid*
-  [{:keys [vbox zoom clip-rulers]}]
+  [{:keys [vbox zoom clip-rulers] :or {clip-rulers false}}]
   (let [page         (mf/deref refs/workspace-page)
         custom-color (:pixel-grid-color page)
         custom-alpha (:pixel-grid-opacity page)
@@ -45,9 +45,7 @@
         opacity      (cond
                        debug?              1
                        (some? custom-alpha) custom-alpha
-                       :else               0.2)
-        ;; Width of the ruler bars in document coordinates.
-        ruler-size   (/ rulers/ruler-area-size zoom)]
+                       :else               0.2)]
     [:g.pixel-grid
      [:defs
       [:pattern {:id "pixel-grid"
@@ -59,15 +57,9 @@
                :style {:fill "none"
                        :stroke stroke
                        :stroke-opacity opacity
-                       :stroke-width (str (/ 1 zoom))}}]]
-      ;; In the wasm render, rulers are drawn on the canvas, so we need to clip
-      ;; this grid overlay
-      (when clip-rulers
-        [:clipPath {:id "clip-pixel-grid"}
-         [:rect {:x (+ (:x vbox) ruler-size)
-                 :y (+ (:y vbox) ruler-size)
-                 :width (max 0 (- (:width vbox) ruler-size))
-                 :height (max 0 (- (:height vbox) ruler-size))}]])]
+                       :stroke-width (str (/ 1 zoom))}}]]]
+     (when clip-rulers
+       [:> rulers/rulers-clip-path* {:id "clip-pixel-grid" :vbox vbox :zoom zoom}])
      [:rect {:x (:x vbox)
              :y (:y vbox)
              :width (:width vbox)

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -851,7 +851,9 @@
           {:zoom zoom
            :selected selected
            :transform transform
-           :focus focus}])
+           :focus focus
+           :vbox vbox
+           :clip-rulers show-rulers?}])
 
        (when show-pixel-grid?
          [:> widgets/pixel-grid* {:vbox vbox

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -855,7 +855,8 @@
 
        (when show-pixel-grid?
          [:> widgets/pixel-grid* {:vbox vbox
-                                  :zoom zoom}])
+                                  :zoom zoom
+                                  :clip-rulers show-rulers?}])
 
        (when show-snap-points?
          [:> snap-points/snap-points*


### PR DESCRIPTION
### Related Ticket

Fixes #10426 

### Summary

This clips the pixel grid SVG so the rulers area is hidden on the wasm renderer.

https://github.com/user-attachments/assets/71a6e833-9546-44ec-a222-c4f6ec4ede3b

### Steps to reproduce 

See #10426 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] ~~Check CI passes successfully.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
