### PR TITLE
:sparkles: Add PENPOT_INTERNAL_URI to exporter for separate internal and public URI handling

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -197,10 +197,10 @@ services:
       - penpot
 
     environment:
-      << : [*penpot-secret-key]
+      << : [*penpot-secret-key, *penpot-public-uri]
       # Don't touch it; this uses an internal docker network to
       # communicate with the frontend.
-      PENPOT_PUBLIC_URI: http://penpot-frontend:8080
+      PENPOT_INTERNAL_URI: http://penpot-frontend:8080
 
       ## Valkey (or previously Redis) is used for the websockets notifications.
       PENPOT_REDIS_URI: redis://penpot-valkey/0

--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -651,6 +651,21 @@ PENPOT_EXPORTER_URI: http://your-penpot-exporter:6061
 
 These variables are used for generate correct nginx.conf file on container startup.
 
+### Exporter
+
+The exporter uses this variable:
+
+```bash
+# Exporter
+PENPOT_INTERNAL_URI: http://penpot-frontend:8080
+```
+
+- `PENPOT_INTERNAL_URI`: The URI used by the exporter's headless browser to
+  communicate with the frontend (internal Docker network). Defaults to
+  `PENPOT_PUBLIC_URI` if not set. The default value
+  `http://penpot-frontend:8080` used in the docker-compose is a good default and
+  it is recommended to keep it unchanged.
+
 ## Other flags
 
 There are other flags that are useful for a more customized Penpot experience. This section has the list of the flags meant

--- a/exporter/src/app/config.cljs
+++ b/exporter/src/app/config.cljs
@@ -22,6 +22,7 @@
 
 (def ^:private defaults
   {:public-uri "http://localhost:3449"
+   :internal-uri nil
    :tenant "default"
    :host "localhost"
    :http-server-port 6061
@@ -33,6 +34,7 @@
   [:map {:title "config"}
    [:secret-key :string]
    [:public-uri {:optional true} ::sm/uri]
+   [:internal-uri {:optional true} ::sm/uri]
    [:exporter-shared-key {:optional true} :string]
    [:host {:optional true} :string]
    [:tenant {:optional true} :string]
@@ -99,6 +101,12 @@
    (c/get config key))
   ([key default]
    (c/get config key default)))
+
+(defn get-internal-uri
+  "Returns internal-uri if set, otherwise falls back to public-uri."
+  []
+  (or (c/get config :internal-uri)
+      (c/get config :public-uri)))
 
 (def management-key
   (let [key (or (c/get config :exporter-shared-key)

--- a/exporter/src/app/core.cljs
+++ b/exporter/src/app/core.cljs
@@ -21,6 +21,7 @@
   [& _]
   (l/info :msg "initializing"
           :public-uri (str (cf/get :public-uri))
+          :internal-uri (str (cf/get-internal-uri))
           :version (:full cf/version))
   (p/do!
    (bwr/init)

--- a/exporter/src/app/handlers/resources.cljs
+++ b/exporter/src/app/handlers/resources.cljs
@@ -79,7 +79,7 @@
                                     :method "POST"
                                     :body fdata
                                     :dispatcher agent}
-                       uri     (-> (cf/get :public-uri)
+                       uri     (-> (cf/get-internal-uri)
                                    (u/ensure-path-slash)
                                    (u/join "api/management/methods/upload-tempfile")
                                    (str))]

--- a/exporter/src/app/renderer/bitmap.cljs
+++ b/exporter/src/app/renderer/bitmap.cljs
@@ -62,7 +62,7 @@
                     :skip-children skip-children
                     :wasm (when is-wasm "true")
                     :scale scale}
-            uri    (-> (cf/get :public-uri)
+            uri    (-> (cf/get-internal-uri)
                        (u/ensure-path-slash)
                        (u/join "render.html")
                        (assoc :query (u/map->query-string params)))]

--- a/exporter/src/app/renderer/pdf.cljs
+++ b/exporter/src/app/renderer/pdf.cljs
@@ -77,7 +77,7 @@
                   (on-object (assoc object :path path))
                   (p/recur (rest objects))))))]
 
-    (let [base-uri (-> (cf/get :public-uri)
+    (let [base-uri (-> (cf/get-internal-uri)
                        (u/ensure-path-slash))]
       (bw/exec! (prepare-options base-uri)
                 (partial render base-uri)))))

--- a/exporter/src/app/renderer/svg.cljs
+++ b/exporter/src/app/renderer/svg.cljs
@@ -108,6 +108,18 @@
     {:width width
      :height height}))
 
+(defn- replace-internal-uris
+  "Replaces internal-uri references with public-uri in SVG output.
+   This ensures that font URLs and other resource references in the
+   exported SVG use the public-facing URI accessible to end users."
+  [svg-content]
+  (let [internal-uri (str (cf/get-internal-uri))
+        public-uri   (str (cf/get :public-uri))]
+    (if (and (not= internal-uri public-uri)
+             (str/includes? svg-content internal-uri))
+      (str/replace svg-content internal-uri public-uri)
+      svg-content)))
+
 (defn render
   [{:keys [page-id file-id share-id objects token scale type]} on-object]
   (letfn [(convert-to-ppm [pngpath]
@@ -320,7 +332,9 @@
 
                       result  (if (contains? cf/flags :exporter-svgo)
                                 (svgo/optimize result svgo/defaultOptions)
-                                result)]
+                                result)
+
+                      result  (replace-internal-uris result)]
 
                 ;; (println "------- ORIGIN:")
                 ;; (cljs.pprint/pprint (xml->clj xmldata))
@@ -349,7 +363,7 @@
                     :render-embed true
                     :object-id (mapv :id objects)
                     :route "objects"}
-            uri    (-> (cf/get :public-uri)
+            uri    (-> (cf/get-internal-uri)
                        (u/ensure-path-slash)
                        (u/join "render.html")
                        (assoc :query (u/map->query-string params)))]


### PR DESCRIPTION
**Note:** This PR was created with AI assistance
## What

The exporter uses `PENPOT_PUBLIC_URI` for both internal communication (headless browser navigating to the frontend's `render.html`) and for resource URL references in exported SVG files (font `@font-face` src URLs, image references, etc.).

In Docker deployments where the public URL differs from the internal Docker network address, exported SVGs contain broken font URLs like `http://penpot-frontend:8080/fonts/sourcesanspro-regular.woff` instead of the public URL.

## Why

The frontend's `render.html` loads `config-render.js` which does not set `penpotPublicURI`, so the frontend falls back to `location.origin`. Since the exporter's headless browser navigates to the internal Docker address, `location.origin` is the internal URI — and this gets embedded in font `@font-face` rules in the SVG output.

## How

- Add `PENPOT_INTERNAL_URI` environment variable to the exporter config, defaulting to `PENPOT_PUBLIC_URI` for backward compatibility.
- Use `internal-uri` for browser navigation in all three renderers (SVG, PDF, bitmap) and for backend API calls in the resource handler.
- Post-process SVG output with `replace-internal-uris` to replace any `internal-uri` references with `public-uri` — following the same pattern as the frontend's `app.main.rasterizer/replace-uris`.
- Update `docker-compose.yaml` to set `PENPOT_INTERNAL_URI` to the internal Docker address and `PENPOT_PUBLIC_URI` to the user-facing address.

Closes #10627
