### PR TITLE
:bug: Fix action entries from different users are not displayed in history

### DIFF
--- a/backend/src/app/rpc.clj
+++ b/backend/src/app/rpc.clj
@@ -333,6 +333,7 @@
           'app.rpc.commands.comments
           'app.rpc.commands.demo
           'app.rpc.commands.files
+          'app.rpc.commands.files-actions
           'app.rpc.commands.files-create
           'app.rpc.commands.files-share
           'app.rpc.commands.files-update

--- a/backend/src/app/rpc/commands/files_actions.clj
+++ b/backend/src/app/rpc/commands/files_actions.clj
@@ -1,0 +1,50 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns app.rpc.commands.files-actions
+  (:require
+   [app.common.schema :as sm]
+   [app.db :as db]
+   [app.rpc :as-alias rpc]
+   [app.rpc.commands.files :as files]
+   [app.rpc.doc :as-alias doc]
+   [app.util.blob :as blob]
+   [app.util.services :as sv]))
+
+;; --- SCHEMA
+
+(def ^:private schema:get-file-actions
+  [:map {:title "get-file-actions"}
+   [:file-id ::sm/uuid]
+   [:limit {:optional true} ::sm/int]])
+
+;; --- COMMAND QUERY: get-file-actions
+
+(sv/defmethod ::get-file-actions
+  "Retrieve recent file changes from all users for display in the
+   History panel's ACTIONS tab. Returns a limited set of change
+   records with profile attribution and decoded changes."
+  {::doc/added "2.17"
+   ::sm/params schema:get-file-actions}
+  [cfg {:keys [::rpc/profile-id file-id] :as params}]
+  (let [limit (or (:limit params) 50)]
+    (db/run! cfg (fn [{:keys [::db/conn]}]
+                   (files/check-read-permissions! conn profile-id file-id)
+
+                   (let [sql (str "SELECT id, profile_id, created_at, revn, changes "
+                                   "FROM file_change "
+                                   "WHERE file_id = ?::uuid "
+                                   "  AND profile_id IS NOT NULL "
+                                   "  AND changes IS NOT NULL "
+                                   "ORDER BY created_at DESC "
+                                   "LIMIT ?")]
+                     (->> (db/exec! conn [sql file-id (int limit)])
+                          (mapv (fn [row]
+                                  {:id         (:id row)
+                                   :profile-id (:profile-id row)
+                                   :created-at (:created-at row)
+                                   :revn       (:revn row)
+                                   :changes    (blob/decode (:changes row))}))))))))

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -37,6 +37,7 @@
    [app.main.data.plugins :as dp]
    [app.main.data.profile :as du]
    [app.main.data.project :as dpj]
+   [app.main.data.workspace.actions :as dwact]
    [app.main.data.workspace.bool :as dwb]
    [app.main.data.workspace.clipboard :as dwcp]
    [app.main.data.workspace.colors :as dwcl]
