### PR TITLE
:bug: Fix blur menu width

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.scss
@@ -10,6 +10,10 @@
 @use "ds/_utils.scss" as *;
 @use "../../../sidebar/common/sidebar.scss" as sidebar;
 
+.element-set {
+  max-width: var(--options-width);
+}
+
 .title-spacing-blur {
   padding-left: var(--sp-xxs);
   margin: 0;


### PR DESCRIPTION
### Related Ticket

<img width="500" height="736" alt="Screenshot from 2026-07-08 09-11-16" src="https://github.com/user-attachments/assets/2dde0ce3-00f0-40d8-83d1-27e58dc4dcff" />
Blur menu is not align in firefox.

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Closes #10576
