### PR TITLE
:bug: Fix modals for nitrate subscription when unlimited

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -315,8 +315,14 @@
         (mf/use-fn
          (mf/deps profile)
          (fn []
-           (if (dnt/is-valid-license? profile)
+           (cond
+             (= (get-subscription-type (-> profile :props :subscription)) "unlimited")
+             (st/emit! (dnt/show-nitrate-popup :nitrate-form {:show-contact-sales-option true}))
+
+             (dnt/is-valid-license? profile)
              (dnt/go-to-nitrate-ac-create-org)
+
+             :else
              (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
 
         on-go-to-cc-click
@@ -755,8 +761,14 @@
         (mf/use-fn
          (mf/deps profile)
          (fn []
-           (if (dnt/is-valid-license? profile)
+           (cond
+             (= (get-subscription-type (-> profile :props :subscription)) "unlimited")
+             (st/emit! (dnt/show-nitrate-popup :nitrate-form {:show-contact-sales-option true}))
+
+             (dnt/is-valid-license? profile)
              (dnt/go-to-nitrate-ac-create-org)
+
+             :else
              (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))]
     (if show-dropdown?
       [:div {:class (stl/css :sidebar-org-switch)}

--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -162,11 +162,11 @@
 
         handle-click
         (mf/use-fn
-         (mf/deps nitrate-license subscription-type)
+         (mf/deps subscription-type)
          (fn []
-           (if (= subscription-type "unlimited")
-             (st/emit! (dnt/show-nitrate-popup :nitrate-dialog {:nitrate-license nitrate-license :show-contact-sales-option true}))
-             (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
+           (st/emit! (dnt/show-nitrate-popup :nitrate-form
+                                             (when (= subscription-type "unlimited")
+                                               {:show-contact-sales-option true})))))
 
         handle-go-to-cc
         (mf/use-fn dnt/go-to-nitrate-ac-create-org)

--- a/frontend/src/app/main/ui/nitrate/nitrate_form.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_form.cljs
@@ -24,7 +24,8 @@
    ::mf/wrap-props true}
   [connectivity]
 
-  (let [online? (:licenses connectivity)
+  (let [show-contact-sales-option (:show-contact-sales-option connectivity)
+        online? (and (:licenses connectivity) (not show-contact-sales-option))
         profile  (mf/deref refs/profile)
         on-click
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26614

### Summary

Users on an Unlimited subscription could still reach the Enterprise self-serve Stripe checkout from the dashboard. The promotional banner CTA opened the wrong contact-Sales modal (`:nitrate-dialog`), and the "+ Create org" button only checked for an active Nitrate license, not the underlying Unlimited plan, so it opened the full Enterprise subscribe modal (`:nitrate-form`) with a Stripe CTA.

### Steps to reproduce 

1. Log in as a user whose `:props/subscription` has `type: "unlimited"` and no active Nitrate license (`:subscription status` is not active/past_due/trialing).
2. On the dashboard:
  - Scenario A: Click the promotional banner's "Try it free for 14 days" / "Upgrade to Nitrate" button.
  - Scenario B: Click the sidebar's "+ Create org" button.
3. Both open the same large "Unlock Enterprise features" modal showing the Enterprise benefits, a contact-sales message, and a sales@penpot.app mailto link.


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
