### PR TITLE
:bug: Fix glitch when using drawing tool in toolbar

### DIFF
--- a/frontend/src/app/main/data/workspace/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/drawing.cljs
@@ -47,16 +47,6 @@
        (when (= tool :path)
          (rx/of (start-drawing :path)))
 
-       (when (= tool :curve)
-         (let [stopper (rx/filter dwc/interrupt? stream)]
-           (->> stream
-                (rx/filter (ptk/type? ::common/handle-finish-drawing))
-                (rx/map (constantly tool))
-                (rx/take 1)
-                (rx/observe-on :async)
-                (rx/map select-for-drawing)
-                (rx/take-until stopper))))
-
        ;; NOTE: comments are a special case and they manage they
        ;; own interrupt cycle.
        (when (= tool :comments)
@@ -68,7 +58,7 @@
            (->> stream
                 (rx/filter dwc/interrupt?)
                 (rx/take 1)
-                (rx/map common/clear-drawing)
+                (rx/map #(common/clear-drawing {:preserve-tool? true}))
                 (rx/take-until stopper))))))))
 
 ;; NOTE/TODO: when an exception is raised in some point of drawing the

--- a/frontend/src/app/main/data/workspace/drawing/common.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/common.cljs
@@ -18,11 +18,14 @@
    [potok.v2.core :as ptk]))
 
 (defn clear-drawing
-  []
-  (ptk/reify ::clear-drawing
-    ptk/UpdateEvent
-    (update [_ state]
-      (dissoc state :workspace-drawing))))
+  ([] (clear-drawing nil))
+  ([{:keys [preserve-tool?]}]
+   (ptk/reify ::clear-drawing
+     ptk/UpdateEvent
+     (update [_ state]
+       (if preserve-tool?
+         (update state :workspace-drawing dissoc :object :lock)
+         (dissoc state :workspace-drawing))))))
 
 (defn handle-finish-drawing
   []
@@ -95,6 +98,5 @@
                 (rx/empty)))))
 
          ;; Delay so the mouse event can read the drawing state
-         (->> (rx/of (clear-drawing))
+         (->> (rx/of (clear-drawing {:preserve-tool? (= tool :curve)}))
               (rx/delay 0)))))))
-

--- a/frontend/src/app/main/data/workspace/edition.cljs
+++ b/frontend/src/app/main/data/workspace/edition.cljs
@@ -14,7 +14,9 @@
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
-(defn interrupt? [e] (= e :interrupt))
+(defn interrupt?
+  [e]
+  (= e :interrupt))
 
 (declare clear-edition-mode)
 
@@ -52,7 +54,7 @@
     (update [_ state]
       (-> state
           (update :workspace-local dissoc :edition :edit-path)
-          (update :workspace-drawing dissoc :tool :object :lock)
+          (update :workspace-drawing dissoc :object :lock)
           (dissoc :workspace-grid-edition)
           (dissoc :workspace-wasm-editor-styles)))
 

--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -18,6 +18,7 @@
    [app.main.data.workspace.colors :as mdc]
    [app.main.data.workspace.comments :as dwcm]
    [app.main.data.workspace.drawing :as dwd]
+   [app.main.data.workspace.drawing.common :as dwdc]
    [app.main.data.workspace.layers :as dwly]
    [app.main.data.workspace.libraries :as dwl]
    [app.main.data.workspace.shape-layout :as dwsl]
@@ -149,7 +150,7 @@
    :escape               {:tooltip (ds/esc)
                           :command "escape"
                           :subsections [:edit]
-                          :fn #(st/emit! :interrupt (dw/deselect-all true))}
+                          :fn #(st/emit! :interrupt (dwdc/clear-drawing) (dw/deselect-all true))}
 
    :find             {:tooltip (ds/meta "F") :command (ds/c-mod "f") :subsections [:edit]
                       :fn #(st/emit! (dw/open-layers-search :find))}

--- a/frontend/src/app/main/ui/workspace/top_toolbar.cljs
+++ b/frontend/src/app/main/ui/workspace/top_toolbar.cljs
@@ -13,6 +13,7 @@
    [app.main.data.modal :as modal]
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.common :as dwc]
+   [app.main.data.workspace.drawing.common :as dwdc]
    [app.main.data.workspace.mcp :as mcp]
    [app.main.data.workspace.media :as dwm]
    [app.main.data.workspace.shortcuts :as sc]
@@ -313,7 +314,9 @@
         on-interrupt
         (mf/use-fn
          (fn []
-           (st/emit! :interrupt (dw/clear-edition-mode))))
+           (st/emit! :interrupt
+                     (dw/clear-edition-mode)
+                     (dwdc/clear-drawing))))
 
         on-select-tool
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

Closes #10284 

### Summary

#### Causes

- After finishing a curve drawing, `clear-drawing` removed `:tool` from `:workspace-drawing` state. The curve tool re-selected itself asynchronously, causing a brief `nil` tool state (move tool flash).
- When clicking the curve tool in the toolbar, `clear-edition-mode` (triggered by `:interrupt`) removed `:tool` from `:workspace-drawing`, creating an intermediate `nil` before `select-for-drawing` set it back.

#### Changes

 - Removed the async curve re-selection subscription. Before the fix, finishing a curve drawing called `clear-drawing` which removed `:tool` from `:workspace-drawing`. This caused the toolbar to briefly show the move tool. The async subscription was a workaround: it watched for `handle-finish-drawing`, then used `(rx/observe-on :async)` to re-select the curve tool on the next tick, restoring what had just been cleared.
- `clear-drawing` now accepts `:preserve-tool?` flag to selectively clear without dropping `:tool`.