### PR TITLE
:bug: Fix sidebar scroll to shape

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -490,8 +490,7 @@
                 selected-child-render-idx
                 (when (> total default-chunk-size)
                   (some (fn [sel-id]
-                          (let [idx (.indexOf shapes sel-id)]
-                            (when (>= idx 0) idx)))
+                          (d/index-of-pred shapes #(= (get % :id) sel-id)))
                         selected))
 
                 ;; Load at least enough to include the selected child plus extra
@@ -509,12 +508,7 @@
 
             (reset! children-count* new-count))
 
-          (reset! children-count* 0))
-
-        (fn []
-          (when-let [obs (mf/ref-val observer-ref)]
-            (.disconnect obs)
-            (mf/set-ref-val! obs nil)))))
+          (reset! children-count* 0))))
 
     ;; Re-observe sentinel whenever children-count changes (sentinel moves)
     ;; and (shapes item) to reconnect observer after shape changes
@@ -523,11 +517,6 @@
             name-node   (mf/ref-val name-node-ref)
             scroll-node (dom/get-parent-with-data name-node "scroll-container")
             lazy-node   (mf/ref-val lazy-ref)]
-
-        ;; Disconnect previous observer
-        (when-let [obs (mf/ref-val observer-ref)]
-          (.disconnect obs)
-          (mf/set-ref-val! observer-ref nil))
 
         ;; Setup new observer if there are more children to load
         (when (and ^boolean is-expanded
@@ -542,7 +531,13 @@
                          (reset! children-count* next-count))))
                 observer (js/IntersectionObserver. cb #js {:root scroll-node})]
             (.observe observer lazy-node)
-            (mf/set-ref-val! observer-ref observer)))))
+            (mf/set-ref-val! observer-ref observer)))
+
+        ;; Disconnect on deps change or unmount; this effect owns the observer
+        (fn []
+          (when-let [obs (mf/ref-val observer-ref)]
+            (.disconnect obs)
+            (mf/set-ref-val! observer-ref nil)))))
 
     [:> layer-item-inner*
      {:ref dref


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10599

### Summary

This PR fixes two issues at once:

1. selection change was disconnecting the IntersectionObserver that drives chunk loading ->  observer teardown moved to the effect that owns it
2. selected element lookup used a wrong-type .indexOf, so the sidebar never loaded the chunk containing the clicked element -> replaced with id-based lookup