@@ -256,7 +257,8 @@
     (watch [_ _ _]
       (rx/merge
        (rx/of (dp/check-open-plugin)
-              (fdf/fix-deleted-fonts-for-local-library file-id))
+              (fdf/fix-deleted-fonts-for-local-library file-id)
+              (dwact/init-actions-state))
        (if (contains? cf/flags :mcp)
          ;; We wait the plugin runtime to be ready before launch the
          ;; mcp initialization

--- a/frontend/src/app/main/data/workspace/actions.cljs
+++ b/frontend/src/app/main/data/workspace/actions.cljs
@@ -1,0 +1,76 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns app.main.data.workspace.actions
+  "Actions management for the History panel's ACTIONS tab.
+
+   Tracks changes made by all users (not just undo entries for the
+   current user). This data is fetched from the server on workspace
+   init and augmented with real-time notifications as remote changes
+   arrive."
+  (:require
+   [app.common.uuid :as uuid]
+   [app.main.repo :as rp]
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
+
+;; Default state for :workspace-actions
+(defonce default-state
+  {:status :loading
+   :data []
+   :profiles #{}})
+
+(declare fetch-actions)
+
+(defn init-actions-state
+  "Initialize the actions state and trigger an initial fetch."
+  []
+  (ptk/reify ::init-actions-state
+    ptk/UpdateEvent
+    (update [_ state]
+      (assoc state :workspace-actions default-state))
+
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (rx/of (fetch-actions)))))
+
+(defn update-actions-state
+  "Merge partial state into :workspace-actions."
+  [actions-state]
+  (ptk/reify ::update-actions-state
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :workspace-actions merge actions-state))))
+
+(defn fetch-actions
+  "Fetch recent file actions from the server for the current file."
+  []
+  (ptk/reify ::fetch-actions
+    ptk/WatchEvent
+    (watch [_ state _]
+      (when-let [file-id (:current-file-id state)]
+        (->> (rp/cmd! :get-file-actions {:file-id file-id :limit 100})
+             (rx/map #(update-actions-state {:status :loaded :data %})))))))
+
+(defn add-remote-action
+  "Add a remote action entry received via real-time notification.
+   `changes` is the vector of changes, `profile-id` identifies the
+   author, and `timestamp` is when the change was made."
+  [profile-id timestamp changes]
+  (ptk/reify ::add-remote-action
+    ptk/UpdateEvent
+    (update [_ state]
+      (let [entry {:profile-id profile-id
+                     :created-at timestamp
+                     :changes    (vec changes)
+                     :id         (uuid/next)}]
+        (update-in state [:workspace-actions :data]
+                   (fn [data]
+                     ;; Prepend new entry and keep at most 200 entries
+                     (let [data (into [entry] data)]
+                       (if (> (count data) 200)
+                         (subvec data 0 200)
+                         data))))))))

--- a/frontend/src/app/main/data/workspace/notifications.cljs
+++ b/frontend/src/app/main/data/workspace/notifications.cljs
@@ -19,6 +19,7 @@
    [app.main.data.plugins :as dpl]
    [app.main.data.websocket :as dws]
    [app.main.data.workspace :as-alias dw]
+   [app.main.data.workspace.actions :as dwact]
    [app.main.data.workspace.common :as dwc]
    [app.main.data.workspace.edition :as dwe]
    [app.main.data.workspace.layout :as dwly]
@@ -246,7 +247,7 @@
   (sm/check-fn schema:handle-file-change))
 
 (defn handle-file-change
-  [{:keys [file-id changes revn vern] :as msg}]
+  [{:keys [file-id profile-id changes revn vern] :as msg}]
 
   (dm/assert!
    "expected valid parameters"
@@ -262,13 +263,17 @@
       ;; and update the persistence internal state with the updated
       ;; file-revn
 
-      (rx/of (dch/commit {:file-id file-id
-                          :file-revn revn
-                          :file-vern vern
-                          :save-undo? false
-                          :source :remote
-                          :redo-changes (vec changes)
-                          :undo-changes []})))))
+      (let [timestamp (ct/now)]
+        (rx/of (dch/commit {:file-id file-id
+                            :file-revn revn
+                            :file-vern vern
+                            :save-undo? false
+                            :source :remote
+                            :redo-changes (vec changes)
+                            :undo-changes []})
+               ;; Record the remote action so it appears in the History
+               ;; panel's ACTIONS tab for all connected users. Issue #10495.
+               (dwact/add-remote-action profile-id timestamp changes))))))
 
 (defn handle-file-deleted
   [{:keys [file-id] :as msg}]

--- a/frontend/src/app/main/ui/workspace/sidebar/history.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/history.cljs
@@ -25,6 +25,9 @@
 (def workspace-undo
   (l/derived :workspace-undo st/state))
 
+(def workspace-actions
+  (l/derived :workspace-actions st/state))
+
 (defn get-object
   "Searches for a shape inside the objects list or inside the undo history"
   [id entries objects]
@@ -277,7 +280,22 @@
                      :by         (:by         raw-entry))))
         entries))
 
