### PR TITLE
:lipstick: Make typography assets adapt width on sidebar resize

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/typographies.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/typographies.scss
@@ -7,7 +7,14 @@
 @use "refactor/common-refactor.scss" as deprecated;
 
 .assets-list {
+  box-sizing: border-box;
+  width: 100%;
   padding: 0 0 0 deprecated.$s-4;
+}
+
+.typographies-group {
+  min-width: 0;
+  width: 100%;
 }
 
 .drop-space {
@@ -24,9 +31,16 @@
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 0;
+  width: 100%;
   margin-bottom: deprecated.$s-4;
   border-radius: deprecated.$br-8;
   background-color: var(--assets-item-background-color);
+
+  > * {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
 }
 
 .dragging {


### PR DESCRIPTION
### Related Ticket

The fix is a styling alignment in the typography assets component. Compare the width/layout rules in `typographies.scss` (and the class bindings in `typographies.cljs`) against how a sibling asset group that already resizes correctly is styled, and bring the typography item/group container in line - typically replacing a fixed/min width or absent `width: 100%`/flex sizing with the responsive rule the other asset groups use so the row follows the sidebar's resizable width. Because the issue carries a `needs definition` label, keep the change minimal and visual-only (match existing asset responsive behavior, do not introduce new layout semantics); confirm against the other asset groups' SCSS to avoid over-reaching.

Fixes #10437

### Summary



### Steps to reproduce



### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
