### PR TITLE
:bug: Fix permission to add a team to an organization

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -1538,8 +1538,9 @@
         can-change-organization? (mf/with-memo [all-organizations]
                                    (> (count all-organizations) 1))
 
-        can-add-to-organization? (mf/with-memo [organizations all-organizations]
-                                   (and (pos? (count all-organizations))
+        can-add-to-organization? (mf/with-memo [organizations all-organizations permissions]
+                                   (and (:is-owner permissions)
+                                        (pos? (count all-organizations))
                                         (not (:is-default team))))
 
         show-org-options-menu*


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26600

### Summary

"Add team to organization" button only available for team owner.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
