### PR TITLE
:sparkles: Disable hot swap of render engines

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -72,7 +72,6 @@
    [app.main.refs :as refs]
    [app.main.repo :as rp]
    [app.main.router :as rt]
-   [app.main.store :as st]
    [app.plugins.register :as preg]
    [app.render-wasm :as wasm]
    [app.render-wasm.api :as wasm.api]
@@ -352,10 +351,8 @@
       (let [stoper-s     (rx/filter (ptk/type? ::finalize-workspace) stream)
             rparams      (rt/get-params state)
             features     (features/get-enabled-features state team-id)
-            ;; since render-wasm/v1 can be hot-toggled by the user, we need to query it
-            ;; from the state with active-feature?
-            render-wasm-enabled? #(features/active-feature? @st/state "render-wasm/v1")
-            render-wasm-ready?   #(and (render-wasm-enabled?)
+            render-wasm-enabled? (features/active-feature? state "render-wasm/v1")
+            render-wasm-ready?   #(and render-wasm-enabled?
                                        wasm-state/context-initialized?
                                        (not @wasm-state/context-lost?))]
 
@@ -368,7 +365,7 @@
                (rx/concat
                 ;; Fetch all essential data that should be loaded before the file
                 (rx/merge
-                 (if ^boolean (render-wasm-enabled?)
+                 (if ^boolean render-wasm-enabled?
                    (->> (rx/from @wasm/module)
                         (rx/filter true?)
                         (rx/tap (fn [_]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -1379,7 +1379,7 @@
   []
   (ptk/reify ::watch-component-changes
     ptk/WatchEvent
-    (watch [_ _ stream]
+    (watch [_ state stream]
       (let [stopper-s
             (->> stream
                  (rx/map ptk/type)
@@ -1449,7 +1449,7 @@
                  (rx/tap #(log/trc :hint "buffer initialized")))]
 
         (when (or (contains? cf/flags :component-thumbnails)
-                  (features/active-feature? @st/state "render-wasm/v1"))
+                  (features/active-feature? state "render-wasm/v1"))
           (->> (rx/merge
                 changes-s
 
@@ -1457,7 +1457,7 @@
                 ;; change so single edits (fill, etc.) update instantly.
                 ;; Non-WASM persists on every render, so it stays on the
                 ;; debounced path below to avoid per-edit backend posts.
-                (if (features/active-feature? @st/state "render-wasm/v1")
+                (if (features/active-feature? state "render-wasm/v1")
                   (->> changes-s
                        (rx/filter (ptk/type? ::component-changed))
                        (rx/map deref)

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -959,32 +959,17 @@
                  ev-name (if (= next-renderer :wasm)
                            "enable-webgl-rendering"
                            "disable-webgl-rendering")]
-
-             (if (cf/external-feature-flag "renderer-hard-reload" "test")
-               ;; Bare RPC + hard reload: skips `du/update-profile-props`, so
-               ;; `features/recompute-features` is not run here; bootstrap
-               ;; after reload resolves render-wasm/v1 from the saved profile.
-               (do
-                 (->> (rx/zip
-                       (rp/cmd! :update-profile-props {:props {:renderer next-renderer}})
-                       (rx/filter (ptk/type? ::ev/chunk-persisted) st/stream))
-                      (rx/timeout 2000 (rx/of :timeout))
-                      (rx/subs! (fn [_]
-                                  (dom/reload-current-window true))
-                                (fn [_]
-                                  (st/emit! (ntf/error (tr "errors.generic"))))))
-                 (st/emit! (ev/event {::ev/name ev-name
-                                      ::ev/origin "workspace:menu"})
-                           (ptk/data-event ::ev/force-persist {})))
-
-               ;; `update-profile-props` WatchEvent calls
-               ;; `features/recompute-features`.
-               (st/emit! (ev/event {::ev/name ev-name
-                                    ::ev/origin "workspace:menu"})
-                         (du/update-profile-props {:renderer next-renderer})
-                         (ntf/success (tr (if (= next-renderer :wasm)
-                                            "webgl.toast.webgl-render-enabled"
-                                            "webgl.toast.webgl-render-disabled"))))))))
+             (->> (rx/zip
+                   (rp/cmd! :update-profile-props {:props {:renderer next-renderer}})
+                   (rx/filter (ptk/type? ::ev/chunk-persisted) st/stream))
+                  (rx/timeout 2000 (rx/of :timeout))
+                  (rx/subs! (fn [_]
+                              (dom/reload-current-window true))
+                            (fn [_]
+                              (st/emit! (ntf/error (tr "errors.generic"))))))
+             (st/emit! (ev/event {::ev/name ev-name
+                                  ::ev/origin "workspace:menu"})
+                       (ptk/data-event ::ev/force-persist {})))))
 
         open-plugins-manager
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

Closes #10441 

### Summary

This removes the A/B test guard for choosing hot swap vs hard reload when switching engines (we're doing hard reload). Also, since the state of the flag is known and immutable once we reach the workspace, we don't need to query the state in real time in the streams.

### Steps to reproduce 

Change render engines via the main menu in the workspace.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
