### PR TITLE
:sparkles: Allow nitrate onboarding to be handled by admin-console

### DIFF
--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -54,7 +54,7 @@
    [:newsletter-news {:optional true} ::sm/boolean]
    [:onboarding-team-id {:optional true} ::sm/uuid]
    [:onboarding-viewed {:optional true} ::sm/boolean]
-   [:pending-nitrate-onboarding {:optional true} ::sm/boolean]
+   [:nitrate-onboarding-viewed {:optional true} ::sm/boolean]
    [:v2-info-shown {:optional true} ::sm/boolean]
    [:welcome-file-id {:optional true} [:maybe ::sm/boolean]]
    [:release-notes-viewed {:optional true}

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -54,6 +54,7 @@
    [:newsletter-news {:optional true} ::sm/boolean]
    [:onboarding-team-id {:optional true} ::sm/uuid]
    [:onboarding-viewed {:optional true} ::sm/boolean]
+   [:pending-nitrate-onboarding {:optional true} ::sm/boolean]
    [:v2-info-shown {:optional true} ::sm/boolean]
    [:welcome-file-id {:optional true} [:maybe ::sm/boolean]]
    [:release-notes-viewed {:optional true}

--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -20,19 +20,13 @@
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
-(def ^:private nitrate-entry-active-key ::nitrate-entry-active)
 (def ^:private nitrate-entry-pending-popup-key ::nitrate-entry-pending-popup)
 
 (defn activate-nitrate-entry-popup!
   []
   (binding [storage/*sync* true]
     (swap! storage/storage assoc
-           nitrate-entry-active-key true
            nitrate-entry-pending-popup-key true)))
-
-(defn nitrate-entry-active?
-  []
-  (true? (get storage/storage nitrate-entry-active-key)))
 
 (defn nitrate-entry-popup-pending?
   []
@@ -42,7 +36,6 @@
   []
   (binding [storage/*sync* true]
     (swap! storage/storage dissoc
-           nitrate-entry-active-key
            nitrate-entry-pending-popup-key)))
 
 (defn show-nitrate-popup

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -10,6 +10,7 @@
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.common :as dcm]
+   [app.main.data.nitrate :as dnt]
    [app.main.data.team :as dtm]
    [app.main.errors :as errors]
    [app.main.refs :as refs]
@@ -156,20 +157,24 @@
         props   (get profile :props)
         section (get data :name)
         team    (mf/deref refs/team)
+        nitrate-entry-active? (dnt/nitrate-entry-popup-pending?)
 
         show-question-modal?
         (and (contains? cf/flags :onboarding)
+             (not nitrate-entry-active?)
              (not (:onboarding-viewed props))
              (not (contains? props :onboarding-questions)))
 
         show-team-modal?
         (and (contains? cf/flags :onboarding)
+             (not nitrate-entry-active?)
              (not (:onboarding-viewed props))
              (not (contains? props :onboarding-team-id))
              (:is-default team))
 
         show-release-modal?
         (and (contains? cf/flags :onboarding)
+             (not nitrate-entry-active?)
              (not (contains? cf/flags :hide-release-modal))
              (:onboarding-viewed props)
              (not= (:release-notes-viewed props) (:main cf/version))

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -10,7 +10,6 @@
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.common :as dcm]
-   [app.main.data.nitrate :as dnt]
    [app.main.data.team :as dtm]
    [app.main.errors :as errors]
    [app.main.refs :as refs]
@@ -157,25 +156,20 @@
         props   (get profile :props)
         section (get data :name)
         team    (mf/deref refs/team)
-        nitrate-entry-active? (dnt/nitrate-entry-active?)
-
 
         show-question-modal?
         (and (contains? cf/flags :onboarding)
-             (not nitrate-entry-active?)
              (not (:onboarding-viewed props))
              (not (contains? props :onboarding-questions)))
 
         show-team-modal?
         (and (contains? cf/flags :onboarding)
-             (not nitrate-entry-active?)
              (not (:onboarding-viewed props))
              (not (contains? props :onboarding-team-id))
              (:is-default team))
 
         show-release-modal?
         (and (contains? cf/flags :onboarding)
-             (not nitrate-entry-active?)
              (not (contains? cf/flags :hide-release-modal))
              (:onboarding-viewed props)
              (not= (:release-notes-viewed props) (:main cf/version))

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -264,14 +264,19 @@
           (swap! storage/session dissoc :template))))))
 
 (defn- use-nitrate-entry-popup
-  [onboarding-viewed?]
-  (mf/with-effect []
-    (when (dnt/nitrate-entry-popup-pending?)
-      (dnt/consume-nitrate-entry-popup!)
-      (when (not onboarding-viewed?)
-        (st/emit! (dprof/update-profile-props {:onboarding-viewed true
-                                               :release-notes-viewed (:main cf/version)
-                                               :pending-nitrate-onboarding true})
+  [onboarding-viewed? nitrate-onboarding-viewed?]
+  (let [nitrate-popup-pending? (dnt/nitrate-entry-popup-pending?)]
+    (mf/with-effect [nitrate-popup-pending? onboarding-viewed? nitrate-onboarding-viewed?]
+      (when nitrate-popup-pending?
+        (dnt/consume-nitrate-entry-popup!)
+        (st/emit! (dprof/update-profile-props
+                   (cond-> {}
+                     (not (or nitrate-onboarding-viewed? onboarding-viewed?))
+                     (assoc :nitrate-onboarding-viewed false)
+
+                     (not onboarding-viewed?)
+                     (assoc :onboarding-viewed true
+                            :release-notes-viewed (:main cf/version))))
                   (dnt/show-nitrate-popup :nitrate-form))))))
 
 (defn- use-pending-action
@@ -327,7 +332,7 @@
 
     (use-plugin-register plugin-url team-id (:id default-project))
     (use-templates-import can-edit? template default-project)
-    (use-nitrate-entry-popup (:onboarding-viewed props))
+    (use-nitrate-entry-popup (:onboarding-viewed props) (:nitrate-onboarding-viewed props))
     (use-pending-action pending-action-id)
 
     [:& (mf/provider ctx/current-project-id) {:value project-id}

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -264,12 +264,15 @@
           (swap! storage/session dissoc :template))))))
 
 (defn- use-nitrate-entry-popup
-  []
+  [onboarding-viewed?]
   (mf/with-effect []
     (when (dnt/nitrate-entry-popup-pending?)
       (dnt/consume-nitrate-entry-popup!)
-      (st/emit! (dprof/update-profile-props {:onboarding-viewed true})
-                (dnt/show-nitrate-popup :nitrate-form)))))
+      (when (not onboarding-viewed?)
+        (st/emit! (dprof/update-profile-props {:onboarding-viewed true
+                                               :release-notes-viewed (:main cf/version)
+                                               :pending-nitrate-onboarding true})
+                  (dnt/show-nitrate-popup :nitrate-form))))))
 
 (defn- use-pending-action
   "Consumes a pending dashboard action from session storage and resumes it"
@@ -289,6 +292,7 @@
   [{:keys [profile project-id team-id search-term plugin-url template section pending-action-id]}]
   (let [team            (mf/deref refs/team)
         projects        (mf/deref refs/projects)
+        props           (get profile :props)
 
         project         (get projects project-id)
         projects        (mf/with-memo [projects team-id]
@@ -323,7 +327,7 @@
 
     (use-plugin-register plugin-url team-id (:id default-project))
     (use-templates-import can-edit? template default-project)
-    (use-nitrate-entry-popup)
+    (use-nitrate-entry-popup (:onboarding-viewed props))
     (use-pending-action pending-action-id)
 
     [:& (mf/provider ctx/current-project-id) {:value project-id}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/us/26603

### Summary

Delegates the onboarding flow to admin-console for accounts created through the pricing page. Penpot no longer shows its onboarding modals in this path; instead, users are redirected to admin-console after payment where a shortened onboarding is presented.

### Steps to reproduce 

1. Visit the pricing page and create a new account via /#/subscribe-nitrate.
2. Verify that the "Upgrade to enterprise" modal appears, no Penpot onboarding should be shown.
3. Complete the payment flow.
4. Verify that you are redirected to admin-console, where the shortened onboarding is displayed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
