### PR TITLE
Fix internal error when dragging a nested layout with boolean shapes inside

### DIFF
--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -715,6 +715,24 @@
             (rx/of (set-temporary-selrect selrect)
                    (set-temporary-modifiers modifiers))))))))
 
+(defn bool-ids-children-first
+  "The bool ancestors of `ids`, ordered children before parents.
+
+   The order matters for the WASM path: it calculates a bool from the
+   STORED content of nested bool children (the CLJS fallback recomputes
+   them recursively), and update-shapes folds each update into the
+   objects seen by the next one — so a nested bool must be recomputed
+   before the outer bool reads its content (see issue #10647)."
+  [objects ids]
+  (->> ids
+       (into #{}
+             (comp
+              (mapcat (partial cfh/get-parents-with-self objects))
+              (filter cfh/bool-shape?)
+              (map :id)))
+       (sort-by #(- (count (cfh/get-parent-ids objects %))))
+       (vec)))
+
 (defn propagate-structure-modifiers
   [modif-tree objects]
   (letfn [(propagate-children
@@ -819,12 +837,7 @@
                       (ctm/apply-structure-modifiers modifiers))))
 
               bool-ids
-              (into #{}
-                    (comp
-                     (mapcat (partial cfh/get-parents-with-self objects))
-                     (filter cfh/bool-shape?)
-                     (map :id))
-                    ids)
+              (bool-ids-children-first objects ids)
 
               undo-id (js/Symbol)]
           (rx/concat

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -2467,9 +2467,13 @@
 
 (defn calculate-bool*
   [bool-type ids]
+  ;; NOTE: heap views are (re)fetched after every allocating call:
+  ;; both _alloc_bytes and _calculate_bool (which allocates the result
+  ;; buffer) can grow WASM memory, and growth detaches any previously
+  ;; captured view (see issue #10647).
   (let [size   (mem/get-alloc-size ids UUID-U8-SIZE)
-        heap   (mem/get-heap-u32)
-        offset (mem/alloc->offset-32 size)]
+        offset (mem/alloc->offset-32 size)
+        heap   (mem/get-heap-u32)]
 
     (reduce (fn [offset id]
               (mem.h32/write-uuid offset heap id))
@@ -2481,6 +2485,7 @@
             (-> (h/call wasm/internal-module "_calculate_bool" (sr/translate-bool-type bool-type))
                 (mem/->offset-32))
 
+            heap    (mem/get-heap-u32)
             length  (aget heap offset)
             data    (mem/slice heap
                                (+ offset 1)
@@ -2503,19 +2508,23 @@
   ;; After the content is returned we discard that temporary context
   (h/call wasm/internal-module "_start_temp_objects")
 
-  (let [bool-type (get shape :bool-type)
-        ids (get shape :shapes)
-        all-children
-        (->> ids
-             (mapcat #(cfh/get-children-with-self objects %)))]
+  ;; NOTE: without the finally, a failure in the body leaves the
+  ;; temporary pool active and every subsequent call panics in
+  ;; _start_temp_objects (see issue #10647).
+  (try
+    (let [bool-type (get shape :bool-type)
+          ids (get shape :shapes)
+          all-children
+          (->> ids
+               (mapcat #(cfh/get-children-with-self objects %)))]
 
-    (h/call wasm/internal-module "_init_shapes_pool" (count all-children))
-    (run! set-object all-children)
+      (h/call wasm/internal-module "_init_shapes_pool" (count all-children))
+      (run! set-object all-children)
 
-    (let [content (-> (calculate-bool* bool-type ids)
-                      (path.impl/path-data))]
-      (h/call wasm/internal-module "_end_temp_objects")
-      content)))
+      (-> (calculate-bool* bool-type ids)
+          (path.impl/path-data)))
+    (finally
+      (h/call wasm/internal-module "_end_temp_objects"))))
 
 (def POSITION-DATA-U8-SIZE 36)
 (def POSITION-DATA-U32-SIZE (/ POSITION-DATA-U8-SIZE 4))

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -717,9 +717,11 @@
                 (aget c5 0) (aget c5 1) (aget c5 2) (aget c5 3)))
 
       ;; Dynamic call for children > 5
-      (let [heap   (mem/get-heap-u32)
-            size   (mem/get-alloc-size children UUID-U8-SIZE)
-            offset (mem/alloc->offset-32 size)]
+      ;; NOTE: the heap view is fetched after the allocation: growing
+      ;; memory detaches previously captured views (see issue #10647)
+      (let [size   (mem/get-alloc-size children UUID-U8-SIZE)
+            offset (mem/alloc->offset-32 size)
+            heap   (mem/get-heap-u32)]
         (reduce
          (fn [offset id]
            (mem.h32/write-uuid offset heap id))
@@ -878,39 +880,45 @@
                   ;; FFI signature flat while letting the renderer fall back
                   ;; to its default dash pattern when no override is stored.
                   dash      (or (:stroke-dash stroke) -1)
-                  gap       (or (:stroke-gap stroke) -1)
-                  offset    (mem/alloc types.fills.impl/FILL-U8-SIZE)
-                  heap      (mem/get-heap-u8)
-                  dview     (js/DataView. (.-buffer heap))]
+                  gap       (or (:stroke-gap stroke) -1)]
               (case align
                 :inner (h/call wasm/internal-module "_add_shape_inner_stroke" width style cap-start cap-end dash gap)
                 :outer (h/call wasm/internal-module "_add_shape_outer_stroke" width style cap-start cap-end dash gap)
                 (h/call wasm/internal-module "_add_shape_center_stroke" width style cap-start cap-end dash gap))
 
-              (cond
-                (some? gradient)
-                (do
-                  (types.fills.impl/write-gradient-fill offset dview opacity gradient)
-                  (h/call wasm/internal-module "_add_shape_stroke_fill")
-                  nil)
+              ;; The staging buffer is allocated only when the stroke has a
+              ;; fill payload to upload (an unconsumed staged buffer fails
+              ;; the next allocation app-wide), and the heap view is created
+              ;; AFTER the stroke-push call above: that call can grow WASM
+              ;; memory, detaching previously captured views (issue #10647).
+              (when (or (some? gradient) (some? image) (some? color))
+                (let [offset (mem/alloc types.fills.impl/FILL-U8-SIZE)
+                      heap   (mem/get-heap-u8)
+                      dview  (js/DataView. (.-buffer heap))]
+                  (cond
+                    (some? gradient)
+                    (do
+                      (types.fills.impl/write-gradient-fill offset dview opacity gradient)
+                      (h/call wasm/internal-module "_add_shape_stroke_fill")
+                      nil)
 
-                (some? image)
-                (let [image-id      (get image :id)
-                      buffer        (uuid/get-u32 image-id)
-                      cached-image? (h/call wasm/internal-module "_is_image_cached"
-                                            (aget buffer 0) (aget buffer 1)
-                                            (aget buffer 2) (aget buffer 3)
-                                            thumbnail?)]
-                  (types.fills.impl/write-image-fill offset dview opacity image)
-                  (h/call wasm/internal-module "_add_shape_stroke_fill")
-                  (when (== cached-image? 0)
-                    (fetch-image shape-id image-id thumbnail?)))
+                    (some? image)
+                    (let [image-id (get image :id)]
+                      (types.fills.impl/write-image-fill offset dview opacity image)
+                      (h/call wasm/internal-module "_add_shape_stroke_fill")
+                      (let [buffer        (uuid/get-u32 image-id)
+                            cached-image? (h/call wasm/internal-module "_is_image_cached"
+                                                  (aget buffer 0) (aget buffer 1)
+                                                  (aget buffer 2) (aget buffer 3)
+                                                  thumbnail?)]
+                        (when (== cached-image? 0)
+                          (fetch-image shape-id image-id thumbnail?))))
 
-                (some? color)
-                (do
-                  (types.fills.impl/write-solid-fill offset dview opacity color)
-                  (h/call wasm/internal-module "_add_shape_stroke_fill")
-                  nil)))))
+                    :else
+                    (do
+                      (types.fills.impl/write-solid-fill offset dview opacity color)
+                      (h/call wasm/internal-module "_add_shape_stroke_fill")
+                      nil)))))))
 
         strokes))
 
@@ -932,17 +940,20 @@
         buffer (js/Uint8Array. padded-size)]
     (path/write-to content (.-buffer buffer) 0)
     (h/call wasm/internal-module "_start_shape_path_buffer")
-    (let [heapu32 (mem/get-heap-u32)]
-      (loop [offset 0]
-        (when (< offset padded-size)
-          (let [end (min padded-size (+ offset (* chunk-size 4)))
-                chunk (.subarray buffer offset end)
-                chunk-u32 (js/Uint32Array. chunk.buffer chunk.byteOffset (quot (.-length chunk) 4))
-                offset-size (.-length chunk-u32)
-                heap-offset (mem/alloc->offset-32 (* 4 offset-size))]
-            (.set heapu32 chunk-u32 heap-offset)
-            (h/call wasm/internal-module "_set_shape_path_chunk_buffer")
-            (recur end)))))
+    (loop [offset 0]
+      (when (< offset padded-size)
+        (let [end (min padded-size (+ offset (* chunk-size 4)))
+              chunk (.subarray buffer offset end)
+              chunk-u32 (js/Uint32Array. chunk.buffer chunk.byteOffset (quot (.-length chunk) 4))
+              offset-size (.-length chunk-u32)
+              heap-offset (mem/alloc->offset-32 (* 4 offset-size))
+              ;; the allocation (and the previous chunk upload) can grow
+              ;; WASM memory, detaching older views: fetch the heap after
+              ;; every allocating call (see issue #10647)
+              heapu32 (mem/get-heap-u32)]
+          (.set heapu32 chunk-u32 heap-offset)
+          (h/call wasm/internal-module "_set_shape_path_chunk_buffer")
+          (recur end))))
     (h/call wasm/internal-module "_set_shape_path_buffer")))
 
 (defn set-shape-svg-raw-content
@@ -1815,9 +1826,11 @@
 (defn set-focus-mode
   [entries]
   (when-not ^boolean (empty? entries)
+    ;; NOTE: the heap view is fetched after the allocation: growing
+    ;; memory detaches previously captured views (see issue #10647)
     (let [size   (mem/get-alloc-size entries UUID-U8-SIZE)
-          heap   (mem/get-heap-u32)
-          offset (mem/alloc->offset-32 size)]
+          offset (mem/alloc->offset-32 size)
+          heap   (mem/get-heap-u32)]
 
       (reduce (fn [offset id]
                 (mem.h32/write-uuid offset heap id))
@@ -1838,10 +1851,12 @@
   Used for viewer fixed-scroll layers; does not change shape hidden flags."
   [shape-ids]
   (when (and (initialized?) (seq shape-ids))
+    ;; NOTE: the heap view is fetched after the allocation: growing
+    ;; memory detaches previously captured views (see issue #10647)
     (let [ids    (vec shape-ids)
           size   (mem/get-alloc-size ids UUID-U8-SIZE)
-          heap   (mem/get-heap-u32)
-          offset (mem/alloc->offset-32 size)]
+          offset (mem/alloc->offset-32 size)
+          heap   (mem/get-heap-u32)]
       (reduce (fn [offset id]
                 (mem.h32/write-uuid offset heap id))
               offset
@@ -1872,10 +1887,14 @@
 (defn propagate-modifiers
   [entries pixel-precision]
   (when-not ^boolean (empty? entries)
-    (let [heapf32 (mem/get-heap-f32)
-          heapu32 (mem/get-heap-u32)
-          size    (mem/get-alloc-size entries INPUT-MODIFIER-U8-SIZE)
-          offset  (mem/alloc->offset-32 size)]
+    ;; NOTE: heap views are (re)fetched after every allocating call:
+    ;; both _alloc_bytes and _propagate_modifiers (which allocates the
+    ;; result buffer) can grow WASM memory, and growth detaches any
+    ;; previously captured view (see issue #10647).
+    (let [size    (mem/get-alloc-size entries INPUT-MODIFIER-U8-SIZE)
+          offset  (mem/alloc->offset-32 size)
+          heapf32 (mem/get-heap-f32)
+          heapu32 (mem/get-heap-u32)]
 
       (reduce (fn [offset [id data]]
                 (let [transform (:transform data)
@@ -1889,6 +1908,8 @@
 
       (let [offset     (-> (h/call wasm/internal-module "_propagate_modifiers" pixel-precision)
                            (mem/->offset-32))
+            heapf32    (mem/get-heap-f32)
+            heapu32    (mem/get-heap-u32)
             length     (aget heapu32 offset)
             max-offset (+ offset 1 (* length MODIFIER-U32-SIZE))
             result     (loop [result (transient [])
@@ -1908,17 +1929,19 @@
   (when-not ^boolean (empty? entries)
     (let [size    (mem/get-alloc-size entries UUID-U8-SIZE)
           offset  (mem/alloc->offset-32 size)
-          heapu32 (mem/get-heap-u32)
-          heapf32 (mem/get-heap-f32)]
+          heapu32 (mem/get-heap-u32)]
 
       (reduce (fn [offset id]
                 (mem.h32/write-uuid offset heapu32 id))
               offset
               entries)
 
-      (let [offset (-> (h/call wasm/internal-module "_get_selection_rect")
-                       (mem/->offset-32))
-            result (dr/read-selection-rect heapf32 offset)]
+      ;; the result buffer allocation can grow WASM memory: fetch the
+      ;; view after the call (see issue #10647)
+      (let [offset  (-> (h/call wasm/internal-module "_get_selection_rect")
+                        (mem/->offset-32))
+            heapf32 (mem/get-heap-f32)
+            result  (dr/read-selection-rect heapf32 offset)]
         (mem/free)
         result))))
 
@@ -2472,15 +2495,17 @@
   ;; buffer) can grow WASM memory, and growth detaches any previously
   ;; captured view (see issue #10647).
   (let [size   (mem/get-alloc-size ids UUID-U8-SIZE)
-        offset (mem/alloc->offset-32 size)
-        heap   (mem/get-heap-u32)]
-
-    (reduce (fn [offset id]
-              (mem.h32/write-uuid offset heap id))
-            offset
-            (rseq ids))
-
+        offset (mem/alloc->offset-32 size)]
+    ;; From this point the staging buffer is allocated on the wasm side:
+    ;; any failure must release it or the next _alloc_bytes anywhere in
+    ;; the app fails with "Bytes already allocated".
     (try
+      (let [heap (mem/get-heap-u32)]
+        (reduce (fn [offset id]
+                  (mem.h32/write-uuid offset heap id))
+                offset
+                (rseq ids)))
+
       (let [offset
             (-> (h/call wasm/internal-module "_calculate_bool" (sr/translate-bool-type bool-type))
                 (mem/->offset-32))
@@ -2494,37 +2519,65 @@
         (mem/free)
         content)
       (catch :default cause
-        (mem/free)
+        ;; best-effort cleanup: it must never mask the original failure
+        (try (mem/free) (catch :default _ nil))
         (throw cause)))))
 
 (defn calculate-bool
   [shape objects]
+  ;; The operands are normalized exactly like the CLJS fallback
+  ;; (calc-bool-content* in app.common.types.path): missing ids, hidden
+  ;; children and svg-raw children do not participate in the operation.
+  (let [ids (into []
+                  (comp (keep (d/getf objects))
+                        (remove :hidden)
+                        (remove cfh/svg-raw-shape?)
+                        (map :id))
+                  (get shape :shapes))]
+    (cond
+      ;; The hook in app.common.types.path is installed at boot, before
+      ;; the async module load finishes: compute through the CLJS
+      ;; fallback instead of calling into an unavailable module.
+      (not (initialized?))
+      (path/calc-bool-content shape objects)
 
-  ;; We need to be able to calculate the boolean data but we cannot
-  ;; depend on the serialization flow.
-  ;; start_temp_object / end_temp_object create a new shapes_pool
-  ;; temporary and then we serialize the objects needed to calculate the
-  ;; boolean object.
-  ;; After the content is returned we discard that temporary context
-  (h/call wasm/internal-module "_start_temp_objects")
+      ;; No effective operands: empty content, without paying the
+      ;; temporary-pool churn nor a zero-byte allocation.
+      (empty? ids)
+      (path.impl/path-data nil)
 
-  ;; NOTE: without the finally, a failure in the body leaves the
-  ;; temporary pool active and every subsequent call panics in
-  ;; _start_temp_objects (see issue #10647).
-  (try
-    (let [bool-type (get shape :bool-type)
-          ids (get shape :shapes)
-          all-children
-          (->> ids
-               (mapcat #(cfh/get-children-with-self objects %)))]
+      :else
+      (do
+        ;; We need to be able to calculate the boolean data but we cannot
+        ;; depend on the serialization flow.
+        ;; start_temp_object / end_temp_object create a new shapes_pool
+        ;; temporary and then we serialize the objects needed to calculate the
+        ;; boolean object.
+        ;; After the content is returned we discard that temporary context
+        (h/call wasm/internal-module "_start_temp_objects")
 
-      (h/call wasm/internal-module "_init_shapes_pool" (count all-children))
-      (run! set-object all-children)
+        ;; NOTE: the temporary pool must be discarded on every path: a
+        ;; failure that leaves it active makes every subsequent call
+        ;; panic in _start_temp_objects (see issue #10647). On the
+        ;; failure path the cleanup is best-effort so it never masks
+        ;; the original error.
+        (try
+          (let [bool-type (get shape :bool-type)
+                all-children
+                (->> ids
+                     (mapcat #(cfh/get-children-with-self objects %)))]
 
-      (-> (calculate-bool* bool-type ids)
-          (path.impl/path-data)))
-    (finally
-      (h/call wasm/internal-module "_end_temp_objects"))))
+            (h/call wasm/internal-module "_init_shapes_pool" (count all-children))
+            (run! set-object all-children)
+
+            (let [content (-> (calculate-bool* bool-type ids)
+                              (path.impl/path-data))]
+              (h/call wasm/internal-module "_end_temp_objects")
+              content))
+          (catch :default cause
+            (try (h/call wasm/internal-module "_end_temp_objects")
+                 (catch :default _ nil))
+            (throw cause)))))))
 
 (def POSITION-DATA-U8-SIZE 36)
 (def POSITION-DATA-U32-SIZE (/ POSITION-DATA-U8-SIZE 4))
@@ -2533,10 +2586,12 @@
   [shape]
   (when (initialized?)
     (use-shape (:id shape))
-    (let [heapf32 (mem/get-heap-f32)
-          heapu32 (mem/get-heap-u32)
-          offset (-> (h/call wasm/internal-module "_calculate_position_data")
+    ;; the result buffer allocation can grow WASM memory: fetch the
+    ;; views after the call (see issue #10647)
+    (let [offset (-> (h/call wasm/internal-module "_calculate_position_data")
                      (mem/->offset-32))
+          heapf32 (mem/get-heap-f32)
+          heapu32 (mem/get-heap-u32)
           length (aget heapu32 offset)
 
           max-offset (+ offset 1 (* length POSITION-DATA-U32-SIZE))

--- a/frontend/test/frontend_tests/data/workspace_modifiers_test.cljs
+++ b/frontend/test/frontend_tests/data/workspace_modifiers_test.cljs
@@ -1,0 +1,80 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns frontend-tests.data.workspace-modifiers-test
+  "Tests for the bool recomputation ordering after applying modifiers
+   (issue #10647 follow-up).
+
+   The wasm boolean calculation uses the STORED content of nested bool
+   children (the CLJS fallback recomputes them recursively), so when a
+   drag triggers the recalculation of several nested bools, the inner
+   ones must be recomputed before the outer ones read their content.
+   Two facts make that ordering sufficient:
+
+   - update-shapes processes ids one at a time, and each step is folded
+     into the changes' file-data (apply-changes-local), so later steps
+     observe earlier results (pinned here).
+   - the bool ids produced for the update are ordered children before
+     parents (pinned here)."
+  (:require
+   [app.common.files.changes-builder :as pcb]
+   [app.common.logic.shapes :as cls]
+   [app.common.types.shape :as cts]
+   [app.common.uuid :as uuid]
+   [app.main.data.workspace.modifiers :as dwm]
+   [cljs.test :as t :include-macros true]))
+
+(defn- make-shape
+  [id type parent-id children-ids]
+  (cts/setup-shape
+   (cond-> {:id id
+            :type type
+            :parent-id parent-id
+            :frame-id uuid/zero
+            :x 0 :y 0 :width 10 :height 10}
+     (= type :bool) (assoc :bool-type :union)
+     (some? children-ids) (assoc :shapes children-ids))))
+
+(defn- nested-bool-objects
+  "root frame ⊃ outer bool ⊃ inner bool ⊃ rect, plus a sibling rect
+   directly inside the outer bool."
+  []
+  (let [outer-id (uuid/next)
+        inner-id (uuid/next)
+        rect-a   (uuid/next)
+        rect-b   (uuid/next)]
+    {:ids     {:outer outer-id :inner inner-id :rect-a rect-a :rect-b rect-b}
+     :objects {uuid/zero (make-shape uuid/zero :frame nil [outer-id])
+               outer-id  (make-shape outer-id :bool uuid/zero [inner-id rect-b])
+               inner-id  (make-shape inner-id :bool outer-id [rect-a])
+               rect-a    (make-shape rect-a :rect inner-id nil)
+               rect-b    (make-shape rect-b :rect outer-id nil)}}))
+
+(t/deftest bool-ids-ordered-children-before-parents
+  "The bool ancestors of the moved shapes must come out children-first,
+   so an outer bool is recomputed after its nested bool."
+  (let [{:keys [ids objects]} (nested-bool-objects)
+        {:keys [outer inner rect-a]} ids
+        result (dwm/bool-ids-children-first objects [rect-a])]
+    (t/is (= #{outer inner} (set result)) "both bool ancestors present, deduped")
+    (t/is (< (.indexOf result inner) (.indexOf result outer))
+          "the nested bool comes before the outer bool")))
+
+(t/deftest update-shapes-steps-observe-earlier-results
+  "generate-update-shapes must fold each shape's update into the
+   objects that the next shape's update-fn receives: the children-first
+   ordering only fixes nested bools because of this."
+  (let [{:keys [ids objects]} (nested-bool-objects)
+        {:keys [outer inner]} ids
+        seen (atom {})
+        update-fn (fn [shape objects']
+                    (swap! seen assoc (:id shape) (get-in objects' [inner :marker]))
+                    (assoc shape :marker :updated))]
+    (-> (pcb/empty-changes nil uuid/zero)
+        (cls/generate-update-shapes [inner outer] update-fn objects {:with-objects? true}))
+    (t/is (nil? (get @seen inner)) "the first step sees the original objects")
+    (t/is (= :updated (get @seen outer))
+          "the second step sees the first step's result")))

--- a/frontend/test/frontend_tests/render_wasm/calculate_bool_test.cljs
+++ b/frontend/test/frontend_tests/render_wasm/calculate_bool_test.cljs
@@ -1,0 +1,196 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns frontend-tests.render-wasm.calculate-bool-test
+  "Unit tests for wasm.api/calculate-bool (issue #10647).
+
+   calculate-bool wraps the WASM boolean calculation in a temporary
+   shapes pool (_start_temp_objects / _end_temp_objects). Two invariants
+   are pinned here:
+
+   1. The temporary pool must ALWAYS be discarded, even when the body
+      throws. If it leaks, every subsequent boolean recalculation panics
+      in _start_temp_objects ('previous have not been restored') and the
+      workspace shows the internal-error screen.
+
+   2. WASM heap views (module.HEAPU32) are replaced by Emscripten when
+      linear memory grows — any view captured before an allocating call
+      goes stale. calculate-bool* must (re)fetch the heap AFTER
+      _alloc_bytes (for the UUID writes) and AFTER _calculate_bool (for
+      reading the result), because both can grow memory."
+  (:require
+   [app.common.uuid :as uuid]
+   [app.render-wasm.api :as wasm.api]
+   [app.render-wasm.wasm :as wasm]
+   [cljs.test :as t :include-macros true]))
+
+;; ---------------------------------------------------------------------------
+;; Fake WASM module
+;; ---------------------------------------------------------------------------
+
+(def ^:private HEAP-U32-LEN 4096)
+
+(defn- make-fake-module
+  "Builds a fake Emscripten module implementing the entry points that
+   calculate-bool touches. State is tracked in the returned map's atoms.
+
+   Options:
+   - :grow-on-alloc? — _alloc_bytes replaces HEAPU32 with a fresh view
+     (simulates memory growth detaching previously captured views).
+   - :grow-on-calc?  — _calculate_bool replaces HEAPU32 with a fresh view
+     that carries the result; the old view holds garbage at the result
+     offset (what a stale view would read after growth)."
+  [{:keys [grow-on-alloc? grow-on-calc?]}]
+  (let [temp-open?   (atom false)
+        temp-starts  (atom 0)
+        temp-ends    (atom 0)
+        received-u32 (atom nil)
+        module       #js {}
+        result-off32 128]
+
+    (unchecked-set module "HEAPU32" (js/Uint32Array. HEAP-U32-LEN))
+
+    (unchecked-set module "_read_error_code" (fn [] 2))
+
+    (unchecked-set module "_start_temp_objects"
+                   (fn []
+                     (swap! temp-starts inc)
+                     (when @temp-open?
+                       (throw (js/Error. "Tried to start a temp objects while the previous have not been restored")))
+                     (reset! temp-open? true)
+                     js/undefined))
+
+    (unchecked-set module "_end_temp_objects"
+                   (fn []
+                     (swap! temp-ends inc)
+                     (when-not @temp-open?
+                       (throw (js/Error. "Tried to end temp objects but not content to be restored is present")))
+                     (reset! temp-open? false)
+                     js/undefined))
+
+    (unchecked-set module "_init_shapes_pool" (fn [_n] js/undefined))
+    (unchecked-set module "_free_bytes" (fn [] js/undefined))
+
+    (unchecked-set module "_alloc_bytes"
+                   (fn [_size]
+                     (when grow-on-alloc?
+                       ;; Emscripten reassigns module.HEAPU32 to a view over
+                       ;; the new (larger) buffer; old views go stale.
+                       (unchecked-set module "HEAPU32" (js/Uint32Array. HEAP-U32-LEN)))
+                     ;; byte offset where the caller must write its input
+                     0))
+
+    (unchecked-set module "_calculate_bool"
+                   (fn [_bool-type]
+                     ;; capture what the caller actually wrote into the
+                     ;; CURRENT heap view (the wasm side reads this memory)
+                     (let [heap (unchecked-get module "HEAPU32")]
+                       (reset! received-u32 (vec (.slice ^js heap 0 8))))
+                     (let [old-heap (unchecked-get module "HEAPU32")]
+                       (when grow-on-calc?
+                         ;; poison the old view at the result offset, then
+                         ;; grow: the result only exists in the new view
+                         (aset old-heap result-off32 1234567)
+                         (unchecked-set module "HEAPU32" (js/Uint32Array. HEAP-U32-LEN)))
+                       (let [heap (unchecked-get module "HEAPU32")]
+                         ;; result: [length=0] → empty path content
+                         (aset heap result-off32 0)))
+                     ;; byte offset of the result
+                     (* 4 result-off32)))
+
+    {:module       module
+     :temp-open?   temp-open?
+     :temp-starts  temp-starts
+     :temp-ends    temp-ends
+     :received-u32 received-u32}))
+
+(defn- with-fake-wasm*
+  "Installs `module` as the active WASM module and `set-object-fn` as
+   wasm.api/set-object, runs (thunk), then restores the originals."
+  [module set-object-fn thunk]
+  (let [orig-module     wasm/internal-module
+        orig-set-object wasm.api/set-object]
+    (set! wasm/internal-module module)
+    (set! wasm.api/set-object set-object-fn)
+    (try
+      (thunk)
+      (finally
+        (set! wasm/internal-module orig-module)
+        (set! wasm.api/set-object orig-set-object)))))
+
+(defn- make-bool-fixture
+  []
+  (let [child-a (uuid/next)
+        child-b (uuid/next)
+        bool-id (uuid/next)]
+    {:child-a child-a
+     :child-b child-b
+     :shape   {:id bool-id :type :bool :bool-type :union :shapes [child-a child-b]}
+     :objects {child-a {:id child-a :type :path}
+               child-b {:id child-b :type :path}}}))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(t/deftest temp-objects-closed-when-body-throws
+  "If anything inside calculate-bool throws (serialization, allocation,
+   the boolean op itself), the temporary pool must still be discarded so
+   the next boolean recalculation does not panic in _start_temp_objects."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        {:keys [module temp-open? temp-ends]} (make-fake-module {})
+        boom (fn [_shape] (throw (js/Error. "set-object failed")))]
+    (with-fake-wasm* module boom
+      (fn []
+        (t/is (thrown? js/Error (wasm.api/calculate-bool shape objects))
+              "the original failure must propagate")
+        (t/is (= 1 @temp-ends) "_end_temp_objects called despite the throw")
+        (t/is (false? @temp-open?) "temporary pool discarded")))))
+
+(t/deftest calculate-bool-recovers-after-previous-failure
+  "A failed calculate-bool must not poison subsequent calls (issue #10647:
+   the reported panic is the SECOND call finding the temp pool still open)."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        {:keys [module temp-open?]} (make-fake-module {})
+        calls (atom 0)
+        ;; first call throws mid-body, later calls succeed
+        flaky (fn [_shape]
+                (when (= 1 (swap! calls inc))
+                  (throw (js/Error. "transient failure"))))]
+    (with-fake-wasm* module flaky
+      (fn []
+        (t/is (thrown? js/Error (wasm.api/calculate-bool shape objects)))
+        (let [content (wasm.api/calculate-bool shape objects)]
+          (t/is (some? content) "second call succeeds after a failed one"))
+        (t/is (false? @temp-open?))))))
+
+(t/deftest uuid-writes-survive-memory-growth-on-alloc
+  "_alloc_bytes can grow WASM memory, detaching any heap view captured
+   before it. The child UUIDs must land in the CURRENT heap view or the
+   wasm side reads zeros (→ 'Invalid UUID' error → leaked temp pool)."
+  (let [{:keys [shape objects child-a child-b]} (make-bool-fixture)
+        {:keys [module received-u32]} (make-fake-module {:grow-on-alloc? true})
+        ;; calculate-bool* writes the ids in reverse order (rseq)
+        expected (into (vec (uuid/get-u32 child-b))
+                       (vec (uuid/get-u32 child-a)))]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (wasm.api/calculate-bool shape objects)
+        (t/is (= expected @received-u32)
+              "wasm reads the ids from the heap that is current after alloc")))))
+
+(t/deftest result-read-from-current-heap-after-calculate
+  "_calculate_bool allocates the result buffer, which can also grow
+   memory. The result must be read through a heap view fetched AFTER the
+   call; a stale view sees garbage at the result offset."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        {:keys [module temp-open?]} (make-fake-module {:grow-on-calc? true})]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (let [content (wasm.api/calculate-bool shape objects)]
+          (t/is (zero? (count content))
+                "empty result parsed from the post-growth heap view"))
+        (t/is (false? @temp-open?))))))

--- a/frontend/test/frontend_tests/render_wasm/calculate_bool_test.cljs
+++ b/frontend/test/frontend_tests/render_wasm/calculate_bool_test.cljs
@@ -8,20 +8,43 @@
   "Unit tests for wasm.api/calculate-bool (issue #10647).
 
    calculate-bool wraps the WASM boolean calculation in a temporary
-   shapes pool (_start_temp_objects / _end_temp_objects). Two invariants
-   are pinned here:
+   shapes pool (_start_temp_objects / _end_temp_objects) and a staging
+   buffer (_alloc_bytes / consuming call / _free_bytes). The invariants
+   pinned here:
 
    1. The temporary pool must ALWAYS be discarded, even when the body
       throws. If it leaks, every subsequent boolean recalculation panics
       in _start_temp_objects ('previous have not been restored') and the
       workspace shows the internal-error screen.
 
-   2. WASM heap views (module.HEAPU32) are replaced by Emscripten when
+   2. The Rust staging buffer must never be left allocated: a leaked
+      buffer makes the NEXT _alloc_bytes anywhere in the app fail with
+      'Bytes already allocated' — a delayed panic misattributed to an
+      unrelated operation.
+
+   3. WASM heap views (module.HEAPU32) are replaced by Emscripten when
       linear memory grows — any view captured before an allocating call
       goes stale. calculate-bool* must (re)fetch the heap AFTER
       _alloc_bytes (for the UUID writes) and AFTER _calculate_bool (for
-      reading the result), because both can grow memory."
+      reading the result), because both can grow memory.
+
+   4. Operand ids are normalized like the CLJS fallback
+      (calc-bool-content* in app.common.types.path): missing ids,
+      hidden children and svg-raw children do not participate. Without
+      this, wasm and the fallback produce different persisted geometry
+      for the same document, and a missing base child silently empties
+      the whole bool.
+
+   5. When the calculation fails, the surfaced error must be the
+      ORIGINAL failure, not a follow-up error from cleanup calls on a
+      dead module.
+
+   6. When the wasm render context is not ready, calculate-bool must
+      compute through the CLJS fallback instead of crashing on an empty
+      module."
   (:require
+   [app.common.types.path :as path]
+   [app.common.types.path.impl :as path.impl]
    [app.common.uuid :as uuid]
    [app.render-wasm.api :as wasm.api]
    [app.render-wasm.wasm :as wasm]
@@ -33,20 +56,40 @@
 
 (def ^:private HEAP-U32-LEN 4096)
 
+(defn- path-data->u32
+  "Return the raw u32 words of a PathData instance."
+  [pd]
+  (let [^js dview (.-buffer pd)]
+    (js/Uint32Array. (.-buffer dview)
+                     (.-byteOffset dview)
+                     (/ (.-byteLength dview) 4))))
+
 (defn- make-fake-module
   "Builds a fake Emscripten module implementing the entry points that
    calculate-bool touches. State is tracked in the returned map's atoms.
+
+   The staging buffer semantics mirror render-wasm/src/wasm/mem.rs:
+   _alloc_bytes fails when a buffer is already staged; the consuming
+   call (_calculate_bool) takes it; _free_bytes discards it.
 
    Options:
    - :grow-on-alloc? — _alloc_bytes replaces HEAPU32 with a fresh view
      (simulates memory growth detaching previously captured views).
    - :grow-on-calc?  — _calculate_bool replaces HEAPU32 with a fresh view
      that carries the result; the old view holds garbage at the result
-     offset (what a stale view would read after growth)."
-  [{:keys [grow-on-alloc? grow-on-calc?]}]
+     offset (what a stale view would read after growth).
+   - :die-on-calc?   — _calculate_bool throws after consuming the staged
+     buffer (models a wasm-side failure).
+   - :dead-cleanup?  — _free_bytes and _end_temp_objects throw (models a
+     module that cannot service further calls after a fatal failure).
+   - :result-segments — PathData written as the _calculate_bool result
+     (defaults to an empty result)."
+  [{:keys [grow-on-alloc? grow-on-calc? die-on-calc? dead-cleanup? result-segments]}]
   (let [temp-open?   (atom false)
         temp-starts  (atom 0)
         temp-ends    (atom 0)
+        staged?      (atom false)
+        alloc-sizes  (atom [])
         received-u32 (atom nil)
         module       #js {}
         result-off32 128]
@@ -66,16 +109,28 @@
     (unchecked-set module "_end_temp_objects"
                    (fn []
                      (swap! temp-ends inc)
+                     (when dead-cleanup?
+                       (throw (js/Error. "end_temp_objects failed (dead module)")))
                      (when-not @temp-open?
                        (throw (js/Error. "Tried to end temp objects but not content to be restored is present")))
                      (reset! temp-open? false)
                      js/undefined))
 
     (unchecked-set module "_init_shapes_pool" (fn [_n] js/undefined))
-    (unchecked-set module "_free_bytes" (fn [] js/undefined))
+
+    (unchecked-set module "_free_bytes"
+                   (fn []
+                     (when dead-cleanup?
+                       (throw (js/Error. "free_bytes failed (dead module)")))
+                     (reset! staged? false)
+                     js/undefined))
 
     (unchecked-set module "_alloc_bytes"
-                   (fn [_size]
+                   (fn [size]
+                     (when @staged?
+                       (throw (js/Error. "Bytes already allocated")))
+                     (reset! staged? true)
+                     (swap! alloc-sizes conj size)
                      (when grow-on-alloc?
                        ;; Emscripten reassigns module.HEAPU32 to a view over
                        ;; the new (larger) buffer; old views go stale.
@@ -87,17 +142,27 @@
                    (fn [_bool-type]
                      ;; capture what the caller actually wrote into the
                      ;; CURRENT heap view (the wasm side reads this memory)
-                     (let [heap (unchecked-get module "HEAPU32")]
-                       (reset! received-u32 (vec (.slice ^js heap 0 8))))
+                     (let [heap  (unchecked-get module "HEAPU32")
+                           words (/ (or (peek @alloc-sizes) 0) 4)]
+                       (reset! received-u32 (vec (.slice ^js heap 0 words))))
+                     ;; the staged input is consumed (bytes_or_empty)
+                     (reset! staged? false)
+                     (when die-on-calc?
+                       (throw (js/Error. "original failure")))
                      (let [old-heap (unchecked-get module "HEAPU32")]
                        (when grow-on-calc?
                          ;; poison the old view at the result offset, then
                          ;; grow: the result only exists in the new view
                          (aset old-heap result-off32 1234567)
                          (unchecked-set module "HEAPU32" (js/Uint32Array. HEAP-U32-LEN)))
-                       (let [heap (unchecked-get module "HEAPU32")]
-                         ;; result: [length=0] → empty path content
-                         (aset heap result-off32 0)))
+                       (let [heap   (unchecked-get module "HEAPU32")
+                             result (some-> result-segments path-data->u32)
+                             length (if result
+                                      (/ (.-length ^js result) path.impl/SEGMENT-U32-SIZE)
+                                      0)]
+                         (aset heap result-off32 length)
+                         (when result
+                           (.set ^js heap result (inc result-off32)))))
                      ;; byte offset of the result
                      (* 4 result-off32)))
 
@@ -105,21 +170,37 @@
      :temp-open?   temp-open?
      :temp-starts  temp-starts
      :temp-ends    temp-ends
+     :staged?      staged?
+     :alloc-sizes  alloc-sizes
      :received-u32 received-u32}))
 
 (defn- with-fake-wasm*
-  "Installs `module` as the active WASM module and `set-object-fn` as
-   wasm.api/set-object, runs (thunk), then restores the originals."
+  "Installs `module` as the active WASM module, `set-object-fn` as
+   wasm.api/set-object and forces wasm.api/initialized? to true, runs
+   (thunk), then restores the originals."
   [module set-object-fn thunk]
-  (let [orig-module     wasm/internal-module
-        orig-set-object wasm.api/set-object]
+  (let [orig-module       wasm/internal-module
+        orig-set-object   wasm.api/set-object
+        orig-initialized? wasm.api/initialized?]
     (set! wasm/internal-module module)
     (set! wasm.api/set-object set-object-fn)
+    (set! wasm.api/initialized? (constantly true))
     (try
       (thunk)
       (finally
         (set! wasm/internal-module orig-module)
-        (set! wasm.api/set-object orig-set-object)))))
+        (set! wasm.api/set-object orig-set-object)
+        (set! wasm.api/initialized? orig-initialized?)))))
+
+(defn- square-content
+  "A simple closed square path as PathData."
+  [x y size]
+  (path.impl/from-plain
+   [{:command :move-to :params {:x x :y y}}
+    {:command :line-to :params {:x (+ x size) :y y}}
+    {:command :line-to :params {:x (+ x size) :y (+ y size)}}
+    {:command :line-to :params {:x x :y (+ y size)}}
+    {:command :close-path :params {}}]))
 
 (defn- make-bool-fixture
   []
@@ -133,7 +214,7 @@
                child-b {:id child-b :type :path}}}))
 
 ;; ---------------------------------------------------------------------------
-;; Tests
+;; Temp pool and staging buffer lifecycle
 ;; ---------------------------------------------------------------------------
 
 (t/deftest temp-objects-closed-when-body-throws
@@ -167,6 +248,45 @@
           (t/is (some? content) "second call succeeds after a failed one"))
         (t/is (false? @temp-open?))))))
 
+(t/deftest staging-buffer-released-when-calculation-fails
+  "A wasm-side failure in _calculate_bool must leave no staged bytes
+   behind: a leaked staging buffer makes the next _alloc_bytes anywhere
+   in the app fail with 'Bytes already allocated'."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        {:keys [module staged? temp-open?]} (make-fake-module {:die-on-calc? true})]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (t/is (thrown? js/Error (wasm.api/calculate-bool shape objects)))
+        (t/is (false? @staged?) "staging buffer released after the failure")
+        (t/is (false? @temp-open?) "temporary pool discarded")))
+    ;; a fresh, healthy module must now work: nothing global was poisoned
+    (let [{:keys [module]} (make-fake-module {})]
+      (with-fake-wasm* module (fn [_shape] nil)
+        (fn []
+          (t/is (some? (wasm.api/calculate-bool shape objects))
+                "subsequent calculations succeed"))))))
+
+(t/deftest original-error-not-masked-by-failing-cleanup
+  "When the module cannot service the cleanup calls after a failure
+   (_free_bytes/_end_temp_objects also throw), the error surfaced to the
+   caller must still be the ORIGINAL failure from _calculate_bool, not a
+   misattributed cleanup error."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        {:keys [module]} (make-fake-module {:die-on-calc? true :dead-cleanup? true})]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (let [err (try
+                    (wasm.api/calculate-bool shape objects)
+                    nil
+                    (catch :default cause cause))]
+          (t/is (some? err) "the failure propagates")
+          (t/is (= "_calculate_bool" (:fn (ex-data err)))
+                "the surfaced error is the original one, not a cleanup error"))))))
+
+;; ---------------------------------------------------------------------------
+;; Heap views across memory growth
+;; ---------------------------------------------------------------------------
+
 (t/deftest uuid-writes-survive-memory-growth-on-alloc
   "_alloc_bytes can grow WASM memory, detaching any heap view captured
    before it. The child UUIDs must land in the CURRENT heap view or the
@@ -194,3 +314,92 @@
           (t/is (zero? (count content))
                 "empty result parsed from the post-growth heap view"))
         (t/is (false? @temp-open?))))))
+
+(t/deftest non-empty-result-read-across-memory-growth
+  "Same as above but with real segments: the segment payload (not just
+   the length word) must be read from the post-growth heap view."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        square (square-content 0 0 10)
+        {:keys [module]} (make-fake-module {:grow-on-calc? true
+                                            :result-segments square})]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (let [content (wasm.api/calculate-bool shape objects)]
+          (t/is (= 5 (count content)) "all segments read")
+          (t/is (= square content) "segment payload identical to what wasm wrote"))))))
+
+;; ---------------------------------------------------------------------------
+;; Operand normalization (parity with the CLJS fallback)
+;; ---------------------------------------------------------------------------
+
+(t/deftest operand-ids-normalized-like-the-cljs-fallback
+  "Hidden children, svg-raw children, missing ids and junk entries must
+   not participate in the boolean operation — same filtering as
+   calc-bool-content* in app.common.types.path. Without this a hidden
+   child still shapes the wasm geometry, and junk/missing entries crash
+   or silently change the result."
+  (let [visible  (uuid/next)
+        hidden   (uuid/next)
+        svg-raw  (uuid/next)
+        missing  (uuid/next)
+        bool-id  (uuid/next)
+        shape    {:id bool-id :type :bool :bool-type :union
+                  :shapes [visible hidden svg-raw missing nil]}
+        objects  {visible {:id visible :type :path}
+                  hidden  {:id hidden :type :path :hidden true}
+                  svg-raw {:id svg-raw :type :svg-raw}}
+        {:keys [module received-u32 temp-starts temp-ends]} (make-fake-module {})]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (let [content (wasm.api/calculate-bool shape objects)]
+          (t/is (some? content) "the calculation succeeds")
+          (t/is (= (vec (uuid/get-u32 visible)) @received-u32)
+                "only the visible, existing, non-svg-raw child participates")
+          (t/is (= 1 @temp-starts))
+          (t/is (= 1 @temp-ends)))))))
+
+(t/deftest degenerate-operand-lists-short-circuit
+  "A bool with no effective operands (empty :shapes, nil :shapes, or all
+   children filtered out) must return empty content without touching the
+   wasm module at all: no temp pool churn, no zero-byte allocations."
+  (let [hidden  (uuid/next)
+        objects {hidden {:id hidden :type :path :hidden true}}]
+    (doseq [shapes [[] nil [hidden]]]
+      (let [shape {:id (uuid/next) :type :bool :bool-type :union :shapes shapes}
+            {:keys [module temp-starts alloc-sizes]} (make-fake-module {})]
+        (with-fake-wasm* module (fn [_shape] nil)
+          (fn []
+            (let [content (wasm.api/calculate-bool shape objects)]
+              (t/is (some? content) (str "returns content for :shapes " (pr-str shapes)))
+              (t/is (zero? (count content)) "content is empty")
+              (t/is (zero? @temp-starts) "no temporary pool created")
+              (t/is (empty? @alloc-sizes) "no wasm allocation performed"))))))))
+
+;; ---------------------------------------------------------------------------
+;; Module readiness
+;; ---------------------------------------------------------------------------
+
+(t/deftest falls-back-to-cljs-when-context-not-ready
+  "The wasm:calc-bool-content hook is installed at boot, before the async
+   module load finishes. In that window calculate-bool must compute the
+   content through the CLJS fallback instead of crashing on the empty
+   module object."
+  (let [child-a (uuid/next)
+        child-b (uuid/next)
+        bool-id (uuid/next)
+        objects {child-a {:id child-a :type :path :content (square-content 0 0 10)}
+                 child-b {:id child-b :type :path :content (square-content 5 5 10)}}
+        shape   {:id bool-id :type :bool :bool-type :union :shapes [child-a child-b]}
+        orig-module       wasm/internal-module
+        orig-initialized? wasm.api/initialized?]
+    ;; the exact boot-time state: empty module, context not initialized
+    (set! wasm/internal-module #js {})
+    (set! wasm.api/initialized? (constantly false))
+    (try
+      (let [content  (wasm.api/calculate-bool shape objects)
+            expected (path/calc-bool-content shape objects)]
+        (t/is (some? content) "no crash while the module is not ready")
+        (t/is (= expected content) "identical to the CLJS fallback result"))
+      (finally
+        (set! wasm/internal-module orig-module)
+        (set! wasm.api/initialized? orig-initialized?)))))

--- a/frontend/test/frontend_tests/render_wasm/calculate_bool_test.cljs
+++ b/frontend/test/frontend_tests/render_wasm/calculate_bool_test.cljs
@@ -80,11 +80,15 @@
      offset (what a stale view would read after growth).
    - :die-on-calc?   — _calculate_bool throws after consuming the staged
      buffer (models a wasm-side failure).
+   - :die-before-consume? — _calculate_bool throws before consuming the
+     staged buffer (models a JS-side failure between the allocation and
+     the consuming call, e.g. a write through a stale view).
    - :dead-cleanup?  — _free_bytes and _end_temp_objects throw (models a
      module that cannot service further calls after a fatal failure).
    - :result-segments — PathData written as the _calculate_bool result
      (defaults to an empty result)."
-  [{:keys [grow-on-alloc? grow-on-calc? die-on-calc? dead-cleanup? result-segments]}]
+  [{:keys [grow-on-alloc? grow-on-calc? die-on-calc? die-before-consume?
+           dead-cleanup? result-segments]}]
   (let [temp-open?   (atom false)
         temp-starts  (atom 0)
         temp-ends    (atom 0)
@@ -140,6 +144,8 @@
 
     (unchecked-set module "_calculate_bool"
                    (fn [_bool-type]
+                     (when die-before-consume?
+                       (throw (js/Error. "failure before consumption")))
                      ;; capture what the caller actually wrote into the
                      ;; CURRENT heap view (the wasm side reads this memory)
                      (let [heap  (unchecked-get module "HEAPU32")
@@ -163,6 +169,9 @@
                          (aset heap result-off32 length)
                          (when result
                            (.set ^js heap result (inc result-off32)))))
+                     ;; writing the result stages a new buffer (write_vec):
+                     ;; the caller must release it after reading
+                     (reset! staged? true)
                      ;; byte offset of the result
                      (* 4 result-off32)))
 
@@ -266,6 +275,18 @@
           (t/is (some? (wasm.api/calculate-bool shape objects))
                 "subsequent calculations succeed"))))))
 
