### PR TITLE
:sparkles: Gate nitrate bulk-create-profiles behind a flag

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -964,12 +964,19 @@ RETURNING id, deleted_at;")
    created users skip email verification and onboarding. Emails that already
    belong to an existing profile are skipped. Intended for the Nitrate admin
    bulk-creation screen; access is gated by the shared key and, in Nitrate, an
-   email allow-list."
+   email allow-list. Requires the `nitrate-bulk-create-profiles` flag, disabled
+   by default so it is only available on test environments."
   {::doc/added "2.19"
    ::sm/params schema:bulk-create-profiles-params
    ::sm/result schema:bulk-create-profiles-result
    ::rpc/auth false}
   [cfg {:keys [password emails]}]
+
+  (when-not (contains? cf/flags :nitrate-bulk-create-profiles)
+    (ex/raise :type :restriction
+              :code :nitrate-bulk-create-profiles-not-allowed
+              :hint "Bulk profile creation is disabled by config."))
+
   (let [derived (aauth/derive-password password)]
     (db/tx-run!
      cfg

--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -167,6 +167,11 @@
     ;; Activates the nitrate module
     :nitrate
 
+    ;; disabled by default. When enabled, allows the nitrate
+    ;; `bulk-create-profiles` method to create batches of already
+    ;; active profiles. Only intended for test environments.
+    :nitrate-bulk-create-profiles
+
     :mcp
     :background-blur
     :available-viewer-wasm


### PR DESCRIPTION
The bulk profile creation endpoint creates already active profiles that skip email verification and onboarding, so it should not be reachable on production deployments. Add the `nitrate-bulk-create-profiles` flag, disabled by default, and reject the call when it is not enabled.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
