### PR TITLE
:bug: Fix inconsistent theme selection (Penpot itself vs. plugins)

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -237,15 +237,7 @@
     :getTheme
     (fn []
       (let [theme (get-in @st/state [:profile :theme])]
-        (cond
-          (or (not theme) (= theme "system"))
-          (theme/get-system-theme)
-
-          (= theme "default")
-          "dark"
-
-          :else
-          theme)))
+        (theme/resolve-theme theme (theme/get-system-theme))))
 
     :getCurrentUser
     (fn []

--- a/frontend/src/app/plugins/events.cljs
+++ b/frontend/src/app/plugins/events.cljs
@@ -53,16 +53,8 @@
 
 (defn- get-theme
   [state]
-  (let [theme (get-in state [:profile :theme])]
-    (cond
-      (or (not theme) (= theme "system"))
-      (theme/get-system-theme)
-
-      (= theme "default")
-      "dark"
-
-      :else
-      theme)))
+  (theme/resolve-theme (get-in state [:profile :theme])
+                       (theme/get-system-theme)))
 
 (defmethod handle-state-change "themechange"
   [_ _ old-val new-val _]
@@ -70,9 +62,7 @@
         new-theme (get-theme new-val)]
     (if (identical? old-theme new-theme)
       ::not-changed
-      (if (= new-theme "default")
-        "dark"
-        new-theme))))
+      new-theme)))
 
 (defmethod handle-state-change "shapechange"
   [_ plugin-id old-val new-val props]

--- a/frontend/src/app/util/theme.cljs
+++ b/frontend/src/app/util/theme.cljs
@@ -45,6 +45,17 @@
     (.removeAttribute node "class")
     (.add ^js (.-classList ^js node) class)))
 
+(defn resolve-theme
+  "Resolves the profile's theme setting to the effective UI theme ('dark' or
+  'light'): 'system' follows the given system theme, 'default' and an unset
+  theme mean dark, and any other value is taken as-is. Single source of truth
+  for the app's own theme and the theme reported to plugins."
+  [profile-theme system-theme]
+  (cond
+    (= profile-theme "system") system-theme
+    (= profile-theme "default") "dark"
+    :else (d/nilv profile-theme "dark")))
+
 (defn use-initialize
   [{profile-theme :theme}]
   (let [system-theme* (mf/use-state get-system-theme)
@@ -58,9 +69,5 @@
           (rx/dispose! s))))
 
     (mf/with-effect [system-theme profile-theme]
-      (set-color-scheme
-       (cond
-         (= profile-theme "system") system-theme
-         (= profile-theme "default") "dark"
-         :else (d/nilv profile-theme "dark")))
+      (set-color-scheme (resolve-theme profile-theme system-theme))
       (notify-color-scheme-listeners!))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

## What

Makes the theme reported to plugins match the theme Penpot actually
displays. Previously, when no theme was explicitly selected in the user's
profile, Penpot itself rendered dark while every plugin was told the theme
was light (on systems whose browser preference is light) — so plugin panels
opened light inside a dark Penpot, and stayed that way.

Fixes #10676

## Why

Penpot itself and the plugin runtime used different default theme selection
strategies when no theme is explicitly selected by the user:

- Penpot itself defaults to **dark**.
- The plugin runtime (both `penpot.theme` and the `themechange` event)
  defaulted to the **system/browser preference**, which can be light.

For every explicit choice — light, dark, system, and the legacy "default" —
the two resolutions already agreed; only the unset case diverged. That is
why the bug hides on any profile that has ever picked a theme, and shows up
on fresh profiles. Plugins cannot work around it: the wrong value is
reported both at open time and on every theme change, so a plugin following
the documented pattern (as all bundled plugins do) has no correct signal
available.

## How

Extract the app's own resolution into a single shared function,
`app.util.theme/resolve-theme` ("system" follows the system theme;
"default" and unset mean dark), and use it everywhere a theme is resolved:

- the app's own `use-initialize` (behaviour unchanged — this is the
  resolution it already implemented inline),
- the plugin runtime's `getTheme` (`penpot.theme`),
- the plugin runtime's `themechange` handling, whose now-dead
  default-to-dark remapping is removed.

With one source of truth, the app and the plugin runtime can no longer
drift apart.

Verified manually in the workspace: with no explicit profile theme, plugins
now open dark to match Penpot, and toggling the profile theme switches the
plugin panel live via `themechange`.