### PR TITLE
:sparkles: Add G6 graph view to the debug graph console

### DIFF
--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -155,7 +155,9 @@ Graph Console
         <desc>
           Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
           and glyph encode the node table; edges are <code>IsChildOf</code>
-          (arrow points to parent). Redraws automatically after live changes.
+          (arrow points to parent). Containers render as foldable boxes:
+          double-click a box to collapse or expand it. Redraws automatically
+          after live changes (fold state survives redraws).
         </desc>
         <div id="graph-legend" style="font-size: 12px; margin: 4px 0;"></div>
         <div id="graph-canvas"
@@ -292,6 +294,12 @@ Graph Console
     "Image":     { color: "#eda100", glyph: "star",     size: 14 }
   };
   const FALLBACK_STYLE = { color: "#767470", glyph: "circle", size: 14 };
+  // Containers become foldable G6 combos (Document excluded: folding the
+  // whole graph is useless). A combo holds the container node itself plus
+  // its direct children; nesting mirrors the IsChildOf tree.
+  const CONTAINER_TABLES = {
+    "Page": true, "Frame": true, "Group": true, "Boolean": true, "SVGRaw": true
+  };
 
   const graphViewStatus = document.getElementById("graph-view-status");
   let g6graph = null;
@@ -301,18 +309,59 @@ Graph Console
     return NODE_STYLES[table] || FALLBACK_STYLE;
   }
 
-  function toG6Data(data) {
-    return {
-      nodes: (data.nodes || []).map(function (n) {
-        return { id: n.id, data: { label: n.label, table: n.table } };
-      }),
-      edges: (data.edges || [])
-        .slice()
-        .sort(function (a, b) { return (a.position || 0) - (b.position || 0); })
-        .map(function (e) {
-          return { source: e.source, target: e.target, data: { position: e.position } };
-        })
-    };
+  function comboIdFor(nodeId) {
+    return "combo:" + nodeId;
+  }
+
+  function toG6Data(data, collapsedIds) {
+    const nodes = data.nodes || [];
+    const edges = (data.edges || [])
+      .slice()
+      .sort(function (a, b) { return (a.position || 0) - (b.position || 0); });
+    const parentOf = {};
+    const childCount = {};
+    edges.forEach(function (e) {
+      parentOf[e.source] = e.target;
+      childCount[e.target] = (childCount[e.target] || 0) + 1;
+    });
+    // Only containers with children get a combo: empty boxes are clutter.
+    const hasCombo = {};
+    nodes.forEach(function (n) {
+      if (CONTAINER_TABLES[n.table] && childCount[n.id]) hasCombo[n.id] = true;
+    });
+    const combos = [];
+    nodes.forEach(function (n) {
+      if (!hasCombo[n.id]) return;
+      const combo = { id: comboIdFor(n.id), data: { label: n.label, table: n.table } };
+      const p = parentOf[n.id];
+      if (p && hasCombo[p]) combo.combo = comboIdFor(p);
+      if (collapsedIds && collapsedIds.has(combo.id)) combo.style = { collapsed: true };
+      combos.push(combo);
+    });
+    const g6nodes = nodes.map(function (n) {
+      const out = { id: n.id, data: { label: n.label, table: n.table } };
+      if (hasCombo[n.id]) {
+        out.combo = comboIdFor(n.id);
+      } else if (parentOf[n.id] && hasCombo[parentOf[n.id]]) {
+        out.combo = comboIdFor(parentOf[n.id]);
+      }
+      return out;
+    });
+    const g6edges = edges.map(function (e) {
+      return { source: e.source, target: e.target, data: { position: e.position } };
+    });
+    return { nodes: g6nodes, edges: g6edges, combos: combos };
+  }
+
+  function collapsedComboIds() {
+    if (!g6graph) return new Set();
+    try {
+      return new Set(g6graph.getComboData()
+        .filter(function (c) { return c.style && c.style.collapsed; })
+        .map(function (c) { return c.id; }));
+    } catch (_err) {
+      return new Set();
+    }
   }
 
   function renderGraph(g6data) {
@@ -326,7 +375,7 @@ Graph Console
       autoFit: "view",
       autoResize: true,
       padding: 20,
-      layout: { type: "antv-dagre", rankdir: "BT", nodesep: 10, ranksep: 40 },
+      layout: { type: "antv-dagre", rankdir: "BT", nodesep: 10, ranksep: 40, sortByCombo: true },
       node: {
         type: function (d) { return nodeStyle(d.data.table).glyph; },
         style: {
@@ -343,7 +392,20 @@ Graph Console
       edge: {
         style: { stroke: "#b3b0a8", endArrow: true, endArrowSize: 6 }
       },
-      behaviors: ["zoom-canvas", "drag-canvas", "drag-element"]
+      combo: {
+        type: "rect",
+        style: {
+          labelText: function (d) { return d.data.label; },
+          labelFontSize: 9,
+          labelFill: "#52514e",
+          labelPlacement: "top",
+          stroke: function (d) { return nodeStyle(d.data.table).color; },
+          lineWidth: 1,
+          fillOpacity: 0.03,
+          radius: 4
+        }
+      },
+      behaviors: ["zoom-canvas", "drag-canvas", "drag-element", "collapse-expand"]
     });
     return g6graph.render();
   }
@@ -375,7 +437,7 @@ Graph Console
           data.nodes.length + " nodes, " + data.edges.length + " edges"
           + " (graph revn " + data.revn + ")"
           + (data.truncated ? " — WARNING: truncated at row cap, view is partial" : "");
-        return renderGraph(toG6Data(data));
+        return renderGraph(toG6Data(data, collapsedComboIds()));
       })
       .catch(function (err) {
         graphViewStatus.textContent = "graph view error: " + err;

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -172,6 +172,7 @@ Graph Console
              style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff;"></div>
         <div id="graph-view-status" style="color: #666; font-size: 12px;"></div>
         <button type="button" id="graph-render-anyway" style="display: none;">Render anyway</button>
+        <button type="button" id="graph-filter-reset" style="display: none;">Show full graph</button>
       </fieldset>
     </div>
     {% endif %}
@@ -306,6 +307,10 @@ Graph Console
   // Above this many nodes the view is not rendered automatically; the
   // "Render anyway" button forces it (~1.5 s per 2k nodes, measured).
   const RENDER_GUARD_NODES = 4000;
+  // G6's entrance/update animation is nice didactics on small graphs but
+  // the performance killer at scale (>2 min at 1700 nodes vs ~1.5 s off);
+  // keep it only below this node count.
+  const ANIMATE_MAX_NODES = 100;
   const LAYOUT_XS = 40;   // horizontal leaf slot spacing
   const LAYOUT_YS = 70;   // vertical rank (depth) spacing
 
@@ -338,9 +343,11 @@ Graph Console
   const graphViewStatus = document.getElementById("graph-view-status");
   let g6graph = null;
   let g6graphLayout = null;
+  let g6graphAnimated = null;
   let refetchTimer = null;
   let lastGraphData = null;
   let renderForced = false;
+  let graphFilterIds = null;
 
   function currentLayoutName() {
     const stored = localStorage.getItem("graph-layout");
@@ -446,9 +453,10 @@ Graph Console
 
   function renderGraph(g6data) {
     const layoutName = currentLayoutName();
-    if (g6graph && g6graphLayout !== layoutName) {
-      // Layout switch: recreate the graph (cheap with animation off);
-      // preset-tree <-> real-layout cannot be swapped on a live instance.
+    const animate = g6data.nodes.length <= ANIMATE_MAX_NODES;
+    if (g6graph && (g6graphLayout !== layoutName || g6graphAnimated !== animate)) {
+      // Layout or animation-mode switch: recreate the graph (cheap);
+      // neither is swappable on a live instance.
       try { g6graph.destroy(); } catch (_err) {}
       g6graph = null;
     }
@@ -459,15 +467,14 @@ Graph Console
       });
     }
     g6graphLayout = layoutName;
+    g6graphAnimated = animate;
     const layoutCfg = LAYOUTS[layoutName];
     const opts = {
       container: "graph-canvas",
       data: g6data,
       autoFit: "view",
       autoResize: true,
-      // Entrance/update animation is the performance killer: 1700 nodes
-      // took >2 min animated vs ~1.5 s without (measured, headless).
-      animation: false,
+      animation: animate,
       padding: 20,
       node: {
         type: function (d) { return nodeStyle(d.data.table).glyph; },
@@ -525,18 +532,53 @@ Graph Console
       + (data.truncated ? " — WARNING: truncated at row cap, view is partial" : "");
   }
 
+  // Query filter: induced subgraph of the already-exported graph, selected
+  // by node ids found in the last Cypher result. No reconstruction from the
+  // query result is needed — ids are enough to slice the cached export.
+  function filteredGraphData() {
+    if (!graphFilterIds) return lastGraphData;
+    const keep = {};
+    const nodes = lastGraphData.nodes.filter(function (n) {
+      if (graphFilterIds.has(n.id)) { keep[n.id] = true; return true; }
+      return false;
+    });
+    const edges = lastGraphData.edges.filter(function (e) {
+      return keep[e.source] && keep[e.target];
+    });
+    return { nodes: nodes, edges: edges,
+             revn: lastGraphData.revn, truncated: lastGraphData.truncated };
+  }
+
+  function applyQueryFilter(ids) {
+    if (!lastGraphData) return;
+    const present = new Set();
+    lastGraphData.nodes.forEach(function (n) { if (ids.has(n.id)) present.add(n.id); });
+    if (!present.size) {
+      graphViewStatus.textContent = "query result matches no nodes in the loaded graph";
+      return;
+    }
+    graphFilterIds = present;
+    renderCurrent();
+  }
+
   function renderCurrent() {
     if (!lastGraphData) return;
-    const data = lastGraphData;
+    const data = filteredGraphData();
     const anywayBtn = document.getElementById("graph-render-anyway");
+    const filterBtn = document.getElementById("graph-filter-reset");
+    if (filterBtn) filterBtn.style.display = graphFilterIds ? "inline" : "none";
+    const filterNote = graphFilterIds
+      ? " — query filter: " + data.nodes.length + " of "
+        + lastGraphData.nodes.length + " nodes"
+      : "";
     if (data.nodes.length > RENDER_GUARD_NODES && !renderForced) {
       graphViewStatus.textContent =
-        graphStatusText(data) + " — too large to render automatically";
+        graphStatusText(data) + filterNote + " — too large to render automatically";
       if (anywayBtn) anywayBtn.style.display = "inline";
       return;
     }
     if (anywayBtn) anywayBtn.style.display = "none";
-    graphViewStatus.textContent = graphStatusText(data);
+    graphViewStatus.textContent = graphStatusText(data) + filterNote;
     renderGraph(toG6Data(data, collapsedComboIds(), foldEnabled()));
   }
 
@@ -547,6 +589,9 @@ Graph Console
     }
     fetch("/dbg/actions/graph-data")
       .then(function (resp) {
+        if (resp.status === 404) {
+          throw new Error("no graph session (backend restarted?) — reload a file");
+        }
         if (!resp.ok) throw new Error("graph-data HTTP " + resp.status);
         return resp.json();
       })
@@ -697,6 +742,17 @@ Graph Console
     }
   }
 
