### PR TITLE
:bug: Fix team last_activity_at calculation

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -845,6 +845,15 @@ RETURNING id, deleted_at;")
              WHERE p.team_id = t.id
                AND p.deleted_at IS NULL
                AND f.deleted_at IS NULL
+            UNION ALL
+            SELECT tpr2.created_at
+              FROM team_profile_rel AS tpr2
+             WHERE tpr2.team_id = t.id
+               AND tpr2.is_owner IS NOT TRUE
+            UNION ALL
+            SELECT ti.updated_at
+              FROM team_invitation AS ti
+             WHERE ti.team_id = t.id
           ) AS activity) AS last_activity_at,
      owner_tpr.profile_id AS owner_profile_id,
      owner_p.fullname AS owner_name,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26640

### Summary

Updated `sql:get-teams-detail` to include member joins and invitations in the `last_activity_at` calculation. Previously, teams appeared inactive even after members joined or were invited. The owner's `team_profile_rel` row is now excluded to avoid counting team creation as activity.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