-(mf/defc history-entry-details* [{:keys [entry]}]
+(defn- action->entry
+  "Convert a server-side action (from :workspace-actions) into the
+   same shape as an undo entry so it can be rendered with the same
+   parsing pipeline. Issue #10495."
+  [profiles action]
+  (let [profile (get profiles (:profile-id action))]
+    {:redo-changes (:changes action)
+     :undo-changes []
+     :timestamp    (:created-at action)
+     :undo-group   (:id action)
+     :by           (or (:fullname profile)
+                       (:email profile)
+                       (dm/str (:profile-id action)))}))
+
+(mf/defc history-entry-details*
+  [{:keys [entry]}]
   (let [{entries :items} (mf/deref workspace-undo)
         objects (mf/deref refs/workspace-page-objects)]
 
@@ -304,10 +322,12 @@
        nil)]))
 
 (mf/defc history-entry*
-  {::mf/props :obj}
   [{:keys [entry idx-entry is-disabled is-current]}]
-  (let [hover?         (mf/use-state false)
-        show-detail?   (mf/use-state false)
+  (let [hover*         (mf/use-state false)
+        hover?         (deref hover*)
+
+        show-detail*   (mf/use-state false)
+        show-detail?   (deref show-detail*)
 
         relative-time  (ct/timeago (:timestamp entry))
         label          (short-id entry)
@@ -321,22 +341,25 @@
                                 (parse-boolean))]
              (dom/stop-propagation event)
              (when has-entry?
-               (swap! show-detail? not)))))]
+               (swap! show-detail* not)))))]
+
     [:div {:class (stl/css-case :history-entry true
                                 :disabled is-disabled
                                 :current is-current
-                                :hover @hover?
-                                :show-detail @show-detail?)
-           :on-pointer-enter #(reset! hover? true)
-           :on-pointer-leave #(reset! hover? false)
+                                :hover hover?
+                                :show-detail show-detail?)
+           :on-pointer-enter #(reset! hover* true)
+           :on-pointer-leave #(reset! hover* false)
            :on-click #(st/emit! (dwu/undo-to-index idx-entry))}
 
      [:div {:class (stl/css :history-entry-summary)}
       [:div {:class (stl/css :history-entry-summary-icon)}
        (entry->icon entry)]
+
       [:div {:class (stl/css :history-entry-summary-text)}
        [:div {:class (stl/css :history-entry-title)}
         (entry->message entry)]
+
        ;; Metadata row: short identifier, relative timestamp, and
        ;; author. Rendered as plain inline text so the natural word
        ;; spacing between tokens ("17bc430 · just now by <Name>") is
@@ -356,33 +379,122 @@
           (when author
             [:span {:class (stl/css :history-entry-author)}
              (tr "workspace.undo.entry.by" author)])])]
+
       (when (:detail entry)
         [:div {:class (stl/css-case :history-entry-summary-button true
-                                    :button-opened @show-detail?)
+                                    :button-opened show-detail?)
                :on-click toggle-show-detail
                :data-has-entry (dm/str (not (nil? (:detail entry))))}
          deprecated-icon/arrow])]
 
-     (when @show-detail?
+     (when show-detail?
+       [:> history-entry-details* {:entry entry}])]))
+
+(mf/defc action-entry*
+  "Render a single action entry from another user. Similar to
+   history-entry* but read-only (no undo click) and always shows
+   the author. Issue #10495."
+  [{:keys [entry]}]
+  (let [hover*         (mf/use-state false)
+        hover?         (deref hover*)
+
+        show-detail*   (mf/use-state false)
+        show-detail?   (deref show-detail*)
+
+        relative-time  (ct/timeago (:timestamp entry))
+        author         (:by entry)
+
+        toggle-show-detail
+        (mf/use-fn
+         (fn [event]
+           (let [has-entry? (-> (dom/get-current-target event)
+                                (dom/get-data "has-entry")
+                                (parse-boolean))]
+             (dom/stop-propagation event)
+             (when has-entry?
+               (swap! show-detail* not)))))]
+
+    [:div {:class (stl/css-case :history-entry true
+                                :action-entry true
+                                :hover hover?
+                                :show-detail show-detail?)
+           :on-pointer-enter #(reset! hover* true)
+           :on-pointer-leave #(reset! hover* false)}
+
+     [:div {:class (stl/css :history-entry-summary)}
+      [:div {:class (stl/css :history-entry-summary-icon)}
+       (entry->icon entry)]
+
+      [:div {:class (stl/css :history-entry-summary-text)}
+       [:div {:class (stl/css :history-entry-title)}
+        (entry->message entry)]
+       (when (or relative-time author)
+         [:div {:class (stl/css :history-entry-meta)}
+          (when relative-time
+            [:span {:class (stl/css :history-entry-time)}
+             relative-time])
+          (when (and relative-time author) " ")
+          (when author
+            [:span {:class (stl/css :history-entry-author)}
+             (tr "workspace.undo.entry.by" author)])])]
+
+      (when (:detail entry)
+        [:div {:class (stl/css-case :history-entry-summary-button true
+                                    :button-opened show-detail?)
+               :on-click toggle-show-detail
+               :data-has-entry (dm/str (not (nil? (:detail entry))))}
+         deprecated-icon/arrow])]
+
+     (when show-detail?
        [:> history-entry-details* {:entry entry}])]))
 
 (mf/defc history-toolbox*
   []
-  (let [objects (mf/deref refs/workspace-page-objects)
+  (let [profiles (mf/deref refs/profiles)
+        objects  (mf/deref refs/workspace-page-objects)
         {:keys [items index]} (mf/deref workspace-undo)
-        entries (parse-entries items objects)]
+        {:keys [data] :or {data nil}} (mf/deref workspace-actions)
+
+        ;; Build an index of undo-group -> position in items for local lookup
+        item-index
+        (mf/with-memo [items]
+          (into {}
+                (map-indexed (fn [i item] [(:undo-group item) i])
+                             items)))
+
+        ;; Parse local undo entries (one-to-one with items order)
+        local-entries (parse-entries items objects)
+
+        ;; Convert server actions to entry format and parse them,
+        ;; marking them as remote so they render as read-only
+        action-entries
+        (mf/with-memo [data profiles objects]
+          (when (seq data)
+            (let [action-items (mapv (partial action->entry profiles) data)]
+              (mapv #(assoc % :remote true)
+                    (parse-entries action-items objects)))))
+
+        ;; Build combined list sorted by timestamp descending
+        all-entries
+        (mf/with-memo [local-entries action-entries]
+          (let [combined (into (vec action-entries) local-entries)]
+            (->> combined
+                 (sort-by :timestamp (fn [a b] (compare b a)))
+                 (vec))))]
+
     [:div {:class (stl/css :history-toolbox)}
-     (if (empty? entries)
+     (if (and (empty? local-entries) (empty? action-entries))
        [:div {:class (stl/css :history-entry-empty)}
         [:> empty-state* {:icon i/history
                           :text (tr "workspace.undo.empty")}]]
        [:ul {:class (stl/css :history-entries)}
-        (for [[idx-entry entry] (->> entries (map-indexed vector) reverse)] #_[i (range 0 10)]
-             [:> history-entry* {:key (str "entry-" idx-entry)
-                                 :entry entry
-                                 :idx-entry idx-entry
-                                 :is-current (= idx-entry index)
-                                 :is-disabled (> idx-entry index)}])])]))
-
-
-
+        (for [[idx entry] (map-indexed vector all-entries)]
+          (if (:remote entry)
+            [:> action-entry* {:key (str "action-" idx)
+                               :entry entry}]
+            (let [undo-idx (get item-index (:undo-group entry) idx)]
+              [:> history-entry* {:key (str "entry-" idx)
+                                  :entry entry
+                                  :idx-entry undo-idx
+                                  :is-current (= undo-idx index)
+                                  :is-disabled (> undo-idx index)}])))])]))

