### PR TITLE
:bug: Fix selrect misplacement on grid and flex layouts

### DIFF
--- a/frontend/src/app/main/data/workspace/grid_layout/editor.cljs
+++ b/frontend/src/app/main/data/workspace/grid_layout/editor.cljs
@@ -11,6 +11,8 @@
    [app.common.types.shape.layout :as ctl]
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace.viewport-wasm :as dwvw]
+   [app.main.streams :as ms]
+   [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
 (defn hover-grid-cell
@@ -88,7 +90,12 @@
   (ptk/reify ::stop-grid-layout-editing
     ptk/UpdateEvent
     (update [_ state]
-      (update state :workspace-grid-edition dissoc grid-id))))
+      (update state :workspace-grid-edition dissoc grid-id))
+
+    ptk/EffectEvent
+    (effect [_ _ _]
+      (rx/push! ms/wasm-modifiers nil)
+      (rx/push! ms/workspace-selrect nil))))
 
 (defn locate-board
   [grid-id]

--- a/frontend/src/app/main/data/workspace/grid_layout/editor.cljs
+++ b/frontend/src/app/main/data/workspace/grid_layout/editor.cljs
@@ -12,7 +12,6 @@
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace.viewport-wasm :as dwvw]
    [app.main.streams :as ms]
-   [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
 (defn hover-grid-cell
@@ -94,8 +93,7 @@
 
     ptk/EffectEvent
     (effect [_ _ _]
-      (rx/push! ms/wasm-modifiers nil)
-      (rx/push! ms/workspace-selrect nil))))
+      (ms/clear-transform-preview!))))
 
 (defn locate-board
   [grid-id]

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -143,8 +143,7 @@
 
     ptk/EffectEvent
     (effect [_ _ _]
-      (rx/push! ms/wasm-modifiers nil)
-      (rx/push! ms/workspace-selrect nil))))
+      (ms/clear-transform-preview!))))
 
 ;; -- Resize --------------------------------------------------------
 

--- a/frontend/src/app/main/streams.cljs
+++ b/frontend/src/app/main/streams.cljs
@@ -32,6 +32,17 @@
 (defonce workspace-selrect
   (rx/behavior-subject nil))
 
+(defn clear-transform-preview!
+  "Reset the interactive-transform preview behaviour-subjects. Controls
+  that drive a live preview (drag/resize/rotate, flex spacing handles,
+  grid track/cell gestures) set these via `set-wasm-modifiers` and clear
+  them at gesture end. If the control unmounts mid-gesture that clearing
+  never runs, so the stale selrect keeps displacing the DOM selection
+  overlay of the next selection. Call from gesture end / unmount cleanup."
+  []
+  (rx/push! wasm-modifiers nil)
+  (rx/push! workspace-selrect nil))
+
 ;; --- Derived streams
 
 (defonce ^:private pointer

--- a/frontend/src/app/main/ui/flex_controls/common.cljs
+++ b/frontend/src/app/main/ui/flex_controls/common.cljs
@@ -1,8 +1,26 @@
 (ns app.main.ui.flex-controls.common
   (:require
    [app.main.constants :as mconst]
+   [app.main.streams :as ms]
    [app.main.ui.formats :as fmt]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
+
+;; ------------------------------------------------
+;; INTERACTIVE TRANSFORM CLEANUP
+;; ------------------------------------------------
+
+(defn clear-transform-preview!
+  "Reset the interactive-transform preview behaviour-subjects. Flex
+  spacing controls (padding/margin/gap) set these via
+  `set-wasm-modifiers` while dragging and only clear them through
+  `finish-transform` on `lost-pointer-capture`. If the control unmounts
+  mid-drag (e.g. the selection changes) that handler never fires and the
+  stale selrect keeps displacing the DOM selection overlay of the next
+  selection. Call from an unmount cleanup guarded on the resizing flag."
+  []
+  (rx/push! ms/wasm-modifiers nil)
+  (rx/push! ms/workspace-selrect nil))
 
 ;; ------------------------------------------------
 ;; CONSTANTS

--- a/frontend/src/app/main/ui/flex_controls/common.cljs
+++ b/frontend/src/app/main/ui/flex_controls/common.cljs
@@ -3,24 +3,16 @@
    [app.main.constants :as mconst]
    [app.main.streams :as ms]
    [app.main.ui.formats :as fmt]
-   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 ;; ------------------------------------------------
 ;; INTERACTIVE TRANSFORM CLEANUP
 ;; ------------------------------------------------
 
-(defn clear-transform-preview!
-  "Reset the interactive-transform preview behaviour-subjects. Flex
-  spacing controls (padding/margin/gap) set these via
-  `set-wasm-modifiers` while dragging and only clear them through
-  `finish-transform` on `lost-pointer-capture`. If the control unmounts
-  mid-drag (e.g. the selection changes) that handler never fires and the
-  stale selrect keeps displacing the DOM selection overlay of the next
-  selection. Call from an unmount cleanup guarded on the resizing flag."
-  []
-  (rx/push! ms/wasm-modifiers nil)
-  (rx/push! ms/workspace-selrect nil))
+;; Flex spacing controls (padding/margin/gap) call this from their
+;; unmount cleanup, guarded on the resizing flag. See
+;; `ms/clear-transform-preview!` for the rationale.
+(def clear-transform-preview! ms/clear-transform-preview!)
 
 ;; ------------------------------------------------
 ;; CONSTANTS

--- a/frontend/src/app/main/ui/flex_controls/gap.cljs
+++ b/frontend/src/app/main/ui/flex_controls/gap.cljs
@@ -98,6 +98,11 @@
                  (when on-change
                    (on-change modifiers)))))))]
 
