### PR TITLE
:bug: Fix MCP local launcher runtime path

### DIFF
--- a/mcp/.npmignore
+++ b/mcp/.npmignore
@@ -1,0 +1,12 @@
+.idea
+.claude
+node_modules
+*.tgz
+*.bak
+*.orig
+temp
+*.tsbuildinfo
+
+# Log files
+logs/
+*.log

--- a/mcp/bin/mcp-local.js
+++ b/mcp/bin/mcp-local.js
@@ -1,31 +1,86 @@
 #!/usr/bin/env node
 
-const { execSync } = require("child_process");
+const { execSync, spawn } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
 const root = path.resolve(__dirname, "..");
 const pkg = require(path.join(root, "package.json"));
+const serverRoot = path.join(root, "packages/server");
+const pluginRoot = path.join(root, "packages/plugin");
+const serverEntry = path.join(serverRoot, "dist/index.js");
 
 function pnpmVersion() {
-  const match = (pkg.packageManager || "").match(/^pnpm@([^+]+)/);
-  return match ? match[1] : "latest";
+    const match = (pkg.packageManager || "").match(/^pnpm@([^+]+)/);
+    return match ? match[1] : "latest";
 }
 
 function run(command) {
-  execSync(command, { cwd: root, stdio: "inherit" });
+    execSync(command, { cwd: root, stdio: "inherit" });
 }
 
