### PR TITLE
Update MCP configuration for Claude Code

### DIFF
--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -234,7 +234,7 @@ Replace `REMOTE_OR_LOCAL_URL` with the URL for your mode.
 {
   "mcpServers": {
     "penpot": {
-      "transport": "http",
+      "type": "http",
       "url": "REMOTE_OR_LOCAL_URL"
     }
   }


### PR DESCRIPTION
The Claude Code configuration expects a `type=http` property (rather than `transport`).

Alternatively we could use the CLI, like so:

```sh
claude mcp add --transport http penpot $REMOTE_OR_LOCAL_URL
```

