### PR TITLE
:bug: Guard workspace-page* when file-id is not a uuid

### DIFF
--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -196,10 +196,7 @@
   {::mf/wrap [mf/memo]}
   [{:keys [team-id project-id file-id page-id layout-name]}]
 
-  (let [file-id          (hooks/use-equal-memo file-id)
-        page-id          (hooks/use-equal-memo page-id)
-
-        layout           (mf/deref refs/workspace-layout)
+  (let [layout           (mf/deref refs/workspace-layout)
         wglobal          (mf/deref refs/workspace-global)
 
         team-ref         (mf/with-memo [team-id]
@@ -287,6 +284,12 @@
 
 (mf/defc workspace-page*
   {::mf/lazy-load true}
-  [props]
-  [:> workspace* props])
+  [{:keys [file-id page-id] :as props}]
+  (let [file-id (hooks/use-equal-memo file-id)
+        page-id (hooks/use-equal-memo page-id)
+        props   (mf/spread-props props {:file-id file-id
+                                        :page-id page-id})]
+
+    (when (uuid? file-id)
+      [:> workspace* props])))
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Fixes a 400 HTTP error from `:get-profiles-for-file-comments` that the client fires when the workspace route is loaded without a `:file-id` query parameter (e.g. `/#/workspace?team-id=...`). This can happen when navigating from viewer to workspace without a file-id in the URL.

## Why

When the URL reached the workspace without a `:file-id`, `workspace*` was emitting `dw/initialize-workspace` with a nil `file-id`, which stored nil in `:current-file-id` in the application state. The `fetch-profiles` event then read nil from state and called `:get-profiles-for-file-comments` with `{:file-id nil}`, producing a 400 response. The `(assert (uuid? file-id) ...)` checks in `initialize-workspace` document the contract, but those asserts are elided in production builds, so the bug only surfaced at runtime.

## How

Move the `use-equal-memo` calls for `file-id` and `page-id` from `workspace*` up to `workspace-page*`, and guard the render with `(when (uuid? file-id) ...)` so `workspace*` only mounts when `file-id` is a valid uuid. Since `workspace*` never mounts with a nil `file-id`, `initialize-workspace` is never emitted with nil, and the 400 is prevented at the source. This mirrors the approach taken in PR #10651 for the `team-container*` / `get-font-variants` fix.

Fixes #10652
