### PR TITLE
:sparkles: Avoid going to last team on login if it is protected by sso

### DIFF
--- a/frontend/src/app/main/data/auth.cljs
+++ b/frontend/src/app/main/data/auth.cljs
@@ -53,12 +53,16 @@
                           :team-id (:default-team-id profile))
                          (dp/update-profile-props {:welcome-file-id nil}))
 
-                  (let [teams   (into #{} (map :id) teams)
-                        team-id (dtm/get-last-team-id)
-                        team-id (if (and team-id (contains? teams team-id))
-                                  team-id
-                                  (:default-team-id profile))]
-                    (rx/of (dcm/go-to-dashboard-recent {:team-id team-id})))))))]
+                  (let [default-team-id (:default-team-id profile)
+                        team-ids        (into #{} (map :id) teams)
+                        team-id         (dtm/get-last-team-id)
+                        team-id         (if (and team-id (contains? team-ids team-id))
+                                          team-id
+                                          default-team-id)]
+                    (->> (dtm/resolve-login-team-id {:team-id team-id
+                                                     :default-team-id default-team-id})
+                         (rx/mapcat (fn [team-id]
+                                      (rx/of (dcm/go-to-dashboard-recent {:team-id team-id}))))))))))]
 
     (ptk/reify ::logged-in
       ptk/WatchEvent

--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -36,6 +36,18 @@
   []
   (::current-team-id storage/global))
 
+(defn resolve-login-team-id
+  "Resolve the team to navigate to after login. Falls back to the
+  default team when the candidate requires SSO and the user has no
+  valid SSO session for it."
+  [{:keys [team-id default-team-id]}]
+  (if (or (not (contains? cf/flags :nitrate))
+          (= team-id default-team-id))
+    (rx/of team-id)
+    (->> (rp/cmd! :check-nitrate-sso {:team-id team-id :url (rt/get-current-href)})
+         (rx/map (fn [{:keys [authorized]}]
+                   (if authorized team-id default-team-id))))))
+
 (defn teams-fetched
   [teams]
   (ptk/reify ::teams-fetched

--- a/frontend/src/app/main/ui/routes.cljs
+++ b/frontend/src/app/main/ui/routes.cljs
@@ -156,12 +156,19 @@
                            (st/emit! (rt/nav :auth-login)))
 
                          empty-path?
-                         (let [team-id (dtm/get-last-team-id)]
-                           (if (contains? teams team-id)
-                             (st/emit! (rt/nav :dashboard-recent
-                                               (assoc query-params :team-id team-id)))
-                             (st/emit! (rt/nav :dashboard-recent
-                                               (assoc query-params :team-id (:default-team-id profile))))))
+                         (let [default-team-id (:default-team-id profile)
+                               last-team-id    (dtm/get-last-team-id)
+                               team-id         (if (contains? teams last-team-id)
+                                                 last-team-id
+                                                 default-team-id)]
+                           (->> (dtm/resolve-login-team-id {:team-id team-id
+                                                            :default-team-id default-team-id})
+                                (rx/subs!
+                                 (fn [team-id]
+                                   (st/emit! (rt/nav :dashboard-recent
+                                                     (assoc query-params :team-id team-id))))
+                                 (fn [cause]
+                                   (errors/on-error cause)))))
 
                          :else
                          (st/emit! (rt/assign-exception {:type :not-found}))))


### PR DESCRIPTION
### Summary

After loging, Penpot redirects the user to its last visited team. It that team was under SSO, and the user can't log to SSO anymore, the user is traped here with no way to go to "Your penpot".

This redirect to the user to "Your Penpot" instead when the user is not logged on the SSO.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
