### PR TITLE
:bug: Fix downgrade to Professional bypassing warning modal

### DIFF
--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -93,7 +93,7 @@
     :profile-id profile-id
     :team-permissions team-permissions}))
 
-(def go-to-subscription-url (u/join cf/public-uri "#/settings/subscriptions"))
+(def go-to-subscription-url (dm/str (u/join cf/public-uri "#/settings/subscriptions")))
 
 (def go-to-ac-url (build-admin-console-url ""))
 

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -502,10 +502,11 @@
         open-contact-sales-modal
         (mf/use-fn
          (mf/deps nitrate-license)
-         (fn [current-subscription subscription-type]
+         (fn [current-subscription subscription-type & [has-billing-access?]]
            (if (= current-subscription "unlimited")
              (st/emit! (dnt/show-nitrate-popup :nitrate-dialog {:nitrate-license nitrate-license :show-contact-sales-option true}))
-             (st/emit! (modal/show :nitrate-contact-sales-dialog {:subscription-type subscription-type})))))
+             (st/emit! (modal/show :nitrate-contact-sales-dialog {:subscription-type subscription-type
+                                                                  :has-billing-access? has-billing-access?})))))
 
         open-cancel-contact-sales-modal
         (mf/use-fn
@@ -702,7 +703,8 @@
                                       (tr "subscription.settings.professional.selfhost.community-support"))]
                          :cta-text (tr "subscription.settings.subscribe")
                          :cta-link (if (and (contains? cf/flags :nitrate) nitrate?)
-                                     #(open-contact-sales-modal subscription-type "Professional")
+                                     #(open-contact-sales-modal subscription-type "Professional"
+                                                                (and (:licenses connectivity) (not (:manual nitrate-license))))
                                      go-to-payments)
                          :cta-text-with-icon (tr "subscription.settings.more-information")
                          :cta-link-with-icon go-to-pricing-page
@@ -825,11 +827,17 @@
 (mf/defc nitrate-contact-sales-dialog
   {::mf/register modal/components
    ::mf/register-as :nitrate-contact-sales-dialog}
-  [{:keys [subscription-type]}]
+  [{:keys [subscription-type has-billing-access?]}]
   (let [handle-close-dialog
         (mf/use-fn
          (fn []
-           (modal/hide!)))]
+           (modal/hide!)))
+
+        handle-continue-click
+        (mf/use-fn
+         (fn []
+           (modal/hide!)
+           (dnt/go-to-nitrate-billing)))]
 
     [:div {:class (stl/css :modal-overlay)}
      [:div {:class (stl/css :modal-dialog)}
@@ -846,15 +854,24 @@
         [:li {:class (stl/css :downgrade-item)} (tr "nitrate.contact-sales.downgrade-teams-available")]
         [:li {:class (stl/css :downgrade-item)} (tr "nitrate.contact-sales.downgrade-storage-limited")]]
 
-       [:div {:class (stl/css :downgrade-warning)}
-        (tr "nitrate.contact-sales.downgrade-contact-info")]
-       [:div {:class (stl/css :action-buttons)}
-        [:> button* {:variant "secondary"
-                     :type "button"
-                     :on-click handle-close-dialog} (tr "ds.confirm-cancel")]
-        [:> button* {:variant "primary"
-                     :type "button"
-                     :on-click #(dom/open-new-window "mailto:sales@penpot.app?subject=Switch%20to%20the%20Unlimited%20plan")} (tr "nitrate.contact-sales.button")]]]]]))
+       (if has-billing-access?
+         [:div {:class (stl/css :action-buttons)}
+          [:> button* {:variant "secondary"
+                       :type "button"
+                       :on-click handle-close-dialog} (tr "ds.confirm-cancel")]
+          [:> button* {:variant "primary"
+                       :type "button"
+                       :on-click handle-continue-click} (tr "labels.continue")]]
+         [:*
+          [:div {:class (stl/css :downgrade-warning)}
+           (tr "nitrate.contact-sales.downgrade-contact-info")]
+          [:div {:class (stl/css :action-buttons)}
+           [:> button* {:variant "secondary"
+                        :type "button"
+                        :on-click handle-close-dialog} (tr "ds.confirm-cancel")]
+           [:> button* {:variant "primary"
+                        :type "button"
+                        :on-click #(dom/open-new-window (dm/str "mailto:sales@penpot.app?subject=Switch%20to%20the%20" subscription-type "%20plan"))} (tr "nitrate.contact-sales.button")]]])]]]))
 
 (mf/defc nitrate-cancel-contact-sales-dialog
   {::mf/register modal/components

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -701,10 +701,8 @@
                                       (tr "subscription.settings.professional.teams-editors-benefit")
                                       (tr "subscription.settings.professional.selfhost.community-support"))]
                          :cta-text (tr "subscription.settings.subscribe")
-                         :cta-link (if (and (contains? cf/flags :nitrate) nitrate? (= subscription-type "nitrate"))
-                                     (if (and (:licenses connectivity) (not (:manual nitrate-license)))
-                                       dnt/go-to-nitrate-billing
-                                       open-cancel-contact-sales-modal)
+                         :cta-link (if (and (contains? cf/flags :nitrate) nitrate?)
+                                     #(open-contact-sales-modal subscription-type "Professional")
                                      go-to-payments)
                          :cta-text-with-icon (tr "subscription.settings.more-information")
                          :cta-link-with-icon go-to-pricing-page

--- a/frontend/test/frontend_tests/data/nitrate_test.cljs
+++ b/frontend/test/frontend_tests/data/nitrate_test.cljs
@@ -64,3 +64,19 @@
                      (u/uri "https://localhost:3449/#/settings/subscriptions"))]
       (t/is (= "https://localhost:3449/#/settings/subscriptions?subscription=nitrate-checkout-error"
                (:error-callback callbacks))))))
+
+(t/deftest go-to-subscription-url-is-a-string
+  (t/testing "must be a string so licenses/billing?callback=... survives query encoding"
+    (t/is (string? dnt/go-to-subscription-url))
+    (t/is (not (u/uri? dnt/go-to-subscription-url)))))
+
+(t/deftest build-admin-console-billing-url-encodes-string-callback
+  (t/testing "billing callback query param round-trips as a real URL string"
+    (let [public-uri (u/uri "https://localhost:3449/")
+          callback   "https://localhost:3449/#/settings/subscriptions"
+          href       (dnt/build-admin-console-url
+                      public-uri
+                      "licenses/billing"
+                      {:callback callback})
+          parsed     (-> href u/uri :query u/query-string->map :callback)]
+      (t/is (= callback parsed)))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26652
### Summary

Clicking "Subscribe" on the Professional plan while on an Enterprise/Nitrate plan redirected straight to the Admin Console billing page with a broken, garbled URL (`[object Object]` entries), instead of showing the required downgrade-warning modal first.

### Steps to reproduce

1. Log in with an account on an active Enterprise/Nitrate plan owning an org.
2. Go to Settings > Subscription (`/settings/subscriptions`).
3. Click "Subscribe" on the Professional plan.
4. Verify the downgrade warning modal appears (instead of an immediate, broken redirect).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