+(t/deftest staging-buffer-released-when-failure-precedes-consumption
+  "A failure BETWEEN the allocation and the consuming call (e.g. a write
+   through a stale view) leaves the staged input buffer allocated on the
+   wasm side: the catch-side cleanup must release it."
+  (let [{:keys [shape objects]} (make-bool-fixture)
+        {:keys [module staged? temp-open?]} (make-fake-module {:die-before-consume? true})]
+    (with-fake-wasm* module (fn [_shape] nil)
+      (fn []
+        (t/is (thrown? js/Error (wasm.api/calculate-bool shape objects)))
+        (t/is (false? @staged?) "staged input buffer released by the cleanup")
+        (t/is (false? @temp-open?) "temporary pool discarded")))))
+
 (t/deftest original-error-not-masked-by-failing-cleanup
   "When the module cannot service the cleanup calls after a failure
    (_free_bytes/_end_temp_objects also throw), the error surfaced to the
@@ -320,13 +341,15 @@
    the length word) must be read from the post-growth heap view."
   (let [{:keys [shape objects]} (make-bool-fixture)
         square (square-content 0 0 10)
-        {:keys [module]} (make-fake-module {:grow-on-calc? true
-                                            :result-segments square})]
+        {:keys [module staged?]} (make-fake-module {:grow-on-calc? true
+                                                    :result-segments square})]
     (with-fake-wasm* module (fn [_shape] nil)
       (fn []
         (let [content (wasm.api/calculate-bool shape objects)]
           (t/is (= 5 (count content)) "all segments read")
-          (t/is (= square content) "segment payload identical to what wasm wrote"))))))
+          (t/is (= square content) "segment payload identical to what wasm wrote")
+          (t/is (false? @staged?)
+                "the result buffer staged by the call was freed after reading"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Operand normalization (parity with the CLJS fallback)

--- a/frontend/test/frontend_tests/render_wasm/shape_serializers_test.cljs
+++ b/frontend/test/frontend_tests/render_wasm/shape_serializers_test.cljs
@@ -211,6 +211,9 @@
                      (aset (unchecked-get module "HEAPU32") result-off32 9999)
                      (install-heap! module)
                      (aset (unchecked-get module "HEAPU32") result-off32 0)
+                     ;; writing the result stages a new buffer (write_vec):
+                     ;; the caller must release it after reading
+                     (reset! staged? true)
                      (* 4 result-off32)))
     {:module module :staged? staged? :received received}))
 
