### PR TITLE
:bug: Make organization logos publicly accessible for invitation emails

### DIFF
--- a/backend/src/app/http/assets.clj
+++ b/backend/src/app/http/assets.clj
@@ -31,7 +31,8 @@
   #{"file-media-object"
     "file-object-thumbnail"
     "team-font-variant"
-    "file-data-fragment"})
+    "file-data-fragment"
+    "organization"})
 
 (defn get-id
   [{:keys [path-params]}]

--- a/backend/test/backend_tests/http_assets_test.clj
+++ b/backend/test/backend_tests/http_assets_test.clj
@@ -110,7 +110,8 @@
     (doseq [bucket ["file-media-object"
                     "file-object-thumbnail"
                     "team-font-variant"
-                    "file-data-fragment"]]
+                    "file-data-fragment"
+                    "organization"]]
       (t/testing (str "bucket: " bucket)
         (let [object  (create-storage-object! storage bucket "public data")
               request {:path-params {:id (str (:id object))}}
@@ -119,6 +120,19 @@
                 (str "bucket " bucket " should not require auth"))
           (t/is (not= 404 (::yres/status response))
                 (str "bucket " bucket " object should exist")))))))
+
+(t/deftest objects-handler-organization-logo-no-auth
+  ;; Organization logos are embedded in unauthenticated contexts, such as
+  ;; the invitation email image shown to a not-yet-registered invitee, so
+  ;; they must be servable without a session or access token.
+  (let [storage  (-> (:app.storage/storage th/*system*)
+                     (configure-storage-backend))
+        cfg      (make-handler-cfg storage)
+        object   (create-storage-object! storage "organization" "logo data")
+        request  {:path-params {:id (str (:id object))}}
+        response (assets/objects-handler cfg request)]
+    (t/is (not= 401 (::yres/status response)))
+    (t/is (not= 404 (::yres/status response)))))
 
 (t/deftest objects-handler-public-bucket-with-auth
   ;; Objects in public buckets should also be accessible WITH authentication.


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26654

### Summary

Organization logos are stored in the `"organization"` storage bucket, which was missing from the backend's `public-buckets` allow-list in `app.http.assets`. As a result, `GET /assets/by-id/:id` for a custom org logo returned 401 for unauthenticated requests. Invitation emails embed the org logo via this same endpoint, but the invited recipient opens the email without a Penpot session or access token, so the logo image failed to load, only for organizations with a custom avatar. Default avatars were unaffected because they are static SVGs served directly by the admin console, not through this authenticated endpoint.

### Steps to reproduce

1. Create or open an organization and set a custom avatar (logo) for it.
2. Invite a user to that organization.
3. Open the invitation email received by the invited user.
4. Observe the organization avatar next to the invitation text — before the fix it does not render (broken/missing image); an organization using the default avatar renders correctly.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
