### PR TITLE
:lipstick: Add vertical spacing between SSO buttons and email field i…

### DIFF
--- a/frontend/src/app/main/ui/auth/common.scss
+++ b/frontend/src/app/main/ui/auth/common.scss
@@ -29,7 +29,7 @@
 
 .separator {
   border-color: var(--modal-separator-background-color);
-  margin: 0;
+  margin: deprecated.$s-16 0;
 }
 
 .auth-title {


### PR DESCRIPTION
### Changes

Fixes missing vertical spacing between the SSO authentication buttons (Google, GitHub, GitLab) and the Work email field in the viewer login modal.

### Issue

Closes #10253

The `.separator` element in `common.scss` had `margin: 0`, which removed all vertical spacing between the SSO buttons and the Work email field label. This made the layout feel cramped and misaligned compared to other auth screens in Penpot.

### Fix

Added `margin: deprecated.$s-16 0` to the `.separator` class, giving it consistent vertical breathing room above and below. This applies across all auth screens that use the separator (login, register, recovery), making spacing consistent throughout.

### Testing

The fix applies to the viewer login modal which requires SSO flags enabled (available on `design.penpot.app`). The separator spacing is also visible on the standard login page at `#/auth/login` where it appears between the form and the "No account yet?" section — confirmed looking correct locally.



Signed-off-by: @Parinith-web <parinithreddymav@gmail.com>