### PR TITLE
:lipstick: Center libraries empty state placeholder vertically

### DIFF
--- a/frontend/src/app/main/ui/dashboard/placeholder.scss
+++ b/frontend/src/app/main/ui/dashboard/placeholder.scss
@@ -99,7 +99,8 @@
 }
 
 .empty-placeholder-libraries {
-  margin: deprecated.$s-16;
+  margin: auto;
+  margin-top: 5%;
 }
 
 .empty-project-container {


### PR DESCRIPTION
### Changes

Improves the visual positioning of the "No libraries yet." empty state
card on the Libraries dashboard page.

### Issue

The empty state card was pinned to the top-left of the content area,
leaving a large unused empty space below it and making it feel
disconnected from the center of the page.

### Result

The card now appears near the top-center of the content area, giving it
a more intentional and balanced placement within the available space.

### Testing

Tested locally via the devenv:

- Confirmed card is horizontally centered and positioned near the top of
  the content area.
- Confirmed layout is unaffected when libraries are present.

### Screenshots

1. before the fix
<img width="1918" height="1148" alt="image" src="https://github.com/user-attachments/assets/b4d0a200-ad03-40bf-8629-4c53ef580ae7" />




3. after the fix
<img width="1918" height="1151" alt="Screenshot 2026-06-27 212552" src="https://github.com/user-attachments/assets/1d5672af-dec5-4725-86ce-245d5d7b8e5d" />


Signed-off-by: @Parinith-web <parinithreddymav@gmail.com>