### PR TITLE
:bug: Hide Organizations header/divider when org list is empty

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -357,9 +357,11 @@
        (tr "dashboard.my-teams")]
       (when (= default-team-id (:default-team-id organization))
         tick-icon)]
-     [:hr {:role "separator" :class (stl/css :team-separator)}]
-     [:li {:role "presentation" :class (stl/css :org-section-label)}
-      (tr "dashboard.section.organizations")]
+     (when (seq organizations)
+       [:*
+        [:hr {:role "separator" :class (stl/css :team-separator)}]
+        [:li {:role "presentation" :class (stl/css :org-section-label)}
+         (tr "dashboard.section.organizations")]])
 
      (for [org-item organizations]
        [:> dropdown-menu-item* {:on-click    on-org-click


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26653

### Summary

Fixes the team switcher dropdown so the "Organizations" section header and its divider are hidden when the current user has no organizations. Previously these were always rendered, leaving an empty-looking section in the dropdown. The fix wraps the header/divider in a check for a non-empty organizations list, mirroring the pattern already used for the "Teams" section in the same component (`organizations-selector-dropdown*` in `frontend/src/app/main/ui/dashboard/sidebar.cljs`).

### Steps to reproduce

1. Log in with a user who does not belong to any organization.
2. Open the Teams dropdown from the sidebar.
3. Before the fix: the "Organizations" heading and its divider are shown even though there are no organizations to list.
4. After the fix: the heading and divider are hidden, and only the relevant actions (e.g. Create org, Go to Admin Console) are displayed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
