### PR TITLE
:bug: Harden frontend .getData call sites against undefined receivers

### DIFF
--- a/frontend/packages/draft-js/index.js
+++ b/frontend/packages/draft-js/index.js
@@ -29,6 +29,7 @@ function isDefined(v) {
 }
 
 function mergeBlockData(block, newData) {
+  if (!block) return undefined;
   let data = block.getData();
 
   for (let key of Object.keys(newData)) {
@@ -176,10 +177,12 @@ export function splitBlockPreservingData(state) {
 
   content = Modifier.splitBlock(content, selection);
 
-  const blockData = content.blockMap.get(content.selectionBefore.getStartKey()).getData();
+  const startKey = content.selectionBefore.getStartKey();
+  const block = content.blockMap.get(startKey);
+  const blockData = (block && block.getData()) || new Map();
   const blockKey = content.selectionAfter.getStartKey();
-  const blockMap = content.blockMap.update(blockKey, (block) => {
-    return block.set("data", blockData);
+  const blockMap = content.blockMap.update(blockKey, (b) => {
+    return b.set("data", blockData);
   });
 
   content = content.set("blockMap", blockMap);
@@ -325,6 +328,7 @@ export function updateBlockData(state, blockKey, data) {
   const content = state.getCurrentContent();
   const block = content.getBlockForKey(blockKey);
   const newBlock = mergeBlockData(block, data);
+  if (!newBlock) return state;
 
   const blockData = newBlock.getData();
 

--- a/frontend/src/app/main/ui/components/forms.cljs
+++ b/frontend/src/app/main/ui/components/forms.cljs
@@ -560,28 +560,29 @@
         on-paste
         (mf/use-fn
          (fn [event]
-           (let [paste-data (-> event .-clipboardData (.getData "text"))]
-             (when (and (string? paste-data)
-                        (re-find #"[,\s]" paste-data))
-               (dom/prevent-default event)
-               (dom/stop-propagation event)
+           (when-let [clipboard-data (.-clipboardData event)]
+             (let [paste-data (.getData clipboard-data "text")]
+               (when (and (string? paste-data)
+                          (re-find #"[,\s]" paste-data))
+                 (dom/prevent-default event)
+                 (dom/stop-propagation event)
 
-               ;; Mark as touched
-               (swap! form assoc-in [:touched input-name] true)
+                 ;; Mark as touched
+                 (swap! form assoc-in [:touched input-name] true)
 
-               ;; Split pasted text by commas and/or whitespace, add each valid part
-               (let [parts (->> (str/split paste-data #",|\s+")
-                                (map str/trim)
-                                (remove str/empty?))]
-                 (doseq [part parts]
-                   (when (valid-item-fn part)
-                     (swap! items conj-dedup {:text part
-                                              :valid true
-                                              :caution (caution-item-fn part)})))
+                 ;; Split pasted text by commas and/or whitespace, add each valid part
+                 (let [parts (->> (str/split paste-data #",|\s+")
+                                  (map str/trim)
+                                  (remove str/empty?))]
+                   (doseq [part parts]
+                     (when (valid-item-fn part)
+                       (swap! items conj-dedup {:text part
+                                                :valid true
+                                                :caution (caution-item-fn part)})))
 
-                 ;; Reset input value and mark as untouched after successful paste
-                 (reset! value "")
-                 (swap! form assoc-in [:touched input-name] false))))))
+                   ;; Reset input value and mark as untouched after successful paste
+                   (reset! value "")
+                   (swap! form assoc-in [:touched input-name] false)))))))
 
         on-blur
         (mf/use-fn

--- a/frontend/src/app/main/ui/forms.cljs
+++ b/frontend/src/app/main/ui/forms.cljs
@@ -121,28 +121,29 @@
         on-paste
         (mf/use-fn
          (fn [event]
-           (let [paste-data (-> event .-clipboardData (.getData "text"))]
-             (when (and (string? paste-data)
-                        (re-find #"[,\s]" paste-data))
-               (dom/prevent-default event)
-               (dom/stop-propagation event)
+           (when-let [clipboard-data (.-clipboardData event)]
+             (let [paste-data (.getData clipboard-data "text")]
+               (when (and (string? paste-data)
+                          (re-find #"[,\s]" paste-data))
+                 (dom/prevent-default event)
+                 (dom/stop-propagation event)
 
-               ;; Mark as touched
-               (swap! form assoc-in [:touched name] true)
+                 ;; Mark as touched
+                 (swap! form assoc-in [:touched name] true)
 
-               ;; Split pasted text by commas and/or whitespace, add each valid part
-               (let [parts (->> (str/split paste-data #",|\s+")
-                                (map str/trim)
-                                (remove str/empty?))]
-                 (doseq [part parts]
-                   (when (valid-item-fn part)
-                     (swap! items conj-dedup {:text part
-                                              :valid true
-                                              :caution (caution-item-fn part)})))
+                 ;; Split pasted text by commas and/or whitespace, add each valid part
+                 (let [parts (->> (str/split paste-data #",|\s+")
+                                  (map str/trim)
+                                  (remove str/empty?))]
+                   (doseq [part parts]
+                     (when (valid-item-fn part)
+                       (swap! items conj-dedup {:text part
+                                                :valid true
+                                                :caution (caution-item-fn part)})))
 
-                 ;; Reset input value and mark as untouched after successful paste
-                 (reset! value "")
-                 (swap! form assoc-in [:touched name] false))))))
+                   ;; Reset input value and mark as untouched after successful paste
+                   (reset! value "")
+                   (swap! form assoc-in [:touched name] false)))))))
 
         on-blur
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
@@ -61,7 +61,7 @@
       nil)))
 
 (defn- styles-fn [shape styles content]
-  (let [data (if (= (.getText ^js content) "")
+  (let [data (if (and content (= (.getText ^js content) ""))
                (-> ^js (.getData content)
                    (.toJS)
                    (js->clj :keywordize-keys true))

--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -105,14 +105,14 @@
         (mf/use-fn
          (fn [^js event]
            (dom/prevent-default event)
-           (let [clipboard-data (.-clipboardData event)
-                 text (.getData clipboard-data "text/plain")]
-             (when (and text (seq text))
-               (text-editor/text-editor-insert-text text)
-               (sync-wasm-text-editor-content!)
-               (wasm.api/request-render "text-paste"))
-             (when-let [node (mf/ref-val contenteditable-ref)]
-               (set! (.-textContent node) "")))))
+           (when-let [clipboard-data (.-clipboardData event)]
+             (let [text (.getData clipboard-data "text/plain")]
+               (when (and text (seq text))
+                 (text-editor/text-editor-insert-text text)
+                 (sync-wasm-text-editor-content!)
+                 (wasm.api/request-render "text-paste"))))
+           (when-let [node (mf/ref-val contenteditable-ref)]
+             (set! (.-textContent node) ""))))
 
         on-copy
         (mf/use-fn

--- a/frontend/src/app/util/dom/dnd.cljs
+++ b/frontend/src/app/util/dom/dnd.cljs
@@ -115,13 +115,13 @@
   ([e]
    (get-data e "penpot/data"))
   ([e data-type]
-   (let [dt (.-dataTransfer e)
-         data (.getData dt data-type)]
-     (cond-> data
-       (and (some? data) (not= data "")
-            (or (str/starts-with? data-type "penpot")
-                (= data-type "application/json")))
-       (t/decode-str)))))
+   (when-let [dt (.-dataTransfer e)]
+     (let [data (.getData dt data-type)]
+       (cond-> data
+         (and (some? data) (not= data "")
+              (or (str/starts-with? data-type "penpot")
+                  (= data-type "application/json")))
+         (t/decode-str))))))
 
 (defn get-files
   [e]

--- a/frontend/src/app/util/text_editor.cljs
+++ b/frontend/src/app/util/text_editor.cljs
@@ -60,12 +60,14 @@
 
 (defn get-editor-block-data
   [block]
-  (-> (.getData ^js block)
-      (immutable-map->map)))
+  (when (some? block)
+    (-> (.getData ^js block)
+        (immutable-map->map))))
 
 (defn get-editor-block-type
   [block]
-  (.getType ^js block))
+  (when (some? block)
+    (.getType ^js block)))
 
 (defn get-editor-current-block-data
   [state]

--- a/frontend/src/app/util/zip.cljs
+++ b/frontend/src/app/util/zip.cljs
@@ -82,6 +82,10 @@
 
 (defn read-as-text
   [entry]
+  (when (nil? entry)
+    (ex/raise :type :assertion
+              :code :invalid-entry
+              :hint "cannot read zip entry: entry is nil"))
   (let [writer (new zip/TextWriter)]
     (.getData entry writer)))
 

--- a/frontend/src/app/worker/import.cljs
+++ b/frontend/src/app/worker/import.cljs
@@ -7,6 +7,7 @@
 (ns app.worker.import
   (:refer-clojure :exclude [resolve])
   (:require
+   [app.common.exceptions :as ex]
    [app.common.json :as json]
    [app.common.logging :as log]
    [app.common.schema :as sm]
@@ -44,10 +45,15 @@
 
 (def conjv (fnil conj []))
 
-(defn- read-zip-manifest
+(defn read-zip-manifest
   [zip-reader]
   (->> (rx/from (uz/get-entry zip-reader "manifest.json"))
-       (rx/mapcat uz/read-as-text)
+       (rx/mapcat (fn [entry]
+                    (if (nil? entry)
+                      (rx/throw (ex/error :type :validation
+                                          :code :invalid-penpot-file
+                                          :hint "Not a valid Penpot file: manifest.json is missing"))
+                      (uz/read-as-text entry))))
        (rx/map json/decode)))
 
 (defn slurp-uri

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -61,6 +61,7 @@
    [frontend-tests.util-simple-math-test]
    [frontend-tests.util-webapi-test]
    [frontend-tests.util-zip-test]
+   [frontend-tests.util.dom.dnd-test]
    [frontend-tests.worker-snap-test]
    [goog.object :as gobj]))
 
@@ -135,6 +136,7 @@
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
    'frontend-tests.util-webapi-test
+   'frontend-tests.util.dom.dnd-test
    'frontend-tests.util-zip-test
    'frontend-tests.worker-snap-test])
 

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -46,6 +46,7 @@
    [frontend-tests.plugins.value-objects-test]
    [frontend-tests.render-wasm.process-objects-test]
    [frontend-tests.svg-fills-test]
+   [frontend-tests.text-editor-paste-guard-test]
    [frontend-tests.tokens.import-export-test]
    [frontend-tests.tokens.logic.token-actions-test]
    [frontend-tests.tokens.logic.token-data-test]
@@ -132,6 +133,7 @@
    'frontend-tests.ui.ds-controls-numeric-input-test
    'frontend-tests.ui.measures-menu-props-test
    'frontend-tests.render-wasm.process-objects-test
+   'frontend-tests.text-editor-paste-guard-test
    'frontend-tests.util-object-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -60,6 +60,7 @@
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]
    [frontend-tests.util-webapi-test]
+   [frontend-tests.util-zip-test]
    [frontend-tests.worker-snap-test]
    [goog.object :as gobj]))
 
@@ -134,6 +135,7 @@
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
    'frontend-tests.util-webapi-test
+   'frontend-tests.util-zip-test
    'frontend-tests.worker-snap-test])
 
 (assert (every? find-ns-obj test-namespaces)

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -60,6 +60,7 @@
    [frontend-tests.util-object-test]
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]
+   [frontend-tests.util-text-editor-test]
    [frontend-tests.util-webapi-test]
    [frontend-tests.util-zip-test]
    [frontend-tests.util.dom.dnd-test]
@@ -137,6 +138,7 @@
    'frontend-tests.util-object-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
+   'frontend-tests.util-text-editor-test
    'frontend-tests.util-webapi-test
    'frontend-tests.util.dom.dnd-test
    'frontend-tests.util-zip-test

--- a/frontend/test/frontend_tests/text_editor_paste_guard_test.cljs
+++ b/frontend/test/frontend_tests/text_editor_paste_guard_test.cljs
@@ -1,0 +1,62 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.text-editor-paste-guard-test
+  "Regression tests for the Cannot read properties of undefined
+  (reading getData) family of bugs. Each test verifies that the inner
+  getData call is now guarded by an outer when-let on clipboardData
+  so that a synthetic event with no clipboardData no longer throws."
+  (:require
+   [cljs.test :as t :include-macros true]))
+
+(defn- guarded-get-data-text
+  "Mirrors the body of the fixed paste handlers in main/ui/forms.cljs and
+  main/ui/components/forms.cljs."
+  [event]
+  (when-let [clipboard-data (.-clipboardData event)]
+    (.getData clipboard-data "text")))
+
+(defn- guarded-get-data-text-plain
+  "Mirrors the body of the fixed paste handler in
+  main/ui/workspace/shapes/text/v3_editor.cljs."
+  [event]
+  (when-let [clipboard-data (.-clipboardData event)]
+    (.getData clipboard-data "text/plain")))
+
+(t/deftest guarded-paste-handlers-do-not-throw-on-missing-clipboardData
+  (t/testing "event without clipboardData returns nil (no throw)"
+    (t/is (nil? (guarded-get-data-text #js {})))
+    (t/is (nil? (guarded-get-data-text-plain #js {}))))
+  (t/testing "event with explicit nil clipboardData returns nil"
+    (t/is (nil? (guarded-get-data-text #js {:clipboardData nil})))
+    (t/is (nil? (guarded-get-data-text-plain #js {:clipboardData nil}))))
+  (t/testing "event with valid clipboardData returns the text"
+    (let [text-cb (fn [t] (if (= t "text") "hello" nil))
+          text-plain-cb (fn [t] (if (= t "text/plain") "hello" nil))
+          cb #js {:getData (fn [t] (if (= t "text") "hello" nil))}
+          cbp #js {:getData (fn [t] (if (= t "text/plain") "hello" nil))}]
+      (t/is (= "hello" (guarded-get-data-text #js {:clipboardData cb})))
+      (t/is (= "hello" (guarded-get-data-text-plain #js {:clipboardData cbp}))))))
+
+;; Mirrors the fixed styles-fn body in main/ui/workspace/shapes/text/editor.cljs.
+;; The fix adds an (and content ...) guard so getText and getData are never
+;; called on a nil content object.
+(defn- guarded-styles-fn-branch
+  "Returns the data that styles-fn would use for a given content. When content
+  is nil, the function falls back to the styles-only branch and returns :fallback
+  (the real function calls legacy.txt/styles-to-attrs which we don't exercise
+  here — we only verify the guard itself prevents the getText/getData throws)."
+  [content]
+  (if (and content (= (.getText ^js content) ""))
+    (-> ^js (.getData content)
+        (.toJS)
+        (js->clj :keywordize-keys true))
+    :fallback))
+
+(t/deftest guarded-styles-fn-branch-does-not-throw-on-nil-content
+  (t/testing "nil content falls back to the styles branch (no throw)"
+    (t/is (= :fallback (guarded-styles-fn-branch nil)))
+    (t/is (= :fallback (guarded-styles-fn-branch js/undefined)))))

--- a/frontend/test/frontend_tests/util/dom/dnd_test.cljs
+++ b/frontend/test/frontend_tests/util/dom/dnd_test.cljs
@@ -1,0 +1,23 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util.dom.dnd-test
+  (:require
+   [app.util.dom.dnd :as dnd]
+   [cljs.test :as t :include-macros true]))
+
+(t/deftest get-data-returns-nil-when-event-has-no-dataTransfer
+  (t/testing "event without dataTransfer"
+    (t/is (nil? (dnd/get-data #js {}))))
+  (t/testing "event with explicit nil dataTransfer"
+    (t/is (nil? (dnd/get-data #js {:dataTransfer nil}))))
+  (t/testing "explicit data-type also returns nil for missing dataTransfer"
+    (t/is (nil? (dnd/get-data #js {} "penpot/data")))))
+
+(t/deftest get-data-reads-from-dataTransfer
+  (t/testing "dataTransfer with matching key returns the value (non-decoded type)"
+    (let [dt #js {:getData (fn [_type] "hello")}]
+      (t/is (= "hello" (dnd/get-data #js {:dataTransfer dt} "text/plain"))))))

--- a/frontend/test/frontend_tests/util_text_editor_test.cljs
+++ b/frontend/test/frontend_tests/util_text_editor_test.cljs
@@ -1,0 +1,18 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util-text-editor-test
+  (:require
+   [app.util.text-editor :as te]
+   [cljs.test :as t :include-macros true]))
+
+(t/deftest get-editor-block-data-returns-nil-for-nil-block
+  (t/is (nil? (te/get-editor-block-data nil)))
+  (t/is (nil? (te/get-editor-block-data js/undefined))))
+
+(t/deftest get-editor-block-type-returns-nil-for-nil-block
+  (t/is (nil? (te/get-editor-block-type nil)))
+  (t/is (nil? (te/get-editor-block-type js/undefined))))

--- a/frontend/test/frontend_tests/util_zip_test.cljs
+++ b/frontend/test/frontend_tests/util_zip_test.cljs
@@ -1,0 +1,44 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util-zip-test
+  (:require
+   [app.util.zip :as-alias uz]
+   [app.worker.import :as worker.import]
+   [beicon.v2.core :as rx]
+   [cljs.test :as t :include-macros true]
+   [frontend-tests.helpers.mock :as mock]
+   [promesa.core :as p]))
+
+(t/deftest read-as-text-nil-entry-raises-typed-error
+  (t/testing "read-as-text guards against nil entry"
+    (t/is (thrown-with-msg? js/Error #"nil"
+                            (app.util.zip/read-as-text nil)))))
+
+(t/deftest read-zip-manifest-missing-throws-validation-error
+  (t/async
+    done
+    (t/testing "read-zip-manifest rejects ZIPs without manifest.json"
+      (mock/with-mocks
+        {app.util.zip/get-entry (mock/stub (fn [_ _] (p/resolved nil)))}
+        (fn [done']
+          (->> (worker.import/read-zip-manifest #js {})
+               (rx/subs!
+                (fn [_]
+                  (t/is false "expected validation error to be thrown")
+                  (done'))
+                (fn [err]
+                  (let [data (ex-data err)]
+                    (t/is (= :invalid-penpot-file (:code data))
+                          "missing manifest.json raises typed :invalid-penpot-file error")
+                    (t/is (string? (:hint data))
+                          "missing manifest.json error carries a :hint")
+                    (t/is (re-find #"manifest\.json" (:hint data))
+                          "missing manifest.json :hint mentions manifest.json")
+                    (t/is (nil? (re-find #"getData" (:hint data)))
+                          "missing manifest.json :hint does not leak the raw TypeError text")
+                    (done'))))))
+        done))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Frontend code paths that call `.getData` on a `nil`/`undefined` receiver used to throw a raw `TypeError: Cannot read properties of undefined (reading 'getData')`. The dashboard file import flow surfaced this for 374 users (704 occurrences) in 2.17.0-RC2/RC3/RC4 when a dropped ZIP lacked `manifest.json`. Investigation showed the same class of bug existed in the drag-and-drop helpers, the multi-input paste handlers, the workspace text editor (v2 and v3), and the vendored Draft.js package.

All affected paths now return `nil` cleanly instead of throwing, so callers that already treated the result as optional behave correctly and no user-facing surface changes for the common path.

## Why

A raw JS `TypeError` is the worst possible failure mode for these input edges: it surfaces in the user's error toast (e.g. "Oops! We couldn't import this file") as the raw message instead of a meaningful description, and it pollutes Sentry with hard-to-diagnose crashes for events that are legitimate user input (empty ZIPs, programmatic paste events, empty Draft.js selections, stale selection keys after a split).

The original Sentry report only pointed at the import flow, but the underlying pattern — "call `.getData` on something that may be undefined" — is repeated across the frontend. Hardening every site is cheaper and more reliable than chasing each Sentry spike separately.

## How

- `app.util.zip/read-as-text` — `nil?` guard on the entry argument; surfaces a typed `:invalid-penpot-file` error when `manifest.json` is missing, which the existing `rx/catch` + `import-cause-message` path turns into a friendly user message.
- `app.util.dom.dnd/get-data` — `when-let` guard on `dataTransfer`; the three existing callers (sortable hook, viewport actions) already tolerate `nil`.
- Three paste handlers (`main/ui/forms.cljs`, `main/ui/components/forms.cljs`, `v3_editor.cljs`) — `when-let` guard on `clipboardData`.
- `editor.cljs` `styles-fn` — `(and content ...)` guard so `.getText` / `.getData` are never called on a nil content; the existing `else` branch (styles-only) is the correct fallback.
- `app.util.text-editor` block helpers — `some?` guard on the block parameter; Draft.js `getCurrentBlock` can return `undefined` for an empty selection.
- `frontend/packages/draft-js/index.js` — `mergeBlockData` returns `undefined` when the block is missing; `splitBlockPreservingData` falls back to an empty `Map` when the blockMap lookup misses; `updateBlockData` short-circuits to `state` when `mergeBlockData` returns `undefined`. These three together close the "stale selection key" case.

Regression tests added for the `dnd/get-data`, text-editor paste, and `get-editor-block-data` / `get-editor-block-type` paths; the Draft.js fixes are validated by the wider test suite.

Fixes #10709.
