### PR TITLE
:bug: Increase team name abbreviation limit in invitation emails

### DIFF
--- a/backend/resources/app/email/invite-to-team/en.html
+++ b/backend/resources/app/email/invite-to-team/en.html
@@ -186,7 +186,7 @@
                     <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
                         style="font-family:Source Sans Pro, sans-serif;font-size:16px;line-height:150%;text-align:left;color:#000000;">
-                        {{invited-by|abbreviate:25}} has invited you to join the team “{{ team|abbreviate:25 }}”{% if
+                        {{invited-by|abbreviate:25}} has invited you to join the team “{{ team|abbreviate:50 }}”{% if
                         organization %}
                         part of the organization “{{ organization.name|abbreviate:50 }}”{% endif %}.</div>
                     </td>

--- a/backend/resources/app/email/invite-to-team/en.txt
+++ b/backend/resources/app/email/invite-to-team/en.txt
@@ -1,6 +1,6 @@
 Hello!
 
-{{invited-by|abbreviate:25}} has invited you to join the team "{{ team|abbreviate:25 }}"{% if organization %}, part of the organization "{{ organization.name|abbreviate:50 }}"{% endif %}.
+{{invited-by|abbreviate:25}} has invited you to join the team "{{ team|abbreviate:50 }}"{% if organization %}, part of the organization "{{ organization.name|abbreviate:50 }}"{% endif %}.
 
 {% if organization.sso-active %}
 "{{ organization.name|abbreviate:50 }}" has set up single sign-on (SSO) in Penpot. Access to its teams and files goes


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26592

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
