### PR TITLE
:bug: Fix tabindex error

### DIFF
--- a/frontend/src/app/main/ui/workspace/top_toolbar.cljs
+++ b/frontend/src/app/main/ui/workspace/top_toolbar.cljs
@@ -337,7 +337,7 @@
     (when-not ^boolean read-only?
       [:div {:role "toolbar"
              :aria-label (tr "workspace.toolbar.label")
-             :tabindex "0"
+             :tab-index "0"
              :class (stl/css-case :toolbar true
                                   :no-rulers (not rulers-enabled)
                                   :hidden toolbar-hidden)}


### PR DESCRIPTION
### Related Ticket

No ticket

### Summary

This fixes this logged error in the console by properly using `tabIndex` attribute (`tabindex` is not recognized by React)

<img width="1187" height="61" alt="image" src="https://github.com/user-attachments/assets/df1ccdda-f17b-4eeb-832e-e1d8ebb62e46" />

### Steps to reproduce 

1. Load a file into the workspace
2. Check the console

Expected result: No `Invalid DOM property tabindex` message in the console.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
