### PR TITLE
:bug: Fix area selection aborted by select-shapes interrupt

### DIFF
--- a/frontend/playwright/ui/specs/text-editor-v2.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v2.spec.js
@@ -344,7 +344,6 @@ test("Preserves empty fill after editing text without changes", async ({ page })
 
   await workspace.createTextShape(190, 150, 300, 200, initialText);
   await workspace.textEditor.stopEditing();
-  await workspace.page.getByRole('button', { name: 'Fill', exact: true }).click();
 
   const fillColorButton = workspace.page.getByRole("button", {
     name: "#000000",

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -275,7 +275,11 @@
             ;; the event loop
             expand-s (->> (rx/of (dwc/expand-all-parents ids objects))
                           (rx/observe-on :async))
-            interrupt-s (rx/of :interrupt ::dwsp/interrupt)]
+            ;; :interrupt aborts drag-stopper; only emit it when clearing edition
+            ;; (unconditional emit broke marquee selection after #10798).
+            interrupt-s (if (some? (dm/get-in state [:workspace-local :edition]))
+                          (rx/of :interrupt ::dwsp/interrupt)
+                          (rx/of ::dwsp/interrupt))]
         (rx/merge expand-s interrupt-s)))))
 
 (defn select-all


### PR DESCRIPTION
## What

Mouse area (marquee) selection was aborted shortly after starting a drag,
so the selection rectangle disappeared and shapes were not selected as
expected.

## Why

PR #10798 made `select-shapes` always emit `:interrupt` so text edition
mode is cleared on selection changes. Area selection calls `select-shapes`
periodically while dragging, and `mse/drag-stopper` stops on `:interrupt`,
which cancelled the marquee mid-gesture.

## How

Emit `:interrupt` from `select-shapes` only when workspace edition mode is
active. Specialized-panel interrupt is unchanged. Shift/deselect paths from
#10798 still always emit `:interrupt`, so exiting text edition on those
selection changes remains intact.

Relates to #10798 
Closes #10872