### PR TITLE
:bug: Fix mismatched subscription in social login

### DIFF
--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -85,9 +85,18 @@
                         ::audit/props (audit/profile->props profile)
                         ::audit/profile-id (:id profile)}))))
 
+(defn- with-nitrate-licence
+  [profile cfg]
+  (if (contains? cf/flags :nitrate)
+    (nitrate/add-nitrate-licence-to-profile cfg profile)
+    profile))
+
 (defmethod process-token :auth
   [{:keys [::db/conn] :as cfg} _params {:keys [profile-id] :as claims}]
-  (let [profile (profile/get-profile conn profile-id)]
+  (let [profile (-> (profile/get-profile conn profile-id)
+                    (profile/strip-private-attrs)
+                    (update :props profile/filter-props)
+                    (with-nitrate-licence cfg))]
     (assoc claims :profile profile)))
 
 ;; --- Team Invitation


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26629

### Summary

Fix social login show wrong subscription tier on first load.

### Steps to reproduce 

1. Account with active Enterprise subscription.
2. Logout and login back via Github social login.
3. First load show Professional tier, Nitrate promo banner visible.
4. Manual reload (F5) fix, show Nitrate tier.

**Correct:** first load should correctly show Enterprise subscription.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
