### PR TITLE
:bug: Fix nitrate ignores sso token expiration

### DIFF
--- a/backend/src/app/auth/oidc.clj
+++ b/backend/src/app/auth/oidc.clj
@@ -459,9 +459,10 @@
     (let [{:keys [status body]} (http/req cfg req {:skip-ssrf-check? (:skip-ssrf-check? provider)})]
       (if (= status 200)
         (let [data (json/decode body)
-              data {:token/access (get data :access_token)
-                    :token/id     (get data :id_token)
-                    :token/type   (get data :token_type)}]
+              data {:token/access     (get data :access_token)
+                    :token/id         (get data :id_token)
+                    :token/type       (get data :token_type)
+                    :token/expires-in (get data :expires_in)}]
           (l/trc :hint "access token fetched"
                  :token-id (:token/id data)
                  :token-type (:token/type data)
@@ -618,6 +619,9 @@
 
       (some? (:external-session-id state))
       (assoc :external-session-id (:external-session-id state))
+
+      (some? (:token/expires-in tdata))
+      (assoc :sso-token-exp (ct/in-future {:seconds (:token/expires-in tdata)}))
 
       ;; If state token comes with props, merge them. The state token
       ;; props can contain pm_ and utm_ prefixed query params.
@@ -899,10 +903,9 @@
           (let [organization-id (:organization-id state)
                 sso             (nitrate/call cfg :get-org-sso {:organization-id organization-id})
                 provider        (prepare-org-sso-provider cfg sso)
-                ;; verify token or throw error
-                _info           (get-info cfg provider state code)
+                info            (get-info cfg provider state code)
                 session         (session/get-session request)
-                exp             (ct/in-future {:hours 48})]
+                exp             (or (:sso-token-exp info) (ct/in-future {:hours 48}))]
             (when (and session organization-id)
               (let [props (-> (or (:props session) {})
                               (update :sso assoc organization-id exp))]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26670

## Rationale

When an organization has SSO active, Penpot caches the user's SSO authentication in the HTTP session to avoid requiring re-authentication on every request. Previously, this cache used a hardcoded 48-hour expiry, regardless of the validity period communicated by the SSO provider. This meant that a user's cached SSO session could outlive the actual token validity granted by the identity provider, creating a security gap where access could persist after the provider considers the session expired. Conversely, for providers granting shorter-lived tokens, users could be unexpectedly forced to re-authenticate.

OIDC providers communicate token validity through standard mechanisms: the `expires_in` field in the token response. These value was already being received by Penpot but discarded during token processing.

## Summary of changes

**`backend/src/app/auth/oidc.clj`**

- **`fetch-access-token`**: Capture the `expires_in` value from the OIDC token response and include it in the returned token data map as `:token/expires-in`.
- **`get-info`**: After processing user info, attach `:sso-token-exp` to the info map. Uses the token response's `expires_in` (relative seconds from now).
- **`callback-handler`** (org SSO branch): Use the provider-derived expiry (`:sso-token-exp`) for the session SSO cache entry instead of the hardcoded 48-hour value. The 48-hour duration is retained as a fallback for providers that do not supply expiry information.

**Note: A 15 minutes cache is left in place for optimization**

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
