### PR TITLE
:bug: Fix empty text shape not being removed

### DIFF
--- a/frontend/playwright/ui/specs/text-editor-v3.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v3.spec.js
@@ -67,3 +67,44 @@ test.describe("BUG 10502 - Mixed families and variants", () => {
   });
 });
 
+test.describe("BUG 10530 - Empty text box left behind when leaving the editor", () => {
+  test("An empty text box is removed when leaving the editor by clicking outside", async ({
+    page,
+  }) => {
+    const workspace = new WasmWorkspacePage(page, { textEditor: true });
+    await workspace.setupEmptyFile();
+    await workspace.goToWorkspace();
+    await workspace.waitForFirstRender();
+
+    const layerRows = workspace.layers.getByTestId("layer-row");
+    await expect(layerRows).toHaveCount(0);
+
+    // Draw an empty text box
+    await workspace.createTextShape(200, 150, 320, 210);
+    // The shape exists while it is being edited
+    await expect(layerRows).toHaveCount(1);
+
+    // Leave the editor by clicking outside
+    await workspace.clickAt(500, 400);
+
+    await expect(layerRows).toHaveCount(0);
+  });
+
+  test("A non-empty text box is kept when leaving the editor by clicking outside", async ({
+    page,
+  }) => {
+    const workspace = new WasmWorkspacePage(page, { textEditor: true });
+    await workspace.setupEmptyFile();
+    await workspace.goToWorkspace();
+    await workspace.waitForFirstRender();
+
+    const layerRows = workspace.layers.getByTestId("layer-row");
+
+    // A text box with content must survive leaving the editor by clicking outside.
+    await workspace.createTextShape(200, 150, 320, 210, "hello");
+    await workspace.clickAt(500, 400);
+
+    await expect(layerRows).toHaveCount(1);
+  });
+});
+

--- a/frontend/src/app/main/data/workspace/edition.cljs
+++ b/frontend/src/app/main/data/workspace/edition.cljs
@@ -10,7 +10,6 @@
    [app.main.data.workspace.path.common :as dwpc]
    [app.main.features :as features]
    [app.render-wasm.api :as wasm.api]
-   [app.render-wasm.text-editor :as text-editor]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -66,6 +65,7 @@
     ptk/EffectEvent
     (effect [_ state _]
       (when (features/active-feature? state "text-editor-wasm/v1")
-        (text-editor/text-editor-dispose)
+        ;; NOTE: the WASM text editor is disposed by the v3 editor component on
+        ;; unmount, *after* it finalizes its content.
         (wasm.api/request-render "clear-edition-mode")))))
 

--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -318,11 +318,13 @@
      (fn []
        (when-let [node (mf/ref-val contenteditable-ref)]
          (.focus node))
-       ;; Explicitly call on-blur here instead of relying on browser blur events,
-       ;; because in Firefox blur is not reliably fired when leaving the text editor
-       ;; by clicking elsewhere. The component does unmount when the shape is
-       ;; deselected, so we can safely call the blur handler here to finalize the editor.
-       on-blur))
+       ;; On unmount, finalize the editor content and then dispose the WASM editor.
+       ;; We finalize on unmount instead of relying on the browser blur event, because
+       ;; it was not being reliable (timing issues, Firefox issues…)
+       (fn []
+         (on-blur)
+         (text-editor/text-editor-dispose)
+         (wasm.api/request-render "text-editor-dispose"))))
 
     (mf/use-effect
      (fn []


### PR DESCRIPTION
### Related Ticket

Fixes #10540 

### Summary

This fixes the issue of an empty text shape not being removed after the user exits the editor by clicking outside (there were issues with the timing of blur an unmounting).

### Steps to reproduce 

See #10540 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
