### PR TITLE
:bug: Fix size badge shows "x" instead of dimensions when creating a path

### DIFF
--- a/frontend/playwright/ui/specs/workspace.spec.js
+++ b/frontend/playwright/ui/specs/workspace.spec.js
@@ -158,6 +158,35 @@ test("Selection size badge shows unrotated dimensions for rotated single selecti
   await expect(badgeText).toHaveText("126 x 134");
 });
 
+test("Selection size badge shows dimensions for path shapes", async ({ page }) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.mockRPC(
+    "update-file?id=*",
+    "workspace/update-file-empty.json",
+  );
+
+  await workspacePage.goToWorkspace();
+
+  // Workaround: hover viewport first to avoid nil mouse position crash
+  await workspacePage.viewport.hover();
+
+  // Draw a path
+  await workspacePage.pathButton.click();
+  await workspacePage.clickAt(779, 163);
+  await workspacePage.clickAt(951, 258);
+
+  // Finish drawing (commits path, path enters edition mode)
+  await page.keyboard.press("Escape");
+
+  // Exit edition mode (path stays selected, badge becomes visible)
+  await page.keyboard.press("Escape");
+
+  const badgeText = page.locator(".selection-size-badge text");
+  await expect(badgeText).toBeVisible();
+  await expect(badgeText).toHaveText(/\d+\.?\d* x \d+\.?\d*/);
+});
+
 test("User makes a group", async ({ page }) => {
   const workspacePage = new WasmWorkspacePage(page);
   await workspacePage.setupEmptyFile();

--- a/frontend/src/app/main/ui/measurements.cljs
+++ b/frontend/src/app/main/ui/measurements.cljs
@@ -232,10 +232,12 @@
         ;; For single shapes we show the original dimensions,
         ;; for multiple shapes show the bounding box
         shape-width  (if single-shape
-                       (dm/get-prop single-shape :width)
+                       (or (dm/get-prop single-shape :width)
+                           (:width selrect))
                        (:width selrect))
         shape-height (if single-shape
-                       (dm/get-prop single-shape :height)
+                       (or (dm/get-prop single-shape :height)
+                           (:height selrect))
                        (:height selrect))
 
         text (dm/str (fmt/format-number shape-width) " x " (fmt/format-number shape-height))


### PR DESCRIPTION
### Related Ticket

Closes #10548 