### PR TITLE
:bug: Mark non-Penpot zip files as unknown in import worker

### DIFF
--- a/frontend/src/app/worker/import.cljs
+++ b/frontend/src/app/worker/import.cljs
@@ -98,7 +98,7 @@
                                      (if (= (:type manifest) "penpot/export-files")
                                        (let [manifest (decode-manifest manifest)]
                                          (assoc file :type :binfile-v3 :files (:files manifest)))
-                                       (assoc file :type :legacy-zip :body body))))
+                                       (assoc file :type :unknown))))
                                   (rx/finalize (partial uz/close zip-reader))))
 
                            (= "application/octet-stream" mtype)


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

The import worker's `analyze-file` function treated any zip file that wasn't a Penpot export as a `:legacy-zip`, causing downstream parsing to crash on unrecognized zip content. Now such files are marked as `:unknown`, matching how other unrecognized formats are handled.

## Why

Non-Penpot zip files could crash the import worker instead of failing gracefully.

## How

Changed the fallthrough case in the zip-file branch of `analyze-file` from `(assoc file :type :legacy-zip :body body)` to `(assoc file :type :unknown)`.

Closes #10781
