### PR TITLE
:bug: Fix text editor not auto-selecting all text on mount

### DIFF
--- a/frontend/playwright/ui/specs/text-editor-v3.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v3.spec.js
@@ -129,3 +129,27 @@ test("BUG 10467 - Auto-width text captures every typed character", async ({
   await workspace.waitForSelectedShapeName("hello world");
 });
 
+test("BUG 10531 - Entering the editor auto-selects the whole text", async ({
+  page,
+}) => {
+  const workspace = new WasmWorkspacePage(page, { textEditor: true });
+  await workspace.setupEmptyFile();
+  await workspace.mockGetFile("text-editor/get-file-lorem-ipsum.json");
+  await workspace.goToWorkspace();
+  await workspace.waitForFirstRender();
+
+  // Select the existing text shape and enter edit mode via Enter
+  await workspace.clickLeafLayer("Lorem ipsum");
+  await workspace.textEditor.startEditing();
+
+  // Copying while editing exports only the selected text as raw text.
+  // Since we just entered the editor, the whole text should be selected.
+  await workspace.copy("keyboard");
+
+  // Assert the text was copied correctly
+  const copiedText = await page.evaluate(() =>
+    navigator.clipboard.readText(),
+  );
+  expect(copiedText).toBe("Lorem ipsum");
+});
+

--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -350,7 +350,10 @@
      (mf/deps contenteditable-ref)
      (fn []
        (when-let [node (mf/ref-val contenteditable-ref)]
-         (.focus node))
+         ;; Focus and select all text on mount (this will trigger on-focus)
+         (.focus node)
+         (text-editor/text-editor-select-all)
+         (wasm.api/request-render "text-editor-select-all-on-mount"))
        ;; On unmount, finalize the editor content and then dispose the WASM editor.
        ;; We finalize on unmount instead of relying on the browser blur event, because
        ;; it was not being reliable (timing issues, Firefox issues…)


### PR DESCRIPTION
### Related Ticket

Fixes #10531 

### Summary

This replicates v2 behavior of selecting the whole text when the text editor is mounted.

https://github.com/user-attachments/assets/e711412f-82c4-489e-908d-77ba41eeadaa

### Steps to reproduce 

See #10531 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
