### PR TITLE
:sparkles: Make stroke to path available without config flag

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -170,7 +170,6 @@
     :mcp
     :background-blur
     :available-viewer-wasm
-    :stroke-path
     :stroke-per-side})
 
 (def all-flags

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -454,8 +454,7 @@
                         :on-click do-transform-to-path}])
 
      (when (and has-strokes?
-                (features/active-feature? @st/state "render-wasm/v1")
-                (contains? cf/flags :stroke-path))
+                (features/active-feature? @st/state "render-wasm/v1"))
        [:> menu-entry* {:title (tr "workspace.shape.menu.stroke-to-path")
                         :on-click do-strokes-to-path}])
 


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10791

### Summary

This PR just removes the config flag

### Steps to reproduce 

Create a path from a stroke 
