### PR TITLE
:bug: Fix text edition state when relesecting

### DIFF
--- a/frontend/playwright/ui/specs/text-editor-v2.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v2.spec.js
@@ -344,6 +344,7 @@ test("Preserves empty fill after editing text without changes", async ({ page })
 
   await workspace.createTextShape(190, 150, 300, 200, initialText);
   await workspace.textEditor.stopEditing();
+  await workspace.page.getByRole('button', { name: 'Fill', exact: true }).click();
 
   const fillColorButton = workspace.page.getByRole("button", {
     name: "#000000",

--- a/frontend/playwright/ui/specs/tokens/text.spec.js
+++ b/frontend/playwright/ui/specs/tokens/text.spec.js
@@ -1,4 +1,7 @@
 import { test, expect } from "@playwright/test";
+import {
+  unfoldTokenType,
+} from "./helpers";
 import { WasmWorkspacePage } from "../../pages/WasmWorkspacePage";
 
 test.beforeEach(async ({ page }) => {
@@ -26,4 +29,48 @@ test("BUG 13958 - Fill token gets detached when editing text shape", async ({ pa
 
   // Assert token is still attached to the shape
   await expect(workspacePage.rightSidebar.getByLabel("xx.alias.color.text.default", { exact: true })).toBeVisible();
+});
+
+test("Selection change clears text-edition mode so tokens can be applied", async ({ page }) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.mockGetFile("workspace/get-file-13958.json");
+  await workspacePage.goToWorkspace();
+  await workspacePage.rectShapeButton.click();
+  await workspacePage.clickWithDragViewportAt(128, 128, 200, 100);
+  await workspacePage.clickLeafLayer("Rectangle");
+
+  // Enter text editing on the text layer
+  await workspacePage.clickLeafLayer("Design tokens are a set");
+  await workspacePage.page.keyboard.press("Enter");
+  await expect(workspacePage.page.getByTestId("text-editor")).toBeVisible();
+
+  // Shift-click another layer to change selection while editing
+  await workspacePage.layers
+    .getByTestId("layer-row")
+    .filter({ hasText: "Rectangle" })
+    .click({ modifiers: ["Shift"] });
+
+  // Text editor should close because selection change emits :interrupt
+  await expect(workspacePage.page.getByTestId("text-editor")).not.toBeAttached();
+
+  // Open tokens tab and try to apply a fill token — should succeed without warning
+  await page.getByRole("tab", { name: "Tokens" }).click();
+
+  const tokensSidebar = page.getByTestId("tokens-sidebar");
+
+  await unfoldTokenType(tokensSidebar, "color");
+
+  // Right-click a color token and apply as fill
+  await tokensSidebar
+    .getByRole('button', { name: '#934846 xx.global.color.red.' })
+    .click({ button: "right" });
+  await workspacePage.tokenContextMenuForToken.getByText("Fill").click();
+
+  // Verify no warning toast appeared about text editing
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: /Tokens can't be applied while editing text/i,
+    }),
+  ).not.toBeVisible();
 });

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -221,7 +221,7 @@
   (ptk/reify ::deselect-shape
     ptk/WatchEvent
     (watch [_ _ _]
-      (rx/of ::dwsp/interrupt))
+      (rx/of :interrupt ::dwsp/interrupt))
     ptk/UpdateEvent
     (update [_ state]
       (-> state
@@ -236,7 +236,7 @@
    (ptk/reify ::shift-select-shapes
      ptk/WatchEvent
      (watch [_ _ _]
-       (rx/of ::dwsp/interrupt))
+       (rx/of :interrupt ::dwsp/interrupt))
      ptk/UpdateEvent
      (update [_ state]
        (let [objects (or objects (dsh/lookup-page-objects state))
@@ -275,7 +275,7 @@
             ;; the event loop
             expand-s (->> (rx/of (dwc/expand-all-parents ids objects))
                           (rx/observe-on :async))
-            interrupt-s (rx/of ::dwsp/interrupt)]
+            interrupt-s (rx/of :interrupt ::dwsp/interrupt)]
         (rx/merge expand-s interrupt-s)))))
 
 (defn select-all

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -8,7 +8,6 @@
   "Generic error handling"
   (:require
    [app.common.exceptions :as ex]
-   [app.common.pprint :as pp]
    [app.common.time :as ct]
    [app.config :as cf]
    [app.main.data.auth :as da]


### PR DESCRIPTION
### Related Ticket

Closes https://github.com/penpot/penpot/issues/9346

### Summary

### Steps to reproduce 

The bug is not fixed for selection changes that go through the plural / shift selection paths.

1. Create a color token
2. Create some shapes 
3. Press T to Enter text edit mode.
4. Change selection to another shape via shift-click.
5. Go back to tokens  tab
6. Apply a design token → toast appears: "Tokens can't be applied while editing text. Select the text layer instead." and the token is silently not applied.

This toas should not appear.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
