### PR TITLE
:bug: Return 400 instead of 500 when ImageMagick fails on invalid images

### DIFF
--- a/backend/src/app/media.clj
+++ b/backend/src/app/media.clj
@@ -184,8 +184,8 @@
                             :env (get-imagemagick-env)
                             :timeout 60)]
     (when (not= 0 (:exit result))
-      (ex/raise :type :internal
-                :code :imagemagick-error
+      (ex/raise :type :validation
+                :code :invalid-image
                 :hint (str "ImageMagick command failed: " (:err result))
                 :cmd cmd
                 :exit (:exit result)))

--- a/backend/test/backend_tests/media_test.clj
+++ b/backend/test/backend_tests/media_test.clj
@@ -67,8 +67,8 @@
         (t/is false "should have thrown")
         (catch Exception e
           (let [data (ex-data e)]
-            ;; Could be validation or imagemagick-error depending on what magick does
-            (t/is (contains? #{:validation :internal} (:type data)))))
+            (t/is (= :validation (:type data)))
+            (t/is (= :invalid-image (:code data)))))
         (finally
           (fs/delete path))))))
 

--- a/frontend/src/app/main/data/media.cljs
+++ b/frontend/src/app/main/data/media.cljs
@@ -70,6 +70,9 @@
               (= (:code error) :media-type-mismatch)
               (tr "errors.media-type-mismatch")
 
+              (= (:code error) :invalid-image)
+              (tr "errors.media-type-not-allowed")
+
               :else
               (tr "errors.unexpected-error"))]
     (rx/of (ntf/error msg))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance

## What

When uploading an image that ImageMagick cannot process (e.g., corrupted PNG with invalid IHDR data), the backend returned HTTP 500 with error code `imagemagick-error`. The frontend treated this as a server error and displayed the full error page instead of showing a user-friendly notification banner.

This PR changes the error to return HTTP 400 with validation error code `invalid-image`, so the frontend shows a proper error banner.

## Why

ImageMagick failures on malformed or oversized images are expected errors caused by user input, not internal server failures. They should be treated as validation errors (HTTP 400) rather than internal errors (HTTP 500).

## How

- Changed `exec-magick!` in `backend/src/app/media.clj` to raise `:type :validation, :code :invalid-image` instead of `:type :internal, :code :imagemagick-error`
- Added `:invalid-image` case to `process-error` in `frontend/src/app/main/data/media.cljs` (used by profile/team photo uploads)
- Updated test assertion in `backend/test/backend_tests/media_test.clj` to expect `:validation` type

Closes #10642
