### PR TITLE
:bug: Fix component variant panel crash with mismatched property counts

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -522,7 +522,7 @@
     [:*
      [:div {:class (stl/css :variant-property-list)}
       (for [[pos prop] (map-indexed vector props-first)]
-        (let [mixed-value? (not-every? #(= (:value prop) (:value (nth % pos))) properties)
+        (let [mixed-value? (not-every? #(= (:value prop) (:value (get % pos))) properties)
               options      (get-options (:name prop))
               boolean-pair (ctv/find-boolean-pair (mapv :id options))
               options      (cond-> options


### PR DESCRIPTION
**Note:** This PR was created with AI assistance

## What

The component variant panel in the sidebar crashes with "No item 1 in vector of length 1" when multiple variant copies with mismatched `:variant-properties` counts are selected together.

## Why

`component-variant-copy*` iterates over the first component's property vector positionally, then calls `nth` on every other selected component's property vector at the same position. If any component has fewer properties, `nth` throws an out-of-bounds error. The render guard (`same-variant?`) only checks `:variant-id` equality, not property count alignment.

## How

Replace `nth` with `get` — `get` returns `nil` past the end of a vector instead of throwing. The property position correctly reports as "mixed" (Multiple) instead of crashing. Zero behavior change for well-formed data (in-bounds `get` ≡ `nth`).

Closes #10615
