### PR TITLE
:sparkles: Add ignore sso flag to nitrate management api endpoints

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -53,7 +53,8 @@
   "Authenticate the current user"
   {::doc/added "2.14"
    ::sm/params [:map]
-   ::sm/result schema:profile}
+   ::sm/result schema:profile
+   ::nitrate/sso false}
   [cfg {:keys [::rpc/profile-id] :as params}]
   (let [profile            (profile/get-profile cfg profile-id)]
     (-> (profile-to-map profile)
@@ -104,7 +105,8 @@
   "List teams for which current user is owner"
   {::doc/added "2.14"
    ::sm/params [:map]
-   ::sm/result schema:get-teams-result}
+   ::sm/result schema:get-teams-result
+   ::nitrate/sso false}
   [cfg {:keys [::rpc/profile-id]}]
   (let [current-user-id (-> (profile/get-profile cfg profile-id) :id)]
     (->> (db/exec! cfg [sql:get-teams current-user-id])
@@ -127,7 +129,8 @@
   collection when replacing an existing one."
   {::doc/added "2.17"
    ::sm/params schema:upload-org-logo
-   ::sm/result schema:upload-org-logo-result}
+   ::sm/result schema:upload-org-logo-result
+   ::nitrate/sso false}
   [{:keys [::sto/storage]} {:keys [content organization-id previous-id]}]
   (when previous-id
     (sto/touch-object! storage previous-id))
@@ -195,7 +198,8 @@
   "List profiles that belong to teams for which current user is owner"
   {::doc/added "2.14"
    ::sm/params [:map]
-   ::sm/result schema:managed-profile-result}
+   ::sm/result schema:managed-profile-result
+   ::nitrate/sso false}
   [cfg {:keys [::rpc/profile-id]}]
   (let [current-user-id (-> (profile/get-profile cfg profile-id) :id)]
     (db/exec! cfg [sql:get-managed-profiles current-user-id current-user-id])))
