### PR TITLE
:bug: Fix masked group position in flex layout on child visibility change

### DIFF
--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -108,6 +108,15 @@ fn calculate_group_bounds(
     shape_bounds.with_points(result)
 }
 
+fn calculate_masked_group_bounds(
+    shape: &Shape,
+    shapes: ShapesPoolRef,
+    bounds: &HashMap<Uuid, Bounds>,
+) -> Option<Bounds> {
+    let mask = shape.mask_id().and_then(|id| shapes.get(id))?;
+    Some(bounds.find(mask))
+}
+
 fn calculate_bool_bounds(
     shape: &Shape,
     shapes: ShapesPoolRef,
@@ -349,10 +358,10 @@ fn propagate_reflow(
             layout_reflows.insert(*id);
         }
         Type::Group(Group { masked: true }) => {
-            let children_ids = shape.children_ids(true);
-            if let Some(child) = children_ids.first().and_then(|id| shapes.get(id)) {
-                let child_bounds = bounds.find(child);
-                bounds.insert(shape.id, child_bounds);
+            // Masked group bounds are the mask shape bounds (first child in stored
+            // order, children_ids returns children in reverse order)
+            if let Some(shape_bounds) = calculate_masked_group_bounds(shape, shapes, bounds) {
+                bounds.insert(shape.id, shape_bounds);
             }
             reflown.insert(*id);
         }
@@ -587,5 +596,36 @@ mod tests {
 
         assert_eq!(bounds.width(), 3.0);
         assert_eq!(bounds.height(), 3.0);
+    }
+
+    #[test]
+    fn test_masked_group_bounds_are_mask_bounds() {
+        let parent_id = Uuid::new_v4();
+        let shapes = {
+            let mut shapes = ShapesPool::new();
+            shapes.initialize(10);
+
+            let mask_id = Uuid::new_v4();
+            let mask = shapes.add_shape(mask_id);
+            mask.set_selrect(1.0, 1.0, 5.0, 5.0);
+
+            let content_id = Uuid::new_v4();
+            let content = shapes.add_shape(content_id);
+            content.set_selrect(0.0, 0.0, 10.0, 10.0);
+
+            let parent = shapes.add_shape(parent_id);
+            parent.set_shape_type(Type::Group(Group { masked: true }));
+            parent.add_child(mask_id);
+            parent.add_child(content_id);
+            parent.set_selrect(1.0, 1.0, 5.0, 5.0);
+            shapes
+        };
+
+        let parent = shapes.get(&parent_id).unwrap();
+
+        let bounds = calculate_masked_group_bounds(parent, &shapes, &HashMap::new()).unwrap();
+
+        assert_eq!(bounds.width(), 4.0);
+        assert_eq!(bounds.height(), 4.0);
     }
 }


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10537

### Summary

`propagate_reflow` recomputed masked-group bounds from `children_ids(true).first()`, but `children_ids` returns children reversed, so the first element was last stored child  (which in the example was the first image, not the mask)

This change should be faster as `children_ids(true)`  was allocating all children every time.

[screen-recorder-wed-jul-15-2026-07-20-28.webm](https://github.com/user-attachments/assets/b27f7e29-13b5-4605-b6b5-0b19a0b3a27e)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
