### PR TITLE
:sparkles: Add timestamp to the frontend error report

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "fmt:clj": "cljfmt fix --parallel=true src/ test/",
     "fmt:js": "prettier -c src/**/*.stories.jsx -c playwright/**/*.js -c scripts/**/*.js -c text-editor/**/*.js -w",
     "fmt:scss": "prettier -c resources/styles -c src/**/*.scss -w",
-    "lint:clj": "clj-kondo --parallel --lint ../common/src src/",
+    "lint:clj": "clj-kondo --config-dir ../.clj-kondo --lint ../common/src src/",
     "lint:js": "exit 0",
     "lint:scss": "pnpm exec stylelint '{src,resources}/**/*.scss'",
     "build:test": "pnpm run build:wasm && clojure -M:dev:shadow-cljs compile test",

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.common.exceptions :as ex]
    [app.common.pprint :as pp]
+   [app.common.time :as ct]
    [app.config :as cf]
    [app.main.data.auth :as da]
    [app.main.data.event :as ev]
@@ -134,13 +135,14 @@
       (with-out-str
         (println "Context:")
         (println "--------------------")
-        (println "Hint:    " (or (:hint data) (ex-message cause) "--"))
-        (println "Prof ID: " (str (or profile-id "--")))
-        (println "Team ID: " (str (or team-id "--")))
+        (println "Timestamp:" (ct/format-inst (ct/now) :rfc1123))
+        (println "Hint:     " (or (:hint data) (ex-message cause) "--"))
+        (println "Prof ID:  " (str (or profile-id "--")))
+        (println "Team ID:  " (str (or team-id "--")))
         (when-let [file-id (or (:file-id data) file-id)]
-          (println "File ID: " (str file-id)))
-        (println "Version: " (:full cf/version))
-        (println "HREF:    " (rt/get-current-href))
+          (println "File ID:  " (str file-id)))
+        (println "Version:  " (:full cf/version))
+        (println "HREF:     " (rt/get-current-href))
         (println)
 
         (println

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -10,9 +10,7 @@
    ["rxjs" :as rxjs]
    [app.common.data :as d]
    [app.common.exceptions :as ex]
-   [app.common.pprint :as pp]
    [app.common.uuid :as uuid]
-   [app.config :as cf]
    [app.main.data.auth :refer [is-authenticated?]]
    [app.main.data.common :as dcm]
    [app.main.errors :as errors]
@@ -347,53 +345,6 @@
      [:div {:class (stl/css :buttons-container)}
       [:> button* {:variant "primary" :on-click on-reload}
        (tr "labels.reload-page")]]]))
-
-(defn- generate-report
-  [data]
-  (try
-    (let [team-id    (:current-team-id @st/state)
-          profile-id (:profile-id @st/state)
-
-          trace      (:app.main.errors/trace data)
-          instance   (:app.main.errors/instance data)]
-      (with-out-str
-        (println "Hint:    " (or (:hint data) (ex-message instance) "--"))
-        (println "Prof ID: " (str (or profile-id "--")))
-        (println "Team ID: " (str (or team-id "--")))
-        (println "URI:     " cf/public-uri)
-
-        (when-let [file-id (:file-id data)]
-          (println "File ID:" (str file-id)))
-
-        (println)
-
-        (println "Data:")
-        (loop [data data]
-          (-> (d/without-qualified data)
-              (dissoc :explain)
-              (d/update-when :data (constantly "(...)"))
-              (pp/pprint {:level 8 :length 10}))
-
-          (println)
-
-          (when-let [explain (:explain data)]
-            (print explain))
-
-          (when (and (= :server-error (:type data))
-                     (contains? data :data))
-            (recur (:data data))))
-
-        (println "Trace:")
-        (println trace)
-        (println)
-
-        (println "Last events:")
-        (pp/pprint @st/last-events {:length 200})
-
-        (println)))
-    (catch :default cause
-      (.error js/console "error on generating report.txt" cause)
-      nil)))
 
 (mf/defc internal-error*
   [{:keys [on-reset report] :as props}]


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Adds an RFC 1123 formatted timestamp to the frontend exception report. The timestamp appears in all error reports submitted to the audit log and in the downloadable `report.txt` from the exception page.

## Why

Exception reports previously lacked a timestamp, making it harder to correlate errors with user activity timelines and server-side logs.

## How

- Added `[app.common.time :as ct]` import to `app.main.errors` and a `Timestamp:` line in `generate-report` using `ct/format-inst` with `:rfc1123` format.
- Removed dead `generate-report` function from `app.main.ui.static` that was never called, along with its unused `app.common.pprint` import.
