### PR TITLE
:wrench: Revert stroke to path flag deletion and enable it by default

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -212,6 +212,7 @@
    :enable-render-wasm-info
    :enable-available-viewer-wasm
    :enable-background-blur
+   :enable-stroke-path
    :enable-token-combobox])
 
 (defn parse

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -506,7 +506,8 @@
                         :on-click do-transform-to-path}])
 
      (when (and has-strokes?
-                (features/active-feature? @st/state "render-wasm/v1"))
+                (features/active-feature? @st/state "render-wasm/v1")
+                (contains? cf/flags :stroke-path))
        [:> menu-entry* {:title (tr "workspace.shape.menu.stroke-to-path")
                         :on-click do-strokes-to-path}])
 


### PR DESCRIPTION
### Related Ticket

No issue

### Summary

Instead of deleting the config flag, enable it by default, as we're doing with other flags

### Steps to reproduce 

Check stroke to path is enabled by default

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
