### PR TITLE
:bug: Handle text node targets in closest-text-editor-content

### DIFF
--- a/frontend/src/app/util/text/ui.cljs
+++ b/frontend/src/app/util/text/ui.cljs
@@ -10,13 +10,23 @@
    [app.main.store :as st]
    [app.util.dom :as dom]))
 
+(defn- get-element
+  "Given a DOM node, returns the nearest Element, walking up from text nodes."
+  [target]
+  (if (and (some? target)
+           (not= (.-nodeType target) js/Node.ELEMENT_NODE))
+    (.-parentElement target)
+    target))
+
 (defn v1-closest-text-editor-content
   [target]
-  (.closest ^js target ".public-DraftEditor-content"))
+  (when-let [el (get-element target)]
+    (.closest ^js el ".public-DraftEditor-content")))
 
 (defn v2-closest-text-editor-content
   [target]
-  (.closest ^js target "[data-itype=\"editor\"]"))
+  (when-let [el (get-element target)]
+    (.closest ^js el "[data-itype=\"editor\"]")))
 
 (defn closest-text-editor-content
   [target]


### PR DESCRIPTION
**Note:** This PR was created with AI assistance

## What

Workspace throws a TypeError (`$target$jscomp$157$$.closest is not a function`) when a keyboard or pointer event fires while the event target is a DOM text node rather than an Element node. This crashes the `closest-text-editor-content` function used by viewport event handlers.

## Why

`event.target` can be a text node (nodeType 3) — for example when clicking inside a contenteditable text editor. Text nodes do not have a `.closest()` method, so the direct call in `v1-closest-text-editor-content` and `v2-closest-text-editor-content` throws.

## How

Added a private `get-element` helper that checks `nodeType` and walks up to the nearest Element via `.parentElement` before calling `.closest()`. This matches the existing pattern in `dom/get-parent-with-data` (`dom.cljs:180-186`). Both v1 and v2 variants now use this guard, covering all three call sites (pointer-down, key-down, key-up handlers).

Fixes #10640
