### PR TITLE
:bug: Fix renaming a variant from the layers panel can break the file

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -703,6 +703,10 @@
    (rename-shape-or-variant nil nil id name))
   ([file-id page-id id name]
    (ptk/reify ::rename-shape-or-variant
+     ptk/UpdateEvent
+     (update [_ state]
+       (update state :workspace-local dissoc :shape-for-rename))
+
      ptk/WatchEvent
      (watch [_ state _]
        (let [file-id (d/nilv file-id (:current-file-id state))
@@ -727,10 +731,7 @@
                   (dwva/update-error component-id))
 
            variant-name
-           (rx/of (dwva/update-properties-names-and-values
-                   component-id variant-id variant-properties {})
-                  (dwva/remove-empty-properties variant-id)
-                  (dwva/update-error component-id name))
+           (rx/of (dwva/update-error component-id name))
 
            :else
            (rx/of (end-rename-shape id name))))))))

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -89,7 +89,7 @@
                      name       (str/trim (dom/get-value name-input))]
                  (on-stop-edit)
                  (reset! edition* false)
-                 (st/emit! (dw/end-rename-shape shape-id name))
+                 (st/emit! (dw/rename-shape-or-variant shape-id name))
                  (when (fn? on-tab-press)
                    (on-tab-press event)))))))
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

### Related Ticket

Closes #10486 

### Summary

#### Root cause

Two paths could leave a variant shape inconsistent — `:name` set to the raw formula string while `:variant-name` retained the old value:

1. Tab key in the layers panel called `end-rename-shape` directly, which set the shape's `:name` via `update-shape` without updating variant properties or `:variant-name`. Enter/blur correctly went through `rename-shape-or-variant`, but Tab bypassed it.
2. Invalid formula branch in `rename-shape-or-variant` called `update-properties-names-and-values` with `{}`, destructively clearing all variant properties instead of just showing a validation error.

#### Changes

`frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs`

- Tab handler now calls rename-shape-or-variant instead of end-rename-shape, so Tab goes through the same variant-aware path as Enter/blur.

`frontend/src/app/main/data/workspace.cljs` (`rename-shape-or-variant`)

- Added `ptk/UpdateEvent` to clean up `:shape-for-rename` from workspace-local state directly on the event (was previously only done in sub-events).
- Invalid formula branch now only calls `update-error` to show a validation marker, instead of clearing all variant properties with `update-properties-names-and-values ... {}`. Properties are preserved so the user can fix the input without data loss.
