### PR TITLE
:bug: Fix render stroke caps on drag

### DIFF
--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1132,6 +1132,10 @@ impl Shape {
             .fold(0.0, f32::max)
     }
 
+    pub fn has_cap_bounds(&self) -> bool {
+        self.cap_bounds_margin() > 0.0
+    }
+
     pub fn mask_id(&self) -> Option<&Uuid> {
         self.children.first()
     }
@@ -1452,7 +1456,8 @@ impl Shape {
             }
         }
 
-        self.blur.is_none()
+        !self.has_cap_bounds()
+            && self.blur.is_none()
             && self.background_blur.is_none()
             && self.shadows.is_empty()
             && (self.opacity - 1.0).abs() <= 1e-4


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10633

### Summary

drag_crop_clip_path only covers the stroke outline, not the stroke caps, so we exclude them in is_safe_for_drag_crop_cache

### Steps to reproduce 

[screen-recorder-thu-jul-09-2026-15-38-31.webm](https://github.com/user-attachments/assets/6dcc962e-373a-4b9c-a3eb-6b3b04d7c608)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