-// pnpm-lock.yaml is hard-excluded by npm pack; it is shipped as pnpm-lock.dist.yaml
-// and restored here before bootstrap runs.
-const distLock = path.join(root, "pnpm-lock.dist.yaml");
-const lock = path.join(root, "pnpm-lock.yaml");
-if (fs.existsSync(distLock)) {
-  fs.copyFileSync(distLock, lock);
+function resolveViteEntry() {
+    try {
+        const vitePkg = require.resolve("vite/package.json", { paths: [root] });
+        return path.join(path.dirname(vitePkg), "bin/vite.js");
+    } catch {
+        return undefined;
+    }
 }
 
-try {
-  run(`npx -y pnpm@${pnpmVersion()} run bootstrap`);
-} catch (error) {
-  process.exit(error.status ?? 1);
+function hasRuntimeArtifacts() {
+    const viteEntry = resolveViteEntry();
+
+    return [
+        serverEntry,
+        path.join(pluginRoot, "dist/index.html"),
+        path.join(pluginRoot, "dist/manifest.json"),
+        viteEntry || "",
+    ].every((file) => fs.existsSync(file));
+}
+
+function startRuntime() {
+    const viteEntry = resolveViteEntry();
+
+    const processes = [
+        spawn(process.execPath, [serverEntry], { cwd: serverRoot, stdio: "inherit" }),
+        spawn(process.execPath, [viteEntry, "preview", "--config", "vite.config.ts"], {
+            cwd: pluginRoot,
+            stdio: "inherit",
+        }),
+    ];
+
+    function stop(signal) {
+        for (const child of processes) {
+            child.kill(signal);
+        }
+    }
+
+    process.on("SIGINT", () => stop("SIGINT"));
+    process.on("SIGTERM", () => stop("SIGTERM"));
+
+    for (const child of processes) {
+        child.on("exit", (code, signal) => {
+            stop(signal || "SIGTERM");
+            process.exit(code ?? (signal ? 1 : 0));
+        });
+    }
+}
+
+if (hasRuntimeArtifacts() && !process.env.WS_URI) {
+    startRuntime();
+} else {
+    // pnpm-lock.yaml is hard-excluded by npm pack; it is shipped as pnpm-lock.dist.yaml
+    // and restored here before bootstrap runs.
+    const distLock = path.join(root, "pnpm-lock.dist.yaml");
+    const lock = path.join(root, "pnpm-lock.yaml");
+    if (fs.existsSync(distLock)) {
+        fs.copyFileSync(distLock, lock);
+    }
+
+    try {
+        run(`npx -y pnpm@${pnpmVersion()} run bootstrap`);
+    } catch (error) {
+        process.exit(error.status ?? 1);
+    }
 }

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -23,6 +23,24 @@
     "url": "https://github.com/penpot/penpot.git"
   },
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
+    "express": "^5.2.1",
+    "ioredis": "^5.11.1",
+    "js-yaml": "^5.2.0",
+    "nrepl-client": "^0.3.0",
+    "pino": "^10.3.1",
+    "pino-loki": "^3.0.0",
+    "pino-pretty": "^13.1.3",
+    "reflect-metadata": "^0.2.2",
+    "sharp": "^0.35.2",
+    "vite": "^8.1.1",
+    "vite-live-preview": "^0.4.0",
+    "ws": "^8.21.0",
+    "zod": "^4.4.3"
+  },
   "devDependencies": {
     "concurrently": "^10.0.3",
     "prettier": "^3.9.4"

--- a/mcp/packages/plugin/.npmignore
+++ b/mcp/packages/plugin/.npmignore
@@ -1,0 +1,23 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/mcp/pnpm-lock.yaml
+++ b/mcp/pnpm-lock.yaml
@@ -7,6 +7,55 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.15.1
+        version: 0.15.1
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
+      js-yaml:
+        specifier: ^5.2.0
+        version: 5.2.0
+      nrepl-client:
+        specifier: ^0.3.0
+        version: 0.3.0
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+      pino-loki:
+        specifier: ^3.0.0
+        version: 3.0.0
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      sharp:
+        specifier: ^0.35.2
+        version: 0.35.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.1.1(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)
+      vite-live-preview:
+        specifier: ^0.4.0
+        version: 0.4.0(vite@8.1.1(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4))
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       concurrently:
         specifier: ^10.0.3
@@ -1196,9 +1245,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1309,9 +1355,6 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
-  sonic-boom@4.2.0:
-    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
-
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -1413,7 +1456,6 @@ packages:
 
   vite-live-preview@0.4.0:
     resolution: {integrity: sha512-Qz8kr0kixXwnQl+zLPZX66OjajN4jnVnDwhNToJsO6TTboUtBo8pEmRuc0iBmkwW9lXR8mOeMu+QtxFkXBcHYg==}
-    hasBin: true
     peerDependencies:
       vite: '>=5.4.0'
 
@@ -2355,9 +2397,9 @@ snapshots:
       minimist: 1.2.8
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 3.0.0
-      pump: 3.0.3
+      pump: 3.0.4
       secure-json-parse: 4.1.0
-      sonic-boom: 4.2.0
+      sonic-boom: 4.2.1
       strip-json-comments: 5.0.3
 
   pino-std-serializers@7.1.0: {}
@@ -2392,11 +2434,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  pump@3.0.3:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
 
   pump@3.0.4:
     dependencies:
@@ -2570,10 +2607,6 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-
-  sonic-boom@4.2.0:
-    dependencies:
-      atomic-sleep: 1.0.0
 
   sonic-boom@4.2.1:
     dependencies:

--- a/mcp/scripts/pack
+++ b/mcp/scripts/pack
@@ -4,6 +4,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+pnpm run build
+
 # pnpm-lock.yaml is hard-excluded by npm, but we need it; ship it under a neutral name
 cp pnpm-lock.yaml pnpm-lock.dist.yaml
 trap 'rm -f pnpm-lock.dist.yaml' EXIT


### PR DESCRIPTION
_Draft for maintainer feedback. I can adjust the runtime/packaging approach if there is a preferred direction._

### Related Ticket

Related to #9947

### Summary

The published local MCP launcher currently behaves like a development bootstrap on every run:

- installs the pnpm workspace
- rebuilds the server and plugin
- then starts the runtime

That makes `npx -y @penpot/mcp` mutate its installed package directory at launch time, which can fail when npm/npx later prunes or reifies that cached install. It also makes normal startup slower than necessary.

This PR keeps the existing bootstrap flow intact, but adds a runtime path for packaged installs:

- detect existing built server and plugin artifacts
- start `packages/server/dist/index.js` directly
- serve the built plugin via `vite preview`
- fall back to the existing bootstrap command when artifacts are missing

The package script used for publishing now builds before `npm pack`, and npm ignore rules allow the built artifacts to be included in the tarball.

Backward compatibility is preserved because source checkouts without `dist` artifacts still use the current bootstrap path exactly as before. The existing `bootstrap` and `bootstrap:multi-user` scripts are unchanged, so developer workflows remain the same.

### Runtime Behavior

For users installing `@penpot/mcp` from npm, a normal launch should be able to:

1. start immediately when runtime artifacts already exist;
2. avoid package installation during normal startup;
3. avoid rebuilding unless artifacts are missing.

Development bootstrap remains available and unchanged, but packaged npm installs can now use the prebuilt runtime path.

### Steps to reproduce

Before this change:

1. Run `npx -y @penpot/mcp`.
2. The launcher runs `pnpm -r install`, `pnpm run build`, and `pnpm run start`.
3. Repeated `npx` runs can fail when npm prunes the nested pnpm install state.

In environments using pnpm versions with stricter build-script approval behavior, the repeated install path can also fail before the MCP server starts.

### Verification

Verified with:

- `node --check bin/mcp-local.js`
- `pnpm exec prettier --check bin/mcp-local.js package.json`
- `pnpm run test`
- `bash scripts/pack`
- production-only install of the generated tarball with `npm install --omit=dev`
- launch of installed `penpot-mcp`, confirming no pnpm install/build output

### Backwards Compatibility

- Existing `bootstrap` and `bootstrap:multi-user` scripts are unchanged.
- Source checkouts without built artifacts still fall back to the existing bootstrap flow.
- Packaged installs with built artifacts can start directly through the runtime path.
- No Docker or self-host configuration is changed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.