--- a/frontend/src/app/main/ui/workspace/sidebar/history.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/history.scss
@@ -41,6 +41,11 @@
   cursor: pointer;
   transition: border 0.2s;
 
+  &.action-entry {
+    cursor: default;
+    opacity: 0.85;
+  }
+
   .history-entry-summary {
     display: flex;
     align-items: center;


### PR DESCRIPTION
### Related Ticket

Closes #10495

### Root cause

The History panel's ACTIONS tab was displaying only the current user's local undo entries. Remote changes received via WebSocket notifications were committed with `:save-undo?` false, excluding them from the undo stack. The `file_change` table in the database already stored all changes with proper `profile_id` attribution, but there was no mechanism to surface this data back to the UI.

### Changes made

#### Backend (1 new file, 1 modified)

1. `backend/src/app/rpc/commands/files_actions.clj` (new) — RPC endpoint `:get-file-actions` that queries the file_change table for a given file, returning the 50 most recent changes with decoded change data, profile attribution, and timestamps.

2. `backend/src/app/rpc.clj` — Registered the new files-actions namespace so it's loaded by the system.

#### Frontend (1 new file, 4 modified)

3. `frontend/src/app/main/data/workspace/actions.cljs` (new) — Data module managing the `:workspace-actions` state. Provides:
   - init-actions-state — Initializes state and triggers fetch on workspace startup
   - fetch-actions — Calls `:get-file-actions` RPC
   - add-remote-action — Appends real-time remote changes to the actions list
   - update-actions-state — Generic state merger

4. `frontend/src/app/main/data/workspace.cljs` — Added `dwact/init-actions-state` to the workspace initialization flow.

5. `frontend/src/app/main/data/workspace/notifications.cljs` — `handle-file-change` now also dispatches `add-remote-action` with the author's `profile-id` and `timestamp` when remote changes arrive.

6. `frontend/src/app/main/ui/workspace/sidebar/history.cljs` — The ACTIONS tab now:
    - Fetches server actions (all users) alongside local undo entries
    - Merges both lists sorted by timestamp
    - Local entries remain clickable for undo/redo navigation
    - Remote entries render as read-only via a new `action-entry*` component

7. `frontend/src/app/main/ui/workspace/sidebar/history.scss` — Added `.action-entry` style (reduced opacity, default cursor) to visually distinguish read-only remote entries.