### PR TITLE
:books: Add .penpot format docs and inspector tool

### DIFF
--- a/docs/technical-guide/developer/data-model/penpot-file-format.md
+++ b/docs/technical-guide/developer/data-model/penpot-file-format.md
@@ -570,6 +570,10 @@ find /tmp/penpot-inspect -name "*.json" | head -20
 cat /tmp/penpot-inspect/files/*/pages/*/*.json | jq .
 ```
 
+### Browser-Based Inspector
+
+For an interactive way to explore a `.penpot` file, try the [**Penpot file inspector**](/technical-guide/developer/data-model/penpot-file-inspector/). It runs entirely in your browser, displays a collapsible file tree, syntax-highlighted JSON, image previews, and clickable cross-references between shapes, components, colors, and media.
+
 ### Quick Inspection Script
 
 ```bash
@@ -603,6 +607,7 @@ rm -rf "$TMPDIR"
 
 ## Cross-References
 
+- [Penpot file inspector](/technical-guide/developer/data-model/penpot-file-inspector/) - Browser-based interactive inspector
 - [Data Model](/technical-guide/developer/data-model/) - Conceptual data model
 - [Data Guide](/technical-guide/developer/data-guide/) - Working with data structures
 - [Export/Import Files](/user-guide/export-import/export-import-files/) - User guide for exporting and importing

