### PR TITLE
:lipstick: Fix templates carousel header overlap and add hover separator

### DIFF
--- a/frontend/src/app/main/ui/dashboard/templates.scss
+++ b/frontend/src/app/main/ui/dashboard/templates.scss
@@ -48,16 +48,16 @@
 .title {
   pointer-events: all;
   width: px2rem(420);
-  inset-block-start: calc(-1 * $sz-40);
+  inset-block-start: calc(-1 * px2rem(44)); 
   text-align: right;
-  height: px2rem(56);
+  height: px2rem(44);                        
   position: absolute;
 }
 
 .title-btn {
   border: none;
   cursor: pointer;
-  height: px2rem(56);
+  height: px2rem(44);                        
   display: inline-flex;
   align-items: center;
   border-start-start-radius: $br-8;
@@ -66,6 +66,12 @@
   z-index: var(--z-index-auto);
   background-color: var(--color-background-tertiary);
   width: 100%;
+  border-block-end: $b-2 solid transparent;
+  transition: border-color 200ms;
+
+  &:hover {
+    border-block-end-color: var(--color-accent-primary);
+  }
 }
 
 .title-text {


### PR DESCRIPTION
### Changes

Fixes a visual overlap between the "Libraries & Templates" header bar and its content area, and adds a hover-visible separator line between them for clearer visual hierarchy.

### Issue

- The header bar's `inset-block-start` offset (-40px) didn't match its actual height (56px), causing it to overlap 16px into the content area below.
- There was no visual boundary between the header and the scrollable template cards, making the two areas blend into each other.

### Result

- Header bar's offset now exactly matches its height, eliminating the overlap.
- A subtle separator line appears along the bottom edge of the header on hover, clearly marking the boundary between header and content.
- Reduced header height slightly (56px → 44px) for a more compact, balanced look.

### Testing

Tested locally via the devenv:

- Confirmed header no longer overlaps the carousel content area.
- Confirmed hover separator line appears correctly along the header's bottom edge.
- Verified header text ("Libraries & Templates" / "Hide") remains vertically centered at the reduced height.

### Screen Recordings

1. before the fix (header overlap, no separator)
https://github.com/user-attachments/assets/99e67c75-de08-49ca-b74f-a8f9feee4749




3. after the fix (overlap resolved, hover separator visible)
https://github.com/user-attachments/assets/667ec50e-aaf4-4156-a543-c761c8ee2307




Signed-off-by: @Parinith-web  <parinithreddymav@gmail.com>