### PR TITLE
:bug: Fix teams' inactive status for nitrate

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -825,11 +825,21 @@ RETURNING id, deleted_at;")
      t.name,
      t.photo_id,
      t.created_at,
-      (SELECT MAX(p2.modified_at)
-         FROM project AS p2
-        WHERE p2.team_id = t.id
-          AND p2.deleted_at IS NULL
-          AND p2.is_default IS FALSE) AS last_activity_at,
+       (SELECT MAX(activity.modified_at)
+          FROM (
+            SELECT p2.modified_at
+              FROM project AS p2
+             WHERE p2.team_id = t.id
+               AND p2.deleted_at IS NULL
+               AND p2.is_default IS FALSE
+            UNION ALL
+            SELECT f.modified_at
+              FROM file AS f
+              JOIN project AS p ON p.id = f.project_id
+             WHERE p.team_id = t.id
+               AND p.deleted_at IS NULL
+               AND f.deleted_at IS NULL
+          ) AS activity) AS last_activity_at,
      owner_tpr.profile_id AS owner_profile_id,
      owner_p.fullname AS owner_name,
      owner_p.photo_id AS owner_photo_id,

--- a/backend/test/backend_tests/rpc_management_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_management_nitrate_test.clj
@@ -171,6 +171,62 @@
     (t/is (= #{(:id team1) (:id team2)}
              (->> out :result :teams (map :id) set)))))
 
+(t/deftest get-teams-detail-last-activity-reflects-file-modifications
+  (let [profile       (th/create-profile* 1 {:is-active true})
+        team          (th/create-team* 1 {:profile-id (:id profile)})
+        organization-id (uuid/random)
+        org-summary   {:id organization-id
+                       :teams [{:id (:id team)}]}
+        params        {::th/type :get-teams-detail
+                       ::rpc/profile-id (:id profile)
+                       :organization-id organization-id}
+
+        call!         (fn []
+                        (with-redefs [nitrate/call (fn [_cfg method _params]
+                                                     (case method
+                                                       :get-org-summary org-summary
+                                                       nil))]
+                          (management-command-with-nitrate! params)))
+
+        empty-out     (call!)
+        empty-team    (-> empty-out :result first)
+
+        project       (th/create-project* 1 {:profile-id (:id profile)
+                                             :team-id (:id team)})
+        file          (th/create-file* 1 {:profile-id (:id profile)
+                                          :project-id (:id project)})
+        file-after-create (th/db-get :file {:id (:id file)})
+        project-after-create (th/db-get :project {:id (:id project)})
+        expected-activity-create (if (.isAfter (:modified-at file-after-create)
+                                               (:modified-at project-after-create))
+                                   (:modified-at file-after-create)
+                                   (:modified-at project-after-create))
+
+        with-file-out (call!)
+        with-file     (-> with-file-out :result first)
+
+        new-activity  (ct/in-future "1h")
+        _             (th/db-update! :file
+                                     {:modified-at new-activity}
+                                     {:id (:id file)})
+        file-after-update (th/db-get :file {:id (:id file)})
+
+        updated-out   (call!)
+        updated-team  (-> updated-out :result first)]
+
+    (t/is (th/success? empty-out))
+    (t/is (= (:id team) (:id empty-team)))
+    (t/is (nil? (:last-activity-at empty-team)))
+
+    (t/is (th/success? with-file-out))
+    (t/is (= (:id team) (:id with-file)))
+    (t/is (= expected-activity-create (:last-activity-at with-file)))
+
+    (t/is (th/success? updated-out))
+    (t/is (= (:id team) (:id updated-team)))
+    (t/is (= (:modified-at file-after-update) (:last-activity-at updated-team)))
+    (t/is (not= (:last-activity-at with-file) (:last-activity-at updated-team)))))
+
 (t/deftest notify-organization-deletion-prefixes-teams-and-publishes-org-deleted-event
   (let [profile           (th/create-profile* 1 {:is-active true})
         ;; One team will have files -> it will be kept and renamed.


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26635

### Summary

Fixed an issue where inactive status correctly excluded the default project, but incorrectly excluded changes within its files.

### Steps to reproduce 
1. Create a new organization named Org-A.
2. Within Org-A, create a new team named Team-A. Do not perform any additional actions in the team after it is created.
3. Open the Admin Console for Org-A and navigate to the Teams tab.
4. Verify that Team-A appears in the list with its "Last Activivty" displayed as Inactive.
5. Open Team-A and navigate to its default Drafts project.
6. Create one or more files in the Drafts project.
7. Return to the Teams tab in the Admin Console for Org-A.
8. Verify that the "Last Activivity" for Team-A has changed from Inactive to Just now (or another recent timestamp that corresponds to when the files were created).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
