### PR TITLE
:bug: Fix too much recursion when clicking shape in comments mode

### DIFF
--- a/frontend/src/app/main/data/workspace/comments.cljs
+++ b/frontend/src/app/main/data/workspace/comments.cljs
@@ -24,7 +24,6 @@
    [app.main.data.workspace.drawing :as dwd]
    [app.main.data.workspace.edition :as dwe]
    [app.main.data.workspace.layout :as dwlo]
-   [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.zoom :as dwz]
    [app.main.repo :as rp]
    [app.main.router :as rt]
@@ -85,8 +84,7 @@
           ;; tool is active. When comments are merely visible during design,
           ;; `select-shape` emits `:interrupt` and this would otherwise wipe
           ;; the freshly selected shape, breaking click selection.
-          comments-mode? (rx/of (dwe/clear-edition-mode)
-                                (dws/deselect-all true))
+          comments-mode? (rx/of (dwe/clear-edition-mode))
           :else          (rx/empty))))))
 
 ;; Event responsible of the what should be executed when user clicked

--- a/frontend/src/app/main/data/workspace/comments.cljs
+++ b/frontend/src/app/main/data/workspace/comments.cljs
@@ -70,7 +70,7 @@
 
              (rx/take-until stopper-s))))))
 
-(defn- handle-interrupt
+(defn handle-interrupt
   []
   (ptk/reify ::handle-interrupt
     ptk/WatchEvent

--- a/frontend/test/frontend_tests/data/workspace_comments_test.cljs
+++ b/frontend/test/frontend_tests/data/workspace_comments_test.cljs
@@ -1,0 +1,84 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns frontend-tests.data.workspace-comments-test
+  (:require
+   [app.main.data.comments :as dcmt]
+   [app.main.data.workspace.comments :as dwcm]
+   [app.main.data.workspace.edition :as dwe]
+   [beicon.v2.core :as rx]
+   [cljs.test :as t :include-macros true]
+   [potok.v2.core :as ptk]))
+
+(t/deftest test-handle-interrupt-draft
+  (t/async
+    done
+    (let [event  (dwcm/handle-interrupt)
+          state  {:comments-local {:draft {:id "draft-id"}}}
+          result (ptk/watch event state (rx/empty))]
+      (->> result
+           (rx/subs!
+            (fn [evt]
+              (t/is (= ::dcmt/close-comment-thread (ptk/type evt))))
+            (fn [err]
+              (done)
+              (js/console.error err)
+              (t/do-report {:type :error :message "Stream error" :actual err}))
+            (fn [_]
+              (done)))))))
+
+(t/deftest test-handle-interrupt-open
+  (t/async
+    done
+    (let [event  (dwcm/handle-interrupt)
+          state  {:comments-local {:open {:id "thread-id"}}}
+          result (ptk/watch event state (rx/empty))]
+      (->> result
+           (rx/subs!
+            (fn [evt]
+              (t/is (= ::dcmt/close-comment-thread (ptk/type evt))))
+            (fn [err]
+              (done)
+              (js/console.error err)
+              (t/do-report {:type :error :message "Stream error" :actual err}))
+            (fn [_]
+              (done)))))))
+
+(t/deftest test-handle-interrupt-comments-mode
+  (t/async
+    done
+    (let [event  (dwcm/handle-interrupt)
+          state  {:workspace-drawing {:tool :comments}}
+          result (ptk/watch event state (rx/empty))]
+      (->> result
+           (rx/subs!
+            (fn [evt]
+              (t/is (= ::dwe/clear-edition-mode (ptk/type evt))))
+            (fn [err]
+              (done)
+              (js/console.error err)
+              (t/do-report {:type :error :message "Stream error" :actual err}))
+            (fn [_]
+              (done)))))))
+
+(t/deftest test-handle-interrupt-noop
+  (t/async
+    done
+    (let [event    (dwcm/handle-interrupt)
+          state    {}
+          result   (ptk/watch event state (rx/empty))
+          emitted? (atom false)]
+      (->> result
+           (rx/subs!
+            (fn [_]
+              (reset! emitted? true))
+            (fn [err]
+              (done)
+              (js/console.error err)
+              (t/do-report {:type :error :message "Stream error" :actual err}))
+            (fn [_]
+              (t/is (false? @emitted?) "should not emit any events")
+              (done)))))))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -12,6 +12,7 @@
    [frontend-tests.data.uploads-test]
    [frontend-tests.data.viewer-test]
    [frontend-tests.data.workspace-colors-test]
+   [frontend-tests.data.workspace-comments-test]
    [frontend-tests.data.workspace-interactions-test]
    [frontend-tests.data.workspace-mcp-test]
    [frontend-tests.data.workspace-media-test]
@@ -85,6 +86,7 @@
    'frontend-tests.data.uploads-test
    'frontend-tests.data.viewer-test
    'frontend-tests.data.workspace-colors-test
+   'frontend-tests.data.workspace-comments-test
    'frontend-tests.data.workspace-interactions-test
    'frontend-tests.data.workspace-mcp-test
    'frontend-tests.data.workspace-media-test


### PR DESCRIPTION
**Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

## What

Workspace crashes with "too much recursion" when a user clicks a shape while the comments tool is active. The potok store's synchronous event processing chain overflows the JS call stack.

## Why

`select-shape` emits `:interrupt` to cancel drawing/edition state. The `initialize-comments` stream watcher filters for `:interrupt` and routes it to `handle-interrupt`. When `comments-mode?` is true, `handle-interrupt` called `deselect-all`, which:

1. Cleared the selection (undoing what `select-shape` just did)
2. Emitted a competing `rt/nav` (removing `board-id`) against `select-shape`'s own `rt/nav` (adding `board-id`)

This created an infinite synchronous recursion cycle: `select-shape` → `:interrupt` → `handle-interrupt` → `deselect-all` → state change → re-trigger, each adding ~15-20 stack frames until overflow.

## How

Removed `dws/deselect-all` from the `comments-mode?` branch of `handle-interrupt`. Edition mode is still cleared via `dwe/clear-edition-mode`. The unused `app.main.data.workspace.selection` require was also removed.

Fixes #10620
