### PR TITLE
:bug: Guard team-container* when team-id is not a uuid

### DIFF
--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -133,18 +133,21 @@
    ::mf/private true}
   [{:keys [team-id children]}]
   (mf/with-effect [team-id]
-    (st/emit! (dtm/initialize-team team-id))
-    (fn []
-      (st/emit! (dtm/finalize-team team-id))))
+    (when (uuid? team-id)
+      (st/emit! (dtm/initialize-team team-id))
+      (fn []
+        (st/emit! (dtm/finalize-team team-id)))))
 
-  (let [{:keys [permissions] :as team} (mf/deref refs/team)]
-    (when (= team-id (:id team))
-      [:> (mf/provider ctx/current-team-id) {:value team-id}
-       [:> (mf/provider ctx/permissions) {:value permissions}
-        [:> (mf/provider ctx/can-edit?) {:value (:can-edit permissions)}
-         ;; The `:key` is mandatory here because we want to reinitialize
-         ;; all dom tree instead of simple rerender.
-         [:* {:key (str team-id)} children]]]])))
+  (if-not (uuid? team-id)
+    nil
+    (let [{:keys [permissions] :as team} (mf/deref refs/team)]
+      (when (= team-id (:id team))
+        [:> (mf/provider ctx/current-team-id) {:value team-id}
+         [:> (mf/provider ctx/permissions) {:value permissions}
+          [:> (mf/provider ctx/can-edit?) {:value (:can-edit permissions)}
+           ;; The `:key` is mandatory here because we want to reinitialize
+           ;; all dom tree instead of simple rerender.
+           [:* {:key (str team-id)} children]]]]))))
 
 (mf/defc page*
   {::mf/props :obj


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Fixes a 400 HTTP error from `:get-font-variants` that the client fires when the dashboard route is loaded without a `:team-id` query parameter (e.g. `/#/dashboard/recent`).

## Why

When the URL reached the dashboard without a `:team-id`, `team-container*` was emitting `dtm/initialize-team` with a `nil` team-id, which set `:current-team-id` to `nil` in the application state. The dashboard and workspace initialize events then built `df/fetch-fonts` with a `nil` team-id, producing a `:get-font-variants` RPC with empty params `{}` that the backend rejected with HTTP 400. The `(assert (uuid? team-id) ...)` checks in `dashboard/initialize` and `workspace/initialize-workspace` document the contract, but those asserts are elided in production builds, so the bug only surfaced at runtime.

## How

Guard `team-container*` in `frontend/src/app/main/ui.cljs` so it skips the `dtm/initialize-team` / `dtm/finalize-team` emissions and returns `nil` (no children, no context providers, no React key) when `team-id` is not a uuid. The `with-effect` body and the render are guarded independently, and the cleanup closure captures the same `team-id` as the setup, so transitioning between valid teams still emits the matching initialize/finalize pair. Since `team-container*` is the single wrapper used by both the dashboard and workspace sections in `page*`, one change covers both entry points without touching the event handlers or the RPC layer.

Fixes #10644