+  let wsClosing = false;
+  let wsReconnectTimer = null;
+
+  function scheduleReconnect() {
+    if (wsClosing || wsReconnectTimer) return;
+    wsReconnectTimer = setTimeout(function () {
+      wsReconnectTimer = null;
+      connect();
+    }, 3000);
+  }
+
   function connect() {
     ws = new WebSocket(wsUrl);
     wsStatus.textContent = "connecting…";
@@ -704,6 +760,9 @@ Graph Console
     ws.addEventListener("open", function () {
       wsStatus.textContent = "subscribed";
       subscribe();
+      // catch up on anything missed while disconnected
+      refreshSyncStatus();
+      scheduleGraphRefetch();
     });
 
     ws.addEventListener("message", function (event) {
@@ -711,7 +770,8 @@ Graph Console
     });
 
     ws.addEventListener("close", function () {
-      wsStatus.textContent = "disconnected";
+      wsStatus.textContent = wsClosing ? "disconnected" : "disconnected — retrying…";
+      scheduleReconnect();
     });
 
     ws.addEventListener("error", function () {
@@ -768,6 +828,24 @@ Graph Console
 
     html += "</tbody></table></fieldset>";
     output.innerHTML = html;
+
+    // Offer to view the result as an induced subgraph: any UUID appearing
+    // in any result cell selects that node in the loaded graph.
+    const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+    const ids = new Set();
+    (result.rows || []).forEach(function (row) {
+      row.forEach(function (cell) {
+        const found = String(cell).match(uuidRe);
+        if (found) found.forEach(function (m) { ids.add(m.toLowerCase()); });
+      });
+    });
+    if (ids.size) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = "Show result in graph view (" + ids.size + " ids)";
+      btn.addEventListener("click", function () { applyQueryFilter(ids); });
+      output.appendChild(btn);
+    }
   }
 
   const queryForm = document.getElementById("graph-query-form");
@@ -857,12 +935,21 @@ Graph Console
     });
   }
 
