### PR TITLE
:bug: Fix text editor cursor being too thin on dpr > 1

### DIFF
--- a/render-wasm/src/render/text_editor.rs
+++ b/render-wasm/src/render/text_editor.rs
@@ -30,7 +30,7 @@ pub fn render_overlay(
     }
 
     if editor_state.cursor_visible {
-        render_cursor(canvas, zoom, editor_state, text_content, shape);
+        render_cursor(canvas, zoom, options.dpr, editor_state, text_content, shape);
     }
 
     canvas.restore();
@@ -39,6 +39,7 @@ pub fn render_overlay(
 fn render_cursor(
     canvas: &Canvas,
     zoom: f32,
+    dpr: f32,
     editor_state: &TextEditorState,
     text_content: &TextContent,
     shape: &Shape,
@@ -54,7 +55,7 @@ fn render_cursor(
         if editor_state.is_overtype_mode {
             rect.width()
         } else {
-            editor_state.theme.cursor_width / zoom
+            editor_state.theme.cursor_width / zoom * dpr
         },
         rect.height(),
     );


### PR DESCRIPTION
### Related Ticket

Fixes #10499 

### Summary

This makes `render_cursor` take into account the DPR (text editor v3)

| With the fix | Without the fix|
|------------|----------------|
| <img width="149" height="93" alt="Cursor with dpr" src="https://github.com/user-attachments/assets/5958334d-660d-4889-b0b6-0dd94c7535f0" /> | <img width="195" height="87" alt="Cursor too thin" src="https://github.com/user-attachments/assets/9f9068d0-e8f2-4cbc-8b98-06331045f115" /> |

### Steps to reproduce

1. Ensure you have a DPR > 1 (for instance, by zooming in with the browser's zoom).
2. Open the text editor and see the cursor

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
