### PR TITLE
:globe_with_meridians: Localize Nitrate subscription flows

### DIFF
--- a/frontend/src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs
@@ -51,7 +51,7 @@
 
        [:div {:class (stl/css :modal-end)}
         [:div {:class (stl/css :modal-title)}
-         (tr "nitrate.activation-success.title")]
+         (tr "nitrate.modal-success.title")]
 
         (when (and manual? date-str)
           [:p {:class (stl/css :modal-text-primary)}

--- a/frontend/src/app/main/ui/nitrate/nitrate_form.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_form.cljs
@@ -58,7 +58,7 @@
          (tr "nitrate.form.title")]
 
         [:p {:class (stl/css :modal-text-large)}
-         (tr "nitrate.form.enterprise-intro")]
+         (tr "nitrate.form.enterprise-intro" ":")]
         [:ul
          [:li {:class (stl/css :modal-text-large)}
           "- " (tr "nitrate.form.enterprise-feature-1")]
@@ -78,7 +78,7 @@
                           :on-click on-click
                           :class (stl/css :modal-button)}
               (if (:subscription profile)
-                (tr "nitrate.form.upgrade")
+                (tr "nitrate.form.start-enterprise")
                 (tr "nitrate.form.try-free"))]
              [:div {:class (stl/css :modal-text-small :modal-info)}
               (tr "nitrate.form.cancel-anytime")]]]

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -72,8 +72,14 @@
      (when benefits-title
        [:h5 {:class (stl/css :benefits-title)} benefits-title])
      [:ul {:class (stl/css :benefits-list)}
-      (for [benefit benefits]
-        [:li {:key (dm/str benefit) :class (stl/css :benefit)} benefit])]
+      (for [[index benefit] (map-indexed vector benefits)]
+        [:li {:key (dm/str index "-" benefit) :class (stl/css :benefit)}
+         (if (map? benefit)
+           [:*
+            [:span {:class (stl/css :benefit-label)} (:label benefit)]
+            " "
+            (:description benefit)]
+           benefit)])]
 
      (when has-cta-button
        [:> button* {:variant "primary"
@@ -440,6 +446,12 @@
         subscription-type
         (if (and (contains? cf/flags :nitrate) nitrate?) (:type nitrate-license) (get-subscription-type subscription))
 
+        subscription-name
+        (cond
+          nitrate?                         (tr "subscription.settings.enterprise")
+          (= subscription-type "unlimited") (tr "subscription.settings.unlimited")
+          (= subscription-type "enterprise") (tr "subscription.settings.enterprise"))
+
         subscription-is-trial?
         (= (:status subscription) "trialing")
 
@@ -573,16 +585,17 @@
       [:div {:class (stl/css :your-subscription)}
        [:h3 {:class (stl/css :plan-section-title)} (tr "subscription.settings.section-plan")]
        (if nitrate?
-         ;; TODO add translations for this texts when we have the definitive ones
-         [:> plan-card* {:card-title "Enterprise"
-                         :card-title-icon i/character-b
+         [:> plan-card* {:card-title (tr "subscription.settings.enterprise")
                          :cancel-at (when (:cancel-at nitrate-license)
                                       (tr "nitrate.subscription.active-until" (ct/format-inst (:cancel-at nitrate-license) "d MMMM, yyyy")))
-                         :benefits-title "Loren ipsum",
-                         :benefits ["Loren ipsum",
-                                    "Loren ipsum",
-                                    "Loren ipsum"]
-                         :cta-text-with-icon (when (not (:manual nitrate-license)) "Admin Console")
+                         :benefits-title (tr "subscription.settings.benefits.nitrate-unlimited-benefits")
+                         :benefits [{:label (tr "subscription.settings.enterprise.nitrate.multi-org-management")
+                                     :description (tr "subscription.settings.enterprise.nitrate.support-team")}
+                                    {:label (tr "subscription.settings.enterprise.nitrate.enterprise-security")
+                                     :description (tr "subscription.settings.enterprise.nitrate.native-sso")}
+                                    {:label (tr "subscription.settings.enterprise.nitrate.advanced-control")
+                                     :description (tr "subscription.settings.enterprise.nitrate.plugin-whitelisting")}]
+                         :cta-text-with-icon (when (not (:manual nitrate-license)) (tr "subscription.settings.admin-console"))
                          :cta-link-with-icon (when (not (:manual nitrate-license)) dnt/go-to-nitrate-ac)
                          :cta-text (if (and (:licenses connectivity) (not (:manual nitrate-license)))
                                      (tr "subscription.settings.manage-your-subscription")
@@ -663,7 +676,7 @@
                       :icon-id "crown"
                       :size "m"}]
            [:span {:class (stl/css :membership-date)}
-            (tr "subscription.settings.support-us-since" subscribed-since)]])
+            (tr "subscription.settings.subscribed-since" subscription-name subscribed-since)]])
 
         [:div {:class (stl/css :membership)}
          [:> icon* {:class (stl/css :penpot-member)
@@ -677,7 +690,7 @@
        (when (not= subscription-type "professional")
          [:> plan-card* {:card-title (tr "subscription.settings.professional")
                          :price-value "$0"
-                         :price-period (tr "subscription.settings.price-editor-month")
+                         :price-period (tr "subscription.settings.price-user-month")
                          :benefits [(if cf/saas?
                                       (tr "subscription.settings.professional.storage-benefit")
                                       (tr "subscription.settings.professional.selfhost.control-over-data")),
@@ -701,7 +714,7 @@
          [:> plan-card* {:card-title (tr "subscription.settings.unlimited")
                          :card-title-icon i/character-u
                          :price-value "$7"
-                         :price-period (tr "subscription.settings.price-editor-month")
+                         :price-period (tr "subscription.settings.price-user-month")
                          :benefits-title (tr "subscription.settings.benefits.all-professional-benefits")
                          :benefits [(tr "subscription.settings.unlimited.storage-benefit"),
                                     (tr "subscription.settings.unlimited.autosave-benefit"),
@@ -730,18 +743,21 @@
                          :show-button-cta (= subscription-type "professional")
                          :current-plan false}])
 
-       ;; TODO add translations for this texts when we have the definitive ones
        (when (and (contains? cf/flags :nitrate) (not nitrate?))
-         [:> plan-card* {:card-title "Enterprise"
-                         :card-title-icon i/character-n
+         [:> plan-card* {:card-title (tr "subscription.settings.enterprise")
                          :price-value "$25"
                          :price-period (tr "subscription.settings.organization-member-month")
-                         :benefits-title (tr "subscription.settings.benefits.all-unlimited-benefits")
-                         :benefits ["Crea organizaciones y añade personas, que usarán Penpot con las reglas que configures."
-                                    "Acceso exclusivo a la Admin Console"
-                                    "Lorem ipsum"]
-                         :cta-text (if nitrate-license (tr "subscription.settings.subscribe") "Try 14 days for free")
-                         :cta-link (if (= subscription-type "unlimited") #(open-contact-sales-modal subscription-type "Nitrate") #(open-subscription-modal "nitrate" subscription))
+                         :benefits-title (tr "subscription.settings.benefits.nitrate-unlimited-benefits")
+                         :benefits [{:label (tr "subscription.settings.enterprise.nitrate.multi-org-management")
+                                     :description (tr "subscription.settings.enterprise.nitrate.support-team")}
+                                    {:label (tr "subscription.settings.enterprise.nitrate.enterprise-security")
+                                     :description (tr "subscription.settings.enterprise.nitrate.native-sso")}
+                                    {:label (tr "subscription.settings.enterprise.nitrate.advanced-control")
+                                     :description (tr "subscription.settings.enterprise.nitrate.plugin-whitelisting")}]
+                         :cta-text (if nitrate-license (tr "subscription.settings.subscribe") (tr "nitrate.form.free-trial-button"))
+                         :cta-link (if (= subscription-type "unlimited")
+                                     #(open-contact-sales-modal subscription-type (tr "subscription.current-plan.nitrate"))
+                                     #(open-subscription-modal "nitrate" subscription))
                          :cta-text-with-icon (tr "subscription.settings.more-information")
                          :cta-link-with-icon go-to-pricing-page
                          :code-action :activate
@@ -775,17 +791,18 @@
        [:> icon* {:icon-id "close"
                   :size "m"}]]
       [:div {:class (stl/css :modal-title :subscription-title :nitrate-subscription)}
-       "Subscribe to the Enterprise plan"]
+       (tr "nitrate.form.title")]
 
       (if (and online? (not show-contact-sales-option))
         [:div {:class (stl/css :modal-content)}
 
          [:*
+          [:div {:class (stl/css :modal-text)} (tr "nitrate.form.enterprise-intro" ":")]
           [:div {:class (stl/css :modal-text :price-text)}
            [:span {:class (stl/css :price-value)} "25$"]
-           (tr "nitrate.form.enterprise.price")]
+           " / " (tr "subscription.settings.organization-member-month")]
           [:div {:class (stl/css :modal-text)}
-           "You won’t be charged right now. Payment will be processed at the end of the trial. Cancel anytime."]
+           (tr "nitrate.form.enterprise-description")]
 
           [:div {:class (stl/css :modal-footer)}
            [:div {:class (stl/css :action-buttons)}
@@ -798,13 +815,11 @@
             [:input
              {:class (stl/css :primary-button)
               :type "button"
-              :value (if nitrate-license (tr "subscription.settings.subscribe") "TRY 14 DAYS FOR FREE")
+              :value (if nitrate-license (tr "subscription.settings.subscribe") (tr "nitrate.form.free-trial-button"))
               :on-click on-subscribe-click}]]]]]
         [:div {:class (stl/css :modal-content :modal-contact-content)}
          [:div {:class (stl/css :modal-text)}
-          "Lorem ipsum lorem ipsum Lorem ipsum lorem ipsum Lorem ipsum lorem ipsum"]
-         [:div {:class (stl/css :modal-text)}
-          (if nitrate-license "Contact us to upgrade to Nitrate:" "Contact us to try Nitrate for 14 days:")]
+          (tr "nitrate.form.enterprise-intro" ".") " " (if nitrate-license (tr "nitrate.form.contact-us-upgrade") (tr "nitrate.form.contact-us-free-trial"))]
          [:div {:class (stl/css :modal-text)}
           [:a {:class (stl/css :cta-button) :href "mailto:sales@penpot.app"}
            "sales@penpot.app"]]])]]))
@@ -824,25 +839,24 @@
        [:> icon* {:icon-id "close"
                   :size "m"}]]
       [:div {:class (stl/css :modal-title :subscription-title)}
-       (dm/str "Switch to " subscription-type " plan?")]
+       (tr "nitrate.contact-sales.title" subscription-type)]
       [:div {:class (stl/css :modal-content)}
        [:div {:class (stl/css :modal-text-medium)}
-        "When you downgrade:"]
+        (tr "nitrate.contact-sales.downgrade-title")]
        [:ul {:class (stl/css :downgrade-list)}
-        [:li {:class (stl/css :downgrade-item)} "Your organization will be deleted."]
-        [:li {:class (stl/css :downgrade-item)} "The teams, projects and files will no longer be part of any organization but they will remain available."]
-        [:li {:class (stl/css :downgrade-item)} "Your total storage, auto-version history, and file recovery period will be limited."]]
+        [:li {:class (stl/css :downgrade-item)} (tr "nitrate.contact-sales.downgrade-org-deleted")]
+        [:li {:class (stl/css :downgrade-item)} (tr "nitrate.contact-sales.downgrade-teams-available")]
+        [:li {:class (stl/css :downgrade-item)} (tr "nitrate.contact-sales.downgrade-storage-limited")]]
 
        [:div {:class (stl/css :downgrade-warning)}
-        "To switch to this plan, please contact our sales team.
-We’ll help you update your subscription and ensure everything is set up correctly."]
+        (tr "nitrate.contact-sales.downgrade-contact-info")]
        [:div {:class (stl/css :action-buttons)}
         [:> button* {:variant "secondary"
                      :type "button"
                      :on-click handle-close-dialog} (tr "ds.confirm-cancel")]
         [:> button* {:variant "primary"
                      :type "button"
-                     :on-click #(dom/open-new-window "mailto:sales@penpot.app?subject=Switch%20to%20the%20Unlimited%20plan")} "Contact sales"]]]]]))
+                     :on-click #(dom/open-new-window "mailto:sales@penpot.app?subject=Switch%20to%20the%20Unlimited%20plan")} (tr "nitrate.contact-sales.button")]]]]]))
 
 (mf/defc nitrate-cancel-contact-sales-dialog
   {::mf/register modal/components
@@ -853,7 +867,7 @@ We’ll help you update your subscription and ensure everything is set up correc
 
         mailto-url
         (dm/str "mailto:sales@penpot.net"
-                "?subject=Request%20to%20Cancel%20Nitrate%20Subscription"
+                "?subject=Request%20to%20Cancel%20Enterprise%20Subscription"
                 "&body=Hello%2C%0A%0A"
                 "I%20would%20like%20to%20cancel%20my%20Enterprise%20subscription.%0A"
                 "Account%20email%3A%20" encoded-email ".%0A%0AThank%20you.")
@@ -869,15 +883,15 @@ We’ll help you update your subscription and ensure everything is set up correc
        [:> icon* {:icon-id "close"
                   :size "m"}]]
       [:div {:class (stl/css :modal-title :subscription-title)}
-       "Cancel subscription"]
+       (tr "nitrate.subscription.settings.manual-cancel")]
 
       [:div {:class (stl/css :modal-content)}
        [:div {:class (stl/css :modal-text-medium)}
-        "To cancel your Nitrate subscription, please contact us at:"]
+        (tr "nitrate.subscription.settings.manual-contact-us")]
        [:a {:class (stl/css :cta-link) :href "mailto:sales@penpot.net"}
         "sales@penpot.net"]
        [:div {:class (stl/css :action-buttons)}
         [:> button* {:class (stl/css :button-full-width)
                      :variant "primary"
                      :type "button"
-                     :on-click #(dom/open-new-window mailto-url)} "Contact us"]]]]]))
+                     :on-click #(dom/open-new-window mailto-url)} (tr "labels.contact-us")]]]]]))

--- a/frontend/src/app/main/ui/settings/subscription.scss
+++ b/frontend/src/app/main/ui/settings/subscription.scss
@@ -162,6 +162,10 @@
   color: var(--color-foreground-secondary);
 }
 
+.benefit-label {
+  font-weight: 600;
+}
+
 .other-subscriptions {
   margin-block-start: px2rem(52);
 }
@@ -437,7 +441,7 @@
   align-items: center;
   display: flex;
   gap: var(--sp-s);
-  margin-block-end: px2rem(34);
+  margin-block: var(--sp-xl);
 }
 
 .price-value {

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -4352,12 +4352,12 @@ msgstr "Enjoy your plan!"
 #: src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs:60
 msgid "nitrate.activation-success.manage-info"
 msgstr ""
-"You can manage your subscription anytime from the Subscription page in your "
-"account settings."
+"You can edit your subscription at any time from the 'Subscription' page in your "
+"account details."
 
 #: src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs:53
-msgid "nitrate.activation-success.title"
-msgstr "You are Business Nitrate!"
+msgid "nitrate.modal-success.title"
+msgstr "Welcome to Enterprise!"
 
 #: src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs:104
 msgid "nitrate.code-activation.footer"
@@ -4383,37 +4383,30 @@ msgstr "Activate"
 msgid "nitrate.code-activation.title"
 msgstr "Activate Nitrate"
 
-#, unused
 msgid "nitrate.contact-sales.button"
 msgstr "Contact sales"
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-contact-info"
 msgstr ""
 "To switch to this plan, please contact our sales team. We'll help you "
 "update your subscription and ensure everything is set up correctly."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-org-deleted"
 msgstr "Your organization will be deleted."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-storage-limited"
 msgstr ""
 "Your total storage, auto-version history, and file recovery period will be "
 "limited."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-teams-available"
 msgstr ""
 "The teams, projects and files will no longer be part of any organization "
 "but they will remain available."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-title"
 msgstr "When you downgrade:"
 
-#, unused
 msgid "nitrate.contact-sales.title"
 msgstr "Switch to %s plan?"
 
@@ -4449,7 +4442,19 @@ msgstr "Full open-source freedom, with the governance your org needs"
 
 #: src/app/main/ui/nitrate/nitrate_form.cljs:54
 msgid "nitrate.form.enterprise-intro"
-msgstr "Everything your teams need to work securely at scale:"
+msgstr "Everything your teams need to work securely at scale%s"
+
+msgid "nitrate.form.enterprise-description"
+msgstr "You won’t be charged right now. Payment will be processed at the end of the trial. Cancel anytime."
+
+msgid "nitrate.form.contact-us-free-trial"
+msgstr "Contact us to try the Enterprise plan for 14 days:"
+
+msgid "nitrate.form.contact-us-upgrade"
+msgstr "Contact us to upgrade to the Enterprise plan:"
+
+msgid "nitrate.form.free-trial-button"
+msgstr "Try 14 days for free"
 
 #: src/app/main/ui/nitrate/nitrate_form.cljs:66, src/app/main/ui/settings/subscription.cljs:767
 msgid "nitrate.form.enterprise.price"
@@ -4463,7 +4468,6 @@ msgstr "Have an activation code?"
 msgid "nitrate.form.see-plan"
 msgstr "See my current plan"
 
-#, unused
 msgid "nitrate.form.start-enterprise"
 msgstr "Get started with Enterprise"
 
@@ -4474,11 +4478,6 @@ msgstr "Unlock Enterprise features"
 #: src/app/main/ui/dashboard/subscription.cljs:209, src/app/main/ui/nitrate/nitrate_form.cljs:75
 msgid "nitrate.form.try-free"
 msgstr "Try it free for 14 days"
-
-#: src/app/main/ui/nitrate/nitrate_form.cljs:74
-#, fuzzy
-msgid "nitrate.form.upgrade"
-msgstr ""
 
 #: src/app/main/ui/settings/subscription.cljs:575
 msgid "nitrate.subscription.active-until"
@@ -4491,6 +4490,9 @@ msgstr "Your Nitrate subscription has been renewed."
 #: src/app/main/ui/settings/subscription.cljs:584
 msgid "nitrate.subscription.settings.manual-cancel"
 msgstr "Cancel subscription"
+
+msgid "nitrate.subscription.settings.manual-contact-us"
+msgstr "To cancel your Nitrate subscription, please contact us at:"
 
 #: src/app/main/ui/settings/subscription.cljs:103
 msgid "nitrate.subscription.settings.renew-with-code"
@@ -5947,6 +5949,9 @@ msgstr "All Professional plan benefits and:"
 msgid "subscription.settings.benefits.all-unlimited-benefits"
 msgstr "All Unlimited plan benefits and:"
 
+msgid "subscription.settings.benefits.nitrate-unlimited-benefits"
+msgstr "All Unlimited plan benefits, plus:"
+
 #: src/app/main/ui/settings/subscription.cljs:62
 msgid "subscription.settings.editors"
 msgstr "(x %s editors)"
@@ -5970,6 +5975,27 @@ msgstr "Flat monthly bill"
 #: src/app/main/ui/settings/subscription.cljs:631, src/app/main/ui/settings/subscription.cljs:641, src/app/main/ui/settings/subscription.cljs:710
 msgid "subscription.settings.enterprise.unlimited-storage-benefit"
 msgstr "Unlimited storage"
+
+msgid "subscription.settings.enterprise.nitrate.multi-org-management"
+msgstr "Multi-Org Management:"
+
+msgid "subscription.settings.enterprise.nitrate.support-team"
+msgstr "Support for complex team hierarchies and separate sub-organizations."
+
+msgid "subscription.settings.enterprise.nitrate.enterprise-security"
+msgstr "Enterprise Security:"
+
+msgid "subscription.settings.enterprise.nitrate.native-sso"
+msgstr "Native SAML/​​SSO and full Audit Trail logging for compliance reporting."
+
+msgid "subscription.settings.enterprise.nitrate.advanced-control"
+msgstr "Advanced Control:"
+
+msgid "subscription.settings.enterprise.nitrate.plugin-whitelisting"
+msgstr "Granular plugin whitelisting, including our secure, isolated MCP Server for AI connectivity."
+
+msgid "subscription.settings.admin-console"
+msgstr "Admin Console"
 
 #: src/app/main/ui/dashboard/subscription.cljs:287, src/app/main/ui/settings/subscription.cljs:583, src/app/main/ui/settings/subscription.cljs:610, src/app/main/ui/settings/subscription.cljs:622, src/app/main/ui/settings/subscription.cljs:634, src/app/main/ui/settings/subscription.cljs:644
 msgid "subscription.settings.manage-your-subscription"
@@ -6050,15 +6076,15 @@ msgstr "More information"
 
 #: src/app/main/ui/settings/subscription.cljs:724
 msgid "subscription.settings.organization-member-month"
-msgstr "org member per month"
+msgstr "org member / month"
 
 #: src/app/main/ui/settings/subscription.cljs:665
 msgid "subscription.settings.other-plans"
 msgstr "Other penpot plans"
 
 #: src/app/main/ui/settings/subscription.cljs:669, src/app/main/ui/settings/subscription.cljs:692
-msgid "subscription.settings.price-editor-month"
-msgstr "editor per month"
+msgid "subscription.settings.price-user-month"
+msgstr "user / month"
 
 #: src/app/main/ui/settings/subscription.cljs:708
 msgid "subscription.settings.price-organization-month"
@@ -6126,10 +6152,9 @@ msgstr "Thank your for chosing the Penpot %s plan!"
 msgid "subscription.settings.success.dialog.title"
 msgstr "You are %s!"
 
-#: src/app/main/ui/settings/subscription.cljs:655
-#, fuzzy
-msgid "subscription.settings.support-us-since"
-msgstr "You've been supporting us with this plan since: %s"
+#: src/app/main/ui/settings/subscription.cljs:679
+msgid "subscription.settings.subscribed-since"
+msgstr "You've been on the %s plan since %s."
 
 #: src/app/main/ui/settings/subscription.cljs:697, src/app/main/ui/settings/subscription.cljs:713
 msgid "subscription.settings.try-it-free"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -4227,12 +4227,12 @@ msgstr "¡Disfruta de tu plan!"
 #: src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs:60
 msgid "nitrate.activation-success.manage-info"
 msgstr ""
-"Puedes gestionar tu suscripción en cualquier momento desde la página de "
-"Suscripción en la configuración de tu cuenta."
+"Puedes editar tu suscripción en cualquier momento desde la página de "
+"'Suscripción' en los detalles de tu cuenta."
 
 #: src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs:53
-msgid "nitrate.activation-success.title"
-msgstr "¡Ya eres Business Nitrate!"
+msgid "nitrate.modal-success.title"
+msgstr "¡Bienvenido a Enterprise!"
 
 #: src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs:104
 msgid "nitrate.code-activation.footer"
@@ -4258,38 +4258,31 @@ msgstr "Activar"
 msgid "nitrate.code-activation.title"
 msgstr "Activar Nitrate"
 
-#, unused
 msgid "nitrate.contact-sales.button"
 msgstr "Contactar con ventas"
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-contact-info"
 msgstr ""
 "Para cambiar a este plan, contacta con nuestro equipo de ventas. Te "
 "ayudaremos a actualizar tu suscripción y a asegurarnos de que todo esté "
 "configurado correctamente."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-org-deleted"
 msgstr "Tu organización será eliminada."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-storage-limited"
 msgstr ""
 "Tu almacenamiento total, el historial de versiones automático y el período "
 "de recuperación de archivos serán limitados."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-teams-available"
 msgstr ""
 "Los equipos, proyectos y archivos dejarán de pertenecer a la organización "
 "pero seguirán disponibles."
 
-#, unused
 msgid "nitrate.contact-sales.downgrade-title"
 msgstr "Al bajar de plan:"
 
-#, unused
 msgid "nitrate.contact-sales.title"
 msgstr "¿Cambiar al plan %s?"
 
@@ -4306,6 +4299,9 @@ msgstr "Contáctanos para probar Enterprise durante 14 días:"
 #: src/app/main/ui/nitrate/nitrate_form.cljs:91
 msgid "nitrate.form.contact-upgrade"
 msgstr "Contáctanos para actualizar a Enterprise:"
+
+msgid "nitrate.form.free-trial-button"
+msgstr "Pruébalo gratis durante 14 días"
 
 #: src/app/main/ui/nitrate/nitrate_form.cljs:82, src/app/main/ui/nitrate/nitrate_form.cljs:102
 msgid "nitrate.form.enter-code"
@@ -4327,7 +4323,16 @@ msgstr "Total libertad open-source, con la gobernanza que tu organización neces
 
 #: src/app/main/ui/nitrate/nitrate_form.cljs:54
 msgid "nitrate.form.enterprise-intro"
-msgstr "Todo lo que tus equipos necesitan para trabajar de forma segura a escala:"
+msgstr "Todo lo que tus equipos necesitan para trabajar de forma segura a escala%s"
+
+msgid "nitrate.form.enterprise-description"
+msgstr "No se te cobrará nada ahora. El pago se procesará al finalizar el período de prueba. Puedes cancelar en cualquier momento."
+
+msgid "nitrate.form.contact-us-free-trial"
+msgstr "Ponte en contacto con nosotros para probar el plan Enterprise durante 14 días:"
+
+msgid "nitrate.form.contact-us-upgrade"
+msgstr "Ponte en contacto con nosotros para actualizar al plan Enterprise:"
 
 #: src/app/main/ui/nitrate/nitrate_form.cljs:66, src/app/main/ui/settings/subscription.cljs:767
 msgid "nitrate.form.enterprise.price"
@@ -4341,7 +4346,6 @@ msgstr "¿Tienes un código de activación?"
 msgid "nitrate.form.see-plan"
 msgstr "Ver mi plan actual"
 
-#, unused
 msgid "nitrate.form.start-enterprise"
 msgstr "Empieza a utilizar Enterprise"
 
@@ -4364,6 +4368,9 @@ msgstr "Tu suscripción de Nitrate se ha renovado."
 #: src/app/main/ui/settings/subscription.cljs:584
 msgid "nitrate.subscription.settings.manual-cancel"
 msgstr "Cancelar subscripción"
+
+msgid "nitrate.subscription.settings.manual-contact-us"
+msgstr "Para cancelar tu suscripción a Nitrate, ponte en contacto con nosotros en:"
 
 #: src/app/main/ui/settings/subscription.cljs:103
 msgid "nitrate.subscription.settings.renew-with-code"
@@ -5805,6 +5812,9 @@ msgstr "Todas las prestaciones del plan Professional y:"
 msgid "subscription.settings.benefits.all-unlimited-benefits"
 msgstr "Todas las prestaciones del plan Unlimited y:"
 
+msgid "subscription.settings.benefits.nitrate-unlimited-benefits"
+msgstr "Todas las ventajas del plan Unlimited, además de:"
+
 #: src/app/main/ui/settings/subscription.cljs:62
 msgid "subscription.settings.editors"
 msgstr "(x %s editores)"
@@ -5828,6 +5838,27 @@ msgstr "Factura mensual fija"
 #: src/app/main/ui/settings/subscription.cljs:631, src/app/main/ui/settings/subscription.cljs:641, src/app/main/ui/settings/subscription.cljs:710
 msgid "subscription.settings.enterprise.unlimited-storage-benefit"
 msgstr "Almacenamiento ilimitado"
+
+msgid "subscription.settings.enterprise.nitrate.multi-org-management"
+msgstr "Gestión multiorganización:"
+
+msgid "subscription.settings.enterprise.nitrate.support-team"
+msgstr "Compatibilidad con jerarquías de equipos complejas y suborganizaciones independientes."
+
+msgid "subscription.settings.enterprise.nitrate.enterprise-security"
+msgstr "Seguridad Enterprise:"
+
+msgid "subscription.settings.enterprise.nitrate.native-sso"
+msgstr "Compatibilidad nativa con SAML/SSO y registro completo de auditoría (Audit Trail) para informes de cumplimiento normativo."
+
+msgid "subscription.settings.enterprise.nitrate.advanced-control"
+msgstr "Control avanzado:"
+
+msgid "subscription.settings.enterprise.nitrate.plugin-whitelisting"
+msgstr "Lista blanca granular de complementos (plugins), incluido nuestro servidor MCP seguro y aislado para la conectividad con IA."
+
+msgid "subscription.settings.admin-console"
+msgstr "Admin Console"
 
 #: src/app/main/ui/dashboard/subscription.cljs:287, src/app/main/ui/settings/subscription.cljs:583, src/app/main/ui/settings/subscription.cljs:610, src/app/main/ui/settings/subscription.cljs:622, src/app/main/ui/settings/subscription.cljs:634, src/app/main/ui/settings/subscription.cljs:644
 msgid "subscription.settings.manage-your-subscription"
@@ -5913,15 +5944,15 @@ msgstr "Más información"
 
 #: src/app/main/ui/settings/subscription.cljs:724
 msgid "subscription.settings.organization-member-month"
-msgstr "miembro organización por mes"
+msgstr "miembro organización / mes"
 
 #: src/app/main/ui/settings/subscription.cljs:665
 msgid "subscription.settings.other-plans"
 msgstr "Otros planes de penpot"
 
 #: src/app/main/ui/settings/subscription.cljs:669, src/app/main/ui/settings/subscription.cljs:692
-msgid "subscription.settings.price-editor-month"
-msgstr "editor por mes"
+msgid "subscription.settings.price-user-month"
+msgstr "usuario / mes"
 
 #: src/app/main/ui/settings/subscription.cljs:708
 msgid "subscription.settings.price-organization-month"
@@ -5991,10 +6022,9 @@ msgstr "¡Gracias por elegir el plan %s de Penpot!"
 msgid "subscription.settings.success.dialog.title"
 msgstr "Eres %s!"
 
-#: src/app/main/ui/settings/subscription.cljs:655
-#, fuzzy
-msgid "subscription.settings.support-us-since"
-msgstr "Nos has estado apoyando con este plan desde: %s"
+#: src/app/main/ui/settings/subscription.cljs:679
+msgid "subscription.settings.subscribed-since"
+msgstr "Llevas en el plan %s desde %s."
 
 #: src/app/main/ui/settings/subscription.cljs:697, src/app/main/ui/settings/subscription.cljs:713
 msgid "subscription.settings.try-it-free"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26340

### Summary
Replace placeholder and hardcoded Nitrate subscription copy with i18n keys.
Update Enterprise plan benefits, dialogs, activation messaging, and EN/ES catalogs.

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