@@ -231,7 +234,78 @@
           (t/is (number? (:kind @received)))
           (t/is (= [] result)
                 "the (empty) result is read from the post-growth view")
-          (t/is (false? @staged?) "no staged buffer left behind"))))))
+          (t/is (false? @staged?)
+                "the result buffer staged by the call was freed after reading"))))))
+
+;; ---------------------------------------------------------------------------
+;; get-selection-rect / calculate-position-data (result reads across growth)
+;; ---------------------------------------------------------------------------
+
+(defn- make-result-read-module
+  "Fake module for wasm calls whose result must be read through a view
+   fetched after the call: `entry` names the export; `result-f32` are
+   the floats written at the result offset in the post-growth view. The
+   pre-growth view is poisoned at the same offset."
+  [entry result-f32]
+  (let [staged?      (atom false)
+        module       #js {}
+        result-off32 128]
+    (install-heap! module)
+    (unchecked-set module "_read_error_code" (fn [] 2))
+    (unchecked-set module "_free_bytes" (fn [] (reset! staged? false) js/undefined))
+    (unchecked-set module "_use_shape" (fn [_a _b _c _d] js/undefined))
+    (unchecked-set module "_alloc_bytes"
+                   (fn [_size]
+                     (when @staged?
+                       (throw (js/Error. "Bytes already allocated")))
+                     (reset! staged? true)
+                     (install-heap! module)
+                     0))
+    (unchecked-set module entry
+                   (fn [& _args]
+                     (reset! staged? false)
+                     (doseq [view ["HEAPU32" "HEAPF32"]]
+                       (aset (unchecked-get module view) result-off32 9999))
+                     (install-heap! module)
+                     (let [heapf32 (unchecked-get module "HEAPF32")]
+                       (dotimes [i (count result-f32)]
+                         (aset heapf32 (+ result-off32 i) (nth result-f32 i))))
+                     (reset! staged? true)
+                     (* 4 result-off32)))
+    {:module module :staged? staged?}))
+
+(t/deftest selection-rect-read-through-current-heap-view
+  "get-selection-rect must read the rect through a view fetched after
+   the call; the pre-call view holds garbage at the result offset."
+  (let [{:keys [module staged?]} (make-result-read-module
+                                  "_get_selection_rect"
+                                  [3 4 1.5 2 1 0 0 1 0 0])]
+    (with-module* module
+      (fn []
+        (let [result (wasm.api/get-selection-rect [(uuid/next)])]
+          (t/is (= 3 (:width result)) "width read from the post-growth view")
+          (t/is (= 4 (:height result)) "height read from the post-growth view")
+          (t/is (false? @staged?)
+                "the result buffer staged by the call was freed after reading"))))))
+
+(t/deftest position-data-read-through-current-heap-view
+  "calculate-position-data must read its result through views fetched
+   after the call; a zero-length result parses to no entries instead of
+   the garbage length in the stale view."
+  (let [{:keys [module staged?]} (make-result-read-module
+                                  "_calculate_position_data"
+                                  [0])
+        orig-initialized? wasm.api/initialized?]
+    (set! wasm.api/initialized? (constantly true))
+    (try
+      (with-module* module
+        (fn []
+          (let [result (wasm.api/calculate-position-data {:id (uuid/next) :content nil})]
+            (t/is (= [] result) "zero-length result parsed from the post-growth view")
+            (t/is (false? @staged?)
+                  "the result buffer staged by the call was freed after reading"))))
+      (finally
+        (set! wasm.api/initialized? orig-initialized?)))))
 
 (t/deftest fill-less-stroke-stages-no-buffer
   "A stroke without color/gradient/image has no fill payload to upload:

--- a/frontend/test/frontend_tests/render_wasm/shape_serializers_test.cljs
+++ b/frontend/test/frontend_tests/render_wasm/shape_serializers_test.cljs
@@ -1,0 +1,247 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns frontend-tests.render-wasm.shape-serializers-test
+  "Unit tests for the WASM heap discipline of shape serializers used by
+   calculate-bool (issue #10647 hardening).
+
+   Emscripten replaces module.HEAPU8/HEAPU32 with fresh views when
+   linear memory grows, so a view captured before an allocating wasm
+   call goes stale and writes through it are lost. Additionally, the
+   Rust staging buffer (_alloc_bytes) must always be consumed or freed:
+   a leaked buffer makes the NEXT _alloc_bytes anywhere in the app fail
+   with 'Bytes already allocated'.
+
+   Covered here:
+   - set-shape-path-content: every chunk must be written through a heap
+     view fetched AFTER that chunk's _alloc_bytes.
+   - set-shape-strokes: the fill payload must be written through a view
+     created AFTER the _add_shape_*_stroke call (which can grow memory),
+     and a stroke without any fill must not stage a buffer at all."
+  (:require
+   [app.common.geom.matrix :as gmt]
+   [app.common.types.fills.impl :as types.fills.impl]
+   [app.common.types.path.impl :as path.impl]
+   [app.common.uuid :as uuid]
+   [app.render-wasm.api :as wasm.api]
+   [app.render-wasm.wasm :as wasm]
+   [cljs.test :as t :include-macros true]))
+
+;; 256KiB backing buffer: one full path chunk fits exactly
+(def ^:private HEAP-U8-LEN (* 256 1024))
+
+(defn- install-heap!
+  "(Re)creates the module heap views over a fresh backing buffer,
+   the way Emscripten does after memory growth."
+  [module]
+  (let [buffer (js/ArrayBuffer. HEAP-U8-LEN)]
+    (unchecked-set module "HEAPU8" (js/Uint8Array. buffer))
+    (unchecked-set module "HEAPU32" (js/Uint32Array. buffer))
+    (unchecked-set module "HEAPF32" (js/Float32Array. buffer))))
+
+(defn- with-module*
+  [module thunk]
+  (let [orig wasm/internal-module]
+    (set! wasm/internal-module module)
+    (try
+      (thunk)
+      (finally
+        (set! wasm/internal-module orig)))))
+
+(defn- path-data->u32
+  [pd]
+  (let [^js dview (.-buffer pd)]
+    (js/Uint32Array. (.-buffer dview)
+                     (.-byteOffset dview)
+                     (/ (.-byteLength dview) 4))))
+
+(defn- big-path-content
+  "A path large enough to need more than one 256KiB upload chunk."
+  [segment-count]
+  (path.impl/from-plain
+   (into [{:command :move-to :params {:x 0 :y 0}}]
+         (map (fn [i] {:command :line-to :params {:x i :y (inc i)}}))
+         (range (dec segment-count)))))
+
+;; ---------------------------------------------------------------------------
+;; set-shape-path-content
+;; ---------------------------------------------------------------------------
+
+(defn- make-path-module
+  "Fake module for set-shape-path-content. Every _alloc_bytes grows the
+   heap (replaces the views); _set_shape_path_chunk_buffer reads the
+   chunk from the CURRENT view, like the wasm side does."
+  []
+  (let [staged?     (atom false)
+        alloc-sizes (atom [])
+        received    (atom [])
+        module      #js {}]
+    (install-heap! module)
+    (unchecked-set module "_read_error_code" (fn [] 2))
+    (unchecked-set module "_start_shape_path_buffer" (fn [] js/undefined))
+    (unchecked-set module "_set_shape_path_buffer" (fn [] js/undefined))
+    (unchecked-set module "_alloc_bytes"
+                   (fn [size]
+                     (when @staged?
+                       (throw (js/Error. "Bytes already allocated")))
+                     (reset! staged? true)
+                     (swap! alloc-sizes conj size)
+                     ;; growth on every allocation: old views go stale
+                     (install-heap! module)
+                     0))
+    (unchecked-set module "_set_shape_path_chunk_buffer"
+                   (fn []
+                     (reset! staged? false)
+                     (let [heap  (unchecked-get module "HEAPU32")
+                           words (/ (peek @alloc-sizes) 4)]
+                       (swap! received into (vec (.slice ^js heap 0 words))))
+                     js/undefined))
+    {:module module :staged? staged? :alloc-sizes alloc-sizes :received received}))
+
+(t/deftest path-chunks-written-through-current-heap-view
+  "Each chunk's bytes must land in the heap view that is current after
+   that chunk's allocation; a view captured before the loop loses every
+   chunk once memory grows."
+  (let [content  (big-path-content 9500)
+        expected (vec (path-data->u32 content))
+        {:keys [module staged? alloc-sizes received]} (make-path-module)]
+    (with-module* module
+      (fn []
+        (wasm.api/set-shape-path-content content)
+        (t/is (= 2 (count @alloc-sizes)) "the content needs two chunks")
+        (t/is (= expected @received)
+              "wasm received exactly the content bytes across all chunks")
+        (t/is (false? @staged?) "no staged buffer left behind")))))
+
+;; ---------------------------------------------------------------------------
+;; set-shape-strokes
+;; ---------------------------------------------------------------------------
+
+(defn- make-strokes-module
+  "Fake module for set-shape-strokes. _add_shape_*_stroke grows the heap
+   (replaces the views); _add_shape_stroke_fill consumes the staged fill
+   payload from the CURRENT view."
+  []
+  (let [staged?     (atom false)
+        alloc-sizes (atom [])
+        fills       (atom [])
+        module      #js {}]
+    (install-heap! module)
+    (unchecked-set module "_read_error_code" (fn [] 2))
+    (unchecked-set module "_clear_shape_strokes" (fn [] js/undefined))
+    (unchecked-set module "_is_image_cached" (fn [_a _b _c _d _t] 1))
+    (doseq [entry ["_add_shape_inner_stroke" "_add_shape_outer_stroke" "_add_shape_center_stroke"]]
+      (unchecked-set module entry
+                     (fn [_w _s _cs _ce _d _g]
+                       ;; pushing a stroke allocates: memory can grow here
+                       (install-heap! module)
+                       js/undefined)))
+    (unchecked-set module "_alloc_bytes"
+                   (fn [size]
+                     (when @staged?
+                       (throw (js/Error. "Bytes already allocated")))
+                     (reset! staged? true)
+                     (swap! alloc-sizes conj size)
+                     0))
+    (unchecked-set module "_add_shape_stroke_fill"
+                   (fn []
+                     (reset! staged? false)
+                     (let [heap (unchecked-get module "HEAPU8")]
+                       (swap! fills conj (vec (.slice ^js heap 0 types.fills.impl/FILL-U8-SIZE))))
+                     js/undefined))
+    {:module module :staged? staged? :alloc-sizes alloc-sizes :fills fills}))
+
+(t/deftest stroke-fill-written-through-current-heap-view
+  "The fill payload must be written through a view created after the
+   stroke-push wasm call: that call can grow memory, and a stale view
+   silently loses the payload (wasm then reads zeros)."
+  (let [{:keys [module staged? fills]} (make-strokes-module)
+        stroke {:stroke-color "#fabada"
+                :stroke-opacity 1
+                :stroke-width 2
+                :stroke-alignment :center
+                :stroke-style :solid}]
+    (with-module* module
+      (fn []
+        (doall (wasm.api/set-shape-strokes (uuid/next) [stroke] false))
+        (t/is (= 1 (count @fills)) "one fill payload uploaded")
+        (t/is (some pos? (subvec (first @fills) 4 8))
+              "the rgba payload is present in the current heap view")
+        (t/is (false? @staged?) "the staged fill buffer was consumed")))))
+
+;; ---------------------------------------------------------------------------
+;; propagate-modifiers
+;; ---------------------------------------------------------------------------
+
+(defn- make-modifiers-module
+  "Fake module for propagate-modifiers. _alloc_bytes and
+   _propagate_modifiers both grow the heap (replace the views); the
+   result exists only in the view that is current after the call, while
+   the pre-call view holds a garbage length at the result offset."
+  []
+  (let [staged?     (atom false)
+        received    (atom nil)
+        module      #js {}
+        result-off32 128]
+    (install-heap! module)
+    (unchecked-set module "_read_error_code" (fn [] 2))
+    (unchecked-set module "_free_bytes" (fn [] (reset! staged? false) js/undefined))
+    (unchecked-set module "_alloc_bytes"
+                   (fn [_size]
+                     (when @staged?
+                       (throw (js/Error. "Bytes already allocated")))
+                     (reset! staged? true)
+                     ;; growth on allocation: old views go stale
+                     (install-heap! module)
+                     0))
+    (unchecked-set module "_propagate_modifiers"
+                   (fn [_pixel-precision]
+                     ;; the wasm side reads the entries from CURRENT memory
+                     (let [heapu32 (unchecked-get module "HEAPU32")
+                           heapf32 (unchecked-get module "HEAPF32")]
+                       (reset! received {:uuid   (vec (.slice ^js heapu32 0 4))
+                                         :matrix (vec (.slice ^js heapf32 4 10))
+                                         :kind   (aget ^js heapu32 10)}))
+                     (reset! staged? false)
+                     ;; poison the old view at the result offset, then grow:
+                     ;; the (empty) result only exists in the new view
+                     (aset (unchecked-get module "HEAPU32") result-off32 9999)
+                     (install-heap! module)
+                     (aset (unchecked-get module "HEAPU32") result-off32 0)
+                     (* 4 result-off32)))
+    {:module module :staged? staged? :received received}))
+
+(t/deftest propagate-modifiers-heap-discipline
+  "The entries must be written through views fetched after the
+   allocation, and the result must be read through views fetched after
+   the call — both calls can grow memory and detach older views."
+  (let [{:keys [module staged? received]} (make-modifiers-module)
+        id      (uuid/next)
+        entries [[id {:transform (gmt/matrix) :kind :parent}]]]
+    (with-module* module
+      (fn []
+        (let [result (wasm.api/propagate-modifiers entries false)]
+          (t/is (= (vec (uuid/get-u32 id)) (:uuid @received))
+                "wasm reads the entry uuid from the current view")
+          (t/is (= [1 0 0 1 0 0] (:matrix @received))
+                "wasm reads the transform from the current view")
+          (t/is (number? (:kind @received)))
+          (t/is (= [] result)
+                "the (empty) result is read from the post-growth view")
+          (t/is (false? @staged?) "no staged buffer left behind"))))))
+
+(t/deftest fill-less-stroke-stages-no-buffer
+  "A stroke without color/gradient/image has no fill payload to upload:
+   it must not allocate a staging buffer that nothing ever consumes
+   (a silent leak that fails the next allocation app-wide)."
+  (let [{:keys [module staged? alloc-sizes]} (make-strokes-module)
+        stroke {:stroke-width 1
+                :stroke-alignment :center}]
+    (with-module* module
+      (fn []
+        (doall (wasm.api/set-shape-strokes (uuid/next) [stroke] false))
+        (t/is (false? @staged?) "no staged buffer left behind")
+        (t/is (empty? @alloc-sizes) "no allocation performed for a fill-less stroke")))))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -47,6 +47,7 @@
    [frontend-tests.plugins.value-objects-test]
    [frontend-tests.render-wasm.calculate-bool-test]
    [frontend-tests.render-wasm.process-objects-test]
+   [frontend-tests.render-wasm.shape-serializers-test]
    [frontend-tests.svg-fills-test]
    [frontend-tests.tokens.import-export-test]
    [frontend-tests.tokens.logic.token-actions-test]
@@ -122,6 +123,7 @@
    'frontend-tests.plugins.value-objects-test
    'frontend-tests.render-wasm.calculate-bool-test
    'frontend-tests.render-wasm.process-objects-test
+   'frontend-tests.render-wasm.shape-serializers-test
    'frontend-tests.svg-fills-test
    'frontend-tests.tokens.import-export-test
    'frontend-tests.tokens.logic.token-actions-test

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -17,6 +17,7 @@
    [frontend-tests.data.workspace-interactions-test]
    [frontend-tests.data.workspace-mcp-test]
    [frontend-tests.data.workspace-media-test]
+   [frontend-tests.data.workspace-modifiers-test]
    [frontend-tests.data.workspace-shortcuts-test]
    [frontend-tests.data.workspace-texts-test]
    [frontend-tests.data.workspace-thumbnails-test]
@@ -93,6 +94,7 @@
    'frontend-tests.data.workspace-interactions-test
    'frontend-tests.data.workspace-mcp-test
    'frontend-tests.data.workspace-media-test
+   'frontend-tests.data.workspace-modifiers-test
    'frontend-tests.data.workspace-shortcuts-test
    'frontend-tests.data.workspace-texts-test
    'frontend-tests.data.workspace-thumbnails-test

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -45,6 +45,7 @@
    [frontend-tests.plugins.tokens-test]
    [frontend-tests.plugins.utils-test]
    [frontend-tests.plugins.value-objects-test]
+   [frontend-tests.render-wasm.calculate-bool-test]
    [frontend-tests.render-wasm.process-objects-test]
    [frontend-tests.svg-fills-test]
    [frontend-tests.tokens.import-export-test]
@@ -119,6 +120,7 @@
    'frontend-tests.plugins.tokens-test
    'frontend-tests.plugins.utils-test
    'frontend-tests.plugins.value-objects-test
+   'frontend-tests.render-wasm.calculate-bool-test
    'frontend-tests.render-wasm.process-objects-test
    'frontend-tests.svg-fills-test
    'frontend-tests.tokens.import-export-test

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -41,7 +41,12 @@ impl State {
     }
 
     // Creates a new temporary shapes pool.
-    // Will panic if a previous temporary pool exists.
+    // Errors if a previous temporary pool exists.
+    //
+    // NOTE: the pool is moved aside, not cloned: cloning the whole pool
+    // doubled memory usage on every boolean calculation (forcing memory
+    // growth on big files) and a failed allocation mid-clone left the
+    // state unrecoverable (see issue #10647).
     pub fn start_temp_objects(&mut self) -> Result<()> {
         if self.saved_shapes.is_some() {
             return Err(Error::CriticalError(
@@ -49,18 +54,16 @@ impl State {
                     .to_string(),
             ));
         }
-        self.saved_shapes = Some(self.shapes.clone());
-        self.shapes = ShapesPool::new();
+        self.saved_shapes = Some(std::mem::replace(&mut self.shapes, ShapesPool::new()));
         Ok(())
     }
 
-    // Disposes of the temporary shapes pool restoring the normal pool
-    // Will panic if a there is no temporary pool.
+    // Disposes of the temporary shapes pool restoring the normal pool.
+    // Errors if there is no temporary pool.
     pub fn end_temp_objects(&mut self) -> Result<()> {
-        self.shapes = self.saved_shapes.clone().ok_or(Error::CriticalError(
+        self.shapes = self.saved_shapes.take().ok_or(Error::CriticalError(
             "Tried to end temp objects but not content to be restored is present".to_string(),
         ))?;
-        self.saved_shapes = None;
         Ok(())
     }
 
@@ -311,5 +314,63 @@ impl State {
         if !self.loading {
             render_state.mark_touched(id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_temp_objects_lifecycle_preserves_the_pool() {
+        let mut state = State::new();
+        let id = Uuid::new_v4();
+        state.shapes.add_shape(id);
+
+        state.start_temp_objects().expect("start should succeed");
+        assert_eq!(state.shapes.len(), 0, "temp pool starts empty");
+        assert!(state.saved_shapes.is_some(), "original pool saved");
+
+        state.end_temp_objects().expect("end should succeed");
+        assert!(state.shapes.has(&id), "original pool restored");
+        assert!(state.saved_shapes.is_none(), "no temp pool left");
+    }
+
+    #[test]
+    fn test_start_temp_objects_twice_fails_without_corrupting_state() {
+        let mut state = State::new();
+        let id = Uuid::new_v4();
+        state.shapes.add_shape(id);
+
+        state
+            .start_temp_objects()
+            .expect("first start should succeed");
+        assert!(
+            state.start_temp_objects().is_err(),
+            "second start must fail"
+        );
+
+        state.end_temp_objects().expect("end should still succeed");
+        assert!(
+            state.shapes.has(&id),
+            "original pool restored after the failed start"
+        );
+    }
+
+    #[test]
+    fn test_end_temp_objects_without_start_fails_and_state_stays_usable() {
+        let mut state = State::new();
+        let id = Uuid::new_v4();
+        state.shapes.add_shape(id);
+
+        assert!(
+            state.end_temp_objects().is_err(),
+            "end without start must fail"
+        );
+        assert!(state.shapes.has(&id), "pool untouched by the failed end");
+
+        state.start_temp_objects().expect("state remains usable");
+        state.end_temp_objects().expect("state remains usable");
+        assert!(state.shapes.has(&id));
     }
 }


### PR DESCRIPTION
### Related Ticket

Fixes #10647

### Summary

Dragging a frame with a layout that contains boolean shapes, when it is nested inside another layout, crashed the workspace with an internal error (`WASM Error (panic)` in `_start_temp_objects`, as in the report attached to the issue).

Two stacked problems caused it:

1. **Stale heap views.** The boolean calculation captured the Emscripten heap view (`HEAPU32`) once and kept using it across calls that can grow WASM memory (allocation, and the calculation itself, which allocates its result). When memory grows, Emscripten replaces the views and the old one goes dead — the child ids were silently written to nowhere and the result was read as garbage. On big files this is near-certain to happen, because `start_temp_objects` deep-cloned the whole shapes pool, doubling memory use on every recalculation.
2. **No cleanup on failure.** When that first failure threw, the temporary shapes pool was never discarded, so *every* later boolean recalculation panicked in `_start_temp_objects` — the user-visible error screen.

The main fix makes `calculate-bool` re-fetch heap views after every allocating call and always discard the temporary pool (and the staging buffer), even when the calculation fails, without masking the original error.

Follow-up hardening in the same area (driven by an adversarial edge-case audit of the fix):

- Bool operands are normalized like the CLJS fallback (`calc-bool-content*`): missing ids, hidden children and svg-raw children no longer participate. Previously a missing base child silently emptied the whole bool, and a hidden child still shaped the geometry.
- Bools with no effective operands short-circuit to empty content (no temp-pool churn, no zero-byte allocation, no `(rseq nil)` crash in release builds).
- While the WASM module is still loading at boot, the calculation transparently falls back to the CLJS implementation instead of crashing on the empty module.
- The same stale-heap-view pattern was fixed in the other serializers on this code path: `set-shape-path-content`, `set-shape-strokes` (which also silently leaked a staging buffer for strokes without fill), `propagate-modifiers`, `get-selection-rect`, `calculate-position-data`, `set-shape-children`, `set-focus-mode` and `set-render-include-filter!`.
- Rust: `State::start/end_temp_objects` now move the shapes pool instead of deep-cloning it (removes the memory doubling that triggered growth, and the unrecoverable state a failed mid-clone allocation produced). Lifecycle unit tests added.
- Nested bools are now recalculated children-first after a drag, so an outer bool reads the freshly recomputed content of the bool inside it instead of stale content (the WASM path uses stored content for nested bools; the ids were previously an unordered set).

### Steps to reproduce

1. Open the file attached to #10647 (Codex Icons) with the WASM renderer enabled.
2. Select an inner layout frame that contains boolean shapes and drag it outside its parent layout.
3. Before: internal error screen (`_start_temp_objects` panic). After: the drag completes normally.

Verification: 25 new Node unit tests (fake WASM module that faithfully simulates Emscripten heap growth and the Rust staging-buffer/temp-pool state machines) — each fix was proven with a failing test first, and the buffer-release assertions were mutation-tested. Full frontend suite: 448 tests / 1836 assertions / 0 failures. Note: the Rust unit tests could not be run locally (the native skia build was not possible on this machine) — they rely on CI.

While auditing this, a pre-existing WASM/CLJS divergence was also found (text and frame children produce different boolean geometry in each engine — glyph outlines/frame rect vs bounding box/children-only). It predates this bug and needs a decision on which behavior is canonical, so it is not touched here; happy to file it as a separate issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.