+  const filterResetBtn = document.getElementById("graph-filter-reset");
+  if (filterResetBtn) {
+    filterResetBtn.addEventListener("click", function () {
+      graphFilterIds = null;
+      renderCurrent();
+    });
+  }
+
   connect();
   refreshSyncStatus();
   renderGraphLegend();
   refetchGraph();
 
   window.addEventListener("beforeunload", function () {
+    wsClosing = true;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(encodeUnsubscribe(fileId));
       ws.close();

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -101,7 +101,8 @@ Graph Console
     </fieldset>
 
     <fieldset>
-      <legend>Cypher query</legend>
+      <legend>LadybugDB <a href="https://docs.ladybugdb.com/cypher/"
+                            target="_blank">Cypher</a></legend>
       <form id="graph-query-form" method="post" action="/dbg/actions/graph-query">
         <div class="row">
           <textarea name="query" rows="8" style="width:100%; font-family: monospace;"

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -154,6 +154,9 @@ Graph Console
           <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
             <input type="checkbox" id="graph-fold-toggle" /> fold containers
           </label>
+          <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
+            layout: <select id="graph-layout-select"></select>
+          </label>
         </legend>
         <desc>
           Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
@@ -306,11 +309,43 @@ Graph Console
   const LAYOUT_XS = 40;   // horizontal leaf slot spacing
   const LAYOUT_YS = 70;   // vertical rank (depth) spacing
 
+  // Layout dropdown source of truth: name -> G6 layout config, or null for
+  // the built-in O(n) tree layout (preset positions from treePositions,
+  // fastest, exploits IsChildOf being a tree). The <select> is populated
+  // from these keys; add/remove/tune entries here. All 13 G6 configs below
+  // were smoke-tested against combo data on this UMD build (2026-07-15).
+  // Note: iterative layouts (force*, fruchterman) are slow on 1000+ nodes;
+  // combo-combined is the only combo-aware one; the rest just get bounding
+  // boxes drawn around wherever they put the member nodes.
+  const LAYOUTS = {
+    "tree":          null,
+    "antv-dagre":    { type: "antv-dagre", rankdir: "BT", nodesep: 10, ranksep: 40, sortByCombo: true },
+    "dagre":         { type: "dagre", rankdir: "BT" },
+    "circular":      { type: "circular" },
+    "concentric":    { type: "concentric" },
+    "radial":        { type: "radial" },
+    "grid":          { type: "grid" },
+    "force":         { type: "force" },
+    "d3-force":      { type: "d3-force" },
+    "force-atlas2":  { type: "force-atlas2" },
+    "fruchterman":   { type: "fruchterman" },
+    "mds":           { type: "mds" },
+    "combo-combined": { type: "combo-combined" },
+    "random":        { type: "random" }
+  };
+  const DEFAULT_LAYOUT = "tree";
+
   const graphViewStatus = document.getElementById("graph-view-status");
   let g6graph = null;
+  let g6graphLayout = null;
   let refetchTimer = null;
   let lastGraphData = null;
   let renderForced = false;
+
+  function currentLayoutName() {
+    const stored = localStorage.getItem("graph-layout");
+    return Object.prototype.hasOwnProperty.call(LAYOUTS, stored) ? stored : DEFAULT_LAYOUT;
+  }
 
   function nodeStyle(table) {
     return NODE_STYLES[table] || FALLBACK_STYLE;
@@ -410,11 +445,22 @@ Graph Console
   }
 
   function renderGraph(g6data) {
+    const layoutName = currentLayoutName();
+    if (g6graph && g6graphLayout !== layoutName) {
+      // Layout switch: recreate the graph (cheap with animation off);
+      // preset-tree <-> real-layout cannot be swapped on a live instance.
+      try { g6graph.destroy(); } catch (_err) {}
+      g6graph = null;
+    }
     if (g6graph) {
       g6graph.setData(g6data);
-      return g6graph.render();
+      return g6graph.render().catch(function (_err) {
+        /* instance may be destroyed mid-render on rapid toggle/layout switches */
+      });
     }
-    g6graph = new G6.Graph({
+    g6graphLayout = layoutName;
+    const layoutCfg = LAYOUTS[layoutName];
+    const opts = {
       container: "graph-canvas",
       data: g6data,
       autoFit: "view",
@@ -453,8 +499,12 @@ Graph Console
         }
       },
       behaviors: ["zoom-canvas", "drag-canvas", "drag-element", "collapse-expand"]
+    };
+    if (layoutCfg) opts.layout = layoutCfg;
+    g6graph = new G6.Graph(opts);
+    return g6graph.render().catch(function (_err) {
+      /* see above */
     });
-    return g6graph.render();
   }
 
   function renderGraphLegend() {
@@ -780,6 +830,21 @@ Graph Console
     foldToggle.checked = foldEnabled();
     foldToggle.addEventListener("change", function () {
       localStorage.setItem("graph-fold-containers", foldToggle.checked ? "1" : "0");
+      renderCurrent();
+    });
+  }
+
+  const layoutSelect = document.getElementById("graph-layout-select");
+  if (layoutSelect) {
+    Object.keys(LAYOUTS).forEach(function (name) {
+      const opt = document.createElement("option");
+      opt.value = name;
+      opt.textContent = name;
+      layoutSelect.appendChild(opt);
+    });
+    layoutSelect.value = currentLayoutName();
+    layoutSelect.addEventListener("change", function () {
+      localStorage.setItem("graph-layout", layoutSelect.value);
       renderCurrent();
     });
   }

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -29,16 +29,15 @@ Graph Console
                  placeholder="file-id"
                  value="{% if session %}{{session.file-id}}{% endif %}" />
         </div>
-        <div class="row">                 
+        <div class="row" style="display: flex; gap: 8px;">
           <input type="submit" value="Load" />
+          {% if session %}
+          <input type="submit" value="Unload" form="graph-unload-form" />
+          {% endif %}
         </div>
       </form>
       {% if session %}
-      <form method="post" action="/dbg/actions/graph-unload">
-        <div class="row">
-          <input type="submit" value="Unload" />
-        </div>
-      </form>
+      <form id="graph-unload-form" method="post" action="/dbg/actions/graph-unload"></form>
       {% endif %}
     </fieldset>
 
@@ -53,7 +52,8 @@ Graph Console
       <legend>Loaded session</legend>
       <desc>
         <p>
-          File: <b>{{session.name}}</b> ({{session.file-id}})<br />
+          File: <b><a id="graph-penpot-link" data-file-id="{{session.file-id}}"
+                      target="_blank">{{session.name}}</a></b> ({{session.file-id}})<br />
           Loaded at revision: <b>{{session.revn}}</b><br />
           Graph revision: <b id="graph-sync-revn">{% if session.graph-revn %}{{session.graph-revn}}{% else %}{{session.revn}}{% endif %}</b><br />
           Schema: <b>{{session.schema-version}}</b><br />
@@ -101,7 +101,8 @@ Graph Console
       <legend>Cypher query</legend>
       <form id="graph-query-form" method="post" action="/dbg/actions/graph-query">
         <div class="row">
-          <textarea name="query" rows="8" style="width:100%; font-family: monospace;">{{query}}</textarea>
+          <textarea name="query" rows="8" style="width:100%; font-family: monospace;"
+                    data-default-query="{{default-query}}">{{query}}</textarea>
         </div>
         <div class="row">
           <input type="submit" value="Run query" />
@@ -153,6 +154,9 @@ Graph Console
           <button type="button" id="graph-maximize" style="margin-left: 1em;">Expand</button>
           <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
             <input type="checkbox" id="graph-fold-toggle" /> fold containers
+          </label>
+          <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
+            <input type="checkbox" id="graph-animate-toggle" /> animate
           </label>
           <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
             layout: <select id="graph-layout-select"></select>
@@ -209,7 +213,27 @@ Graph Console
   const tree = document.getElementById("graph-files-tree");
   const loadForm = document.getElementById("graph-load-form");
   const loadInput = loadForm ? loadForm.querySelector("input[name=file-id]") : null;
+  const penpotLink = document.getElementById("graph-penpot-link");
   if (!tree) return;
+
+  // Make the loaded-session file name a link into the Penpot workspace.
+  // The legacy /#/workspace/<project-id>/<file-id> route resolves the team
+  // itself, and project-id is already in the files-tree payload; same
+  // origin as this page, so no base URL to configure.
+  function linkLoadedFile(teams) {
+    if (!penpotLink || !penpotLink.dataset.fileId) return;
+    const fileId = penpotLink.dataset.fileId;
+    teams.forEach(function (team) {
+      (team.projects || []).forEach(function (project) {
+        (project.files || []).forEach(function (file) {
+          if (file.id === fileId) {
+            penpotLink.href = "/#/workspace/" + project.id + "/" + file.id;
+            penpotLink.title = "Open in Penpot";
+          }
+        });
+      });
+    });
+  }
 
   function fileLink(file) {
     const li = document.createElement("li");
@@ -236,6 +260,7 @@ Graph Console
     .then(function (data) {
       tree.textContent = "";
       const teams = data.teams || [];
+      linkLoadedFile(teams);
       if (!teams.length) {
         tree.textContent = "No files found.";
         return;
@@ -304,6 +329,9 @@ Graph Console
     "Image":     { color: "#eda100", glyph: "star",     size: 14 }
   };
   const FALLBACK_STYLE = { color: "#767470", glyph: "circle", size: 14 };
+  // Legend glyph characters mirroring the G6 node types above.
+  const GLYPH_CHARS = { diamond: "◆", rect: "■", hexagon: "⬢",
+                        circle: "●", triangle: "▲", star: "★" };
   // Above this many nodes the view is not rendered automatically; the
   // "Render anyway" button forces it (~1.5 s per 2k nodes, measured).
   const RENDER_GUARD_NODES = 4000;
@@ -346,6 +374,7 @@ Graph Console
   let g6graphAnimated = null;
   let refetchTimer = null;
   let lastGraphData = null;
+  let lastGraphSig = null;
   let renderForced = false;
   let graphFilterIds = null;
 
@@ -364,6 +393,12 @@ Graph Console
 
   function foldEnabled() {
     return localStorage.getItem("graph-fold-containers") !== "0";
+  }
+
+  // Off ⇒ animation disabled unconditionally, incl. small graphs (the
+  // adaptive ≤ ANIMATE_MAX_NODES rule only applies when this is on).
+  function animateEnabled() {
+    return localStorage.getItem("graph-animate") !== "0";
   }
 
   // IsChildOf is a tree, so an O(n) tidy layout replaces a generic DAG
@@ -391,7 +426,7 @@ Graph Console
     return pos;
   }
 
-  function toG6Data(data, collapsedIds, withCombos) {
+  function toG6Data(data, collapsedIds, withCombos, presetPositions) {
     const nodes = data.nodes || [];
     const edges = (data.edges || [])
       .slice()
@@ -402,7 +437,9 @@ Graph Console
       parentOf[e.source] = e.target;
       (childrenOf[e.target] = childrenOf[e.target] || []).push(e.source);
     });
-    const pos = treePositions(nodes, parentOf, childrenOf);
+    // Preset positions only for the built-in tree layout; under a G6
+    // layout they would make animated renders flash tree-then-layout.
+    const pos = presetPositions ? treePositions(nodes, parentOf, childrenOf) : null;
     // Foldable = has children and has a parent: the IsChildOf root of the
     // loaded graph (today a Document, later maybe a Project or Team) is
     // never a combo — folding the whole graph is useless. Empty containers
@@ -423,10 +460,12 @@ Graph Console
       combos.push(combo);
     });
     const g6nodes = nodes.map(function (n) {
-      const p = pos[n.id] || { x: 0, y: 0 };
       const out = { id: n.id,
-                    data: { label: n.label, table: n.table },
-                    style: { x: p.x, y: p.y } };
+                    data: { label: n.label, table: n.table } };
+      if (pos) {
+        const p = pos[n.id] || { x: 0, y: 0 };
+        out.style = { x: p.x, y: p.y };
+      }
       if (hasCombo[n.id]) {
         out.combo = comboIdFor(n.id);
       } else if (parentOf[n.id] && hasCombo[parentOf[n.id]]) {
@@ -453,7 +492,7 @@ Graph Console
 
   function renderGraph(g6data) {
     const layoutName = currentLayoutName();
-    const animate = g6data.nodes.length <= ANIMATE_MAX_NODES;
+    const animate = animateEnabled() && g6data.nodes.length <= ANIMATE_MAX_NODES;
     if (g6graph && (g6graphLayout !== layoutName || g6graphAnimated !== animate)) {
       // Layout or animation-mode switch: recreate the graph (cheap);
       // neither is swappable on a live instance.
@@ -505,7 +544,28 @@ Graph Console
           radius: 4
         }
       },
-      behaviors: ["zoom-canvas", "drag-canvas", "drag-element", "collapse-expand"]
+      behaviors: ["zoom-canvas", "drag-canvas", "drag-element", "collapse-expand"],
+      plugins: [{
+        key: "toolbar",
+        type: "toolbar",
+        position: "top-left",
+        getItems: function () {
+          return [
+            { id: "auto-fit", value: "auto-fit" },
+            { id: "request-fullscreen", value: "expand" },
+            { id: "exit-fullscreen", value: "restore" }
+          ];
+        },
+        onClick: function (value) {
+          if (value === "auto-fit") {
+            if (g6graph) g6graph.fitView();
+          } else if (value === "expand") {
+            setExpanded(true);
+          } else if (value === "restore") {
+            setExpanded(false);
+          }
+        }
+      }]
     };
     if (layoutCfg) opts.layout = layoutCfg;
     g6graph = new G6.Graph(opts);
@@ -518,11 +578,10 @@ Graph Console
     const el = document.getElementById("graph-legend");
     el.innerHTML = Object.keys(NODE_STYLES).map(function (table) {
       const s = NODE_STYLES[table];
-      return '<span style="margin-right: 1em;">'
-        + '<i style="display: inline-block; width: 10px; height: 10px;'
-        + ' margin-right: 3px; border: 1px solid #52514e;'
-        + ' background: ' + s.color + ';"></i>'
-        + escapeHtml(table) + " (" + s.glyph + ")</span>";
+      return '<span style="margin-right: 1em; white-space: nowrap;">'
+        + '<span style="color: ' + s.color + '; font-size: 14px;">'
+        + (GLYPH_CHARS[s.glyph] || "●") + '</span> '
+        + escapeHtml(table) + "</span>";
     }).join("");
   }
 
@@ -579,7 +638,8 @@ Graph Console
     }
     if (anywayBtn) anywayBtn.style.display = "none";
     graphViewStatus.textContent = graphStatusText(data) + filterNote;
-    renderGraph(toG6Data(data, collapsedComboIds(), foldEnabled()));
+    renderGraph(toG6Data(data, collapsedComboIds(), foldEnabled(),
+                         LAYOUTS[currentLayoutName()] == null));
   }
 
   function refetchGraph() {
@@ -596,7 +656,13 @@ Graph Console
         return resp.json();
       })
       .then(function (data) {
+        // Skip the repaint when the display projection is unchanged: a
+        // change burst that only touches non-projected attrs (e.g. moving
+        // shapes around) bumps revn but not the picture.
+        const sig = JSON.stringify([data.nodes, data.edges, data.truncated]);
         lastGraphData = data;
+        if (sig === lastGraphSig) return;
+        lastGraphSig = sig;
         renderCurrent();
       })
       .catch(function (err) {
@@ -813,15 +879,22 @@ Graph Console
       + " style=\"border-collapse: collapse; width: 100%;\">"
       + "<thead><tr>";
 
-    (result.columns || []).forEach(function (column) {
-      html += "<th>" + escapeHtml(column) + "</th>";
+    // filter_* columns feed node ids to the graph-view filter below but
+    // are hidden from the table (convention; see default query).
+    const columns = result.columns || [];
+    const visibleIdx = [];
+    columns.forEach(function (column, i) {
+      if (!/^filter_/.test(column)) visibleIdx.push(i);
+    });
+    visibleIdx.forEach(function (i) {
+      html += "<th>" + escapeHtml(columns[i]) + "</th>";
     });
     html += "</tr></thead><tbody>";
 
     (result.rows || []).forEach(function (row) {
       html += "<tr>";
-      row.forEach(function (cell) {
-        html += "<td><code>" + escapeHtml(cell) + "</code></td>";
+      visibleIdx.forEach(function (i) {
+        html += "<td><code>" + escapeHtml(row[i]) + "</code></td>";
       });
       html += "</tr>";
     });
@@ -850,6 +923,19 @@ Graph Console
 
   const queryForm = document.getElementById("graph-query-form");
   if (queryForm) {
+    // Keep the query text across page reloads (load/unload/full-reload all
+    // re-render the page with the default query). Only restore over the
+    // default, never over a server-rendered non-default query.
+    const queryInput = queryForm.querySelector("textarea[name=query]");
+    const defaultQuery = (queryInput.dataset.defaultQuery || "").trim();
+    const storedQuery = localStorage.getItem("graph-query");
+    if (storedQuery && storedQuery.trim() !== defaultQuery
+        && queryInput.value.trim() === defaultQuery) {
+      queryInput.value = storedQuery;
+    }
+    queryInput.addEventListener("input", function () {
+      localStorage.setItem("graph-query", queryInput.value);
+    });
     queryForm.addEventListener("submit", function (event) {
       event.preventDefault();
       const formData = new FormData(queryForm);
@@ -891,6 +977,25 @@ Graph Console
     resizeGraphSoon();
   }
 
+  // Follow container size (window resizes, flex reflow). Only setSize —
+  // the user's viewport must persist; explicit re-fit is the toolbar's
+  // auto-fit (or expand/restore, which do fitView via resizeGraphSoon).
+  const canvasEl = document.getElementById("graph-canvas");
+  if (typeof ResizeObserver !== "undefined" && canvasEl) {
+    let resizeRaf = null;
+    new ResizeObserver(function () {
+      if (resizeRaf) return;
+      resizeRaf = requestAnimationFrame(function () {
+        resizeRaf = null;
+        if (g6graph) {
+          try {
+            g6graph.setSize(canvasEl.clientWidth, canvasEl.clientHeight);
+          } catch (_err) { /* instance mid-recreate */ }
+        }
+      });
+    }).observe(canvasEl);
+  }
+
   if (maximizeBtn && graphColumn) {
     maximizeBtn.addEventListener("click", function () {
       setExpanded(!graphColumn.classList.contains("graph-view-expanded"));
@@ -908,6 +1013,15 @@ Graph Console
     foldToggle.checked = foldEnabled();
     foldToggle.addEventListener("change", function () {
       localStorage.setItem("graph-fold-containers", foldToggle.checked ? "1" : "0");
+      renderCurrent();
+    });
+  }
+
+  const animateToggle = document.getElementById("graph-animate-toggle");
+  if (animateToggle) {
+    animateToggle.checked = animateEnabled();
+    animateToggle.addEventListener("change", function () {
+      localStorage.setItem("graph-animate", animateToggle.checked ? "1" : "0");
       renderCurrent();
     });
   }

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -151,18 +151,24 @@ Graph Console
       <fieldset id="graph-view-panel">
         <legend>Graph view
           <button type="button" id="graph-maximize" style="margin-left: 1em;">Expand</button>
+          <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
+            <input type="checkbox" id="graph-fold-toggle" /> fold containers
+          </label>
         </legend>
         <desc>
           Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
           and glyph encode the node table; edges are <code>IsChildOf</code>
-          (arrow points to parent). Containers render as foldable boxes:
-          double-click a box to collapse or expand it. Redraws automatically
-          after live changes (fold state survives redraws).
+          (arrow points to parent). With "fold containers" on, anything with
+          children (except the root) renders as a foldable box: double-click
+          to collapse or expand. Redraws automatically after live changes
+          (fold state survives redraws). Very large graphs need an explicit
+          "Render anyway".
         </desc>
         <div id="graph-legend" style="font-size: 12px; margin: 4px 0;"></div>
         <div id="graph-canvas"
              style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff;"></div>
         <div id="graph-view-status" style="color: #666; font-size: 12px;"></div>
+        <button type="button" id="graph-render-anyway" style="display: none;">Render anyway</button>
       </fieldset>
     </div>
     {% endif %}
@@ -294,16 +300,17 @@ Graph Console
     "Image":     { color: "#eda100", glyph: "star",     size: 14 }
   };
   const FALLBACK_STYLE = { color: "#767470", glyph: "circle", size: 14 };
-  // Containers become foldable G6 combos (Document excluded: folding the
-  // whole graph is useless). A combo holds the container node itself plus
-  // its direct children; nesting mirrors the IsChildOf tree.
-  const CONTAINER_TABLES = {
-    "Page": true, "Frame": true, "Group": true, "Boolean": true, "SVGRaw": true
-  };
+  // Above this many nodes the view is not rendered automatically; the
+  // "Render anyway" button forces it (~1.5 s per 2k nodes, measured).
+  const RENDER_GUARD_NODES = 4000;
+  const LAYOUT_XS = 40;   // horizontal leaf slot spacing
+  const LAYOUT_YS = 70;   // vertical rank (depth) spacing
 
   const graphViewStatus = document.getElementById("graph-view-status");
   let g6graph = null;
   let refetchTimer = null;
+  let lastGraphData = null;
+  let renderForced = false;
 
   function nodeStyle(table) {
     return NODE_STYLES[table] || FALLBACK_STYLE;
@@ -313,22 +320,57 @@ Graph Console
     return "combo:" + nodeId;
   }
 
-  function toG6Data(data, collapsedIds) {
+  function foldEnabled() {
+    return localStorage.getItem("graph-fold-containers") !== "0";
+  }
+
+  // IsChildOf is a tree, so an O(n) tidy layout replaces a generic DAG
+  // layout: depth = rank (y), post-order leaf slots = x, parents centered
+  // over their children. antv-dagre needed ~7 s at 1700 nodes; this is free.
+  function treePositions(nodes, parentOf, childrenOf) {
+    const pos = {};
+    let slot = 0;
+    function place(id, depth) {
+      const kids = childrenOf[id] || [];
+      if (!kids.length) {
+        pos[id] = { x: slot * LAYOUT_XS, y: depth * LAYOUT_YS };
+        slot += 1;
+        return;
+      }
+      kids.forEach(function (k) { place(k, depth + 1); });
+      const xs = kids.map(function (k) { return pos[k].x; });
+      pos[id] = { x: (Math.min.apply(null, xs) + Math.max.apply(null, xs)) / 2,
+                  y: depth * LAYOUT_YS };
+      slot += 1; // breathing room between adjacent subtrees
+    }
+    nodes.forEach(function (n) {
+      if (!parentOf[n.id]) place(n.id, 0);
+    });
+    return pos;
+  }
+
+  function toG6Data(data, collapsedIds, withCombos) {
     const nodes = data.nodes || [];
     const edges = (data.edges || [])
       .slice()
       .sort(function (a, b) { return (a.position || 0) - (b.position || 0); });
     const parentOf = {};
-    const childCount = {};
+    const childrenOf = {};
     edges.forEach(function (e) {
       parentOf[e.source] = e.target;
-      childCount[e.target] = (childCount[e.target] || 0) + 1;
+      (childrenOf[e.target] = childrenOf[e.target] || []).push(e.source);
     });
-    // Only containers with children get a combo: empty boxes are clutter.
+    const pos = treePositions(nodes, parentOf, childrenOf);
+    // Foldable = has children and has a parent: the IsChildOf root of the
+    // loaded graph (today a Document, later maybe a Project or Team) is
+    // never a combo — folding the whole graph is useless. Empty containers
+    // stay plain nodes.
     const hasCombo = {};
-    nodes.forEach(function (n) {
-      if (CONTAINER_TABLES[n.table] && childCount[n.id]) hasCombo[n.id] = true;
-    });
+    if (withCombos) {
+      nodes.forEach(function (n) {
+        if ((childrenOf[n.id] || []).length && parentOf[n.id]) hasCombo[n.id] = true;
+      });
+    }
     const combos = [];
     nodes.forEach(function (n) {
       if (!hasCombo[n.id]) return;
@@ -339,7 +381,10 @@ Graph Console
       combos.push(combo);
     });
     const g6nodes = nodes.map(function (n) {
-      const out = { id: n.id, data: { label: n.label, table: n.table } };
+      const p = pos[n.id] || { x: 0, y: 0 };
+      const out = { id: n.id,
+                    data: { label: n.label, table: n.table },
+                    style: { x: p.x, y: p.y } };
       if (hasCombo[n.id]) {
         out.combo = comboIdFor(n.id);
       } else if (parentOf[n.id] && hasCombo[parentOf[n.id]]) {
@@ -374,8 +419,10 @@ Graph Console
       data: g6data,
       autoFit: "view",
       autoResize: true,
+      // Entrance/update animation is the performance killer: 1700 nodes
+      // took >2 min animated vs ~1.5 s without (measured, headless).
+      animation: false,
       padding: 20,
-      layout: { type: "antv-dagre", rankdir: "BT", nodesep: 10, ranksep: 40, sortByCombo: true },
       node: {
         type: function (d) { return nodeStyle(d.data.table).glyph; },
         style: {
@@ -422,6 +469,27 @@ Graph Console
     }).join("");
   }
 
+  function graphStatusText(data) {
+    return data.nodes.length + " nodes, " + data.edges.length + " edges"
+      + " (graph revn " + data.revn + ")"
+      + (data.truncated ? " — WARNING: truncated at row cap, view is partial" : "");
+  }
+
+  function renderCurrent() {
+    if (!lastGraphData) return;
+    const data = lastGraphData;
+    const anywayBtn = document.getElementById("graph-render-anyway");
+    if (data.nodes.length > RENDER_GUARD_NODES && !renderForced) {
+      graphViewStatus.textContent =
+        graphStatusText(data) + " — too large to render automatically";
+      if (anywayBtn) anywayBtn.style.display = "inline";
+      return;
+    }
+    if (anywayBtn) anywayBtn.style.display = "none";
+    graphViewStatus.textContent = graphStatusText(data);
+    renderGraph(toG6Data(data, collapsedComboIds(), foldEnabled()));
+  }
+
   function refetchGraph() {
     if (typeof G6 === "undefined") {
       graphViewStatus.textContent = "G6 failed to load (CDN unreachable)";
@@ -433,11 +501,8 @@ Graph Console
         return resp.json();
       })
       .then(function (data) {
-        graphViewStatus.textContent =
-          data.nodes.length + " nodes, " + data.edges.length + " edges"
-          + " (graph revn " + data.revn + ")"
-          + (data.truncated ? " — WARNING: truncated at row cap, view is partial" : "");
-        return renderGraph(toG6Data(data, collapsedComboIds()));
+        lastGraphData = data;
+        renderCurrent();
       })
       .catch(function (err) {
         graphViewStatus.textContent = "graph view error: " + err;
@@ -707,6 +772,23 @@ Graph Console
           && graphColumn.classList.contains("graph-view-expanded")) {
         setExpanded(false);
       }
+    });
+  }
+
+  const foldToggle = document.getElementById("graph-fold-toggle");
+  if (foldToggle) {
+    foldToggle.checked = foldEnabled();
+    foldToggle.addEventListener("change", function () {
+      localStorage.setItem("graph-fold-containers", foldToggle.checked ? "1" : "0");
+      renderCurrent();
+    });
+  }
+
+  const renderAnywayBtn = document.getElementById("graph-render-anyway");
+  if (renderAnywayBtn) {
+    renderAnywayBtn.addEventListener("click", function () {
+      renderForced = true;
+      renderCurrent();
     });
   }
 

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -11,7 +11,10 @@ Graph Console
   </div>
 </nav>
 <main class="dashboard">
-  <section class="widget" style="max-width: none;">
+  <!-- flex: 1 1 0 + min-width: 0: size this .dashboard flex item from the
+       viewport, never from content — content-driven growth (e.g. the G6
+       canvas) would otherwise feed back into column width. -->
+  <section class="widget" style="max-width: none; flex: 1 1 0; min-width: 0;">
     <p><a href="/dbg">&larr; Back to debug</a></p>
 
     <div style="display: flex; gap: 16px; align-items: flex-start;">
@@ -151,7 +154,6 @@ Graph Console
          style="flex: 1 1 auto; min-width: 0;">
       <fieldset id="graph-view-panel">
         <legend>Graph view
-          <button type="button" id="graph-maximize" style="margin-left: 1em;">Expand</button>
           <label style="margin-left: 1em; font-size: 12px; font-weight: normal;">
             <input type="checkbox" id="graph-fold-toggle" /> fold containers
           </label>
@@ -173,7 +175,7 @@ Graph Console
         </desc>
         <div id="graph-legend" style="font-size: 12px; margin: 4px 0;"></div>
         <div id="graph-canvas"
-             style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff;"></div>
+             style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff; overflow: hidden;"></div>
         <div id="graph-view-status" style="color: #666; font-size: 12px;"></div>
         <button type="button" id="graph-render-anyway" style="display: none;">Render anyway</button>
         <button type="button" id="graph-filter-reset" style="display: none;">Show full graph</button>
@@ -189,6 +191,13 @@ Graph Console
   #graph-view-column {
     position: sticky;
     top: 8px;
+  }
+  /* Fieldsets default to min-inline-size: min-content, so the panel could
+     never shrink below its content and grew with the G6 canvas instead
+     (content -> fieldset -> column -> canvas feedback). Let it shrink;
+     the legend wraps and the canvas clips. */
+  #graph-view-panel {
+    min-inline-size: 0;
   }
   #graph-view-column.graph-view-expanded {
     position: fixed;
@@ -512,7 +521,6 @@ Graph Console
       container: "graph-canvas",
       data: g6data,
       autoFit: "view",
-      autoResize: true,
       animation: animate,
       padding: 20,
       node: {
@@ -582,7 +590,9 @@ Graph Console
         + '<span style="color: ' + s.color + '; font-size: 14px;">'
         + (GLYPH_CHARS[s.glyph] || "●") + '</span> '
         + escapeHtml(table) + "</span>";
-    }).join("");
+      // join with a space: the spans are nowrap, so the separator is the
+      // only soft-wrap opportunity in the legend row
+    }).join(" ");
   }
 
   function graphStatusText(data) {
@@ -955,8 +965,8 @@ Graph Console
   }
 
   // In-page expand (no Fullscreen API): keeps browser chrome and window
-  // manager splits usable while the graph takes the whole page.
-  const maximizeBtn = document.getElementById("graph-maximize");
+  // manager splits usable while the graph takes the whole page. Entered
+  // via the toolbar's expand icon; exited via its exit icon or Esc.
   const graphColumn = document.getElementById("graph-view-column");
 
   function resizeGraphSoon() {
@@ -973,13 +983,16 @@ Graph Console
 
   function setExpanded(expanded) {
     graphColumn.classList.toggle("graph-view-expanded", expanded);
-    maximizeBtn.textContent = expanded ? "Restore (Esc)" : "Expand";
     resizeGraphSoon();
   }
 
-  // Follow container size (window resizes, flex reflow). Only setSize —
-  // the user's viewport must persist; explicit re-fit is the toolbar's
-  // auto-fit (or expand/restore, which do fitView via resizeGraphSoon).
+  // Follow container size (G6's autoResize is inert on this build).
+  // Safe only because the container's width is viewport-driven and can
+  // never follow the canvas: the fieldset's min-content floor is removed
+  // (#graph-view-panel min-inline-size: 0) and #graph-canvas clips
+  // (overflow: hidden). Without both, observer -> setSize -> wider canvas
+  // -> wider column -> observer is a runaway growth loop that also wipes
+  // the painted canvas on every step.
   const canvasEl = document.getElementById("graph-canvas");
   if (typeof ResizeObserver !== "undefined" && canvasEl) {
     let resizeRaf = null;
@@ -987,19 +1000,18 @@ Graph Console
       if (resizeRaf) return;
       resizeRaf = requestAnimationFrame(function () {
         resizeRaf = null;
-        if (g6graph) {
-          try {
-            g6graph.setSize(canvasEl.clientWidth, canvasEl.clientHeight);
-          } catch (_err) { /* instance mid-recreate */ }
-        }
+        if (!g6graph) return;
+        try {
+          const cur = g6graph.getSize();
+          const w = canvasEl.clientWidth;
+          const h = canvasEl.clientHeight;
+          if (!cur || cur[0] !== w || cur[1] !== h) g6graph.setSize(w, h);
+        } catch (_err) { /* instance mid-recreate */ }
       });
     }).observe(canvasEl);
   }
 
-  if (maximizeBtn && graphColumn) {
-    maximizeBtn.addEventListener("click", function () {
-      setExpanded(!graphColumn.classList.contains("graph-view-expanded"));
-    });
+  if (graphColumn) {
     document.addEventListener("keydown", function (ev) {
       if (ev.key === "Escape"
           && graphColumn.classList.contains("graph-view-expanded")) {

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -89,6 +89,19 @@ Graph Console
     </fieldset>
 
     <fieldset>
+      <legend>Graph view</legend>
+      <desc>
+        Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
+        and glyph encode the node table; edges are <code>IsChildOf</code>
+        (arrow points to parent). Redraws automatically after live changes.
+      </desc>
+      <div id="graph-legend" style="font-size: 12px; margin: 4px 0;"></div>
+      <div id="graph-canvas"
+           style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff;"></div>
+      <div id="graph-view-status" style="color: #666; font-size: 12px;"></div>
+    </fieldset>
+
+    <fieldset>
       <legend>Cypher query</legend>
       <form id="graph-query-form" method="post" action="/dbg/actions/graph-query">
         <div class="row">
@@ -137,6 +150,7 @@ Graph Console
 </main>
 
 {% if session %}
+<script src="https://cdn.jsdelivr.net/npm/@antv/g6@5/dist/g6.min.js"></script>
 <script>
 (function () {
   const fileId = "{{session.file-id}}";
@@ -153,6 +167,122 @@ Graph Console
   const changelogEmpty = document.getElementById("graph-changelog-empty");
 
   let ws = null;
+
+  // --- G6 graph view -------------------------------------------------
+  // Color+glyph per node table. Colors from the validated categorical
+  // palette; within-glyph pairs are the only ones color must separate
+  // alone (every node also carries a direct name label + legend).
+  const NODE_STYLES = {
+    "Document":  { color: "#0b0b0b", glyph: "diamond",  size: 28 },
+    "Page":      { color: "#2a78d6", glyph: "rect",     size: 22 },
+    "Frame":     { color: "#008300", glyph: "hexagon",  size: 18 },
+    "Group":     { color: "#4a3aa7", glyph: "hexagon",  size: 18 },
+    "Boolean":   { color: "#eda100", glyph: "hexagon",  size: 18 },
+    "SVGRaw":    { color: "#767470", glyph: "hexagon",  size: 18 },
+    "Rectangle": { color: "#eb6834", glyph: "rect",     size: 14 },
+    "Circle":    { color: "#1baf7a", glyph: "circle",   size: 14 },
+    "Path":      { color: "#e34948", glyph: "triangle", size: 14 },
+    "Text":      { color: "#e87ba4", glyph: "circle",   size: 14 },
+    "Image":     { color: "#eda100", glyph: "star",     size: 14 }
+  };
+  const FALLBACK_STYLE = { color: "#767470", glyph: "circle", size: 14 };
+
+  const graphViewStatus = document.getElementById("graph-view-status");
+  let g6graph = null;
+  let refetchTimer = null;
+
+  function nodeStyle(table) {
+    return NODE_STYLES[table] || FALLBACK_STYLE;
+  }
+
+  function toG6Data(data) {
+    return {
+      nodes: (data.nodes || []).map(function (n) {
+        return { id: n.id, data: { label: n.label, table: n.table } };
+      }),
+      edges: (data.edges || [])
+        .slice()
+        .sort(function (a, b) { return (a.position || 0) - (b.position || 0); })
+        .map(function (e) {
+          return { source: e.source, target: e.target, data: { position: e.position } };
+        })
+    };
+  }
+
+  function renderGraph(g6data) {
+    if (g6graph) {
+      g6graph.setData(g6data);
+      return g6graph.render();
+    }
+    g6graph = new G6.Graph({
+      container: "graph-canvas",
+      data: g6data,
+      autoFit: "view",
+      padding: 20,
+      layout: { type: "antv-dagre", rankdir: "BT", nodesep: 10, ranksep: 40 },
+      node: {
+        type: function (d) { return nodeStyle(d.data.table).glyph; },
+        style: {
+          size: function (d) { return nodeStyle(d.data.table).size; },
+          fill: function (d) { return nodeStyle(d.data.table).color; },
+          stroke: "#52514e",
+          lineWidth: 0.5,
+          labelText: function (d) { return d.data.label; },
+          labelFontSize: 9,
+          labelFill: "#0b0b0b",
+          labelPlacement: "bottom"
+        }
+      },
+      edge: {
+        style: { stroke: "#b3b0a8", endArrow: true, endArrowSize: 6 }
+      },
+      behaviors: ["zoom-canvas", "drag-canvas", "drag-element"]
+    });
+    return g6graph.render();
+  }
+
+  function renderGraphLegend() {
+    const el = document.getElementById("graph-legend");
+    el.innerHTML = Object.keys(NODE_STYLES).map(function (table) {
+      const s = NODE_STYLES[table];
+      return '<span style="margin-right: 1em;">'
+        + '<i style="display: inline-block; width: 10px; height: 10px;'
+        + ' margin-right: 3px; border: 1px solid #52514e;'
+        + ' background: ' + s.color + ';"></i>'
+        + escapeHtml(table) + " (" + s.glyph + ")</span>";
+    }).join("");
+  }
+
+  function refetchGraph() {
+    if (typeof G6 === "undefined") {
+      graphViewStatus.textContent = "G6 failed to load (CDN unreachable)";
+      return;
+    }
+    fetch("/dbg/actions/graph-data")
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("graph-data HTTP " + resp.status);
+        return resp.json();
+      })
+      .then(function (data) {
+        graphViewStatus.textContent =
+          data.nodes.length + " nodes, " + data.edges.length + " edges"
+          + " (graph revn " + data.revn + ")"
+          + (data.truncated ? " — WARNING: truncated at row cap, view is partial" : "");
+        return renderGraph(toG6Data(data));
+      })
+      .catch(function (err) {
+        graphViewStatus.textContent = "graph view error: " + err;
+      });
+  }
+
+  function scheduleGraphRefetch() {
+    if (refetchTimer) clearTimeout(refetchTimer);
+    refetchTimer = setTimeout(function () {
+      refetchTimer = null;
+      refetchGraph();
+    }, 400);
+  }
+  // --- end G6 graph view ---------------------------------------------
 
   function encodeTransitUuid(uuid) {
     return "~u" + uuid;
@@ -274,6 +404,7 @@ Graph Console
 
     appendChange(msg.revn, summarizeChanges(msg.changes));
     setTimeout(refreshSyncStatus, 150);
+    scheduleGraphRefetch();
   }
 
   function subscribe() {
@@ -377,6 +508,8 @@ Graph Console
 
   connect();
   refreshSyncStatus();
+  renderGraphLegend();
+  refetchGraph();
 
   window.addEventListener("beforeunload", function () {
     if (ws && ws.readyState === WebSocket.OPEN) {

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -11,8 +11,11 @@ Graph Console
   </div>
 </nav>
 <main class="dashboard">
-  <section class="widget">
+  <section class="widget" style="max-width: none;">
     <p><a href="/dbg">&larr; Back to debug</a></p>
+
+    <div style="display: flex; gap: 16px; align-items: flex-start;">
+    <div style="flex: 0 0 440px; min-width: 360px;">
 
     <fieldset>
       <legend>Load graph in memory</legend>
@@ -20,7 +23,7 @@ Graph Console
         Projects the Penpot file into an in-memory Ladybug database for this
         admin session. Loading a new file replaces the previous one.
       </desc>
-      <form method="post" action="/dbg/actions/graph-load">
+      <form id="graph-load-form" method="post" action="/dbg/actions/graph-load">
         <div class="row">
           <input type="text" style="width:420px" name="file-id"
                  placeholder="file-id"
@@ -37,6 +40,12 @@ Graph Console
         </div>
       </form>
       {% endif %}
+    </fieldset>
+
+    <fieldset>
+      <legend>Files</legend>
+      <desc>Teams &rarr; projects &rarr; files. Click a file to load it.</desc>
+      <div id="graph-files-tree" style="font-size: 13px;">Loading&hellip;</div>
     </fieldset>
 
     {% if session %}
@@ -89,19 +98,6 @@ Graph Console
     </fieldset>
 
     <fieldset>
-      <legend>Graph view</legend>
-      <desc>
-        Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
-        and glyph encode the node table; edges are <code>IsChildOf</code>
-        (arrow points to parent). Redraws automatically after live changes.
-      </desc>
-      <div id="graph-legend" style="font-size: 12px; margin: 4px 0;"></div>
-      <div id="graph-canvas"
-           style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff;"></div>
-      <div id="graph-view-status" style="color: #666; font-size: 12px;"></div>
-    </fieldset>
-
-    <fieldset>
       <legend>Cypher query</legend>
       <form id="graph-query-form" method="post" action="/dbg/actions/graph-query">
         <div class="row">
@@ -146,8 +142,110 @@ Graph Console
       {% endif %}
     </div>
     {% endif %}
+
+    </div><!-- left column -->
+
+    {% if session %}
+    <div id="graph-view-column"
+         style="flex: 1 1 auto; min-width: 0; position: sticky; top: 8px;">
+      <fieldset id="graph-view-panel">
+        <legend>Graph view
+          <button type="button" id="graph-maximize" style="margin-left: 1em;">Maximize</button>
+        </legend>
+        <desc>
+          Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
+          and glyph encode the node table; edges are <code>IsChildOf</code>
+          (arrow points to parent). Redraws automatically after live changes.
+        </desc>
+        <div id="graph-legend" style="font-size: 12px; margin: 4px 0;"></div>
+        <div id="graph-canvas"
+             style="width: 100%; height: 600px; border: 1px solid #ccc; background: #fff;"></div>
+        <div id="graph-view-status" style="color: #666; font-size: 12px;"></div>
+      </fieldset>
+    </div>
+    {% endif %}
+
+    </div><!-- flex row -->
   </section>
 </main>
+
+<style>
+  #graph-view-panel:fullscreen {
+    background: #fff;
+    overflow: auto;
+    padding: 12px;
+  }
+  #graph-view-panel:fullscreen #graph-canvas {
+    height: calc(100vh - 110px) !important;
+  }
+  #graph-files-tree summary { cursor: pointer; }
+  #graph-files-tree ul { margin: 2px 0 4px 0; padding-left: 2em; }
+  #graph-files-tree a { text-decoration: none; }
+  #graph-files-tree a:hover { text-decoration: underline; }
+</style>
+
+<script>
+(function () {
+  const tree = document.getElementById("graph-files-tree");
+  const loadForm = document.getElementById("graph-load-form");
+  const loadInput = loadForm ? loadForm.querySelector("input[name=file-id]") : null;
+  if (!tree) return;
+
+  function fileLink(file) {
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = "#";
+    a.textContent = file.name;
+    a.title = file.id;
+    a.addEventListener("click", function (ev) {
+      ev.preventDefault();
+      if (loadInput) {
+        loadInput.value = file.id;
+        loadForm.submit();
+      }
+    });
+    li.appendChild(a);
+    return li;
+  }
+
+  fetch("/dbg/actions/graph-files")
+    .then(function (resp) {
+      if (!resp.ok) throw new Error("graph-files HTTP " + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      tree.textContent = "";
+      const teams = data.teams || [];
+      if (!teams.length) {
+        tree.textContent = "No files found.";
+        return;
+      }
+      teams.forEach(function (team) {
+        const teamEl = document.createElement("details");
+        const teamSummary = document.createElement("summary");
+        teamSummary.textContent = team.name;
+        teamEl.appendChild(teamSummary);
+        (team.projects || []).forEach(function (project) {
+          const projEl = document.createElement("details");
+          projEl.style.marginLeft = "1em";
+          const projSummary = document.createElement("summary");
+          projSummary.textContent = project.name;
+          projEl.appendChild(projSummary);
+          const list = document.createElement("ul");
+          (project.files || []).forEach(function (file) {
+            list.appendChild(fileLink(file));
+          });
+          projEl.appendChild(list);
+          teamEl.appendChild(projEl);
+        });
+        tree.appendChild(teamEl);
+      });
+    })
+    .catch(function (err) {
+      tree.textContent = "Failed to load file tree: " + err;
+    });
+})();
+</script>
 
 {% if session %}
 <script src="https://cdn.jsdelivr.net/npm/@antv/g6@5/dist/g6.min.js"></script>
@@ -218,6 +316,7 @@ Graph Console
       container: "graph-canvas",
       data: g6data,
       autoFit: "view",
+      autoResize: true,
       padding: 20,
       layout: { type: "antv-dagre", rankdir: "BT", nodesep: 10, ranksep: 40 },
       node: {
@@ -503,6 +602,33 @@ Graph Console
         .catch(function (err) {
           renderQueryOutput({ error: String(err) });
         });
+    });
+  }
+
+  const maximizeBtn = document.getElementById("graph-maximize");
+  const graphPanel = document.getElementById("graph-view-panel");
+  if (maximizeBtn && graphPanel) {
+    maximizeBtn.addEventListener("click", function () {
+      if (document.fullscreenElement) {
+        document.exitFullscreen();
+      } else {
+        graphPanel.requestFullscreen().catch(function (err) {
+          graphViewStatus.textContent = "fullscreen rejected: " + err;
+        });
+      }
+    });
+    document.addEventListener("fullscreenchange", function () {
+      maximizeBtn.textContent =
+        document.fullscreenElement ? "Exit fullscreen" : "Maximize";
+      setTimeout(function () {
+        if (g6graph) {
+          const canvas = document.getElementById("graph-canvas");
+          try {
+            g6graph.setSize(canvas.clientWidth, canvas.clientHeight);
+            g6graph.fitView();
+          } catch (_err) { /* autoResize covers most cases */ }
+        }
+      }, 120);
     });
   }
 

--- a/backend/resources/app/templates/graph-console.tmpl
+++ b/backend/resources/app/templates/graph-console.tmpl
@@ -147,10 +147,10 @@ Graph Console
 
     {% if session %}
     <div id="graph-view-column"
-         style="flex: 1 1 auto; min-width: 0; position: sticky; top: 8px;">
+         style="flex: 1 1 auto; min-width: 0;">
       <fieldset id="graph-view-panel">
         <legend>Graph view
-          <button type="button" id="graph-maximize" style="margin-left: 1em;">Maximize</button>
+          <button type="button" id="graph-maximize" style="margin-left: 1em;">Expand</button>
         </legend>
         <desc>
           Renders the in-memory Ladybug graph with AntV G6 (CDN). Node color
@@ -170,13 +170,21 @@ Graph Console
 </main>
 
 <style>
-  #graph-view-panel:fullscreen {
+  #graph-view-column {
+    position: sticky;
+    top: 8px;
+  }
+  #graph-view-column.graph-view-expanded {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
     background: #fff;
     overflow: auto;
     padding: 12px;
+    margin: 0;
   }
-  #graph-view-panel:fullscreen #graph-canvas {
-    height: calc(100vh - 110px) !important;
+  #graph-view-column.graph-view-expanded #graph-canvas {
+    height: calc(100vh - 160px) !important;
   }
   #graph-files-tree summary { cursor: pointer; }
   #graph-files-tree ul { margin: 2px 0 4px 0; padding-left: 2em; }
@@ -605,30 +613,38 @@ Graph Console
     });
   }
 
+  // In-page expand (no Fullscreen API): keeps browser chrome and window
+  // manager splits usable while the graph takes the whole page.
   const maximizeBtn = document.getElementById("graph-maximize");
-  const graphPanel = document.getElementById("graph-view-panel");
-  if (maximizeBtn && graphPanel) {
-    maximizeBtn.addEventListener("click", function () {
-      if (document.fullscreenElement) {
-        document.exitFullscreen();
-      } else {
-        graphPanel.requestFullscreen().catch(function (err) {
-          graphViewStatus.textContent = "fullscreen rejected: " + err;
-        });
+  const graphColumn = document.getElementById("graph-view-column");
+
+  function resizeGraphSoon() {
+    setTimeout(function () {
+      if (g6graph) {
+        const canvas = document.getElementById("graph-canvas");
+        try {
+          g6graph.setSize(canvas.clientWidth, canvas.clientHeight);
+          g6graph.fitView();
+        } catch (_err) { /* autoResize covers most cases */ }
       }
+    }, 120);
+  }
+
+  function setExpanded(expanded) {
+    graphColumn.classList.toggle("graph-view-expanded", expanded);
+    maximizeBtn.textContent = expanded ? "Restore (Esc)" : "Expand";
+    resizeGraphSoon();
+  }
+
+  if (maximizeBtn && graphColumn) {
+    maximizeBtn.addEventListener("click", function () {
+      setExpanded(!graphColumn.classList.contains("graph-view-expanded"));
     });
-    document.addEventListener("fullscreenchange", function () {
-      maximizeBtn.textContent =
-        document.fullscreenElement ? "Exit fullscreen" : "Maximize";
-      setTimeout(function () {
-        if (g6graph) {
-          const canvas = document.getElementById("graph-canvas");
-          try {
-            g6graph.setSize(canvas.clientWidth, canvas.clientHeight);
-            g6graph.fitView();
-          } catch (_err) { /* autoResize covers most cases */ }
-        }
-      }, 120);
+    document.addEventListener("keydown", function (ev) {
+      if (ev.key === "Escape"
+          && graphColumn.classList.contains("graph-view-expanded")) {
+        setExpanded(false);
+      }
     });
   }
 

--- a/backend/src/app/graph/bulk.clj
+++ b/backend/src/app/graph/bulk.clj
@@ -51,6 +51,43 @@
     (coll? v)     (csv-escape-string (json/encode v))
     :else         (csv-escape-string (str v))))
 
+(defn- kuzu-list-element
+  "Format one element of a Ladybug LIST column for CSV COPY. Kuzu parses
+  the (CSV-unquoted) field as a list literal: bare values for UUID/number
+  elements, single-quoted strings (backslash-escaped) for STRING/JSON."
+  [elem-type v]
+  (cond
+    (nil? v)
+    "NULL"
+
+    (contains? #{"STRING" "JSON"} elem-type)
+    (let [s (if (coll? v) (json/encode v) (csv-normalize-string (str v)))]
+      (str "'" (-> s
+                   (str/replace "\\" "\\\\")
+                   (str/replace "'" "\\'"))
+           "'"))
+
+    :else
+    (str v)))
+
+(defn- kuzu-list-cell
+  "CSV cell for a LIST-typed column (`UUID[]`, `STRING[]`, `JSON[]`, …).
+  JSON-encoding the collection (as `csv-cell` does) is wrong here: Kuzu
+  expects its own list literal, e.g. `[id1,id2]` with bare elements."
+  [ladybug-type v]
+  (let [elem-type (subs ladybug-type 0 (- (count ladybug-type) 2))
+        elems     (if (coll? v) (seq v) [v])]
+    (csv-escape-string
+     (str "[" (str/join "," (map #(kuzu-list-element elem-type %) elems)) "]"))))
+
+(defn- csv-typed-cell
+  [ladybug-type v]
+  (if (and (some? v)
+           (string? ladybug-type)
+           (str/ends-with? ladybug-type "[]"))
+    (kuzu-list-cell ladybug-type v)
+    (csv-cell v)))
+
 (defn- cypher-file-path
   [^File file]
   (-> (.getAbsolutePath file)
@@ -59,11 +96,13 @@
 
 (defn- write-node-csv!
   [^File file table rows]
-  (let [columns (nodes/column-keys table)]
+  (let [columns (nodes/column-keys table)
+        types   (mapv #(nodes/column-ladybug-type table %) columns)]
     (with-open [w (io/writer file :encoding "UTF-8")]
       (.write w (str (str/join "," (map name columns)) "\n"))
       (doseq [row rows]
-        (.write w (str (str/join "," (map #(csv-cell (get row %)) columns))
+        (.write w (str (str/join "," (map (fn [k t] (csv-typed-cell t (get row k)))
+                                          columns types))
                        "\n"))))))
 
 (defn- write-edge-csv!

--- a/backend/src/app/graph/debug.clj
+++ b/backend/src/app/graph/debug.clj
@@ -24,11 +24,17 @@
 (set! *warn-on-reflection* true)
 
 (def default-query
-  "Default console query. The `filter_*` columns carry node ids for the
-  graph-view result filter; the results table hides them (see
-  `hide-filter-columns` and the template's `renderQueryOutput`)."
-  (str "MATCH (s)-[r]->(t) "
-       "RETURN s.name, label(s) AS src, label(r) AS rel, t.name, label(t) AS tgt, "
+  "Default console query, written to be self-explanatory in the textarea.
+  The `filter_*` columns carry node ids for the graph-view result filter;
+  the results table hides them (see `hide-filter-columns` and the
+  template's `renderQueryOutput`)."
+  (str "MATCH (s)-[r]->(t)\n"
+       "// WHERE some condition\n"
+       "RETURN label(s) AS src, s.name,\n"
+       "       label(r) AS rel,\n"
+       "       t.name, label(t) AS tgt,\n"
+       "\n"
+       "// filter_* columns omitted from table; these needed for graph view\n"
        "s.id AS filter_src_id, t.id AS filter_tgt_id;"))
 
 (defonce ^:private sessions

--- a/backend/src/app/graph/debug.clj
+++ b/backend/src/app/graph/debug.clj
@@ -66,8 +66,9 @@
     (some-> (get @sessions (session-key profile-id))
             (as-> current
                   (when (= file-id (:file-id current))
-                    (let [result (graph.sync/apply-changes!
-                                  conn (:index current) changes revn)
+                    (let [result (locking (:lock current)
+                                   (graph.sync/apply-changes!
+                                    conn (:index current) changes revn))
                           sync-at (ct/now)]
                       (swap! sessions assoc-in [(session-key profile-id) :index]
                              (:index result))
@@ -152,8 +153,12 @@
                                                       :skip-validation? true)
             index (graph.sync/build-index file-id (:revn meta) (:projection meta))
             session
+            ;; :lock serializes access to the shared Connection between the
+            ;; msgbus sync loop (writes) and HTTP handlers (reads); the Java
+            ;; binding gives no thread-safety guarantee for one Connection.
             (-> {:db db
                  :conn conn
+                 :lock (Object.)
                  :file-id file-id
                  :meta meta
                  :index index
@@ -174,9 +179,10 @@
     (ex/raise :type :validation
               :code :missing-query
               :hint "cypher query is required"))
-  (if-let [{:keys [conn]} (get @sessions (session-key profile-id))]
-    (-> (ladybug/query-on-connection! conn statement)
-        format-query-result)
+  (if-let [{:keys [conn lock]} (get @sessions (session-key profile-id))]
+    (locking (or lock ::no-lock)
+      (-> (ladybug/query-on-connection! conn statement)
+          format-query-result))
     (ex/raise :type :not-found
               :code :graph-session-not-loaded
               :hint "load a file graph before running queries")))
@@ -220,14 +226,15 @@
   loaded. Queries the Ladybug database (not the sync index) so the view
   reflects actual DB state, including drift."
   [profile-id]
-  (when-let [{:keys [conn file-id index]} (get @sessions (session-key profile-id))]
-    (let [{:keys [nodes] nodes-truncated? :truncated?} (export-nodes conn)
-          {:keys [edges] edges-truncated? :truncated?} (export-edges conn)]
-      {:file-id   (str file-id)
-       :revn      (:revn index)
-       :truncated (boolean (or nodes-truncated? edges-truncated?))
-       :nodes     nodes
-       :edges     edges})))
+  (when-let [{:keys [conn lock file-id index]} (get @sessions (session-key profile-id))]
+    (locking (or lock ::no-lock)
+      (let [{:keys [nodes] nodes-truncated? :truncated?} (export-nodes conn)
+            {:keys [edges] edges-truncated? :truncated?} (export-edges conn)]
+        {:file-id   (str file-id)
+         :revn      (:revn index)
+         :truncated (boolean (or nodes-truncated? edges-truncated?))
+         :nodes     nodes
+         :edges     edges}))))
 
 (defn console-context
   "Build template data for the graph debug console page."

--- a/backend/src/app/graph/debug.clj
+++ b/backend/src/app/graph/debug.clj
@@ -12,6 +12,7 @@
    [app.common.time :as ct]
    [app.graph.ingest :as graph.ingest]
    [app.graph.ladybug :as ladybug]
+   [app.graph.schema.nodes :as nodes]
    [app.graph.sync :as graph.sync]
    [app.msgbus :as mbus]
    [clojure.string :as str]
@@ -179,6 +180,54 @@
     (ex/raise :type :not-found
               :code :graph-session-not-loaded
               :hint "load a file graph before running queries")))
+
+(def ^:private export-max-rows
+  "Row cap for graph-view export queries; far above expected per-file node
+  and edge counts. `:truncated` in the export signals when it was hit."
+  100000)
+
+(defn- export-nodes
+  [conn]
+  (reduce
+   (fn [acc {:keys [table]}]
+     (let [stmt (str "MATCH (n:" (nodes/match-label table)
+                     ") RETURN n.id AS id, n.name AS name;")
+           {:keys [rows truncated?]}
+           (ladybug/query-on-connection! conn stmt :max-rows export-max-rows)]
+       (-> acc
+           (update :nodes into
+                   (map (fn [[id label]]
+                          {:id (str id) :label (str label) :table table}))
+                   rows)
+           (update :truncated? #(or % truncated?)))))
+   {:nodes [] :truncated? false}
+   nodes/node-types))
+
+(defn- export-edges
+  [conn]
+  (let [stmt (str "MATCH (a)-[r:IsChildOf]->(b) "
+                  "RETURN a.id AS source, b.id AS target, r.position AS position;")
+        {:keys [rows truncated?]}
+        (ladybug/query-on-connection! conn stmt :max-rows export-max-rows)]
+    {:edges (mapv (fn [[source target position]]
+                    {:source (str source) :target (str target) :position position})
+                  rows)
+     :truncated? truncated?}))
+
+(defn export-graph-data!
+  "Export the node/edge inventory of the in-memory graph for `profile-id`
+  as plain data for the debug graph view. Returns nil when no session is
+  loaded. Queries the Ladybug database (not the sync index) so the view
+  reflects actual DB state, including drift."
+  [profile-id]
+  (when-let [{:keys [conn file-id index]} (get @sessions (session-key profile-id))]
+    (let [{:keys [nodes] nodes-truncated? :truncated?} (export-nodes conn)
+          {:keys [edges] edges-truncated? :truncated?} (export-edges conn)]
+      {:file-id   (str file-id)
+       :revn      (:revn index)
+       :truncated (boolean (or nodes-truncated? edges-truncated?))
+       :nodes     nodes
+       :edges     edges})))
 
 (defn console-context
   "Build template data for the graph debug console page."

--- a/backend/src/app/graph/debug.clj
+++ b/backend/src/app/graph/debug.clj
@@ -77,7 +77,8 @@
     (some-> (get @sessions (session-key profile-id))
             (as-> current
                   (when (= file-id (:file-id current))
-                    (let [result (locking (:lock current)
+                    (let [lock   (:lock current)
+                          result (locking lock
                                    (graph.sync/apply-changes!
                                     conn (:index current) changes revn))
                           sync-at (ct/now)]
@@ -191,7 +192,7 @@
               :code :missing-query
               :hint "cypher query is required"))
   (if-let [{:keys [conn lock]} (get @sessions (session-key profile-id))]
-    (locking (or lock ::no-lock)
+    (locking lock
       (-> (ladybug/query-on-connection! conn statement)
           format-query-result))
     (ex/raise :type :not-found
@@ -238,7 +239,7 @@
   reflects actual DB state, including drift."
   [profile-id]
   (when-let [{:keys [conn lock file-id index]} (get @sessions (session-key profile-id))]
-    (locking (or lock ::no-lock)
+    (locking lock
       (let [{:keys [nodes] nodes-truncated? :truncated?} (export-nodes conn)
             {:keys [edges] edges-truncated? :truncated?} (export-edges conn)]
         {:file-id   (str file-id)

--- a/backend/src/app/graph/debug.clj
+++ b/backend/src/app/graph/debug.clj
@@ -24,7 +24,12 @@
 (set! *warn-on-reflection* true)
 
 (def default-query
-  "MATCH (n:Document) RETURN n.id AS id, n.name AS name;")
+  "Default console query. The `filter_*` columns carry node ids for the
+  graph-view result filter; the results table hides them (see
+  `hide-filter-columns` and the template's `renderQueryOutput`)."
+  (str "MATCH (s)-[r]->(t) "
+       "RETURN s.name, label(s) AS src, label(r) AS rel, t.name, label(t) AS tgt, "
+       "s.id AS filter_src_id, t.id AS filter_tgt_id;"))
 
 (defonce ^:private sessions
   (atom {}))
@@ -236,12 +241,26 @@
          :nodes     nodes
          :edges     edges}))))
 
+(defn- hide-filter-columns
+  "Drop `filter_*` columns from a query result before HTML table render;
+  they exist to feed node ids to the graph-view filter, not for reading.
+  The JSON response path keeps the full result."
+  [{:keys [columns rows] :as result}]
+  (let [idxs (vec (keep-indexed
+                   (fn [i c] (when-not (str/starts-with? (str c) "filter_") i))
+                   columns))]
+    (if (or (empty? idxs) (= (count idxs) (count columns)))
+      result
+      (assoc result
+             :columns (mapv (vec columns) idxs)
+             :rows    (mapv (fn [row] (mapv (vec row) idxs)) rows)))))
+
 (defn console-context
   "Build template data for the graph debug console page."
   [profile-id & {:keys [query query-result error message]}]
   {:session       (session-info profile-id)
    :query         (or query default-query)
-   :query-result  query-result
+   :query-result  (some-> query-result hide-filter-columns)
    :error         error
    :message       message
    :default-query default-query})

--- a/backend/src/app/graph/ladybug.clj
+++ b/backend/src/app/graph/ladybug.clj
@@ -97,7 +97,13 @@
 (defn- value->clj
   [^Value value]
   (when-not (.isNull value)
-    (let [v (.getValue value)]
+    (let [v (try
+              (.getValue value)
+              (catch Exception _
+                ;; LIST/STRUCT values are not supported by the binding's
+                ;; getValue (\"value_get_value\"); fall back to the textual
+                ;; representation so console queries do not crash.
+                (.toString value)))]
       (cond
         (instance? Long v)    v
         (instance? Integer v) (long v)

--- a/backend/src/app/http/debug.clj
+++ b/backend/src/app/http/debug.clj
@@ -415,6 +415,49 @@
      ::yres/headers {"content-type" "application/json; charset=utf-8"}
      ::yres/body    (json/encode {:error "no-session"})}))
 
+(def ^:private sql:graph-files
+  "select t.id   as team_id,    t.name as team_name,
+          p.id   as project_id, p.name as project_name,
+          f.id   as file_id,    f.name as file_name
+     from team as t
+     join team_profile_rel as tpr on (tpr.team_id = t.id)
+     join project as p on (p.team_id = t.id)
+     join file as f on (f.project_id = p.id)
+    where tpr.profile_id = ?
+      and t.deleted_at is null
+      and p.deleted_at is null
+      and f.deleted_at is null
+    order by t.name, p.name, f.name
+    limit 500")
+
+(defn- graph-files-tree
+  [rows]
+  (->> (group-by (juxt :team-id :team-name) rows)
+       (mapv (fn [[[team-id team-name] team-rows]]
+               {:id   (str team-id)
+                :name team-name
+                :projects
+                (->> (group-by (juxt :project-id :project-name) team-rows)
+                     (mapv (fn [[[project-id project-name] project-rows]]
+                             {:id    (str project-id)
+                              :name  project-name
+                              :files (mapv (fn [{:keys [file-id file-name]}]
+                                             {:id (str file-id) :name file-name})
+                                           project-rows)}))
+                     (sort-by :name)
+                     (vec))}))
+       (sort-by :name)
+       (vec)))
+
+(defn graph-files-handler
+  "List teams -> projects -> files reachable by the current profile, as
+  plain JSON for the graph console file tree."
+  [{:keys [::db/pool]} {:keys [::session/profile-id]}]
+  (let [rows (db/exec! pool [sql:graph-files profile-id])]
+    {::yres/status  200
+     ::yres/headers {"content-type" "application/json; charset=utf-8"}
+     ::yres/body    (json/encode {:teams (graph-files-tree rows)})}))
+
 (defn- json-request?
   [request]
   (some-> request
@@ -706,6 +749,7 @@
      ["/graph-reload" {:handler (partial graph-reload-handler cfg)}]
      ["/graph-sync-status" {:handler (partial graph-sync-status-handler cfg)}]
      ["/graph-data" {:handler (partial graph-data-handler cfg)}]
+     ["/graph-files" {:handler (partial graph-files-handler cfg)}]
      ["/file-import" {:handler (partial import-handler cfg)}]
      ["/file-raw-export-import" {:handler (partial raw-export-import-handler cfg)}]]]])
 

--- a/backend/src/app/http/debug.clj
+++ b/backend/src/app/http/debug.clj
@@ -13,6 +13,7 @@
    [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.features :as cfeat]
+   [app.common.json :as json]
    [app.common.logging :as l]
    [app.common.pprint :as pp]
    [app.common.time :as ct]
@@ -402,6 +403,18 @@
      ::yres/headers {"content-type" "application/json; charset=utf-8"}
      ::yres/body    (t/encode-str {:error "no-session"} {:type :json-verbose})}))
 
+(defn graph-data-handler
+  "Export the in-memory session graph as plain JSON (not transit) for the
+  G6 graph view embedded in the console page."
+  [_cfg {:keys [::session/profile-id]}]
+  (if-let [data (graph.debug/export-graph-data! profile-id)]
+    {::yres/status  200
+     ::yres/headers {"content-type" "application/json; charset=utf-8"}
+     ::yres/body    (json/encode data)}
+    {::yres/status  404
+     ::yres/headers {"content-type" "application/json; charset=utf-8"}
+     ::yres/body    (json/encode {:error "no-session"})}))
+
 (defn- json-request?
   [request]
   (some-> request
@@ -692,6 +705,7 @@
      ["/graph-unload" {:handler (partial graph-unload-handler cfg)}]
      ["/graph-reload" {:handler (partial graph-reload-handler cfg)}]
      ["/graph-sync-status" {:handler (partial graph-sync-status-handler cfg)}]
+     ["/graph-data" {:handler (partial graph-data-handler cfg)}]
      ["/file-import" {:handler (partial import-handler cfg)}]
      ["/file-raw-export-import" {:handler (partial raw-export-import-handler cfg)}]]]])
 


### PR DESCRIPTION
Renders the in-memory Ladybug session graph in the debug console (`/dbg/graph`) with AntV G6 and keeps it in sync with live file changes. Built on top of `superalex-graph-malli-schema`.

## Substrate changes (worth reviewing and adopting even if the graph view is not merged)

These modify pre-existing behavior of the graph backend and stand on their own:

- `app.graph.bulk/write-node-csv!` — staging-CSV cells are now typed per column: LIST-typed columns (`UUID[]`, `STRING[]`, `JSON[]`) emit Kuzu list literals instead of JSON arrays. Without this, `COPY … .csv` fails for any file whose shapes have children (`shapes UUID[]` parses `["uuid",…]` as a quoted element). Affects every ingest, not just the console.
- `app.graph.ladybug/value->clj` — wraps `.getValue` in try/catch with a fallback to the Value's string representation; LIST/STRUCT-valued query results previously threw `value_get_value` and killed the whole request for any reader (console, stats, srepl).
- `app.graph.debug` — the session map gains a `:lock`, and every path touching the shared `Connection` (msgbus sync writes, console queries, exports) takes it. The Java binding gives no thread-safety guarantee for a single Connection; a lost `DETACH DELETE` was observed under concurrent read load without the lock.

## Feature changes (visible)

- Graph view fieldset on `/dbg/graph`: node-link rendering of the loaded session (G6 v5, CDN UMD, no build step). Node color+glyph encode the node table, every node carries its name label, legend above the canvas; edges are `IsChildOf` with arrows to the parent.
- Live refresh: the page's existing `/ws/notifications` subscription triggers a debounced refetch; the ws feed auto-reconnects after backend restarts; refetches that leave the display projection unchanged skip the repaint.
- Files tree (teams → projects → files) with click-to-load; the loaded file name links to its Penpot workspace.
- Layout dropdown: O(n) tidy tree layout (default, exploits `IsChildOf` being a tree) plus 13 G6 layouts; "fold containers" renders any container with children as a collapsible combo (double-click), fold state survives redraws; graphs above 4000 nodes require an explicit "Render anyway"; an "animate" toggle disables animation unconditionally (entrance animation is the freeze mechanism at scale).
- On-canvas toolbar: auto-fit, and in-page expand/restore (Esc also restores).
- Query panel: retitled "LadybugDB Cypher" with a docs link; self-explanatory multi-line default query; columns aliased `filter_*` are hidden from the results table but drive "Show result in graph view", which renders the induced subgraph of ids found in the result; query text persists across page reloads.
- New endpoints: `GET /dbg/actions/graph-data` (plain-JSON node/edge export of the session, row-capped with a `truncated` flag) and `GET /dbg/actions/graph-files` (teams/projects/files tree). Both plain JSON, not transit.
- Two-column console layout (controls left, sticky graph right).
