### PR TITLE
:bug: Clamp gradient stop offsets to valid range

### DIFF
--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -9,6 +9,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
+   [app.common.math :as mth]
    [app.common.schema :as sm]
    [app.common.types.color :as clr]
    [app.common.types.fills :as types.fills]
@@ -950,7 +951,8 @@
                       (or (not cap-stops?) (< (count stops) types.fills/MAX-GRADIENT-STOPS))]
 
                   (if can-add-stop?
-                    (let [new-stop (-> (clr/interpolate-gradient stops offset)
+                    (let [offset (mth/clamp offset 0 1)
+                          new-stop (-> (clr/interpolate-gradient stops offset)
                                        (split-color-components))
                           stops (conj stops new-stop)
                           stops (into [] (sort-by :offset stops))
@@ -973,7 +975,8 @@
                       stops (mapv split-color-components
                                   (if cap-stops?
                                     (take types.fills/MAX-GRADIENT-STOPS stops)
-                                    stops))]
+                                    stops))
+                      stops (mapv #(update % :offset (fn [o] (mth/clamp o 0 1))) stops)]
                   (-> state
                       (assoc :current-color (get stops stop))
                       (assoc :stops stops))))))))

--- a/frontend/src/app/main/store.cljs
+++ b/frontend/src/app/main/store.cljs
@@ -121,7 +121,7 @@
                    delta      (if prev-t
                                 (str "(+" (ct/diff-ms prev-t t) "ms)")
                                 "(+0ms)")
-                    delta-pad  (str/pad delta {:length 10 :type :right})]
+                   delta-pad  (str/pad delta {:length 10 :type :right})]
                (recur t
                       (next xs)
                       (conj! out (str iso "  " delta-pad "  " name))))

--- a/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
@@ -228,14 +228,15 @@
                             (mth/precision 2))]
              (swap! preview-state assoc :offset offset))))
 
-        handle-preview-down
-        (mf/use-fn
-         (mf/deps on-add-stop-preview)
-         (fn [^js e]
-           (let [offset (-> (event->offset e)
-                            (mth/precision 2))]
-             (when on-add-stop-preview
-               (on-add-stop-preview offset)))))
+         handle-preview-down
+         (mf/use-fn
+          (mf/deps on-add-stop-preview)
+          (fn [^js e]
+            (let [offset (-> (event->offset e)
+                             (mth/clamp 0 1)
+                             (mth/precision 2))]
+              (when on-add-stop-preview
+                (on-add-stop-preview offset)))))
 
         handle-stop-marker-pointer-down
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
@@ -228,15 +228,15 @@
                             (mth/precision 2))]
              (swap! preview-state assoc :offset offset))))
 
-         handle-preview-down
-         (mf/use-fn
-          (mf/deps on-add-stop-preview)
-          (fn [^js e]
-            (let [offset (-> (event->offset e)
-                             (mth/clamp 0 1)
-                             (mth/precision 2))]
-              (when on-add-stop-preview
-                (on-add-stop-preview offset)))))
+        handle-preview-down
+        (mf/use-fn
+         (mf/deps on-add-stop-preview)
+         (fn [^js e]
+           (let [offset (-> (event->offset e)
+                            (mth/clamp 0 1)
+                            (mth/precision 2))]
+             (when on-add-stop-preview
+               (on-add-stop-preview offset)))))
 
         handle-stop-marker-pointer-down
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
@@ -177,24 +177,24 @@
          (fn []
            (swap! handler-state assoc :display? false)))
 
