### PR TITLE
:bug: Ensure text position-data always includes :fills key

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -2554,7 +2554,7 @@
                  (when (and element element-text)
                    (let [text (subs element-text start-pos end-pos)]
                      (d/patch-object
-                      txt/default-text-attrs
+                      (txt/get-default-text-attrs)
                       (d/without-nils
                        {:x x
                         :y (+ y height)

--- a/frontend/src/app/util/text_svg_position.cljs
+++ b/frontend/src/app/util/text_svg_position.cljs
@@ -9,6 +9,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.transit :as transit]
+   [app.common.types.text :as txt]
    [app.main.fonts :as fonts]
    [app.util.dom :as dom]
    [app.util.text-position-data :as tpd]
@@ -105,7 +106,8 @@
                      :text-decoration (dm/str (get-prop styles "text-decoration"))
                      :letter-spacing  (dm/str (get-prop styles "letter-spacing"))
                      :font-style      (dm/str (get-prop styles "font-style"))
-                     :fills           (transit/decode-str (get-prop styles "--fills"))
+                     :fills           (or (transit/decode-str (get-prop styles "--fills"))
+                                          txt/default-text-fills)
                      :text            text})))]
 
     (when (some? shape-id)


### PR DESCRIPTION
**Note:** This PR was created with AI assistance

## What

Text shape updates fail with a backend validation error because `position-data` entries are missing the required `:fills` key.

## Why

Two independent frontend code paths can produce 'position-data' entries without the `:fills` key:

1. **WASM path** (`api.cljs`): `calculate-position-data` uses `txt/default-text-attrs` as the base map, which does not include `:fills`. When the content element has no explicit fills, `d/without-nils` strips the nil value and the result lacks `:fills`.

2. **DOM path** (`text_svg_position.cljs`): `calc-position-data` reads fills from the CSS custom property `--fills`. When this property is absent, `get-prop` returns nil and the `(filter val)` transducer removes the `:fills` entry.

## How

- WASM path: Changed from `txt/default-text-attrs` to `(txt/get-default-text-attrs)`, which always includes fills defaulting to black.

- DOM path: Added a fallback `(or ... txt/default-text-fills)` so fills defaults when the CSS property is absent.

Fixes #10646
