### PR TITLE
:bug: Strip Authorization header when proxying asset redirects to S3

### DIFF
--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -86,6 +86,7 @@ http {
             set $real_mtype "$upstream_http_x_mtype";
 
             proxy_set_header Host "$redirect_host";
+            proxy_set_header Authorization "";
             proxy_hide_header etag;
             proxy_hide_header x-amz-id-2;
             proxy_hide_header x-amz-request-id;

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -94,6 +94,7 @@ http {
             proxy_buffering off;
 
             proxy_set_header Host "$redirect_host";
+            proxy_set_header Authorization "";
             proxy_hide_header etag;
             proxy_hide_header x-amz-id-2;
             proxy_hide_header x-amz-request-id;


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Asset downloads fail in production S3 when the client authenticates with an access token instead of a session cookie. S3 returns "Only one auth mechanism allowed" because it receives both the presigned URL's query-string signature and the client's `Authorization: Token ...` header.

## Why

Nginx's `@handle_redirect` block follows the backend's 307 redirect to a presigned S3 URL but forwards the client's `Authorization` header to S3. MinIO in devenv ignores the extra header, so the bug only manifests in production with strict S3-compatible storage.

## How

Added `proxy_set_header Authorization "";` to the `@handle_redirect` location block in both the devenv and production nginx configs, stripping the client's auth header before proxying to S3.


Fixes #10776
