### PR TITLE
:bug: Fix wasm layout identity propagate

### DIFF
--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -705,16 +705,21 @@ impl Shape {
     }
 
     pub fn set_path_segments(&mut self, segments: Vec<Segment>) {
-        let path = Path::new(segments);
         match &mut self.shape_type {
             Type::Bool(Bool { bool_type, .. }) => {
+                let path = match bool_type {
+                    // Exclusion booleans are computed with even-odd semantics but
+                    // PathData uploads do not carry the fill rule.
+                    BoolType::Exclusion => Path::new(segments).with_even_odd(true),
+                    _ => Path::new(segments),
+                };
                 self.shape_type = Type::Bool(Bool {
                     bool_type: *bool_type,
                     path,
                 });
             }
             Type::Path(_) => {
-                self.shape_type = Type::Path(path);
+                self.shape_type = Type::Path(Path::new(segments));
             }
             _ => {}
         };

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -667,9 +667,12 @@ pub fn reflow_flex_layout(
                 transform.post_concat(&Matrix::translate(delta_v));
             }
 
-            result.push_back(Modifier::transform_propagate(child.id, transform));
-            if child.has_layout() {
-                result.push_back(Modifier::reflow(child.id, force_reflow));
+            // Skip identity: propagating it fans out through the whole subtree.
+            if !math::identitish(&transform) {
+                result.push_back(Modifier::transform_propagate(child.id, transform));
+                if child.has_layout() {
+                    result.push_back(Modifier::reflow(child.id, force_reflow));
+                }
             }
 
             shape_anchor = next_anchor(

--- a/render-wasm/src/shapes/modifiers/grid_layout.rs
+++ b/render-wasm/src/shapes/modifiers/grid_layout.rs
@@ -884,9 +884,12 @@ pub fn reflow_grid_layout(
             transform.post_concat(&Matrix::translate(delta_v));
         }
 
-        result.push_back(Modifier::transform_propagate(child.id, transform));
-        if child.has_layout() {
-            result.push_back(Modifier::reflow(child.id, force_reflow));
+        // Skip identity: propagating it fans out through the whole subtree.
+        if !math::identitish(&transform) {
+            result.push_back(Modifier::transform_propagate(child.id, transform));
+            if child.has_layout() {
+                result.push_back(Modifier::reflow(child.id, force_reflow));
+            }
         }
     }
 

--- a/render-wasm/src/shapes/paths.rs
+++ b/render-wasm/src/shapes/paths.rs
@@ -251,6 +251,9 @@ impl Path {
 
     pub fn to_skia_path(&self, svg_attrs: Option<&SvgAttrs>) -> skia::Path {
         let mut path = self.skia_path.snapshot();
+        if self.is_even_odd() {
+            path.set_fill_type(skia::PathFillType::EvenOdd);
+        }
         if let Some(attrs) = svg_attrs {
             if attrs.fill_rule == FillRule::Evenodd {
                 path.set_fill_type(skia::PathFillType::EvenOdd);


### PR DESCRIPTION
### Related Ticket

Closes #10647 

This PR solves two issues:

1. Exclude boolean holes missing in WASM
Exclude (difference) booleans lost their interior holes in the WASM renderer while SVG looked correct. Path data uploaded from CLJS does not carry the fill rule, and to_skia_path did not apply even-odd for those paths. Exclusion needs even-odd to preserve holes; without it, Skia filled them as solid shapes.

Reproduce: Import the .penpot from the issue, copy one of the icons that uses an exclude boolean, and observe that the inner content/holes disappear under the WASM renderer.

<img width="588" height="238" alt="ev2" src="https://github.com/user-attachments/assets/203317bc-2a19-44e9-a15a-266193bdaf54" />

2. Drag freezes on large nested-layout files
Dragging shapes in large files with many nested flex/grid layouts froze the WASM renderer (SVG was fine). On each drag frame, layout reflow emitted identity transforms for unchanged children, and those were propagated through the whole subtree. That O(subtree) work per pointer move stalled the UI.

Reproduce: Drag one the icons from the imagen

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
