### PR TITLE
:bug: Fix text editor cursor visibility on dark backgrounds

### DIFF
--- a/render-wasm/src/render/text_editor.rs
+++ b/render-wasm/src/render/text_editor.rs
@@ -65,8 +65,8 @@ fn render_cursor(
         paint.set_blend_mode(BlendMode::Exclusion);
         paint.set_color(Color::WHITE);
     } else {
-        paint.set_blend_mode(BlendMode::SrcOver);
-        paint.set_color(editor_state.theme.cursor_color);
+        paint.set_blend_mode(BlendMode::Difference);
+        paint.set_color(Color::WHITE);
     }
 
     let shape_matrix = shape.get_matrix();


### PR DESCRIPTION

### Related Ticket

Fixes #10856

### Summary

Use `BlendMode::Difference` with `Color::WHITE` for normal caret rendering in Text Editor V3 so the cursor automatically inverts against dark, light, and colored backgrounds.

<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/6db0aa85-1c77-496f-94ad-5e2812de85a0" />


### steps to verify
1. Create a text shape with a dark fill (e.g. black or navy).
2. Enter edit mode and confirm the blinking caret is clearly visible against the dark background.
3. Repeat with a light-fill text shape to confirm no regression from the previous behavior.



### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
