### PR TITLE
:bug: Skip end-user SSO gate on nitrate org management endpoints

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -509,7 +509,8 @@ RETURNING id, deleted_at;")
   "Get valid invitations for an organization, returning at most one invitation per email."
   {::doc/added "2.16"
    ::sm/params schema:get-org-invitations-params
-   ::sm/result schema:get-org-invitations-result}
+   ::sm/result schema:get-org-invitations-result
+   ::rpc/auth false}
   [cfg {:keys [organization-id]}]
   (let [team-ids (noh/get-org-team-ids cfg organization-id)]
     (db/run! cfg (fn [{:keys [::db/conn]}]
@@ -535,7 +536,8 @@ RETURNING id, deleted_at;")
 (sv/defmethod ::delete-org-invitations
   "Delete all invitations for one email in an organization scope (org + org teams)."
   {::doc/added "2.16"
-   ::sm/params schema:delete-org-invitations-params}
+   ::sm/params schema:delete-org-invitations-params
+   ::rpc/auth false}
   [cfg {:keys [organization-id email]}]
   (let [clean-email (profile/clean-email email)
         team-ids    (noh/get-org-team-ids cfg organization-id)]
@@ -866,7 +868,8 @@ RETURNING id, deleted_at;")
    including owner info and project/file/member counts."
   {::doc/added "2.20"
    ::sm/params schema:get-teams-detail-params
-   ::sm/result schema:get-teams-detail-result}
+   ::sm/result schema:get-teams-detail-result
+   ::rpc/auth false}
   [cfg {:keys [organization-id]}]
   (let [org-summary (nitrate/call cfg :get-org-summary {:organization-id organization-id})
         team-ids    (into [] (comp d/xf:map-id (filter uuid?)) (:teams org-summary))]


### PR DESCRIPTION
get-teams-detail, get-org-invitations and delete-org-invitations lacked ::rpc/auth false, so wrap-nitrate-sso ran on them whenever params carried an organization-id. For SSO-active orgs this rejected the org owner's admin-console reads with a 401, since their Penpot session has no SSO grant for the org. These are shared-key protected management calls made on the org owner's behalf and never use profile-id, so they should not require an end-user SSO session — matching their sibling endpoints.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
