### PR TITLE
:bug: Fix selrect recalculation after pasting properties onto text

### DIFF
--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -709,18 +709,27 @@
             (cfeat/check-paste-features! features (:features pdata))
             (case (:type pdata)
               :copied-props
-
-              (rx/concat
-               (->> (rx/of pdata)
-                    (rx/mapcat (partial upload-images (:current-file-id state)))
-                    (rx/map
-                     #(dwsh/update-shapes
-                       selected
-                       (fn [shape objects] (cts/patch-props shape (:props pdata) objects))
-                       {:with-objects? true})))
-               (rx/of (ptk/data-event :layout/update {:ids selected})))
-              ;;
+              (let [objects (dsh/lookup-page-objects state)
+                    ids     (seq (filter #(cfh/text-shape? (get objects %)) selected))
+                    undo-id (js/Symbol)]
+                (rx/concat
+                 (rx/of (dwu/start-undo-transaction undo-id))
+                 (->> (rx/of pdata)
+                      (rx/mapcat (partial upload-images (:current-file-id state)))
+                      (rx/map
+                       #(dwsh/update-shapes
+                         selected
+                         (fn [shape objects] (cts/patch-props shape (:props pdata) objects))
+                         {:with-objects? true
+                          :undo-transation? false})))
+                 (rx/of (ptk/data-event :layout/update {:ids selected}))
+                 ;; Re-measure text shapes in WASM renderer mode and commit single undo transaction
+                 (if (and (seq ids)
+                          (features/active-feature? state "render-wasm/v1"))
+                   (rx/of (dwwt/resize-wasm-text-all ids {:undo-id undo-id}))
+                   (rx/of (dwu/commit-undo-transaction undo-id)))))
               (rx/empty))))))))
+
 
 (defn paste-shapes
   [{in-viewport? :in-viewport :as pdata}]

--- a/frontend/src/app/main/data/workspace/wasm_text.cljs
+++ b/frontend/src/app/main/data/workspace/wasm_text.cljs
@@ -78,17 +78,20 @@
 (defn resize-wasm-text
   "Resize a single text shape (auto-width/auto-height) by id.
   No-op if the id is not a text shape or is :fixed."
-  [id]
-  (ptk/reify ::resize-wasm-text
-    ptk/WatchEvent
-    (watch [_ state _]
-      (let [objects (dsh/lookup-page-objects state)
-            shape   (get objects id)]
-        (if (and (some? shape)
-                 (cfh/text-shape? shape)
-                 (not= :fixed (:grow-type shape)))
-          (rx/of (dwm/apply-wasm-modifiers (resize-wasm-text-modifiers shape)))
-          (rx/empty))))))
+  ([id]
+   (resize-wasm-text id nil))
+  ([id opts]
+   (ptk/reify ::resize-wasm-text
+     ptk/WatchEvent
+     (watch [_ state _]
+       (let [objects (dsh/lookup-page-objects state)
+             shape   (get objects id)]
+         (if (and (some? shape)
+                  (cfh/text-shape? shape)
+                  (not= :fixed (:grow-type shape)))
+           (rx/of (dwm/apply-wasm-modifiers (resize-wasm-text-modifiers shape) opts))
+           (rx/empty)))))))
+
 
 (defn resize-wasm-text-debounce-commit
   ([]
@@ -205,18 +208,21 @@
 
 (defn resize-wasm-text-all
   "Resize all text shapes (auto-width/auto-height) from a collection of ids."
-  [ids]
-  (ptk/reify ::resize-wasm-text-all
-    ptk/WatchEvent
-    (watch [_ state stream]
-      (let [resize-stream
-            (->> (rx/from ids)
-                 (rx/map resize-wasm-text-debounce))]
-        (if (::dwsh/update-shapes-buffer state)
-          ;; If we're in the middle of a token propagation we wait until is finished to
-          ;; recalculate the text sizes
-          (->> stream
-               (rx/filter (ptk/type? ::dwsh/update-shapes-buffer-commit))
-               (rx/take 1)
-               (rx/mapcat (constantly resize-stream)))
-          resize-stream)))))
+  ([ids]
+   (resize-wasm-text-all ids nil))
+  ([ids opts]
+   (ptk/reify ::resize-wasm-text-all
+     ptk/WatchEvent
+     (watch [_ state stream]
+       (let [resize-stream
+             (->> (rx/from ids)
+                  (rx/map #(resize-wasm-text-debounce % opts)))]
+         (if (::dwsh/update-shapes-buffer state)
+           ;; If we're in the middle of a token propagation we wait until is finished to
+           ;; recalculate the text sizes
+           (->> stream
+                (rx/filter (ptk/type? ::dwsh/update-shapes-buffer-commit))
+                (rx/take 1)
+                (rx/mapcat (constantly resize-stream)))
+           resize-stream))))))
+


### PR DESCRIPTION
### Related Ticket
Fixes #10840

### Summary
The WASM text renderer wasn't re-measuring `selrect` after pasting properties onto a text shape — font size updated visually, but the selection rect and handles stayed at the old size.

Fix: `paste-transit-props` now dispatches `resize-wasm-text-all` on the target text shapes when `render-wasm/v1` is active. I also grouped the prop-patch and the resize into a single undo transaction (using Penpot's existing `:undo-transation?` option, same pattern as `paste-html-text`/`paste-text`) so one Ctrl+Z reverts both the font size and the selrect together.

Legacy SVG renderer is untouched — the change is scoped behind the `render-wasm/v1` feature flag.

[Screencast from 28-07-26 12:51:48 AM IST.webm](https://github.com/user-attachments/assets/17883210-960c-4d7b-a81c-129dc002127c)


### Steps to Verify
1. Enable the WASM renderer (`enable-render-wasm` in `config.js`).
2. Create a small text shape (14px) and a large one (110px).
3. Copy properties from the large one (`Ctrl+Alt+C`), paste onto the small one (`Ctrl+Alt+V`).
4. Selrect/handles should expand instantly to match the new size.
5. Press `Ctrl+Z` once — both font size and selrect should revert together.

### Checklist
- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.