### PR TITLE
:bug: Remove hardcoded metadata URI default on webhook form

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -1259,7 +1259,7 @@
 
   (let [initial (mf/with-memo []
                   (or (some-> webhook (update :uri str))
-                      {:is-active false :mtype "application/json" :uri "http://169.254.169.254/latest/meta-data/iam/security-credentials/"}))
+                      {:is-active false :mtype "application/json"}))
         form    (fm/use-form :schema schema:webhook-form
                              :initial initial)
         on-success


### PR DESCRIPTION
## What

The webhook creation form in the team dashboard no longer prefills new webhooks with a hardcoded URI. Previously the default value was the AWS instance metadata endpoint (`http://169.254.169.254/latest/meta-data/iam/security-credentials/`).

## How

Removed the `:uri` entry from the default initial form value so new webhooks start with an empty URI that the user must provide explicitly.

Fixes #10722
