### PR TITLE
:wrench: Pin mattermost-notify action to its v2.1.0 commit SHA

### DIFF
--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Notify Mattermost
         if: failure()
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/build-docker-devenv.yml
+++ b/.github/workflows/build-docker-devenv.yml
@@ -40,7 +40,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
 
       - name: Notify Mattermost
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Notify Mattermost
         if: failure()
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Notify Mattermost
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/plugins-deploy-api-doc.yml
+++ b/.github/workflows/plugins-deploy-api-doc.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Notify Mattermost
         if: failure()
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/plugins-deploy-package.yml
+++ b/.github/workflows/plugins-deploy-package.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Notify Mattermost
         if: failure()
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/plugins-deploy-styles-doc.yml
+++ b/.github/workflows/plugins-deploy-styles-doc.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Notify Mattermost
         if: failure()
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Notify Mattermost
         if: failure()
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK }}
           MATTERMOST_CHANNEL: bot-alerts-cicd


### PR DESCRIPTION
### What
Pin `mattermost/action-mattermost-notify@master` → `ae31bb6…` everywhere it's used (8 workflows), tag
kept in a trailing comment.

### Why
`@master` is a moving ref. Every use is handed `secrets.MATTERMOST_WEBHOOK`, and several of those jobs
(build-docker, build-bundle, plugins-deploy) also hold AWS S3, `DOCKER_REGISTRY` and
`CLOUDFLARE_API_TOKEN` secrets in sibling steps. If the action's `master` were moved (compromise or an
accidental change), the new code would run alongside those secrets — the class behind the 2025
`tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Renovate/Dependabot can bump it. Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the secret exposure, and the pinned SHA myself.</sub>
