### PR TITLE
:bug: Fix undo crash after deleting a word

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -1311,7 +1311,14 @@
                                                     {:new-shape? new-shape?
                                                      :content-has-text? content-has-text?
                                                      :content content
-                                                     :original-content original-content
+                                                     ;; Undo baseline for the finalize commit: restore the
+                                                     ;; content as it was right before this commit. For existing
+                                                     ;; shapes that's `prev-content`; using the (unset, nil)
+                                                     ;; `original-content` here wiped `:content` to nil on undo,
+                                                     ;; which emptied the shape and crashed the WASM editor's
+                                                     ;; select-all on 0 paragraphs. New shapes keep the previous
+                                                     ;; behavior (their create is bundled in the undo group).
+                                                     :original-content (if new-shape? original-content prev-content)
                                                      :update-name? update-name?
                                                      :name name})))
                    (rx/empty))

--- a/render-wasm/src/state/text_editor.rs
+++ b/render-wasm/src/state/text_editor.rs
@@ -436,7 +436,7 @@ impl TextEditorState {
     pub fn select_all(&mut self, text_content: &TextContent) -> bool {
         self.is_pointer_selection_active = false;
         self.set_caret_from_position(&TextPositionWithAffinity::empty());
-        let num_paragraphs = text_content.paragraphs().len() - 1;
+        let num_paragraphs = text_content.paragraphs().len().saturating_sub(1);
         let Some(last_paragraph) = text_content.paragraphs().last() else {
             return false;
         };

--- a/render-wasm/src/wasm/text/helpers.rs
+++ b/render-wasm/src/wasm/text/helpers.rs
@@ -195,6 +195,10 @@ pub fn move_cursor_up(
     _text_content: &TextContent,
 ) -> TextPositionWithAffinity {
     // TODO: Implement proper line-based navigation using line metrics
+    if paragraphs.is_empty() || cursor.paragraph >= paragraphs.len() {
+        return *cursor;
+    }
+
     if cursor.paragraph > 0 {
         let prev_para = cursor.paragraph - 1;
         let char_count = paragraph_char_count(&paragraphs[prev_para]);
@@ -212,6 +216,10 @@ pub fn move_cursor_down(
     _text_content: &TextContent,
 ) -> TextPositionWithAffinity {
     // TODO: Implement proper line-based navigation using line metrics
+    if paragraphs.is_empty() || cursor.paragraph >= paragraphs.len() {
+        return *cursor;
+    }
+
     if cursor.paragraph < paragraphs.len() - 1 {
         let next_para = cursor.paragraph + 1;
         let char_count = paragraph_char_count(&paragraphs[next_para]);


### PR DESCRIPTION
### Related Ticket

Fixes #10815 

### Summary

This fixes a text editor v3 crash after doing an undo following a text deletion, due to an Undo-related bug (we were setting the content to `nil`). It also introduces some guards to prevent similar crashes.

### Steps to reproduce 

See #10815 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