@@ -234,7 +238,8 @@
   "Get summary information for a list of teams"
   {::doc/added "2.15"
    ::sm/params schema:get-teams-summary-params
-   ::sm/result schema:get-teams-summary-result}
+   ::sm/result schema:get-teams-summary-result
+   ::nitrate/sso false}
   [cfg {:keys [ids]}]
   (let [;; Handle one or multiple params
         ids (cond
@@ -373,7 +378,8 @@ RETURNING id, deleted_at;")
   "For a given user, find all owned organizations and apply the deleted-org
    transfer rules to their imported Your Penpot teams."
   {::doc/added "2.18"
-   ::sm/params schema:notify-user-organizations-deletion}
+   ::sm/params schema:notify-user-organizations-deletion
+   ::nitrate/sso false}
   [cfg {:keys [profile-id]}]
   (let [owned-orgs (nitrate/call cfg :get-owned-orgs {:profile-id profile-id})]
     (doseq [org owned-orgs]
@@ -399,7 +405,8 @@ RETURNING id, deleted_at;")
   "Get profile by email"
   {::doc/added "2.15"
    ::sm/params [:map [:email ::sm/email]]
-   ::sm/result schema:profile}
+   ::sm/result schema:profile
+   ::nitrate/sso false}
   [cfg {:keys [email]}]
   (let [profile (db/exec-one! cfg [sql:get-profile-by-email email])]
     (when-not profile
@@ -422,7 +429,8 @@ RETURNING id, deleted_at;")
   "Get profile by email"
   {::doc/added "2.15"
    ::sm/params [:map [:id ::sm/uuid]]
-   ::sm/result schema:profile}
+   ::sm/result schema:profile
+   ::nitrate/sso false}
   [cfg {:keys [id]}]
   (let [profile (db/exec-one! cfg [sql:get-profile-by-id id])]
     (when-not profile
@@ -482,7 +490,8 @@ RETURNING id, deleted_at;")
   {::doc/added "2.15"
    ::sm/params [:map
                 [:email ::sm/email]
-                [:organization schema:organization-with-avatar]]}
+                [:organization schema:organization-with-avatar]]
+   ::nitrate/sso false}
   [cfg params]
   (db/tx-run! cfg ti/create-org-invitation params)
   nil)
@@ -510,7 +519,7 @@ RETURNING id, deleted_at;")
   {::doc/added "2.16"
    ::sm/params schema:get-org-invitations-params
    ::sm/result schema:get-org-invitations-result
-   ::rpc/auth false}
+   ::nitrate/sso false}
   [cfg {:keys [organization-id]}]
   (let [team-ids (noh/get-org-team-ids cfg organization-id)]
     (db/run! cfg (fn [{:keys [::db/conn]}]
@@ -537,7 +546,7 @@ RETURNING id, deleted_at;")
   "Delete all invitations for one email in an organization scope (org + org teams)."
   {::doc/added "2.16"
    ::sm/params schema:delete-org-invitations-params
-   ::rpc/auth false}
+   ::nitrate/sso false}
   [cfg {:keys [organization-id email]}]
   (let [clean-email (profile/clean-email email)
         team-ids    (noh/get-org-team-ids cfg organization-id)]
@@ -606,7 +615,8 @@ RETURNING id, deleted_at;")
                 [:organization-id ::sm/uuid]
                 [:organization-name ::sm/text]
                 [:default-team-id ::sm/uuid]]
-   ::db/transaction true}
+   ::db/transaction true
+   ::nitrate/sso false}
   [cfg {:keys [profile-id organization-id organization-name default-team-id] :as params}]
   (let [{:keys [valid-teams-to-delete-ids
                 valid-teams-to-transfer
@@ -643,7 +653,8 @@ RETURNING id, deleted_at;")
                 [:organization-id ::sm/uuid]
                 [:default-team-id ::sm/uuid]]
    ::sm/result schema:get-remove-from-org-summary-result
-   ::db/transaction true}
+   ::db/transaction true
+   ::nitrate/sso false}
   [cfg {:keys [profile-id organization-id default-team-id]}]
   (let [{:keys [valid-teams-to-delete-ids
                 valid-teams-to-transfer
@@ -744,7 +755,8 @@ RETURNING id, deleted_at;")
   "Return if there are any team invitations for emails that are not organization members."
   {::doc/added "2.18"
    ::sm/params schema:org-team-invitations-for-non-members-params
-   ::sm/result schema:exists-org-team-invitations-for-non-members-result}
+   ::sm/result schema:exists-org-team-invitations-for-non-members-result
+   ::nitrate/sso false}
   [cfg params]
   (db/run! cfg (fn [{:keys [::db/conn]}]
                  {:exists (boolean (non-member-org-team-invitations-exist? conn params))})))
@@ -753,7 +765,8 @@ RETURNING id, deleted_at;")
   "Delete team invitations for emails that are not organization members."
   {::doc/added "2.18"
    ::sm/params schema:org-team-invitations-for-non-members-params
-   ::db/transaction true}
+   ::db/transaction true
+   ::nitrate/sso false}
   [cfg params]
   (db/run! cfg (fn [{:keys [::db/conn]}]
                  (let [{:keys [emails-array teams-array]}
@@ -869,7 +882,7 @@ RETURNING id, deleted_at;")
   {::doc/added "2.20"
    ::sm/params schema:get-teams-detail-params
    ::sm/result schema:get-teams-detail-result
-   ::rpc/auth false}
+   ::nitrate/sso false}
   [cfg {:keys [organization-id]}]
   (let [org-summary (nitrate/call cfg :get-org-summary {:organization-id organization-id})
         team-ids    (into [] (comp d/xf:map-id (filter uuid?)) (:teams org-summary))]


### PR DESCRIPTION
### Summary

Add ignore sso flag to nitrate management api endpoints

Most of the endpoints doesn't need it now, but it is better to be explicit

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