--- a/docs/technical-guide/developer/data-model/penpot-file-format.md
+++ b/docs/technical-guide/developer/data-model/penpot-file-format.md
@@ -1,0 +1,623 @@
+---
+title: 3.02.01. Penpot file format (.penpot)
+desc: Complete technical specification for the .penpot file format, including structure, schemas, and inspection methods.
+---
+
+# Penpot File Format (.penpot)
+
+The `.penpot` file format is Penpot's native export format for design files. It's a ZIP archive containing JSON metadata and binary assets, designed to be open, inspectable, and efficient.
+
+## Overview
+
+The `.penpot` format (version 3) uses a ZIP container with JSON files for metadata and binary files for media assets. This approach provides several advantages:
+
+- **Open and inspectable**: All metadata is human-readable JSON
+- **Efficient**: ZIP compression reduces file size
+- **Interoperable**: Standard formats enable third-party tooling
+- **Versioned**: Clear versioning system for format and data evolution
+
+## Version History
+
+| Version | Description | Status |
+|---------|-------------|--------|
+| v1 | Custom binary format | Deprecated |
+| v2 | SQLite-based format | Never released (internal only) |
+| v3 | ZIP + JSON format | **Current** |
+
+## File Structure
+
+A `.penpot` file contains the following structure:
+
+```
+pencil.penpot (ZIP archive)
+├── manifest.json                          # Root metadata
+├── files/
+│   ├── {file-id}.json                     # File metadata
+│   └── {file-id}/
+│       ├── pages/
+│       │   ├── {page-id}.json             # Page metadata
+│       │   └── {page-id}/
+│       │       └── {shape-id}.json        # Individual shapes
+│       ├── media/
+│       │   └── {media-id}.json            # Media references
+│       ├── colors/
+│       │   └── {color-id}.json            # Library colors
+│       ├── components/
+│       │   └── {component-id}.json        # Library components
+│       ├── typographies/
+│       │   └── {typography-id}.json       # Library typographies
+│       ├── tokens.json                    # Design tokens library
+│       └── thumbnails/
+│           └── {tag}/{page-id}/{frame-id}.json  # Thumbnail metadata
+└── objects/
+    ├── {uuid}.json                        # Storage object metadata
+    └── {uuid}.{ext}                       # Binary media files (png, jpg, etc.)
+```
+
+## Manifest Specification
+
+The `manifest.json` file is the root of the archive and contains metadata about the export.
+
+### Schema
+
+```json
+{
+  "version": 1,
+  "type": "penpot/export-files",
+  "generatedBy": "penpot/2.12.0",
+  "refer": "penpot",
+  "files": [
+    {
+      "id": "uuid",
+      "name": "File Name",
+      "features": ["feature1", "feature2"]
+    }
+  ],
+  "relations": []
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | integer | Yes | Format version (currently `1`) |
+| `type` | string | Yes | Must be `"penpot/export-files"` |
+| `generatedBy` | string | No | Penpot version that created the file |
+| `refer` | string | No | Source system (typically `"penpot"`) |
+| `files` | array | Yes | List of files in the archive |
+| `files[].id` | UUID | Yes | File identifier |
+| `files[].name` | string | Yes | File name |
+| `files[].features` | array | Yes | Set of feature flags |
+| `relations` | array | No | Library relationships `[file-id, library-id]` |
+
+### Example
+
+```json
+{
+  "type": "penpot/export-files",
+  "version": 1,
+  "generatedBy": "penpot/2.12.0-RC1-99-g40c27591f",
+  "refer": "penpot",
+  "files": [
+    {
+      "id": "73b59a94-3ea3-8189-8007-3d36adc8c3e3",
+      "name": "Pencil | Penpot Design System",
+      "features": [
+        "fdata/path-data",
+        "design-tokens/v1",
+        "variants/v1",
+        "layout/grid",
+        "components/v2",
+        "fdata/shape-data-type"
+      ]
+    }
+  ],
+  "relations": []
+}
+```
+
+## File Metadata
+
+Each file has a JSON file at `files/{file-id}.json` containing the file's metadata.
+
+### Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | File identifier |
+| `name` | string | Yes | File name |
+| `revn` | integer | Yes | Revision number |
+| `vern` | integer | No | Version number |
+| `createdAt` | timestamp | Yes | Creation timestamp |
+| `modifiedAt` | timestamp | Yes | Last modification timestamp |
+| `deletedAt` | timestamp | No | Deletion timestamp (if soft-deleted) |
+| `projectId` | UUID | No | Project identifier |
+| `teamId` | UUID | No | Team identifier |
+| `isShared` | boolean | No | Whether file is a shared library |
+| `hasMediaTrimmed` | boolean | No | Whether media has been trimmed |
+| `features` | array | Yes | Set of enabled feature flags |
+| `migrations` | array | No | List of applied data migrations |
+| `options` | object | No | File-level options |
+
+### Features
+
+The `features` field is a set of strings indicating which features are enabled in the file. Common features include:
+
+| Feature | Description |
+|---------|-------------|
+| `fdata/path-data` | Path data format |
+| `fdata/shape-data-type` | Shape data type system |
+| `design-tokens/v1` | Design tokens support |
+| `variants/v1` | Component variants |
+| `layout/grid` | Grid layout system |
+| `components/v2` | Component system v2 |
+| `plugins/runtime` | Plugin runtime support |
+
+### Migrations
+
+The `migrations` field lists all data migrations applied to the file. This ensures backward compatibility when the data model evolves.
+
+### Example
+
+```json
+{
+  "id": "73b59a94-3ea3-8189-8007-3d36adc8c3e3",
+  "name": "Pencil | Penpot Design System",
+  "revn": 28425,
+  "vern": 0,
+  "createdAt": "2025-12-10T10:24:18.686066Z",
+  "modifiedAt": "2025-12-10T12:13:49.799076Z",
+  "teamId": "b62e1aa4-d9a7-8147-8005-2813bed4056e",
+  "projectId": "f23add0e-6b77-8069-8005-41b48b93a5da",
+  "isShared": true,
+  "features": [
+    "fdata/path-data",
+    "design-tokens/v1",
+    "variants/v1",
+    "layout/grid",
+    "components/v2",
+    "fdata/shape-data-type"
+  ],
+  "migrations": [
+    "legacy-2",
+    "legacy-3",
+    "0001-remove-tokens-from-groups",
+    "0002-normalize-bool-content-v2"
+  ],
+  "options": {
+    "componentsV2": true
+  }
+}
+```
+
+## Pages and Shapes
+
+### Page Structure
+
+Each page is stored at `files/{file-id}/pages/{page-id}.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Page identifier |
+| `name` | string | Yes | Page name |
+| `index` | integer | No | Page order in the file |
+| `options` | object | No | Page options (guides, etc.) |
+| `background` | string | No | Background color (hex) |
+| `flows` | object | No | Prototype flows |
+| `guides` | object | No | Ruler guides |
+
+### Shapes
+
+Individual shapes are stored at `files/{file-id}/pages/{page-id}/{shape-id}.json`.
+
+#### Shape Types
+
+Penpot supports 9 shape types:
+
+| Type | Description |
+|------|-------------|
+| `frame` | Container frame (artboard) |
+| `group` | Group of shapes |
+| `rect` | Rectangle |
+| `circle` | Circle/Ellipse |
+| `path` | Vector path |
+| `text` | Text shape |
+| `image` | Image |
+| `bool` | Boolean operation |
+| `svg-raw` | Raw SVG element |
+
+#### Base Shape Attributes
+
+All shapes share these base attributes:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Shape identifier |
+| `name` | string | Yes | Shape name |
+| `type` | string | Yes | Shape type (see above) |
+| `selrect` | object | Yes | Selection rectangle `{x, y, width, height}` |
+| `points` | array | Yes | Array of points `[{x, y}, ...]` |
+| `transform` | array | Yes | 2D transformation matrix |
+| `transformInverse` | array | Yes | Inverse transformation matrix |
+| `parentId` | UUID | Yes | Parent shape identifier |
+| `frameId` | UUID | Yes | Containing frame identifier |
+
+#### Geometry Attributes
+
+Shapes with geometry (frame, rect, circle, image, svg-raw, text):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `x` | number | Yes | X position |
+| `y` | number | Yes | Y position |
+| `width` | number | Yes | Width |
+| `height` | number | Yes | Height |
+
+#### Generic Attributes
+
+Optional attributes available on all shapes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fills` | array | Fill styles |
+| `strokes` | array | Stroke styles |
+| `opacity` | number | Opacity (0-1) |
+| `blendMode` | string | Blend mode |
+| `shadow` | array | Shadow effects |
+| `blur` | object | Blur effect |
+| `constraintsH` | string | Horizontal constraint |
+| `constraintsV` | string | Vertical constraint |
+| `r1`, `r2`, `r3`, `r4` | number | Border radius corners |
+| `blocked` | boolean | Shape is locked |
+| `hidden` | boolean | Shape is hidden |
+| `collapsed` | boolean | Shape is collapsed |
+| `componentId` | UUID | Component reference |
+| `componentFile` | UUID | Component library file |
+| `shapeRef` | UUID | Shape reference for components |
+| `touched` | array | Modified component properties |
+| `interactions` | array | Prototype interactions |
+| `exports` | array | Export settings |
+| `grids` | array | Grid configurations |
+| `appliedTokens` | object | Applied design tokens |
+| `pluginData` | object | Plugin-specific data |
+
+#### Type-Specific Attributes
+
+**Frame**
+- `shapes`: array of child shape UUIDs
+- `showContent`: boolean
+- `hideInViewer`: boolean
+
+**Group**
+- `shapes`: array of child shape UUIDs
+
+**Bool**
+- `shapes`: array of child shape UUIDs
+- `boolType`: string (`union`, `difference`, `exclude`, `intersection`)
+- `content`: path data
+
+**Path**
+- `content`: path data (SVG path commands)
+
+**Text**
+- `content`: text content with formatting
+- `positionData`: glyph position data
+
+**Image**
+- `metadata`: object with `width`, `height`, `mtype`, `id`
+
+### Example Shape
+
+```json
+{
+  "id": "260aea33-4e55-808c-8007-3d4f2efe4230",
+  "name": "Rectangle",
+  "type": "rect",
+  "x": 100,
+  "y": 100,
+  "width": 200,
+  "height": 150,
+  "selrect": {
+    "x": 100,
+    "y": 100,
+    "width": 200,
+    "height": 150
+  },
+  "points": [
+    {"x": 100, "y": 100},
+    {"x": 300, "y": 100},
+    {"x": 300, "y": 250},
+    {"x": 100, "y": 250}
+  ],
+  "transform": [1, 0, 0, 1, 0, 0],
+  "transformInverse": [1, 0, 0, 1, 0, 0],
+  "parentId": "00000000-0000-0000-0000-000000000000",
+  "frameId": "00000000-0000-0000-0000-000000000001",
+  "fills": [
+    {
+      "color": "#FF5733",
+      "opacity": 1
+    }
+  ],
+  "r1": 8,
+  "r2": 8,
+  "r3": 8,
+  "r4": 8
+}
+```
+
+## Library Assets
+
+### Colors
+
+Stored at `files/{file-id}/colors/{color-id}.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Color identifier |
+| `name` | string | Yes | Color name |
+| `path` | string | No | Path in the library tree |
+| `opacity` | number | No | Opacity (0-1) |
+| `color` | string | Conditional | Hex color (for plain colors) |
+| `gradient` | object | Conditional | Gradient definition |
+| `image` | object | Conditional | Image fill definition |
+
+#### Plain Color Example
+
+```json
+{
+  "id": "abc123...",
+  "name": "Primary Blue",
+  "path": "Brand/Primary",
+  "color": "#0066CC",
+  "opacity": 1
+}
+```
+
+#### Gradient Color Example
+
+```json
+{
+  "id": "def456...",
+  "name": "Sunset Gradient",
+  "gradient": {
+    "type": "linear",
+    "startX": 0,
+    "startY": 0,
+    "endX": 1,
+    "endY": 1,
+    "stops": [
+      {"color": "#FF6B6B", "offset": 0, "opacity": 1},
+      {"color": "#4ECDC4", "offset": 1, "opacity": 1}
+    ]
+  }
+}
+```
+
+### Components
+
+Stored at `files/{file-id}/components/{component-id}.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Component identifier |
+| `name` | string | Yes | Component name |
+| `path` | string | Yes | Path in the library tree |
+| `mainInstanceId` | UUID | Yes | Root shape of main instance |
+| `mainInstancePage` | UUID | Yes | Page containing main instance |
+| `modifiedAt` | timestamp | No | Last modification |
+| `objects` | object | No | Captured shapes (if deleted) |
+
+### Typographies
+
+Stored at `files/{file-id}/typographies/{typography-id}.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Typography identifier |
+| `name` | string | Yes | Typography name |
+| `fontId` | string | Yes | Font identifier |
+| `fontFamily` | string | Yes | Font family name |
+| `fontVariantId` | string | Yes | Font variant |
+| `fontSize` | string | Yes | Font size |
+| `fontWeight` | string | Yes | Font weight |
+| `fontStyle` | string | Yes | Font style |
+| `lineHeight` | string | Yes | Line height |
+| `letterSpacing` | string | Yes | Letter spacing |
+| `textTransform` | string | Yes | Text transform |
+
+### Design Tokens
+
+Stored at `files/{file-id}/tokens.json`.
+
+The tokens library contains:
+
+- **Sets**: Collections of tokens organized hierarchically
+- **Themes**: Named combinations of token sets
+- **Active Themes**: Currently applied themes
+
+#### Token Structure
+
+```json
+{
+  "sets": {
+    "core": {
+      "id": "uuid",
+      "name": "Core",
+      "tokens": {
+        "color": {
+          "primary": {
+            "id": "uuid",
+            "name": "primary",
+            "type": "color",
+            "value": "#0066CC"
+          }
+        }
+      }
+    }
+  },
+  "themes": {
+    "light": {
+      "id": "uuid",
+      "name": "Light",
+      "sets": ["core"]
+    }
+  },
+  "activeThemes": ["light"]
+}
+```
+
+## Media and Storage Objects
+
+### Storage Objects
+
+Binary assets (images, fonts, etc.) are stored in the `objects/` directory.
+
+Each storage object has:
+- `objects/{uuid}.json` - Metadata
+- `objects/{uuid}.{ext}` - Binary content (png, jpg, svg, etc.)
+
+#### Metadata Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Storage object identifier |
+| `size` | integer | Yes | File size in bytes |
+| `contentType` | string | Yes | MIME type |
+| `bucket` | string | Yes | Storage bucket |
+| `hash` | string | No | Content hash (blake2b) |
+
+#### Example
+
+```json
+{
+  "id": "0039433d-adc8-430d-b2c3-d884dea6e050",
+  "size": 575,
+  "contentType": "image/png",
+  "bucket": "file-media-object",
+  "hash": "blake2b:77d447db38eb5daf31acb7344a504cacc6b79aa11855a00501d9475c595053d0"
+}
+```
+
+### Media References
+
+File media references are stored at `files/{file-id}/media/{media-id}.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | UUID | Yes | Media identifier |
+| `name` | string | Yes | File name |
+| `width` | integer | Yes | Image width |
+| `height` | integer | Yes | Image height |
+| `mtype` | string | Yes | MIME type |
+| `mediaId` | UUID | Yes | Reference to storage object |
+| `thumbnaillId` | UUID | No | Reference to thumbnail |
+| `isLocal` | boolean | No | Whether media is local to file |
+
+### Thumbnails
+
+Page thumbnails are stored at `files/{file-id}/thumbnails/{tag}/{page-id}/{frame-id}.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fileId` | UUID | Yes | File identifier |
+| `pageId` | UUID | Yes | Page identifier |
+| `frameId` | UUID | Yes | Frame identifier |
+| `tag` | string | Yes | Thumbnail tag |
+| `mediaId` | UUID | Yes | Reference to storage object |
+
+## Plugin Data
+
+Plugins can store custom data on files, pages, shapes, components, colors, and typographies using the `pluginData` field.
+
+### Structure
+
+```json
+{
+  "pluginData": {
+    "plugin-id": {
+      "key1": "value1",
+      "key2": "value2"
+    }
+  }
+}
+```
+
+The plugin ID is a keyword (e.g., `"my-plugin"`), and the values are string key-value pairs.
+
+## Inspecting a .penpot File
+
+### List Contents
+
+```bash
+unzip -l design.penpot
+```
+
+### Extract and View
+
+```bash
+# Extract to temporary directory
+unzip design.penpot -d /tmp/penpot-inspect
+
+# View manifest
+cat /tmp/penpot-inspect/manifest.json | jq .
+
+# List all files
+find /tmp/penpot-inspect -name "*.json" | head -20
+
+# View a specific shape
+cat /tmp/penpot-inspect/files/*/pages/*/*.json | jq .
+```
+
+### Quick Inspection Script
+
+```bash
+#!/bin/bash
+# Inspect .penpot file structure
+
+FILE=$1
+TMPDIR=$(mktemp -d)
+
+unzip -q "$FILE" -d "$TMPDIR"
+
+echo "=== Manifest ==="
+cat "$TMPDIR/manifest.json" | jq '{type, version, files: [.files[] | {id, name}]}'
+
+echo -e "\n=== Files ==="
+for f in "$TMPDIR"/files/*.json; do
+  echo "- $(jq -r '.name' "$f")"
+done
+
+echo -e "\n=== Pages ==="
+for f in "$TMPDIR"/files/*/pages/*.json; do
+  echo "- $(jq -r '.name' "$f")"
+done
+
+echo -e "\n=== Storage Objects ==="
+ls -lh "$TMPDIR"/objects/*.{png,jpg,svg} 2>/dev/null | wc -l
+echo "media files"
+
+rm -rf "$TMPDIR"
+```
+
+## Cross-References
+
+- [Data Model](/technical-guide/developer/data-model/) - Conceptual data model
+- [Data Guide](/technical-guide/developer/data-guide/) - Working with data structures
+- [Export/Import Files](/user-guide/export-import/export-import-files/) - User guide for exporting and importing
+
+## Source Code References
+
+The authoritative schema definitions are in the Penpot source code:
+
+- **Manifest**: `backend/src/app/binfile/v3.clj` (schema:manifest)
+- **File**: `common/src/app/common/types/file.cljc` (schema:file)
+- **Page**: `common/src/app/common/types/page.cljc` (schema:page)
+- **Shape**: `common/src/app/common/types/shape.cljc` (schema:shape)
+- **Component**: `common/src/app/common/types/component.cljc` (schema:component)
+- **Color**: `common/src/app/common/types/color.cljc` (schema:library-color)
+- **Typography**: `common/src/app/common/types/typography.cljc` (schema:typography)
+- **Tokens**: `common/src/app/common/types/tokens_lib.cljc` (schema:tokens-lib)
+- **Plugin Data**: `common/src/app/common/types/plugins.cljc` (schema:plugin-data)
+- **Features**: `common/src/app/common/features.cljc` (schema:features)

--- a/docs/technical-guide/developer/data-model/penpot-file-inspector.njk
+++ b/docs/technical-guide/developer/data-model/penpot-file-inspector.njk
@@ -1,0 +1,1258 @@
+---
+title: 3.02.02. Penpot file inspector
+desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file to explore its ZIP structure, browse JSON contents, preview images, and navigate cross-references.
+---
+
+<style>
+  .inspector-wrap {
+    margin: 1rem 0 2rem;
+    display: block;
+  }
+  .inspector-drop {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border: 2px dashed var(--color-gray-medium);
+    border-radius: 8px;
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    background: var(--color-gray-light);
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .inspector-drop:hover,
+  .inspector-drop.dragover {
+    border-color: var(--primarydark);
+    background: var(--advice);
+  }
+  .inspector-drop input[type=file] { display: none; }
+  .inspector-drop-title { font-size: 1.1rem; font-weight: 600; margin: 0 0 0.4rem; color: var(--color-gray-dark); }
+  .inspector-drop-hint { font-size: 0.9rem; color: var(--graymedium); margin: 0; }
+  .inspector-status {
+    margin-top: 0.8rem;
+    font-size: 0.9rem;
+    color: var(--graymedium);
+    min-height: 1.2em;
+  }
+  .inspector-status.error { color: #b00020; }
+
+  .inspector-layout {
+    display: grid;
+    grid-template-columns: 280px minmax(0, 1fr);
+    gap: 1rem;
+    margin-top: 1.5rem;
+    min-height: 500px;
+  }
+  @media (max-width: 900px) {
+    .inspector-layout { grid-template-columns: 1fr; }
+    .inspector-sidebar { max-height: 320px; }
+  }
+
+  .inspector-sidebar {
+    grid-column: 1;
+    order: 1;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 6px;
+    background: var(--white);
+    overflow: auto;
+    padding: 0.6rem;
+    font-size: 0.9rem;
+  }
+  .inspector-search {
+    width: 100%;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 4px;
+    margin-bottom: 0.6rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+  }
+  .inspector-tree { list-style: none; padding: 0; margin: 0; }
+  .inspector-tree ul {
+    list-style: none;
+    padding-left: 1rem;
+    margin: 0;
+  }
+  .inspector-tree li { margin: 0; }
+  .inspector-tree-row {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.3rem;
+    border-radius: 4px;
+    cursor: pointer;
+    user-select: none;
+    line-height: 1.4;
+  }
+  .inspector-tree-row:hover { background: var(--color-gray-light); }
+  .inspector-tree-row.active { background: var(--advice); color: var(--primarydark); font-weight: 500; }
+  .inspector-tree-toggle {
+    display: inline-block;
+    width: 1em;
+    text-align: center;
+    color: var(--graymedium);
+    flex-shrink: 0;
+  }
+  .inspector-tree-toggle.leaf { visibility: hidden; }
+  .inspector-tree-icon { flex-shrink: 0; font-size: 0.85em; }
+  .inspector-tree-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .inspector-tree-size { color: var(--graymedium); font-size: 0.75rem; flex-shrink: 0; }
+  .inspector-tree-row.hidden { display: none; }
+  .inspector-search-empty { color: var(--graymedium); font-style: italic; padding: 0.4rem; }
+
+  .inspector-content {
+    grid-column: 2;
+    order: 2;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 6px;
+    background: var(--white);
+    overflow: auto;
+    padding: 1.2rem;
+  }
+
+  .inspector-empty { color: var(--graymedium); text-align: center; padding: 3rem 1rem; }
+
+  .inspector-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.8rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--color-gray-medium);
+  }
+  .inspector-toolbar input[type=search] {
+    flex: 1;
+    min-width: 200px;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+  .inspector-toolbar label { font-size: 0.85rem; color: var(--graymedium); }
+  .inspector-toolbar input[type=number] {
+    width: 4rem;
+    padding: 0.3rem 0.4rem;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 4px;
+    font-family: inherit;
+  }
+  .inspector-toolbar button {
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--color-gray-medium);
+    background: var(--white);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+  }
+  .inspector-toolbar button:hover { background: var(--color-gray-light); }
+
+  .inspector-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+  }
+  .inspector-card {
+    background: var(--color-gray-light);
+    border-radius: 6px;
+    padding: 0.8rem;
+  }
+  .inspector-card-label { font-size: 0.75rem; text-transform: uppercase; color: var(--graymedium); letter-spacing: 0.04em; }
+  .inspector-card-value { font-size: 1.4rem; font-weight: 600; color: var(--color-gray-dark); margin-top: 0.2rem; }
+  .inspector-card-detail { font-size: 0.8rem; color: var(--graymedium); margin-top: 0.2rem; }
+
+  .inspector-shape-card {
+    background: var(--color-gray-light);
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 6px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+  }
+  .inspector-shape-card h3 { margin: 0 0 0.5rem; font-size: 1rem; }
+  .inspector-shape-grid { display: grid; grid-template-columns: max-content 1fr; gap: 0.3rem 0.8rem; font-size: 0.85rem; }
+  .inspector-shape-grid dt { color: var(--graymedium); }
+  .inspector-shape-grid dd { margin: 0; }
+  .inspector-swatch {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    border: 1px solid var(--color-gray-medium);
+    vertical-align: middle;
+    margin-right: 0.3em;
+  }
+  .inspector-shape-thumb {
+    max-width: 120px;
+    max-height: 80px;
+    border: 1px solid var(--color-gray-medium);
+    background: var(--white);
+    display: block;
+    margin-top: 0.4rem;
+  }
+
+  .inspector-media {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: flex-start;
+  }
+  .inspector-media-preview {
+    background: var(--color-gray-light);
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 6px;
+    padding: 1rem;
+    text-align: center;
+    max-width: 100%;
+  }
+  .inspector-media-preview img { max-width: 400px; max-height: 400px; display: block; }
+  .inspector-media-info { font-size: 0.85rem; }
+  .inspector-media-info dt { color: var(--graymedium); }
+
+  .inspector-jtree { font-family: 'Menlo', 'Consolas', monospace; font-size: 0.85rem; line-height: 1.5; }
+  .inspector-jtree .jrow { display: flex; align-items: flex-start; }
+  .inspector-jtree .jtoggle {
+    display: inline-block;
+    width: 1em;
+    cursor: pointer;
+    color: var(--graymedium);
+    user-select: none;
+    flex-shrink: 0;
+  }
+  .inspector-jtree .jtoggle.leaf { visibility: hidden; }
+  .inspector-jtree .jkey { color: #2a6f97; }
+  .inspector-jtree .jstr { color: #2a8030; }
+  .inspector-jtree .jnum { color: #c75b12; }
+  .inspector-jtree .jbool { color: #7b3aa3; }
+  .inspector-jtree .jnull { color: var(--graymedium); font-style: italic; }
+  .inspector-jtree .jmeta { color: var(--graymedium); margin-left: 0.4em; }
+  .inspector-jtree .jrow.match > .jkey,
+  .inspector-jtree .jrow.match > .jstr,
+  .inspector-jtree .jrow.match > .jnum { background: #fff3a3; }
+  .inspector-jtree .jchildren.collapsed { display: none; }
+  .inspector-jtree .juuid { color: #1d6fb8; text-decoration: underline dotted; cursor: pointer; }
+  .inspector-jtree .juuid:hover { background: var(--advice); }
+
+  .inspector-backlinks {
+    margin-top: 1rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid var(--color-gray-medium);
+    font-size: 0.85rem;
+  }
+  .inspector-backlinks h4 { margin: 0 0 0.4rem; font-size: 0.85rem; text-transform: uppercase; color: var(--graymedium); letter-spacing: 0.04em; }
+  .inspector-backlinks ul { list-style: none; padding: 0; margin: 0; }
+  .inspector-backlinks li { margin: 0 0 0.2rem; }
+  .inspector-backlinks a { cursor: pointer; }
+
+  .inspector-error {
+    padding: 1rem;
+    background: #fde8e8;
+    border: 1px solid #b00020;
+    border-radius: 4px;
+    color: #b00020;
+    font-size: 0.9rem;
+  }
+</style>
+
+<h1 id="penpot-file-inspector">Penpot file inspector</h1>
+
+<p class="main-paragraph">Upload a <code class="language-text">.penpot</code> file to explore its contents. The inspector runs entirely in your browser — your file is never uploaded to a server.</p>
+
+<div class="inspector-wrap">
+  <label class="inspector-drop" id="drop-zone">
+    <input type="file" id="file-input" accept=".penpot,.zip" />
+    <p class="inspector-drop-title">Drop a <code>.penpot</code> file here, or click to choose</p>
+    <p class="inspector-drop-hint">Supported: <code>.penpot</code> (v3 ZIP format)</p>
+  </label>
+  <div class="inspector-status" id="status"></div>
+
+  <div class="inspector-layout" id="app" hidden>
+    <aside class="inspector-sidebar">
+      <input type="search" class="inspector-search" id="tree-search" placeholder="Filter files..." />
+      <div class="inspector-tree" id="tree"></div>
+    </aside>
+    <main class="inspector-content" id="content">
+      <div class="inspector-empty">Select a file from the sidebar to inspect it.</div>
+    </main>
+  </div>
+</div>
+
+<h2 id="how-it-works">How it works</h2>
+
+<p>This tool is a static page with no backend. When you upload a file, the browser:</p>
+
+<ol>
+  <li>Reads the file as a ZIP archive using <a href="https://stuk.github.io/jszip/">JSZip</a> (loaded lazily from a CDN on first use).</li>
+  <li>Parses the manifest, file metadata, and structure to build an overview.</li>
+  <li>Lets you navigate the file tree, view JSON contents with syntax highlighting, preview embedded images, and click through cross-references (UUIDs).</li>
+</ol>
+
+<p>For full details on the file format, see the <a href="/technical-guide/developer/data-model/penpot-file-format/">complete technical specification</a>.</p>
+
+<h2 id="privacy">Privacy</h2>
+
+<p>Your file is processed entirely in your browser. Nothing is uploaded to any server. The only network request the page makes is fetching the JSZip library from <code class="language-text">cdn.jsdelivr.net</code> on the first file upload.</p>
+
+<script type="module">
+(function () {
+  'use strict';
+
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'];
+  const FONT_EXTS = ['woff', 'woff2', 'ttf', 'otf'];
+  const JSON_EXTS = ['json'];
+
+  const MIME_BY_EXT = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    svg: 'image/svg+xml',
+    woff: 'font/woff',
+    woff2: 'font/woff2',
+    ttf: 'font/ttf',
+    otf: 'font/otf',
+  };
+
+  function mimeFor(name) {
+    return MIME_BY_EXT[getExt(name)] || 'application/octet-stream';
+  }
+
+  let JSZip = null;
+  let currentArchive = null;
+  let currentFiles = []; // [{ name, dir, json, blob, url, type }]
+  let fileIndex = new Map(); // name -> file entry
+  let selectedName = null;
+  let backlinks = new Map(); // uuid -> [filename, ...]
+
+  const dropZone = document.getElementById('drop-zone');
+  const fileInput = document.getElementById('file-input');
+  const statusEl = document.getElementById('status');
+  const appEl = document.getElementById('app');
+  const treeEl = document.getElementById('tree');
+  const contentEl = document.getElementById('content');
+  const treeSearch = document.getElementById('tree-search');
+
+  function setStatus(msg, isError) {
+    statusEl.textContent = msg || '';
+    statusEl.classList.toggle('error', !!isError);
+  }
+
+  async function loadJSZip() {
+    if (JSZip) return JSZip;
+    setStatus('Loading JSZip...');
+    const mod = await import('https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm');
+    JSZip = mod.default;
+    return JSZip;
+  }
+
+  function getExt(name) {
+    const m = name.match(/\.([^.]+)$/);
+    return m ? m[1].toLowerCase() : '';
+  }
+
+  function isImage(name) { return IMAGE_EXTS.includes(getExt(name)); }
+  function isFont(name) { return FONT_EXTS.includes(getExt(name)); }
+  function isJson(name) { return getExt(name) === 'json'; }
+
+  function formatSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+  }
+
+  function iconFor(name, isDir) {
+    if (isDir) return '\u{1F4C1}';
+    const ext = getExt(name);
+    if (ext === 'json') return '\u{1F4CB}';
+    if (isImage(name)) return '\u{1F5BC}';
+    if (isFont(name)) return '\u{1F520}';
+    return '\u{1F4CE}';
+  }
+
+  function resetArchive() {
+    currentFiles.forEach(f => { if (f.url) URL.revokeObjectURL(f.url); });
+    currentFiles = [];
+    fileIndex.clear();
+    backlinks.clear();
+    selectedName = null;
+  }
+
+  async function handleFile(file) {
+    if (!file) return;
+    setStatus('');
+    resetArchive();
+    try {
+      const Zip = await loadJSZip();
+      setStatus('Extracting ' + file.name + '...');
+      const zip = await Zip.loadAsync(file);
+      currentArchive = { name: file.name, zip };
+
+      const names = [];
+      zip.forEach((relPath, entry) => {
+        if (!entry.dir) names.push(relPath);
+      });
+      names.sort();
+
+      let count = 0;
+      for (const name of names) {
+        const entry = zip.file(name);
+        if (!entry) continue;
+        const blob = await entry.async('blob');
+        const ext = getExt(name);
+        const mime = MIME_BY_EXT[ext] || '';
+        const entry_data = {
+          name,
+          blob,
+          size: blob.size,
+          type: mime || blob.type,
+          ext,
+          url: null,
+          json: null,
+        };
+        if (isJson(name)) {
+          try {
+            const text = await blob.text();
+            entry_data.json = JSON.parse(text);
+            if (entry_data.json) {
+              entry_data.url = null;
+            }
+          } catch (e) {
+            entry_data.json = null;
+            entry_data.parseError = e.message;
+          }
+        } else if (isImage(name) || isFont(name)) {
+          const typedBlob = new Blob([blob], { type: mime || 'application/octet-stream' });
+          entry_data.type = typedBlob.type;
+          entry_data.url = URL.createObjectURL(typedBlob);
+        }
+        currentFiles.push(entry_data);
+        fileIndex.set(name, entry_data);
+        count++;
+      }
+
+      for (const f of currentFiles) {
+        if (!f.json) continue;
+        if (typeof f.json.contentType !== 'string') continue;
+        if (f.json.id && typeof f.json.id === 'string') {
+          const storageId = f.json.id;
+          for (const other of currentFiles) {
+            if (other === f) continue;
+            if (other.url && other.name.startsWith('objects/' + storageId + '.') && other.type !== f.json.contentType) {
+              URL.revokeObjectURL(other.url);
+              const tb = new Blob([other.blob], { type: f.json.contentType });
+              other.url = URL.createObjectURL(tb);
+              other.type = f.json.contentType;
+            }
+          }
+        }
+      }
+
+      indexBacklinks();
+      setStatus('Loaded ' + count + ' files from ' + file.name);
+      appEl.hidden = false;
+      buildTree();
+      showOverview();
+    } catch (e) {
+      setStatus('Failed to load: ' + e.message, true);
+      console.error(e);
+    }
+  }
+
+  function indexBacklinks() {
+    backlinks.clear();
+    for (const f of currentFiles) {
+      if (!f.json) continue;
+      const myId = typeof f.json.id === 'string' && UUID_RE.test(f.json.id) ? f.json.id : null;
+      const refs = new Set();
+      walkJson(f.json, (val) => {
+        if (typeof val === 'string' && UUID_RE.test(val) && val !== myId) {
+          refs.add(val);
+        }
+      });
+      for (const ref of refs) {
+        if (!backlinks.has(ref)) backlinks.set(ref, []);
+        backlinks.get(ref).push(f.name);
+      }
+    }
+  }
+
+  function walkJson(node, visit) {
+    if (node === null) return;
+    if (Array.isArray(node)) {
+      for (const v of node) { visit(v); walkJson(v, visit); }
+    } else if (typeof node === 'object') {
+      for (const [k, v] of Object.entries(node)) { visit(k); visit(v); walkJson(v, visit); }
+    }
+  }
+
+  function buildTree() {
+    treeEl.innerHTML = '';
+    const root = { name: '', children: new Map(), isDir: true };
+    for (const f of currentFiles) {
+      const parts = f.name.split('/');
+      let cur = root;
+      for (let i = 0; i < parts.length - 1; i++) {
+        const part = parts[i];
+        if (!cur.children.has(part)) {
+          cur.children.set(part, { name: part, children: new Map(), isDir: true, files: [] });
+        }
+        cur = cur.children.get(part);
+      }
+      const leaf = parts[parts.length - 1];
+      cur.children.set(leaf, {
+        name: leaf,
+        fullPath: f.name,
+        isDir: false,
+        file: f,
+      });
+    }
+    treeEl.appendChild(renderTreeNode(root, true));
+  }
+
+  function renderTreeNode(node, isRoot) {
+    const ul = document.createElement('ul');
+    if (!isRoot) ul.style.paddingLeft = '0.4rem';
+    const entries = Array.from(node.children ? node.children.values() : []);
+    entries.sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    for (const child of entries) {
+      const li = document.createElement('li');
+      const row = document.createElement('div');
+      row.className = 'inspector-tree-row';
+      const toggle = document.createElement('span');
+      toggle.className = 'inspector-tree-toggle';
+      if (child.isDir) {
+        toggle.textContent = '\u25BE';
+        let collapsed = false;
+        const childUl = renderTreeNode(child, false);
+        childUl.style.display = '';
+        toggle.addEventListener('click', (e) => {
+          e.stopPropagation();
+          collapsed = !collapsed;
+          childUl.style.display = collapsed ? 'none' : '';
+          toggle.textContent = collapsed ? '\u25B8' : '\u25BE';
+        });
+        row.addEventListener('click', () => toggle.click());
+        row.appendChild(toggle);
+        row.appendChild(iconSpan(iconFor(child.name, true)));
+        row.appendChild(labelSpan(child.name));
+        li.appendChild(row);
+        li.appendChild(childUl);
+      } else {
+        toggle.classList.add('leaf');
+        row.appendChild(toggle);
+        row.appendChild(iconSpan(iconFor(child.file.name, false)));
+        row.appendChild(labelSpan(child.name));
+        if (child.file.size != null) {
+          row.appendChild(sizeSpan(formatSize(child.file.size)));
+        }
+        row.addEventListener('click', () => selectFile(child.file.name, row));
+        row._fullPath = child.file.name;
+        li.appendChild(row);
+        child._row = row;
+        child._name = child.name;
+      }
+      ul.appendChild(li);
+    }
+    return ul;
+  }
+
+  function iconSpan(text) {
+    const s = document.createElement('span');
+    s.className = 'inspector-tree-icon';
+    s.textContent = text + ' ';
+    return s;
+  }
+  function labelSpan(text) {
+    const s = document.createElement('span');
+    s.className = 'inspector-tree-label';
+    s.textContent = text;
+    return s;
+  }
+  function sizeSpan(text) {
+    const s = document.createElement('span');
+    s.className = 'inspector-tree-size';
+    s.textContent = text;
+    return s;
+  }
+
+  function selectFile(name, rowEl) {
+    selectedName = name;
+    document.querySelectorAll('.inspector-tree-row.active').forEach(r => r.classList.remove('active'));
+    if (rowEl) rowEl.classList.add('active');
+    const f = fileIndex.get(name);
+    if (!f) return;
+    contentEl.innerHTML = '';
+    if (f.json !== null && f.json !== undefined) {
+      renderJsonContent(f);
+    } else if (f.url && isImage(f.name)) {
+      renderMediaContent(f);
+    } else if (f.url && isFont(f.name)) {
+      renderMediaContent(f);
+    } else if (f.parseError) {
+      const err = document.createElement('div');
+      err.className = 'inspector-error';
+      err.textContent = 'Failed to parse JSON: ' + f.parseError;
+      contentEl.appendChild(err);
+    } else if (f.blob) {
+      renderBinaryContent(f);
+    }
+  }
+
+  function isShapeFile(name) {
+    return /^files\/[^/]+\/pages\/[^/]+\/[^/]+\.json$/.test(name);
+  }
+  function isMediaJsonFile(name) {
+    return /^files\/[^/]+\/media\/[^/]+\.json$/.test(name);
+  }
+
+  function renderJsonContent(f) {
+    if (isShapeFile(f.name)) {
+      const card = buildShapeCard(f.json, f.name);
+      if (card) contentEl.appendChild(card);
+    }
+    const toolbar = buildJsonToolbar(f);
+    contentEl.appendChild(toolbar);
+    const treeWrap = document.createElement('div');
+    treeWrap.className = 'inspector-jtree';
+    const root = renderJsonNode(f.json, null, true, 0, f.name);
+    treeWrap.appendChild(root);
+    contentEl.appendChild(treeWrap);
+    renderBacklinks(f);
+  }
+
+  function buildJsonToolbar(f) {
+    const bar = document.createElement('div');
+    bar.className = 'inspector-toolbar';
+    const search = document.createElement('input');
+    search.type = 'search';
+    search.placeholder = 'Search keys/values...';
+    const depthLabel = document.createElement('label');
+    depthLabel.textContent = 'Expand to depth:';
+    const depthInput = document.createElement('input');
+    depthInput.type = 'number';
+    depthInput.min = '0';
+    depthInput.max = '20';
+    depthInput.value = '2';
+    const expandBtn = document.createElement('button');
+    expandBtn.textContent = 'Apply';
+    const collapseBtn = document.createElement('button');
+    collapseBtn.textContent = 'Collapse all';
+
+    search.addEventListener('input', () => {
+      applyJsonSearch(search.value);
+    });
+    expandBtn.addEventListener('click', () => {
+      const d = parseInt(depthInput.value, 10);
+      applyJsonDepth(isNaN(d) ? 99 : d);
+    });
+    collapseBtn.addEventListener('click', () => {
+      applyJsonDepth(0);
+      depthInput.value = '0';
+    });
+
+    bar.appendChild(search);
+    bar.appendChild(depthLabel);
+    bar.appendChild(depthInput);
+    bar.appendChild(expandBtn);
+    bar.appendChild(collapseBtn);
+    return bar;
+  }
+
+  function applyJsonSearch(q) {
+    const ql = (q || '').toLowerCase().trim();
+    const rows = contentEl.querySelectorAll('.inspector-jtree .jrow');
+    rows.forEach(r => r.classList.remove('match'));
+    if (!ql) return;
+    rows.forEach(r => {
+      const text = r.textContent.toLowerCase();
+      if (text.includes(ql)) {
+        r.classList.add('match');
+        let p = r.parentElement;
+        while (p && !p.classList.contains('jchildren')) {
+          if (p.classList.contains('jchildren') && p.classList.contains('collapsed')) {
+            const t = p.previousElementSibling?.querySelector?.('.jtoggle');
+            if (t) t.click();
+          }
+          p = p.parentElement;
+        }
+      }
+    });
+  }
+
+  function applyJsonDepth(depth) {
+    const children = contentEl.querySelectorAll('.inspector-jtree .jchildren');
+    children.forEach(c => {
+      const lvl = parseInt(c.dataset.depth, 10);
+      if (lvl < depth) {
+        c.classList.remove('collapsed');
+        const t = c.previousElementSibling;
+        if (t) {
+          const tg = t.querySelector('.jtoggle');
+          if (tg) tg.textContent = '\u25BE';
+        }
+      } else {
+        c.classList.add('collapsed');
+        const t = c.previousElementSibling;
+        if (t) {
+          const tg = t.querySelector('.jtoggle');
+          if (tg) tg.textContent = '\u25B8';
+        }
+      }
+    });
+  }
+
+  function renderJsonNode(value, key, isLast, depth, fileName) {
+    const row = document.createElement('div');
+    row.className = 'jrow';
+    const toggle = document.createElement('span');
+    toggle.className = 'jtoggle';
+    row.appendChild(toggle);
+
+    if (key !== null && key !== undefined) {
+      const k = document.createElement('span');
+      k.className = 'jkey';
+      k.textContent = JSON.stringify(key);
+      row.appendChild(k);
+      row.appendChild(textSpan(': '));
+    }
+
+    const type = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
+    if (type === 'object' && value !== null) {
+      const keys = Object.keys(value);
+      const meta = document.createElement('span');
+      meta.className = 'jmeta';
+      meta.textContent = '{ ' + keys.length + ' keys }';
+      row.appendChild(meta);
+      toggle.textContent = '\u25BE';
+      const children = document.createElement('div');
+      children.className = 'jchildren';
+      children.dataset.depth = String(depth);
+      if (depth >= 2) {
+        children.classList.add('collapsed');
+        toggle.textContent = '\u25B8';
+      }
+      toggle.addEventListener('click', () => {
+        const collapsed = children.classList.toggle('collapsed');
+        toggle.textContent = collapsed ? '\u25B8' : '\u25BE';
+      });
+      keys.forEach((k, i) => {
+        children.appendChild(renderJsonNode(value[k], k, i === keys.length - 1, depth + 1, fileName));
+      });
+      const wrap = document.createElement('div');
+      wrap.appendChild(row);
+      wrap.appendChild(children);
+      return wrap;
+    } else if (type === 'array') {
+      const meta = document.createElement('span');
+      meta.className = 'jmeta';
+      meta.textContent = '[ ' + value.length + ' items ]';
+      row.appendChild(meta);
+      toggle.textContent = '\u25BE';
+      const children = document.createElement('div');
+      children.className = 'jchildren';
+      children.dataset.depth = String(depth);
+      if (depth >= 2) {
+        children.classList.add('collapsed');
+        toggle.textContent = '\u25B8';
+      }
+      toggle.addEventListener('click', () => {
+        const collapsed = children.classList.toggle('collapsed');
+        toggle.textContent = collapsed ? '\u25B8' : '\u25BE';
+      });
+      value.forEach((v, i) => {
+        children.appendChild(renderJsonNode(v, i, i === value.length - 1, depth + 1, fileName));
+      });
+      const wrap = document.createElement('div');
+      wrap.appendChild(row);
+      wrap.appendChild(children);
+      return wrap;
+    } else {
+      toggle.classList.add('leaf');
+      const val = document.createElement('span');
+      if (type === 'string') {
+        if (UUID_RE.test(value)) {
+          val.className = 'juuid';
+          val.textContent = JSON.stringify(value);
+          val.title = 'Jump to referenced file';
+          val.addEventListener('click', (e) => {
+            e.stopPropagation();
+            jumpToUuid(value);
+          });
+        } else {
+          val.className = 'jstr';
+          val.textContent = JSON.stringify(value);
+        }
+      } else if (type === 'number') {
+        val.className = 'jnum';
+        val.textContent = String(value);
+      } else if (type === 'boolean') {
+        val.className = 'jbool';
+        val.textContent = String(value);
+      } else if (type === 'null') {
+        val.className = 'jnull';
+        val.textContent = 'null';
+      } else {
+        val.textContent = String(value);
+      }
+      row.appendChild(val);
+      if (!isLast) row.appendChild(textSpan(','));
+      return row;
+    }
+  }
+
+  function textSpan(t) {
+    const s = document.createElement('span');
+    s.textContent = t;
+    return s;
+  }
+
+  function jumpToUuid(uuid) {
+    const candidates = [];
+    for (const f of currentFiles) {
+      if (f.name.includes(uuid) || (f.json && JSON.stringify(f.json).includes(uuid))) {
+        candidates.push(f);
+      }
+    }
+    const exact = candidates.find(f => f.name.includes(uuid) && /[/.]json$|[/.][a-z0-9]+$/.test(f.name));
+    let target = null;
+    if (exact) {
+      target = exact;
+    } else {
+      const mediaRef = candidates.find(f => isMediaJsonFile(f.name) && f.json && (f.json.id === uuid || f.json.mediaId === uuid));
+      if (mediaRef) target = mediaRef;
+      else if (candidates.length > 0) target = candidates[0];
+    }
+    if (target) {
+      const row = findTreeRow(target.name);
+      if (row) {
+        expandAncestors(row);
+        selectFile(target.name, row);
+        row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    } else {
+      setStatus('UUID ' + uuid + ' is referenced but no matching file was found in the archive.', true);
+      setTimeout(() => setStatus('Loaded ' + currentFiles.length + ' files'), 3000);
+    }
+  }
+
+  function findTreeRow(name) {
+    const rows = document.querySelectorAll('.inspector-tree-row');
+    for (const r of rows) {
+      if (r._fullPath === name) return r;
+    }
+    return null;
+  }
+
+  function expandAncestors(row) {
+    let parent = row.parentElement;
+    while (parent) {
+      if (parent.classList && parent.classList.contains('jchildren')) {
+        parent.classList.remove('collapsed');
+        const t = parent.previousElementSibling?.querySelector?.('.jtoggle');
+        if (t) t.textContent = '\u25BE';
+      }
+      parent = parent.parentElement;
+    }
+  }
+
+  function renderBacklinks(f) {
+    if (!f.json) return;
+    const myId = typeof f.json.id === 'string' && UUID_RE.test(f.json.id) ? f.json.id : null;
+    if (!myId) return;
+    const refs = backlinks.get(myId) || [];
+    if (refs.length === 0) return;
+    const wrap = document.createElement('div');
+    wrap.className = 'inspector-backlinks';
+    const h = document.createElement('h4');
+    h.textContent = 'Referenced by (' + refs.length + ')';
+    wrap.appendChild(h);
+    const ul = document.createElement('ul');
+    for (const refFile of refs) {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.textContent = refFile;
+      a.addEventListener('click', () => {
+        const row = findTreeRow(refFile);
+        if (row) {
+          expandAncestors(row);
+          selectFile(refFile, row);
+          row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
+      });
+      li.appendChild(a);
+      ul.appendChild(li);
+    }
+    wrap.appendChild(ul);
+    contentEl.appendChild(wrap);
+  }
+
+  function buildShapeCard(shape, fileName) {
+    if (!shape || typeof shape !== 'object') return null;
+    const card = document.createElement('div');
+    card.className = 'inspector-shape-card';
+    const h = document.createElement('h3');
+    h.textContent = (shape.name || '(unnamed)') + ' \u2014 ' + (shape.type || '?');
+    card.appendChild(h);
+    const dl = document.createElement('dl');
+    dl.className = 'inspector-shape-grid';
+    function addRow(label, val) {
+      const dt = document.createElement('dt'); dt.textContent = label;
+      const dd = document.createElement('dd'); dd.textContent = val;
+      dl.appendChild(dt); dl.appendChild(dd);
+    }
+    if (shape.id) addRow('id', shape.id);
+    if (shape.x != null && shape.y != null) addRow('position', shape.x + ', ' + shape.y);
+    if (shape.width != null && shape.height != null) addRow('size', shape.width + ' \u00D7 ' + shape.height);
+    if (shape.rotation != null && shape.rotation !== 0) addRow('rotation', shape.rotation + '\u00B0');
+    if (shape.opacity != null && shape.opacity !== 1) addRow('opacity', shape.opacity);
+    if (shape.blendMode && shape.blendMode !== 'normal') addRow('blend', shape.blendMode);
+    if (shape.fills && shape.fills.length > 0) {
+      const dt = document.createElement('dt'); dt.textContent = 'fills';
+      const dd = document.createElement('dd');
+      shape.fills.forEach((f, i) => {
+        if (f.fillColor) {
+          const sw = document.createElement('span');
+          sw.className = 'inspector-swatch';
+          sw.style.background = renderFillColor(f.fillColor);
+          dd.appendChild(sw);
+          dd.appendChild(textSpan(f.fillColor + ' '));
+        } else if (f.fillImage) {
+          dd.appendChild(textSpan('[image fill] '));
+        } else if (f.fillGradient) {
+          dd.appendChild(textSpan('[gradient] '));
+        }
+      });
+      dl.appendChild(dt); dl.appendChild(dd);
+    }
+    if (shape.strokes && shape.strokes.length > 0) {
+      const dt = document.createElement('dt'); dt.textContent = 'strokes';
+      const dd = document.createElement('dd');
+      shape.strokes.forEach((s) => {
+        if (s.strokeColor) {
+          const sw = document.createElement('span');
+          sw.className = 'inspector-swatch';
+          sw.style.background = renderFillColor(s.strokeColor);
+          dd.appendChild(sw);
+          dd.appendChild(textSpan(s.strokeColor + ' '));
+        }
+      });
+      dl.appendChild(dt); dl.appendChild(dd);
+    }
+    if (shape.content && typeof shape.content === 'object' && shape.content.text) {
+      const dt = document.createElement('dt'); dt.textContent = 'text';
+      const dd = document.createElement('dd');
+      const preview = String(shape.content.text).slice(0, 100);
+      dd.textContent = preview + (String(shape.content.text).length > 100 ? '\u2026' : '');
+      dl.appendChild(dt); dl.appendChild(dd);
+    }
+    card.appendChild(dl);
+
+    if (shape.type === 'image' || (shape.metadata && shape.metadata.id)) {
+      const mediaId = shape.metadata && shape.metadata.id;
+      if (mediaId) {
+        const mediaFile = findMediaFileForShape(mediaId);
+        if (mediaFile && mediaFile.url && isImage(mediaFile.name)) {
+          const img = document.createElement('img');
+          img.className = 'inspector-shape-thumb';
+          img.src = mediaFile.url;
+          img.alt = 'media preview';
+          card.appendChild(img);
+        }
+      }
+    }
+    return card;
+  }
+
+  function findMediaFileForShape(mediaId) {
+    for (const f of currentFiles) {
+      if (isMediaJsonFile(f.name) && f.json && f.json.id === mediaId) {
+        if (f.json.mediaId) {
+          const obj = findStorageObject(f.json.mediaId);
+          if (obj) return obj;
+        }
+      }
+    }
+    return null;
+  }
+
+  function findStorageObject(storageId) {
+    for (const f of currentFiles) {
+      if (f.name.startsWith('objects/' + storageId + '.') || f.name === 'objects/' + storageId) {
+        return f;
+      }
+    }
+    return null;
+  }
+
+  function renderFillColor(c) {
+    if (!c) return 'transparent';
+    if (typeof c === 'string') {
+      if (c.startsWith('#')) return c;
+      return '#' + c;
+    }
+    if (typeof c === 'object') {
+      if (c.color) return renderFillColor(c.color);
+      if (c.r != null) {
+        const a = c.alpha != null ? c.alpha : 1;
+        return 'rgba(' + c.r + ',' + c.g + ',' + c.b + ',' + a + ')';
+      }
+    }
+    return 'transparent';
+  }
+
+  function renderMediaContent(f) {
+    const wrap = document.createElement('div');
+    wrap.className = 'inspector-media';
+    const preview = document.createElement('div');
+    preview.className = 'inspector-media-preview';
+    if (isImage(f.name)) {
+      const img = document.createElement('img');
+      img.src = f.url;
+      img.alt = f.name;
+      preview.appendChild(img);
+    } else if (isFont(f.name)) {
+      const label = document.createElement('div');
+      label.textContent = 'Font file: ' + f.name;
+      label.style.padding = '2rem';
+      label.style.color = 'var(--graymedium)';
+      preview.appendChild(label);
+    }
+    wrap.appendChild(preview);
+    const info = document.createElement('dl');
+    info.className = 'inspector-shape-grid inspector-media-info';
+    function addInfo(label, val) {
+      const dt = document.createElement('dt'); dt.textContent = label;
+      const dd = document.createElement('dd'); dd.textContent = val;
+      info.appendChild(dt); info.appendChild(dd);
+    }
+    addInfo('name', f.name);
+    addInfo('size', formatSize(f.size));
+    addInfo('mime', f.type || '(unknown)');
+    wrap.appendChild(info);
+    contentEl.appendChild(wrap);
+
+    if (isMediaJsonFile(f.name)) {
+      renderJsonContentFor(f);
+    } else {
+      const mediaJson = findMediaJsonForObject(f.name);
+      if (mediaJson) {
+        const note = document.createElement('div');
+        note.style.marginTop = '1rem';
+        note.style.fontSize = '0.85rem';
+        note.style.color = 'var(--graymedium)';
+        note.textContent = 'Referenced by: ';
+        const a = document.createElement('a');
+        a.textContent = mediaJson.name;
+        a.style.cursor = 'pointer';
+        a.addEventListener('click', () => {
+          const row = findTreeRow(mediaJson.name);
+          if (row) { expandAncestors(row); selectFile(mediaJson.name, row); }
+        });
+        note.appendChild(a);
+        contentEl.appendChild(note);
+      }
+    }
+  }
+
+  function findMediaJsonForObject(objectPath) {
+    const m = objectPath.match(/^objects\/([^.]+)/);
+    if (!m) return null;
+    const storageId = m[1];
+    for (const f of currentFiles) {
+      if (isMediaJsonFile(f.name) && f.json && f.json.mediaId === storageId) return f;
+    }
+    return null;
+  }
+
+  function renderJsonContentFor(f) {
+    const h = document.createElement('h3');
+    h.style.marginTop = '1.5rem';
+    h.style.fontSize = '0.95rem';
+    h.textContent = 'Metadata';
+    contentEl.appendChild(h);
+    const treeWrap = document.createElement('div');
+    treeWrap.className = 'inspector-jtree';
+    treeWrap.appendChild(renderJsonNode(f.json, null, true, 0, f.name));
+    contentEl.appendChild(treeWrap);
+    renderBacklinks(f);
+  }
+
+  function renderBinaryContent(f) {
+    const info = document.createElement('div');
+    info.innerHTML = '<p><strong>' + escapeHtml(f.name) + '</strong></p>' +
+      '<p>Size: ' + formatSize(f.size) + '<br>Type: ' + (f.type || '(unknown)') + '</p>';
+    contentEl.appendChild(info);
+    if (f.url) {
+      const a = document.createElement('a');
+      a.href = f.url;
+      a.download = f.name.split('/').pop();
+      a.textContent = 'Download';
+      a.className = 'inspector-card';
+      a.style.display = 'inline-block';
+      a.style.textDecoration = 'none';
+      contentEl.appendChild(a);
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]);
+  }
+
+  function showOverview() {
+    contentEl.innerHTML = '';
+    const summary = buildOverview();
+    contentEl.appendChild(summary);
+    const h = document.createElement('h2');
+    h.textContent = 'Quick links';
+    h.style.marginTop = '1.5rem';
+    h.style.fontSize = '1.1rem';
+    contentEl.appendChild(h);
+    const ul = document.createElement('ul');
+    const manifest = currentFiles.find(f => f.name === 'manifest.json');
+    if (manifest) ul.appendChild(quickLink(manifest.name, 'manifest.json'));
+    for (const f of currentFiles) {
+      if (/^files\/[^/]+\.json$/.test(f.name)) {
+        ul.appendChild(quickLink(f.name, f.name.split('/').pop()));
+      }
+    }
+    for (const f of currentFiles) {
+      if (isMediaJsonFile(f.name)) {
+        ul.appendChild(quickLink(f.name, f.name));
+        break;
+      }
+    }
+    contentEl.appendChild(ul);
+  }
+
+  function buildOverview() {
+    const wrap = document.createElement('div');
+    const summary = collectSummary();
+    const grid = document.createElement('div');
+    grid.className = 'inspector-summary';
+    function addCard(label, value, detail) {
+      const c = document.createElement('div');
+      c.className = 'inspector-card';
+      c.innerHTML = '<div class="inspector-card-label">' + escapeHtml(label) + '</div>' +
+        '<div class="inspector-card-value">' + escapeHtml(String(value)) + '</div>' +
+        (detail ? '<div class="inspector-card-detail">' + detail + '</div>' : '');
+      grid.appendChild(c);
+    }
+    addCard('Version', summary.version || '?');
+    addCard('Generator', summary.generator || '?');
+    addCard('Files', summary.fileCount, summary.fileNames.length <= 3 ? summary.fileNames.join(', ') : summary.fileNames.slice(0, 3).join(', ') + '\u2026');
+    addCard('Pages', summary.pageCount);
+    addCard('Shapes', summary.shapeCount);
+    addCard('Library assets', summary.colors + ' colors, ' + summary.components + ' components, ' + summary.typographies + ' typographies');
+    addCard('Storage objects', summary.storageCount, 'total ' + formatSize(summary.storageSize));
+    addCard('Media types', Object.entries(summary.mediaByMime).map(([k, v]) => k + ': ' + v).join(', ') || '\u2014');
+    wrap.appendChild(grid);
+
+    if (summary.relations && Object.keys(summary.relations).length > 0) {
+      const h = document.createElement('h3');
+      h.style.fontSize = '1rem';
+      h.style.marginTop = '1rem';
+      h.textContent = 'Library dependencies';
+      wrap.appendChild(h);
+      const ul = document.createElement('ul');
+      for (const [k, v] of Object.entries(summary.relations)) {
+        const li = document.createElement('li');
+        li.textContent = k + ' \u2192 ' + (Array.isArray(v) ? v.join(', ') : String(v));
+        ul.appendChild(li);
+      }
+      wrap.appendChild(ul);
+    }
+    return wrap;
+  }
+
+  function collectSummary() {
+    const out = { fileCount: 0, fileNames: [], pageCount: 0, shapeCount: 0,
+      colors: 0, components: 0, typographies: 0, storageCount: 0, storageSize: 0,
+      mediaByMime: {}, relations: null, version: null, generator: null };
+    const manifest = currentFiles.find(f => f.name === 'manifest.json');
+    if (manifest && manifest.json) {
+      out.version = manifest.json.version;
+      out.generator = manifest.json.generator;
+      out.fileCount = (manifest.json.files || []).length;
+      out.fileNames = (manifest.json.files || []).map(f => f.name || '?');
+      if (manifest.json.relations) out.relations = manifest.json.relations;
+    }
+    for (const f of currentFiles) {
+      const m = f.name.match(/^files\/[^/]+\/pages\/[^/]+\.json$/);
+      if (m) out.pageCount++;
+      const sm = f.name.match(/^files\/[^/]+\/pages\/[^/]+\/[^/]+\.json$/);
+      if (sm) out.shapeCount++;
+      if (/^files\/[^/]+\/colors\/[^/]+\.json$/.test(f.name)) out.colors++;
+      if (/^files\/[^/]+\/components\/[^/]+\.json$/.test(f.name)) out.components++;
+      if (/^files\/[^/]+\/typographies\/[^/]+\.json$/.test(f.name)) out.typographies++;
+      if (/^objects\//.test(f.name)) {
+        out.storageCount++;
+        out.storageSize += f.size;
+        const mime = f.type || 'application/octet-stream';
+        out.mediaByMime[mime] = (out.mediaByMime[mime] || 0) + 1;
+      }
+    }
+    return out;
+  }
+
+  function quickLink(fileName, label) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.textContent = label;
+    a.style.cursor = 'pointer';
+    a.addEventListener('click', () => {
+      const row = findTreeRow(fileName);
+      if (row) { expandAncestors(row); selectFile(fileName, row); }
+    });
+    li.appendChild(a);
+    return li;
+  }
+
+  treeSearch.addEventListener('input', () => {
+    const q = treeSearch.value.toLowerCase().trim();
+    const rows = document.querySelectorAll('.inspector-tree .inspector-tree-row');
+    if (!q) {
+      rows.forEach(r => r.classList.remove('hidden'));
+      document.querySelectorAll('.inspector-search-empty').forEach(e => e.remove());
+      return;
+    }
+    rows.forEach(r => {
+      const label = r.querySelector('.inspector-tree-label')?.textContent.toLowerCase() || '';
+      r.classList.toggle('hidden', !label.includes(q));
+    });
+    const empty = document.querySelector('.inspector-search-empty');
+    const anyVisible = Array.from(rows).some(r => !r.classList.contains('hidden'));
+    if (!anyVisible && !empty) {
+      const e = document.createElement('div');
+      e.className = 'inspector-search-empty';
+      e.textContent = 'No files match.';
+      treeEl.appendChild(e);
+    } else if (anyVisible && empty) {
+      empty.remove();
+    }
+  });
+
+  dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+  });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+  dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    const f = e.dataTransfer.files[0];
+    if (f) handleFile(f);
+  });
+  fileInput.addEventListener('change', (e) => {
+    const f = e.target.files[0];
+    if (f) handleFile(f);
+    e.target.value = '';
+  });
+
+  window.__inspector = { handleFile };
+})();
+</script>

--- a/docs/technical-guide/developer/data-model/penpot-file-inspector.njk
+++ b/docs/technical-guide/developer/data-model/penpot-file-inspector.njk
@@ -276,11 +276,12 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
   .inspector-media-info { font-size: 0.85rem; }
   .inspector-media-info dt { color: var(--graymedium); }
 
-  .inspector-jtree { font-family: 'Menlo', 'Consolas', monospace; font-size: 0.85rem; line-height: 1.5; }
-  .inspector-jtree .jrow { display: flex; align-items: flex-start; }
+  .inspector-jtree { font-family: 'Menlo', 'Consolas', monospace; font-size: 0.85rem; line-height: 1.6; }
+  .inspector-jtree .jrow { display: flex; align-items: flex-start; padding: 0.05rem 0; }
   .inspector-jtree .jtoggle {
     display: inline-block;
-    width: 1em;
+    width: 1.2em;
+    text-align: center;
     cursor: pointer;
     color: var(--graymedium);
     user-select: none;
@@ -293,10 +294,15 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
   .inspector-jtree .jbool { color: #7b3aa3; }
   .inspector-jtree .jnull { color: var(--graymedium); font-style: italic; }
   .inspector-jtree .jmeta { color: var(--graymedium); margin-left: 0.4em; }
+  .inspector-jtree .jchildren {
+    padding-left: 1.2rem;
+    border-left: 1px dotted #d0d0d0;
+    margin-left: 0.1em;
+  }
+  .inspector-jtree .jchildren.collapsed { display: none; }
   .inspector-jtree .jrow.match > .jkey,
   .inspector-jtree .jrow.match > .jstr,
   .inspector-jtree .jrow.match > .jnum { background: #fff3a3; }
-  .inspector-jtree .jchildren.collapsed { display: none; }
   .inspector-jtree .juuid { color: #1d6fb8; text-decoration: underline dotted; cursor: pointer; }
   .inspector-jtree .juuid:hover { background: var(--advice); }
 

--- a/docs/technical-guide/developer/data-model/penpot-file-inspector.njk
+++ b/docs/technical-guide/developer/data-model/penpot-file-inspector.njk
@@ -4,6 +4,14 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
 ---
 
 <style>
+  .main-container:has(.inspector-wrap) .sidebar {
+    display: none;
+  }
+  .main-content:has(.inspector-wrap) {
+    max-width: none;
+    flex: 1 1 100%;
+    min-width: 0;
+  }
   .inspector-wrap {
     margin: 1rem 0 2rem;
     display: block;
@@ -36,36 +44,91 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
   }
   .inspector-status.error { color: #b00020; }
 
-  .inspector-layout {
+  .inspector-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 1.5rem;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 6px;
+    background: var(--color-gray-light);
+  }
+  .inspector-picker input[type=text] {
+    flex: 1;
+    min-width: 240px;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--color-gray-medium);
+    border-radius: 4px;
+    font-family: 'Menlo', 'Consolas', monospace;
+    font-size: 0.85rem;
+    background: var(--white);
+  }
+  .inspector-picker button {
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--color-gray-medium);
+    background: var(--white);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-family: inherit;
+    white-space: nowrap;
+  }
+  .inspector-picker button:hover:not(:disabled) {
+    background: var(--advice);
+    border-color: var(--primarydark);
+  }
+  .inspector-picker button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .inspector-picker button.active {
+    background: var(--advice);
+    color: var(--primarydark);
+    border-color: var(--primarydark);
+    font-weight: 600;
+  }
+  .inspector-current-path {
+    font-family: 'Menlo', 'Consolas', monospace;
+    font-size: 0.8rem;
+    color: var(--graymedium);
+    margin-top: 0.5rem;
+    margin-left: 0.2rem;
+    min-height: 1.2em;
+    word-break: break-all;
+  }
+
+  .inspector-main {
     display: grid;
     grid-template-columns: 280px minmax(0, 1fr);
     gap: 1rem;
-    margin-top: 1.5rem;
-    min-height: 500px;
+    margin-top: 0.5rem;
   }
   @media (max-width: 900px) {
-    .inspector-layout { grid-template-columns: 1fr; }
-    .inspector-sidebar { max-height: 320px; }
+    .inspector-main { grid-template-columns: 1fr; }
   }
-
-  .inspector-sidebar {
-    grid-column: 1;
-    order: 1;
+  .inspector-tree-panel {
     border: 1px solid var(--color-gray-medium);
     border-radius: 6px;
     background: var(--white);
-    overflow: auto;
     padding: 0.6rem;
     font-size: 0.9rem;
+    max-height: 75vh;
+    overflow: auto;
+    position: sticky;
+    top: 1rem;
+    align-self: start;
   }
-  .inspector-search {
+  .inspector-tree-search {
     width: 100%;
     padding: 0.4rem 0.6rem;
     border: 1px solid var(--color-gray-medium);
     border-radius: 4px;
-    margin-bottom: 0.6rem;
+    margin-bottom: 0.5rem;
     font-size: 0.85rem;
     font-family: inherit;
+    box-sizing: border-box;
   }
   .inspector-tree { list-style: none; padding: 0; margin: 0; }
   .inspector-tree ul {
@@ -85,13 +148,18 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
     line-height: 1.4;
   }
   .inspector-tree-row:hover { background: var(--color-gray-light); }
-  .inspector-tree-row.active { background: var(--advice); color: var(--primarydark); font-weight: 500; }
+  .inspector-tree-row.active {
+    background: var(--advice);
+    color: var(--primarydark);
+    font-weight: 500;
+  }
   .inspector-tree-toggle {
     display: inline-block;
     width: 1em;
     text-align: center;
     color: var(--graymedium);
     flex-shrink: 0;
+    cursor: pointer;
   }
   .inspector-tree-toggle.leaf { visibility: hidden; }
   .inspector-tree-icon { flex-shrink: 0; font-size: 0.85em; }
@@ -101,13 +169,12 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
   .inspector-search-empty { color: var(--graymedium); font-style: italic; padding: 0.4rem; }
 
   .inspector-content {
-    grid-column: 2;
-    order: 2;
     border: 1px solid var(--color-gray-medium);
     border-radius: 6px;
     background: var(--white);
     overflow: auto;
     padding: 1.2rem;
+    min-height: 75vh;
   }
 
   .inspector-empty { color: var(--graymedium); text-align: center; padding: 3rem 1rem; }
@@ -266,14 +333,23 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
   </label>
   <div class="inspector-status" id="status"></div>
 
-  <div class="inspector-layout" id="app" hidden>
-    <aside class="inspector-sidebar">
-      <input type="search" class="inspector-search" id="tree-search" placeholder="Filter files..." />
-      <div class="inspector-tree" id="tree"></div>
-    </aside>
-    <main class="inspector-content" id="content">
-      <div class="inspector-empty">Select a file from the sidebar to inspect it.</div>
-    </main>
+  <div id="app" hidden>
+    <div class="inspector-picker">
+      <input type="text" list="file-list" id="file-picker-input" placeholder="Search files in archive..." />
+      <datalist id="file-list"></datalist>
+      <button id="file-picker-go" type="button">Open</button>
+      <button id="file-picker-back" type="button">&#8592; Overview</button>
+    </div>
+    <div class="inspector-current-path" id="current-path">File overview</div>
+    <div class="inspector-main">
+      <aside class="inspector-tree-panel">
+        <input type="search" class="inspector-tree-search" id="tree-search" placeholder="Filter files in tree..." />
+        <div class="inspector-tree" id="tree"></div>
+      </aside>
+      <main class="inspector-content" id="content">
+        <div class="inspector-empty">Upload a file to begin.</div>
+      </main>
+    </div>
   </div>
 </div>
 
@@ -330,8 +406,13 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
   const fileInput = document.getElementById('file-input');
   const statusEl = document.getElementById('status');
   const appEl = document.getElementById('app');
-  const treeEl = document.getElementById('tree');
   const contentEl = document.getElementById('content');
+  const fileListEl = document.getElementById('file-list');
+  const filePickerInput = document.getElementById('file-picker-input');
+  const filePickerGo = document.getElementById('file-picker-go');
+  const filePickerBack = document.getElementById('file-picker-back');
+  const currentPathEl = document.getElementById('current-path');
+  const treeEl = document.getElementById('tree');
   const treeSearch = document.getElementById('tree-search');
 
   function setStatus(msg, isError) {
@@ -452,6 +533,7 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
       indexBacklinks();
       setStatus('Loaded ' + count + ' files from ' + file.name);
       appEl.hidden = false;
+      populateFileList();
       buildTree();
       showOverview();
     } catch (e) {
@@ -487,6 +569,16 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
     }
   }
 
+  function populateFileList() {
+    fileListEl.innerHTML = '';
+    const names = currentFiles.map(f => f.name).sort();
+    for (const name of names) {
+      const opt = document.createElement('option');
+      opt.value = name;
+      fileListEl.appendChild(opt);
+    }
+  }
+
   function buildTree() {
     treeEl.innerHTML = '';
     const root = { name: '', children: new Map(), isDir: true };
@@ -496,7 +588,7 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
       for (let i = 0; i < parts.length - 1; i++) {
         const part = parts[i];
         if (!cur.children.has(part)) {
-          cur.children.set(part, { name: part, children: new Map(), isDir: true, files: [] });
+          cur.children.set(part, { name: part, children: new Map(), isDir: true });
         }
         cur = cur.children.get(part);
       }
@@ -523,23 +615,22 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
       const li = document.createElement('li');
       const row = document.createElement('div');
       row.className = 'inspector-tree-row';
+      row.dataset.fullpath = child.fullPath || '';
       const toggle = document.createElement('span');
       toggle.className = 'inspector-tree-toggle';
       if (child.isDir) {
         toggle.textContent = '\u25BE';
-        let collapsed = false;
         const childUl = renderTreeNode(child, false);
-        childUl.style.display = '';
         toggle.addEventListener('click', (e) => {
           e.stopPropagation();
-          collapsed = !collapsed;
-          childUl.style.display = collapsed ? 'none' : '';
-          toggle.textContent = collapsed ? '\u25B8' : '\u25BE';
+          const collapsed = childUl.style.display === 'none';
+          childUl.style.display = collapsed ? '' : 'none';
+          toggle.textContent = collapsed ? '\u25BE' : '\u25B8';
         });
-        row.addEventListener('click', () => toggle.click());
         row.appendChild(toggle);
         row.appendChild(iconSpan(iconFor(child.name, true)));
         row.appendChild(labelSpan(child.name));
+        row.addEventListener('click', () => toggle.click());
         li.appendChild(row);
         li.appendChild(childUl);
       } else {
@@ -550,11 +641,8 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
         if (child.file.size != null) {
           row.appendChild(sizeSpan(formatSize(child.file.size)));
         }
-        row.addEventListener('click', () => selectFile(child.file.name, row));
-        row._fullPath = child.file.name;
+        row.addEventListener('click', () => selectFile(child.file.name));
         li.appendChild(row);
-        child._row = row;
-        child._name = child.name;
       }
       ul.appendChild(li);
     }
@@ -580,12 +668,48 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
     return s;
   }
 
-  function selectFile(name, rowEl) {
+  function findTreeRow(name) {
+    const rows = treeEl.querySelectorAll('.inspector-tree-row');
+    for (const r of rows) {
+      if (r.dataset.fullpath === name) return r;
+    }
+    return null;
+  }
+
+  function expandTreeAncestors(row) {
+    let el = row;
+    while (el) {
+      if (el.tagName === 'UL' && el.style.display === 'none') {
+        el.style.display = '';
+        const prev = el.previousElementSibling;
+        if (prev) {
+          const toggle = prev.querySelector('.inspector-tree-toggle');
+          if (toggle) toggle.textContent = '\u25BE';
+        }
+      }
+      el = el.parentElement;
+    }
+  }
+
+  function updateTreeActive(name) {
+    treeEl.querySelectorAll('.inspector-tree-row.active').forEach(r => r.classList.remove('active'));
+    if (!name) return;
+    const row = findTreeRow(name);
+    if (!row) return;
+    row.classList.add('active');
+    expandTreeAncestors(row);
+    row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }
+
+  function selectFile(name) {
     selectedName = name;
-    document.querySelectorAll('.inspector-tree-row.active').forEach(r => r.classList.remove('active'));
-    if (rowEl) rowEl.classList.add('active');
     const f = fileIndex.get(name);
-    if (!f) return;
+    if (!f) {
+      setStatus('File not found: ' + name, true);
+      return;
+    }
+    updatePickerState(name);
+    updateTreeActive(name);
     contentEl.innerHTML = '';
     if (f.json !== null && f.json !== undefined) {
       renderJsonContent(f);
@@ -601,6 +725,38 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
     } else if (f.blob) {
       renderBinaryContent(f);
     }
+  }
+
+  function updatePickerState(name) {
+    if (name) {
+      filePickerInput.value = name;
+      currentPathEl.textContent = name;
+      filePickerBack.classList.remove('active');
+    } else {
+      filePickerInput.value = '';
+      currentPathEl.textContent = 'File overview';
+      filePickerBack.classList.add('active');
+      treeEl.querySelectorAll('.inspector-tree-row.active').forEach(r => r.classList.remove('active'));
+    }
+  }
+
+  function goToOverview() {
+    selectedName = null;
+    updatePickerState(null);
+    showOverview();
+  }
+
+  function goToFileFromPicker() {
+    const name = filePickerInput.value.trim();
+    if (!name) {
+      setStatus('Type or pick a file from the archive.', true);
+      return;
+    }
+    if (!fileIndex.has(name)) {
+      setStatus('No file matches "' + name + '".', true);
+      return;
+    }
+    selectFile(name);
   }
 
   function isShapeFile(name) {
@@ -828,35 +984,11 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
       else if (candidates.length > 0) target = candidates[0];
     }
     if (target) {
-      const row = findTreeRow(target.name);
-      if (row) {
-        expandAncestors(row);
-        selectFile(target.name, row);
-        row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      }
+      selectFile(target.name);
+      contentEl.scrollTop = 0;
     } else {
       setStatus('UUID ' + uuid + ' is referenced but no matching file was found in the archive.', true);
       setTimeout(() => setStatus('Loaded ' + currentFiles.length + ' files'), 3000);
-    }
-  }
-
-  function findTreeRow(name) {
-    const rows = document.querySelectorAll('.inspector-tree-row');
-    for (const r of rows) {
-      if (r._fullPath === name) return r;
-    }
-    return null;
-  }
-
-  function expandAncestors(row) {
-    let parent = row.parentElement;
-    while (parent) {
-      if (parent.classList && parent.classList.contains('jchildren')) {
-        parent.classList.remove('collapsed');
-        const t = parent.previousElementSibling?.querySelector?.('.jtoggle');
-        if (t) t.textContent = '\u25BE';
-      }
-      parent = parent.parentElement;
     }
   }
 
@@ -877,12 +1009,8 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
       const a = document.createElement('a');
       a.textContent = refFile;
       a.addEventListener('click', () => {
-        const row = findTreeRow(refFile);
-        if (row) {
-          expandAncestors(row);
-          selectFile(refFile, row);
-          row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-        }
+        selectFile(refFile);
+        contentEl.scrollTop = 0;
       });
       li.appendChild(a);
       ul.appendChild(li);
@@ -1050,8 +1178,8 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
         a.textContent = mediaJson.name;
         a.style.cursor = 'pointer';
         a.addEventListener('click', () => {
-          const row = findTreeRow(mediaJson.name);
-          if (row) { expandAncestors(row); selectFile(mediaJson.name, row); }
+          selectFile(mediaJson.name);
+          contentEl.scrollTop = 0;
         });
         note.appendChild(a);
         contentEl.appendChild(note);
@@ -1205,36 +1333,12 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
     a.textContent = label;
     a.style.cursor = 'pointer';
     a.addEventListener('click', () => {
-      const row = findTreeRow(fileName);
-      if (row) { expandAncestors(row); selectFile(fileName, row); }
+      selectFile(fileName);
+      contentEl.scrollTop = 0;
     });
     li.appendChild(a);
     return li;
   }
-
-  treeSearch.addEventListener('input', () => {
-    const q = treeSearch.value.toLowerCase().trim();
-    const rows = document.querySelectorAll('.inspector-tree .inspector-tree-row');
-    if (!q) {
-      rows.forEach(r => r.classList.remove('hidden'));
-      document.querySelectorAll('.inspector-search-empty').forEach(e => e.remove());
-      return;
-    }
-    rows.forEach(r => {
-      const label = r.querySelector('.inspector-tree-label')?.textContent.toLowerCase() || '';
-      r.classList.toggle('hidden', !label.includes(q));
-    });
-    const empty = document.querySelector('.inspector-search-empty');
-    const anyVisible = Array.from(rows).some(r => !r.classList.contains('hidden'));
-    if (!anyVisible && !empty) {
-      const e = document.createElement('div');
-      e.className = 'inspector-search-empty';
-      e.textContent = 'No files match.';
-      treeEl.appendChild(e);
-    } else if (anyVisible && empty) {
-      empty.remove();
-    }
-  });
 
   dropZone.addEventListener('dragover', (e) => {
     e.preventDefault();
@@ -1251,6 +1355,39 @@ desc: Interactive browser-based inspector for .penpot (v3) files. Upload a file 
     const f = e.target.files[0];
     if (f) handleFile(f);
     e.target.value = '';
+  });
+
+  filePickerGo.addEventListener('click', goToFileFromPicker);
+  filePickerInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); goToFileFromPicker(); }
+  });
+  filePickerInput.addEventListener('change', () => {
+    if (fileIndex.has(filePickerInput.value)) goToFileFromPicker();
+  });
+  filePickerBack.addEventListener('click', goToOverview);
+
+  treeSearch.addEventListener('input', () => {
+    const q = treeSearch.value.toLowerCase().trim();
+    const rows = treeEl.querySelectorAll('.inspector-tree-row');
+    if (!q) {
+      rows.forEach(r => r.classList.remove('hidden'));
+      treeEl.querySelectorAll('.inspector-search-empty').forEach(e => e.remove());
+      return;
+    }
+    rows.forEach(r => {
+      const label = r.querySelector('.inspector-tree-label')?.textContent.toLowerCase() || '';
+      r.classList.toggle('hidden', !label.includes(q));
+    });
+    const empty = treeEl.querySelector('.inspector-search-empty');
+    const anyVisible = Array.from(rows).some(r => !r.classList.contains('hidden'));
+    if (!anyVisible && !empty) {
+      const e = document.createElement('div');
+      e.className = 'inspector-search-empty';
+      e.textContent = 'No files match.';
+      treeEl.appendChild(e);
+    } else if (anyVisible && empty) {
+      empty.remove();
+    }
   });
 
   window.__inspector = { handleFile };

--- a/docs/user-guide/export-import/export-import-files.njk
+++ b/docs/user-guide/export-import/export-import-files.njk
@@ -48,21 +48,22 @@ desc: Learn how to import and export files in Penpot, the free, open-source desi
 <figure><img src="/img/import-export/import-selection.webp" alt="Import penpot file" /></figure>
 
 <h2 id="penpot-formats">Penpot file format</h2>
-<p>Penpot export to a unique format that streamline the import and export of files and assets by being more efficient and interoperable.</p>
+<p>Penpot exports to a unique format that streamlines the import and export of files and assets by being more efficient and interoperable.</p>
 <p>Unlike other design tools, <strong>Penpot's format is built on standard languages</strong>. The exported file is essentially a ZIP archive containing binary assets (such as bitmap and vector images) alongside a readable JSON structure. By avoiding proprietary formats, Penpot empowers users with autonomy from specific tools while enabling seamless third-party integrations.</p>
+<p>For a detailed look at what's inside a .penpot file, see <a href="/user-guide/export-import/penpot-file-format/">The .penpot file format</a>. Developers can also check the <a href="/technical-guide/developer/data-model/penpot-file-format/">technical specification</a>.</p>
 
 <h3>Deprecated Penpot file formats</h3>
 <p class="advice">These formats can only be exported from version 2.3 or earlier versions, but can be imported to any Penpot version.</p>
 <p>There are two different deprecated Penpot file formats in which you can import/export Penpot files. A standard one and a binary one. You always have the chance to use both for any file.</p>
-<h4>[Deprecated] Penpot file (.penpot).</h4>
+<h4>[Deprecated] Binary file (.penpot) — v1</h4>
 <p>The fast one. Binary Penpot specific.</p>
 <ul>
   <li>✅ Highly efficient in terms of memory and transfer time when exporting and importing.</li>
   <li>❌ It can be opened only in Penpot.</li>
   <li>❌ Not transparent, code difficult to explore.</li>
 </ul>
-<h4>[Deprecated] Standard file (.zip).</h4>
-<p>The open one. A compressed file that includes SVG and JSON.</p>
+<h4>[Deprecated] Standard file (.zip) — v2 (never released)</h4>
+<p>The open one. A compressed file that includes SVG and JSON. This format was developed but never released to users.</p>
 <ul>
   <li>✅ Allows the file to be opened by other softwares (still, for those cases export to SVG seems to be the common practice).</li>
   <li>✅ Allows some automations and integrations.</li>

--- a/docs/user-guide/export-import/index.njk
+++ b/docs/user-guide/export-import/index.njk
@@ -13,7 +13,13 @@ desc: Begin with the Penpot user guide! Get quickstarts, shortcuts, and tutorial
       <p>How to export and import your Penpot files</p>
     </a>
   </li>
-    <li>
+  <li>
+    <a href="/user-guide/export-import/penpot-file-format/">
+      <h2>The .penpot file format →</h2>
+      <p>Understand what's inside a .penpot file and how to inspect it</p>
+    </a>
+  </li>
+  <li>
     <a href="/user-guide/export-import/exporting-layers/">
       <h2>Exporting layers →</h2>
       <p>How to export elements from your design into different file formats</p>

--- a/docs/user-guide/export-import/penpot-file-format.njk
+++ b/docs/user-guide/export-import/penpot-file-format.njk
@@ -1,0 +1,154 @@
+---
+title: The .penpot file format
+order: 2
+desc: Understand the .penpot file format, what's inside, and how to inspect your design files.
+---
+
+<h1 id="penpot-file-format">The .penpot file format</h1>
+<p class="main-paragraph">Penpot's native file format is designed to be open, inspectable, and efficient. Unlike proprietary formats, you can always look inside a .penpot file to understand your design data.</p>
+
+<h2 id="what-is-penpot-format">What is a .penpot file?</h2>
+
+<p>A <code class="language-text">.penpot</code> file is a <strong>ZIP archive</strong> containing:</p>
+<ul>
+  <li><strong>JSON metadata</strong> — human-readable descriptions of your pages, shapes, colors, components, and more</li>
+  <li><strong>Binary media files</strong> — images, fonts, and other assets used in your design</li>
+</ul>
+
+<p>This means your design data is never locked in a proprietary format. You can always unzip a .penpot file and read the JSON to understand what's inside.</p>
+
+<h2 id="whats-inside">What's inside a .penpot file?</h2>
+
+<p>When you unzip a .penpot file, you'll find this structure:</p>
+
+<figure>
+<pre class="language-text"><code>your-design.penpot (ZIP archive)
+├── manifest.json          ← Table of contents
+├── files/                 ← Your design data
+│   ├── file-metadata.json
+│   └── file-data/
+│       ├── pages/         ← Each page of your design
+│       ├── colors/        ← Library colors
+│       ├── components/    ← Library components
+│       ├── typographies/  ← Library typographies
+│       ├── tokens.json    ← Design tokens
+│       └── media/         ← Media references
+└── objects/               ← Images and binary assets</code></pre>
+</figure>
+
+<h3>manifest.json</h3>
+<p>The manifest is the table of contents. It tells you:</p>
+<ul>
+  <li>Which version of the format is used</li>
+  <li>Which Penpot version created the file</li>
+  <li>What files are included</li>
+  <li>What features are enabled</li>
+</ul>
+
+<h3>File data</h3>
+<p>The <code class="language-text">files/</code> directory contains all your design data organized by type:</p>
+<ul>
+  <li><strong>Pages</strong> — Each page is split into individual shape files for efficiency</li>
+  <li><strong>Colors</strong> — Your color library with hex values, gradients, or image fills</li>
+  <li><strong>Components</strong> — Reusable component definitions</li>
+  <li><strong>Typographies</strong> — Text style definitions</li>
+  <li><strong>Tokens</strong> — Design tokens organized in sets and themes</li>
+  <li><strong>Media</strong> — References to images and other assets</li>
+</ul>
+
+<h3>Objects</h3>
+<p>The <code class="language-text">objects/</code> directory contains the actual binary files (PNG, JPG, SVG) referenced by your design. Each object has a JSON metadata file alongside the binary file.</p>
+
+<h2 id="how-to-inspect">How to inspect a .penpot file</h2>
+
+<p>Since .penpot files are just ZIP archives, you can inspect them with standard tools.</p>
+
+<h3>On macOS or Linux</h3>
+
+<p><strong>1. List the contents without extracting:</strong></p>
+<pre class="language-bash"><code>unzip -l your-design.penpot</code></pre>
+
+<p><strong>2. Extract to a temporary folder:</strong></p>
+<pre class="language-bash"><code>unzip your-design.penpot -d /tmp/penpot-inspect</code></pre>
+
+<p><strong>3. View the manifest:</strong></p>
+<pre class="language-bash"><code>cat /tmp/penpot-inspect/manifest.json | jq .</code></pre>
+
+<p><strong>4. Browse the structure:</strong></p>
+<pre class="language-bash"><code>tree /tmp/penpot-inspect</code></pre>
+
+<p><strong>5. View a specific shape:</strong></p>
+<pre class="language-bash"><code>cat /tmp/penpot-inspect/files/*/pages/*/*.json | jq .</code></pre>
+
+<h3>On Windows</h3>
+
+<p><strong>1. Right-click the .penpot file</strong> and select "Extract All..." or use 7-Zip.</p>
+
+<p><strong>2. Browse the extracted folder</strong> to see the structure.</p>
+
+<p><strong>3. Open any JSON file</strong> with a text editor or use a JSON viewer tool.</p>
+
+<h3>Using AI tools</h3>
+
+<p>You can use the <a href="/mcp/">Penpot MCP server</a> to inspect .penpot files with AI assistance. The MCP server can read and analyze your design files, making it easy to understand complex designs or automate tasks.</p>
+
+<h2 id="versioning">Format versions</h2>
+
+<p>The .penpot format has evolved over time:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Description</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>v3</strong></td>
+      <td>ZIP + JSON format (current)</td>
+      <td>✅ Current</td>
+    </tr>
+    <tr>
+      <td>v1</td>
+      <td>Custom binary format</td>
+      <td>⚠️ Deprecated</td>
+    </tr>
+  </tbody>
+</table>
+
+<p class="advice">All current Penpot versions export in v3 format. Old v1 files can still be imported, but new exports will use v3.</p>
+
+<h3>Version numbers inside the file</h3>
+
+<p>Inside a .penpot file, you'll see two different version numbers:</p>
+
+<ul>
+  <li><strong>Format version</strong> (in <code class="language-text">manifest.json</code>) — Tracks changes to the ZIP structure itself. Currently <code class="language-text">1</code>.</li>
+  <li><strong>Data version</strong> (in each file's JSON) — Tracks changes to the data model. This number increases as Penpot evolves.</li>
+</ul>
+
+<h3>Feature flags</h3>
+
+<p>Files also include a list of <strong>feature flags</strong> that indicate which capabilities are used. For example:</p>
+
+<ul>
+  <li><code class="language-text">design-tokens/v1</code> — Uses design tokens</li>
+  <li><code class="language-text">components/v2</code> — Uses the v2 component system</li>
+  <li><code class="language-text">variants/v1</code> — Uses component variants</li>
+  <li><code class="language-text">layout/grid</code> — Uses grid layouts</li>
+</ul>
+
+<p>These flags help Penpot know what features need to be supported when importing the file.</p>
+
+<h2 id="for-developers">For developers</h2>
+
+<p>If you're building tools or integrations that work with .penpot files, the <a href="/technical-guide/developer/data-model/penpot-file-format/">complete technical specification</a> provides detailed schema definitions for every JSON file in the archive.</p>
+
+<p>Key resources:</p>
+<ul>
+  <li><a href="/technical-guide/developer/data-model/penpot-file-format/">Technical specification</a> — Complete schema reference</li>
+  <li><a href="/mcp/">MCP Server</a> — AI-powered file inspection and manipulation</li>
+  <li><a href="/technical-guide/developer/data-model/">Data model</a> — Conceptual overview of Penpot's data structures</li>
+</ul>

--- a/docs/user-guide/export-import/penpot-file-format.njk
+++ b/docs/user-guide/export-import/penpot-file-format.njk
@@ -149,6 +149,7 @@ desc: Understand the .penpot file format, what's inside, and how to inspect your
 <p>Key resources:</p>
 <ul>
   <li><a href="/technical-guide/developer/data-model/penpot-file-format/">Technical specification</a> — Complete schema reference</li>
+  <li><a href="/technical-guide/developer/data-model/penpot-file-inspector/">File inspector</a> — Browser-based tool to interactively explore a .penpot file</li>
   <li><a href="/mcp/">MCP Server</a> — AI-powered file inspection and manipulation</li>
   <li><a href="/technical-guide/developer/data-model/">Data model</a> — Conceptual overview of Penpot's data structures</li>
 </ul>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MPL-2.0",
   "author": "Kaleidos INC Sucursal en España SL",
   "private": true,
-  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
+  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
   "repository": {
     "type": "git",
     "url": "https://github.com/penpot/penpot"
@@ -16,10 +16,12 @@
     "fmt": "./scripts/fmt"
   },
   "devDependencies": {
+    "@playwright/mcp": "^0.0.76",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^26.0.1",
     "esbuild": "^0.28.1",
     "mdts": "^0.20.3",
     "nrepl-client": "^0.3.0",
-    "opencode-ai": "^1.17.11"
+    "playwright": "^1.61.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/mcp':
+        specifier: ^0.0.76
+        version: 0.0.76
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
@@ -20,9 +26,9 @@ importers:
       nrepl-client:
         specifier: ^0.3.0
         version: 0.3.0
-      opencode-ai:
-        specifier: ^1.17.11
-        version: 1.17.11
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
 
 packages:
 
@@ -187,6 +193,16 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@playwright/mcp@0.0.76':
+    resolution: {integrity: sha512-ICcW6wAV+HoNEco19eni+JTVylCIIedruWkrRl2Rsv/qcGhBZLT/c0I1VounjIjSVSupw3pHmcr3CNCikTHTBQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
@@ -364,6 +380,11 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -545,75 +566,6 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
-  opencode-ai@1.17.11:
-    resolution: {integrity: sha512-a4331YhfsIiDSve0YRP2eNdlY1iDqhzw979Ky66XWiKDA8jeykfsqGUDAmKYKjS3hLV8U8+krFBuMFVO7p5ptQ==}
-    cpu: [arm64, x64]
-    os: [darwin, linux, win32]
-    hasBin: true
-
-  opencode-darwin-arm64@1.17.11:
-    resolution: {integrity: sha512-WpBokL8RL8BvdPKzJhQlLbVigz4jT0uESDWgwLcsU2JAP8hOWc/bMgzf87C7VtJlcjUY9ao60UzbPlsUffb/0g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  opencode-darwin-x64-baseline@1.17.11:
-    resolution: {integrity: sha512-hay37M7ALa4/4RrtJDggnOOCL226+cgQQQ0KiBFWNMDhygtwBszQnZmNxWxZtoRNIr3sIIS8JNsuBfhG4OwXYg==}
-    cpu: [x64]
-    os: [darwin]
-
-  opencode-darwin-x64@1.17.11:
-    resolution: {integrity: sha512-ZxQzLT92FT96Y8ahpHZiejD+m7vQYhAfskfzMwc0baDjkctEXy6UkZT5gY5jTDl+Bb74xgmKYJK6Lz20luhOXA==}
-    cpu: [x64]
-    os: [darwin]
-
-  opencode-linux-arm64-musl@1.17.11:
-    resolution: {integrity: sha512-haM+NZ/CC14VdHSi81pRlYDbLvu3sXAQF8HH1t7yi0YpH3wLibq0Ms8prM0809Sza+30pyUIxH6aoYghnr2Juw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  opencode-linux-arm64@1.17.11:
-    resolution: {integrity: sha512-CN3LSlqSrC1LbYHXZs21B8hIB951ebCRowwC+p4SDwPPUKknRzGYi5V7FjXAp8xq5hx27/QGgmGjfauv6RbAiA==}
-    cpu: [arm64]
-    os: [linux]
-
-  opencode-linux-x64-baseline-musl@1.17.11:
-    resolution: {integrity: sha512-AR3soQ1kYquD+QHaNDcWhHxd6lT8yUZJ2jsnls+7oOTisQWUspi5TpFD5FL4Et1MMtoJx63CAySDTzUpRXUO9Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  opencode-linux-x64-baseline@1.17.11:
-    resolution: {integrity: sha512-y0sibv7zg0KDLD7hdMCLe4+YYP6t5PQmqTV88KR7jWIU7qvl1hyuIAI84QLCt+7DACpNsFsUfofu6Hib051jZw==}
-    cpu: [x64]
-    os: [linux]
-
-  opencode-linux-x64-musl@1.17.11:
-    resolution: {integrity: sha512-cl2SMRa1c6dJMxvs5BQMy7Q2LVBwGXbLHpjc0OaeMkdORwdBfwCXfW1GNA61pNR4mMHMKrbFEV6dETqCDuIaWQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  opencode-linux-x64@1.17.11:
-    resolution: {integrity: sha512-at2oODO6N4yMTlvtKOFECVDvj4Nz3iFygmSKyoVdokgpMhYt6l9ta63pEp1jAaTxLpjQGbCzpRYbY/QqRAeB9Q==}
-    cpu: [x64]
-    os: [linux]
-
-  opencode-windows-arm64@1.17.11:
-    resolution: {integrity: sha512-pWOT/Ml4e3S12BQTmw8i+CsQ7QF0kI6Z//9z/N60gLW1U5afVYQpHkT1pT5RVjysPVHP8G4TN7Rbyi8m+fapCQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  opencode-windows-x64-baseline@1.17.11:
-    resolution: {integrity: sha512-RkJX3S77bzFZOHyQsqBqkI567hGHiTGU2TTIkBphYvRNxCQy+ZDjn3QAh+h7zyCHfieeWRKA96kl9ycKaJGO4A==}
-    cpu: [x64]
-    os: [win32]
-
-  opencode-windows-x64@1.17.11:
-    resolution: {integrity: sha512-4ON++fPbRVhLpYvy6j0RolFstU1OncbqZ4FLFeAkC4L6CNO06kHEwmwRfEVcGo+zFpug/ljdW2T0W+sYBw20SA==}
-    cpu: [x64]
-    os: [win32]
-
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -634,6 +586,26 @@ packages:
 
   plantuml@0.0.2:
     resolution: {integrity: sha512-3YzQJUO1Yg+mDckTm3Ht5Q8bmtN8g3M9LD8fXqiqHDW3vzUpHrUe9lxVY6AT1I50w7FdOned0hhJno4JBIku2g==}
+
+  playwright-core@1.61.0-alpha-1781023400000:
+    resolution: {integrity: sha512-UdtUd9qnCO0zvb8p3OvOZpelY6mA40mTb3NmWGuMtrD+hqqWuorWCPlSGwj7jw/LEB9AxvYLHTL1CJi2flvksg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0-alpha-1781023400000:
+    resolution: {integrity: sha512-8TRUG3IvwaAhuVm6k3C5vB7CwC5Fxq76DCCxOgPr6r1dpTedDwxlmdOBUkSZ0zxfxP14jcuPxi86/Trq4eA03w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
@@ -864,6 +836,15 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
+  '@playwright/mcp@0.0.76':
+    dependencies:
+      playwright: 1.61.0-alpha-1781023400000
+      playwright-core: 1.61.0-alpha-1781023400000
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@simple-git/args-pathspec@1.0.3': {}
 
   '@simple-git/argv-parser@1.1.1':
@@ -1079,6 +1060,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   get-intrinsic@1.3.0:
@@ -1263,57 +1247,6 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  opencode-ai@1.17.11:
-    optionalDependencies:
-      opencode-darwin-arm64: 1.17.11
-      opencode-darwin-x64: 1.17.11
-      opencode-darwin-x64-baseline: 1.17.11
-      opencode-linux-arm64: 1.17.11
-      opencode-linux-arm64-musl: 1.17.11
-      opencode-linux-x64: 1.17.11
-      opencode-linux-x64-baseline: 1.17.11
-      opencode-linux-x64-baseline-musl: 1.17.11
-      opencode-linux-x64-musl: 1.17.11
-      opencode-windows-arm64: 1.17.11
-      opencode-windows-x64: 1.17.11
-      opencode-windows-x64-baseline: 1.17.11
-
-  opencode-darwin-arm64@1.17.11:
-    optional: true
-
-  opencode-darwin-x64-baseline@1.17.11:
-    optional: true
-
-  opencode-darwin-x64@1.17.11:
-    optional: true
-
-  opencode-linux-arm64-musl@1.17.11:
-    optional: true
-
-  opencode-linux-arm64@1.17.11:
-    optional: true
-
-  opencode-linux-x64-baseline-musl@1.17.11:
-    optional: true
-
-  opencode-linux-x64-baseline@1.17.11:
-    optional: true
-
-  opencode-linux-x64-musl@1.17.11:
-    optional: true
-
-  opencode-linux-x64@1.17.11:
-    optional: true
-
-  opencode-windows-arm64@1.17.11:
-    optional: true
-
-  opencode-windows-x64-baseline@1.17.11:
-    optional: true
-
-  opencode-windows-x64@1.17.11:
-    optional: true
-
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -1331,6 +1264,22 @@ snapshots:
     dependencies:
       execa: 4.1.0
       get-stream: 5.2.0
+
+  playwright-core@1.61.0-alpha-1781023400000: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.0-alpha-1781023400000:
+    dependencies:
+      playwright-core: 1.61.0-alpha-1781023400000
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   powershell-utils@0.1.0: {}
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Add comprehensive user-facing documentation for the `.penpot` file format (v3) — Penpot's native ZIP+JSON export format — plus a browser-based inspector tool that runs entirely client-side. Targets both developers building integrations and power users who want to inspect their design files.

## Why

The `.penpot` format is a key differentiator — open, inspectable, based on standard technologies — but there was no public documentation explaining its structure, and no easy way to inspect a file beyond unzipping it and reading JSON by hand. This PR closes both gaps.

## How

- **Technical specification** at `docs/technical-guide/developer/data-model/penpot-file-format.md`: complete schema reference for all JSON files in the archive (manifest, file metadata, pages, shapes, library assets, storage objects, plugin data), with field tables, examples, inspection commands, and source code references to the authoritative malli schemas.
- **User-facing overview** at `docs/user-guide/export-import/penpot-file-format.njk`: accessible explanation of the format, visual structure diagram, step-by-step inspection guides for macOS/Linux/Windows, version history, and feature flags.
- **Updated** `docs/user-guide/export-import/export-import-files.njk`: clarified the current format is not deprecated, added cross-links to the new pages, and noted that v2 was never released.
- **Updated** `docs/user-guide/export-import/index.njk`: added the new page to the section landing.
- **Browser-based file inspector** at `docs/technical-guide/developer/data-model/penpot-file-inspector.njk`: single-page, no-build tool. Drop or pick a `.penpot` file, browse its directory tree, view JSON with syntax highlighting and search, preview embedded images, and click through UUID cross-references between shapes, components, colors, and media. JSZip is loaded lazily from a CDN on first use. The page uses the full viewport width with a 2-column layout (file tree on the left, content on the right). Nested JSON values are properly indented with subtle vertical guide lines. Layout collapses to 1 column below 900px.

Closes #10673
