### PR TITLE
:bug: Fix inspect in workspace displays shape size twice when selecting a shape

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -505,7 +505,8 @@
        (when (and (seq selected-shapes)
                   (not transform)
                   (not text-editing?)
-                  (not edition))
+                  (not edition)
+                  (not mode-inspect?))
          [:> msr/selection-size-badge*
           {:selrect (gsh/shapes->rect selected-shapes)
            :zoom zoom}])

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -776,6 +776,7 @@
                   (not transform)
                   (not text-editing?)
                   (not edition)
+                  (not mode-inspect?)
                   (not page-transition?))
          [:> msr/selection-size-badge*
           {:selrect (gsh/shapes->rect selected-shapes)


### PR DESCRIPTION
### Related Ticket

Closes #10470 