+    (mf/with-effect []
+      (fn []
+        (when (some? @resizing)
+          (fcc/clear-transform-preview!))))
+
     [:g.gap-rect
      [:rect.info-area
       {:x (:x rect-data)

--- a/frontend/src/app/main/ui/flex_controls/margin.cljs
+++ b/frontend/src/app/main/ui/flex_controls/margin.cljs
@@ -105,6 +105,11 @@
                  (when on-change
                    (on-change modifiers)))))))]
 
+    (mf/with-effect []
+      (fn []
+        (when @resizing?
+          (fcc/clear-transform-preview!))))
+
     [:rect.margin-rect
      {:x (:x rect-data)
       :y (:y rect-data)

--- a/frontend/src/app/main/ui/flex_controls/padding.cljs
+++ b/frontend/src/app/main/ui/flex_controls/padding.cljs
@@ -105,6 +105,11 @@
                  (when on-change
                    (on-change modifiers)))))))]
 
+    (mf/with-effect []
+      (fn []
+        (when @resizing?
+          (fcc/clear-transform-preview!))))
+
     [:g.padding-rect
      [:rect.info-area
       {:x (:x rect-data)


### PR DESCRIPTION
### Related Ticket

No reference ticket

### Summary

DOM selection overlay was displaced after leaving a grid/flex layout. workspace-selrect, wasm-modifiers are defonce behavior-subjects set by set-wasm-modifiers but cleared only by finish-transform. If a control unmounted on the interaction, the stale selrect still displaced the next selection

Example:

[screen-recorder-fri-jul-24-2026-13-59-09.webm](https://github.com/user-attachments/assets/58a8217b-4a56-4a76-bb35-81c6c8c815c1)

Fix: Clear both streams on stop-grid-layout-editing (grid) and on flex-control unmount while resizing via `fcc/clear-transform-preview! (padding/margin/gap)`. Only affects render-wasm.

Note: when moving selectors to WASM, this issue should not happen either

### Steps to reproduce

Sometimes is not trivial to reproduce, but doing this several times should trigger it (check the video from above):

1. Select a frame with grid layout and enter grid edit mode.
2. Start a gesture on it by grabbing a grid track or cell.
3. Before releasing cleanly, select the frame above.
4. The new selection's DOM selectors are displaced by the old frame's offset.
