### PR TITLE
:bug: Show flex/grid element options for text layers in a layout

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -171,7 +171,7 @@
          :cell (ctl/get-cell-by-shape-id (first parents) (first ids))}])
 
      (when is-layout-child?
-       [:& layout-item-menu*
+       [:> layout-item-menu*
         {:ids ids
          :type type
          :values layout-item-values


### PR DESCRIPTION
> This pull request was prepared with AI assistance (Claude Opus 4.8) as part of a Penpot MCP self-improvement initiative. All logic has been reviewed and verified by the human author, including a live reproduction in a devenv.

## Related issue

Closes #10514

## Summary

When a text element is placed inside a frame with a flex or grid layout, the layout-item ("FLEX ELEMENT" / "GRID ELEMENT") options were missing from the Design panel. The same options render correctly for every other shape type (boards, rectangles, paths, etc.) in the same context, so text was the only affected type -- a regression.

## Root cause

`text.cljs` invoked the shared `layout-item-menu*` component with `[:&` (cljs-map props) instead of `[:>` (JS object props):

```clojure
;; frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
(when is-layout-child?
  [:& layout-item-menu*        ; <- should be [:>
   {:ids ids
    :type type
    ...}])
```

`layout-item-menu*` is memoized with a custom equality check (`check-layout-item-menu-props`) that reads its props as a JS object via `unchecked-get` with camelCase keys (`"isLayoutChild"`, `"isFlexParent"`, `"isGridParent"`, `"appliedTokens"`, ...). Those keys only exist when the component is invoked with `[:>` (rumext converts the map to a JS object with camelCased keys). With `[:&` the props arrive as a cljs map, the camelCase lookups miss, and the flex/grid element controls do not render for text.

Every other shape option file (`rect.cljs`, `circle.cljs`, `path.cljs`, `group.cljs`, `svg_raw.cljs`) already uses `[:>` -- `text.cljs` was the lone outlier.

## Fix

Invoke `layout-item-menu*` with `[:>` in `text.cljs`, matching the other shapes and the component's prop expectations. One-character change; the passed props are otherwise identical to `rect.cljs`.

## Verification (live, in a devenv)

Made a board a flex container so its text child became a flex item, then selected the text:

- Before: the Design panel showed only a bare "LAYOUT ELEMENT" label with the sizing icons -- no STATIC/ABSOLUTE toggle, Z-index or margin controls.
- After: the text shows the full "FLEX ELEMENT" section (STATIC/ABSOLUTE, Z-index, vertical/horizontal margins, sizing and alignment) -- identical to a board child in the same container.

`clj-kondo` and `cljfmt` are clean for the changed file; the frontend compiles with 0 warnings.
