### PR TITLE
:bug: Fix prototype interaction targets appear in view mode automatically when linked

### DIFF
--- a/frontend/src/app/main/data/workspace/interactions.cljs
+++ b/frontend/src/app/main/data/workspace/interactions.cljs
@@ -327,9 +327,10 @@
 
          (when (:hide-in-viewer target-frame)
            ;; If the target frame is hidden, we need to unhide it so
-           ;; users can navigate to it.
+           ;; users can navigate to it, but only if the user hasn't
+           ;; explicitly hidden it. See #9049.
            (dwsh/update-shapes [(:id target-frame)]
-                               #(dissoc % :hide-in-viewer)))
+                               cls/show-in-viewer))
 
          (cond
            (or (nil? shape)


### PR DESCRIPTION
### Related Ticket

Closes #9049 

### Summary

The `finish-edit-interaction` function (called when you drag an arrow to create/edit an interaction) was unconditionally removing `:hide-in-viewer` from the target frame via `#(dissoc % :hide-in-viewer)`. This meant that even if a user explicitly unchecked "Show in view mode" on a board, creating a prototype interaction to it would force it visible again.

The fix changes it to use `cls/show-in-viewer` instead, which already had the guard for this exact issue (added in `common/src/app/common/logic/shapes.cljc:541-550`):

```
;; Preserves explicit :hide-in-viewer true so users' intent is respected
(when (:hide-in-viewer target-frame)
  (dwsh/update-shapes [(:id target-frame)]
                      cls/show-in-viewer))
```

Now the three interaction-creation paths (`add-interaction`, `add-new-interaction`, `update-interaction`, and `finish-edit-interaction`) all consistently use `cls/show-in-viewer`, which skips the unhiding when the user explicitly hid the frame.