-         points-on-pointer-down
-         (mf/use-fn
-          (mf/deps stops)
-          (fn [e]
-            (dom/prevent-default e)
-            (dom/stop-propagation e)
-            (when can-add-stop?
-              (let [raw-pt (dom/get-client-position e)
-                    position (uwvv/point->viewport raw-pt)
-                    lv (-> (gpt/to-vec from-p to-p) (gpt/unit))
-                    nv (gpt/normal-left lv)
-                    offset (-> (gsp/project-t position [from-p to-p] nv)
-                               (mth/clamp 0 1)
-                               (mth/precision 2))
-                    new-stop (cc/interpolate-gradient stops offset)
-                    stops (conj stops new-stop)
-                    stops (->> stops (sort-by :offset) (into []))]
-                (st/emit! (dc/update-colorpicker-stops stops))))))
+        points-on-pointer-down
+        (mf/use-fn
+         (mf/deps stops)
+         (fn [e]
+           (dom/prevent-default e)
+           (dom/stop-propagation e)
+           (when can-add-stop?
+             (let [raw-pt (dom/get-client-position e)
+                   position (uwvv/point->viewport raw-pt)
+                   lv (-> (gpt/to-vec from-p to-p) (gpt/unit))
+                   nv (gpt/normal-left lv)
+                   offset (-> (gsp/project-t position [from-p to-p] nv)
+                              (mth/clamp 0 1)
+                              (mth/precision 2))
+                   new-stop (cc/interpolate-gradient stops offset)
+                   stops (conj stops new-stop)
+                   stops (->> stops (sort-by :offset) (into []))]
+               (st/emit! (dc/update-colorpicker-stops stops))))))
 
         points-on-pointer-move
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
@@ -177,23 +177,24 @@
          (fn []
            (swap! handler-state assoc :display? false)))
 
-        points-on-pointer-down
-        (mf/use-fn
-         (mf/deps stops)
-         (fn [e]
-           (dom/prevent-default e)
-           (dom/stop-propagation e)
-           (when can-add-stop?
-             (let [raw-pt (dom/get-client-position e)
-                   position (uwvv/point->viewport raw-pt)
-                   lv (-> (gpt/to-vec from-p to-p) (gpt/unit))
-                   nv (gpt/normal-left lv)
-                   offset (-> (gsp/project-t position [from-p to-p] nv)
-                              (mth/precision 2))
-                   new-stop (cc/interpolate-gradient stops offset)
-                   stops (conj stops new-stop)
-                   stops (->> stops (sort-by :offset) (into []))]
-               (st/emit! (dc/update-colorpicker-stops stops))))))
+         points-on-pointer-down
+         (mf/use-fn
+          (mf/deps stops)
+          (fn [e]
+            (dom/prevent-default e)
+            (dom/stop-propagation e)
+            (when can-add-stop?
+              (let [raw-pt (dom/get-client-position e)
+                    position (uwvv/point->viewport raw-pt)
+                    lv (-> (gpt/to-vec from-p to-p) (gpt/unit))
+                    nv (gpt/normal-left lv)
+                    offset (-> (gsp/project-t position [from-p to-p] nv)
+                               (mth/clamp 0 1)
+                               (mth/precision 2))
+                    new-stop (cc/interpolate-gradient stops offset)
+                    stops (conj stops new-stop)
+                    stops (->> stops (sort-by :offset) (into []))]
+                (st/emit! (dc/update-colorpicker-stops stops))))))
 
         points-on-pointer-move
         (mf/use-fn


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Gradient stop offsets outside the valid range [0, 1] were being sent to the server, causing "invalid shape found" errors when users edited gradient strokes or fills. The shape would fail to save, blocking the user's workflow.

## Why

The `project-t` function returns unclamped parametric values. When users clicked or dragged gradient handlers near or beyond the gradient line endpoints, the calculated offset could become negative or greater than 1 (e.g., -1.56). The server schema correctly validates that offsets must be in [0, 1], but the frontend wasn't enforcing this constraint before sending the data.

## How

Added `mth/clamp` to offset calculations at three points:
1. Viewport gradient handler (`points-on-pointer-down`) - clamps offset before creating new stops
2. Colorpicker gradient preview (`handle-preview-down`) - clamps offset before adding stops
3. Data layer (`update-colorpicker-add-stop` and `update-colorpicker-stops`) - defensive clamping ensures invalid offsets are corrected even if they enter the system from other sources

This follows the existing pattern already used in `handle-marker-pointer-move`, which correctly clamps offsets.

Fixes #10879
