### PR TITLE
:wrench: Auto-confirm pnpm modules purge in MCP bootstrap #10680

### DIFF
--- a/mcp/pnpm-workspace.yaml
+++ b/mcp/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# auto-confirm node_modules purge when pnpm detects an incompatible modules
+# directory (e.g. after a store location or pnpm major version change),
+# preventing the interactive prompt from blocking bootstrap
+confirmModulesPurge: false
+
 allowBuilds:
   esbuild: true
   sharp: false


### PR DESCRIPTION
### Related Ticket

* #10680 

### Summary

pnpm occasionally detects an incompatible `node_modules` directory (e.g. after a store location or pnpm major version change) and interactively asks whether to remove and recreate it, blocking the MCP bootstrap (particulary problematic when this occurs in the devenv tmux pane). 
This PR sets `confirmModulesPurge: false` in `mcp/pnpm-workspace.yaml` so the purge is auto-confirmed; this file is included in the npm pack tarball and applies to all install invocations from a single place.