### PR TITLE
:bug: Fix text editor not repainting text if there was not a geometry change

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -524,21 +524,26 @@ impl RenderState {
                 .is_some_and(|s| s.is_safe_for_drag_crop_cache(tree));
         }
 
-        // If the moving content overlaps this cached crop, do not use the cached pixels
-        // for this frame. We intentionally keep the cache entry: overlap is typically
-        // transient during drag, and once the moving content leaves the area the crop
-        // becomes valid again (stationary shape unchanged).
-        if let Some(moved) = moved_bounds {
-            let intersects = self
-                .backbuffer_crop_cache
-                .get(&node_id)
-                .is_some_and(|crop| moved.intersects(crop.src_doc_bounds));
-
-            if intersects {
-                return false;
+        match moved_bounds {
+            // Something is actually moving/resizing. If the moving content overlaps this
+            // cached crop, do not use the cached pixels for this frame. We intentionally
+            // keep the cache entry: overlap is typically transient during drag, and once
+            // the moving content leaves the area the crop becomes valid again (stationary
+            // shape unchanged).
+            Some(moved) => {
+                let intersects = self
+                    .backbuffer_crop_cache
+                    .get(&node_id)
+                    .is_some_and(|crop| moved.intersects(crop.src_doc_bounds));
+                !intersects
             }
+
+            // Interactive-transform mode is active but nothing is moving (no modifiers):
+            // e.g. editing a text shape inside this board reflows its content without
+            // changing geometry. The cached crop was captured before the edit, so blitting
+            // it would paint stale pixels over the freshly rendered tiles. Render live.
+            None => false,
         }
-        true
     }
 
     pub fn try_new(width: i32, height: i32) -> Result<RenderState> {


### PR DESCRIPTION
### Related Ticket

Fixes #10536 

### Summary

Texts that were not changing geometry while they were being edited (for instance, a text with auto-height that didn't changed its lines) were being cached, so they appeared stale.

https://github.com/user-attachments/assets/abbe6372-56b3-40ab-8dcf-b2e1cc5ea7b7


### Steps to reproduce 

See #10536 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
