### PR TITLE
:bug: Fix crash when converting SVG-raw shape to path

### DIFF
--- a/common/src/app/common/types/path.cljc
+++ b/common/src/app/common/types/path.cljc
@@ -392,7 +392,9 @@
   ([shape]
    (convert-to-path shape {}))
   ([shape objects]
-   (-> (stp/convert-to-path shape objects)
-       (update :content impl/path-data))))
+   (let [shape' (stp/convert-to-path shape objects)]
+     (if (identical? shape shape')
+       shape'
+       (update shape' :content impl/path-data)))))
 
 (dm/export impl/decode-segments)

--- a/common/test/common_tests/types/path_data_test.cljc
+++ b/common/test/common_tests/types/path_data_test.cljc
@@ -1370,6 +1370,15 @@
     ;; A path shape stays a path shape unchanged
     (t/is (= :path (:type result)))))
 
+(t/deftest shape-to-path-svg-raw-does-not-throw
+  (let [shape  {:type :svg-raw :x 0.0 :y 0.0 :width 100.0 :height 50.0
+                :selrect (make-selrect 0.0 0.0 100.0 50.0)
+                :content {:tag :text :attrs {:style {}}
+                          :content [{:tag :tspan :attrs {} :content ["x"]}]}}
+        result (path/convert-to-path shape {})]
+    (t/is (= :svg-raw (:type result)))
+    (t/is (some? (:content result)))))
+
 (t/deftest shape-to-path-rect-with-radius
   (let [shape  {:type :rect :x 0.0 :y 0.0 :width 100.0 :height 100.0
                 :r1 10.0 :r2 10.0 :r3 10.0 :r4 10.0


### PR DESCRIPTION
**Note:** This PR was created with AI assistance

## What

Flattening an SVG-raw shape (imported SVG element) via the context menu or Plugin API crashes the workspace with an "unexpected data" internal error. SVG-raw shapes store their `:content` as hiccup-style maps which `path-data` cannot consume.

## Why

`path/convert-to-path` unconditionally called `(update :content impl/path-data)` on the result of `stp/convert-to-path`. The `stp` layer has no `:svg-raw` case, so it falls through to the default and returns the shape unchanged — with hiccup content still in `:content`. `impl/path-data` then rejects the map with "unexpected data".

## How

Guard the content-to-PathData coercion with `identical?` so it only runs when `stp/convert-to-path` actually produced a new value. Pass-through shapes (SVG-raw, existing paths, any unsupported type) are returned unchanged. Real conversions (rect, circle, image, text, group, frame, bool) always produce new maps, so the coercion still runs as a safety no-op.

Fixes #10612
