### PR TITLE
:bug: Fix crash when editing justified text in wasm editor

### DIFF
--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -227,6 +227,22 @@
     :add-children    2
     :scale-content 3))
 
+(def ^:private reverse-enum
+  (memoize
+   (fn [id]
+     (let [values (unchecked-get wasm/serializers id)]
+       (reduce (fn [acc k] (assoc acc (unchecked-get values k) k))
+               {}
+               (js/Object.keys values))))))
+
+(defn- untranslate
+  "Reverse of `translate`: maps a wasm numeric discriminant back to its name.
+   Keywords (eg. `:multiple`) pass through untouched."
+  [id value default]
+  (if (keyword? value)
+    value
+    (d/nilv (get (reverse-enum id) value) default)))
+
 (defn translate-grow-type
   [grow-type]
   (let [values (unchecked-get wasm/serializers "grow-type")
@@ -239,11 +255,19 @@
         default (unchecked-get values "top")]
     (d/nilv (unchecked-get values (d/name vertical-align)) default)))
 
+(defn untranslate-vertical-align
+  [vertical-align]
+  (untranslate "vertical-align" vertical-align "top"))
+
 (defn translate-text-align
   [text-align]
   (let [values (unchecked-get wasm/serializers "text-align")
         default (unchecked-get values "left")]
     (d/nilv (unchecked-get values (d/name text-align)) default)))
+
+(defn untranslate-text-align
+  [text-align]
+  (untranslate "text-align" text-align "left"))
 
 
 ;; TODO: Find/Create a Rust enum for this
@@ -253,6 +277,10 @@
         default (unchecked-get values "none")]
     (d/nilv (unchecked-get values (d/name text-transform)) default)))
 
+(defn untranslate-text-transform
+  [text-transform]
+  (untranslate "text-transform" text-transform "none"))
+
 
 (defn translate-text-decoration
   [text-decoration]
@@ -260,11 +288,19 @@
         default (unchecked-get values "none")]
     (d/nilv (unchecked-get values (d/name text-decoration)) default)))
 
+(defn untranslate-text-decoration
+  [text-decoration]
+  (untranslate "text-decoration" text-decoration "none"))
+
 (defn translate-text-direction
   [text-direction]
   (let [values (unchecked-get wasm/serializers "text-direction")
         default (unchecked-get values "ltr")]
     (d/nilv (unchecked-get values (d/name text-direction)) default)))
+
+(defn untranslate-text-direction
+  [text-direction]
+  (untranslate "text-direction" text-direction "ltr"))
 
 
 (defn translate-font-style
@@ -278,6 +314,10 @@
       "regular" (unchecked-get values "normal")
       "italic" (unchecked-get values "italic")
       default)))
+
+(defn untranslate-font-style
+  [font-style]
+  (untranslate "font-style" font-style "normal"))
 
 (defn translate-browser
   [browser]

--- a/frontend/src/app/render_wasm/text_editor.cljs
+++ b/frontend/src/app/render_wasm/text_editor.cljs
@@ -266,53 +266,6 @@
      2 :multiple
      0)))
 
-(defn- text-editor-translate-vertical-align
-  [vertical-align]
-  (case vertical-align
-    0 "top"
-    1 "center"
-    2 "bottom"))
-
-(defn- text-editor-translate-text-align
-  [text-align]
-  (case text-align
-    0 "left"
-    1 "center"
-    2 "right"
-    text-align))
-
-(defn- text-editor-translate-text-direction
-  [text-direction]
-  (case text-direction
-    0 "ltr"
-    1 "rtl"
-    text-direction))
-
-(defn- text-editor-translate-text-transform
-  [text-transform]
-  (case text-transform
-    0 "none"
-    1 "lowercase"
-    2 "uppercase"
-    3 "capitalize"
-    text-transform))
-
-(defn- text-editor-translate-text-decoration
-  [text-decoration]
-  (case text-decoration
-    0 "none"
-    1 "underline"
-    2 "linethrough"
-    3 "overline"
-    text-decoration))
-
-(defn- text-editor-translate-font-style
-  [font-style]
-  (case font-style
-    0 "normal"
-    1 "italic"
-    font-style))
-
 (defn- text-editor-compute-font-variant-id
   [font-id font-weight font-style]
   (let [font-data (main-fonts/get-font-data font-id)
@@ -362,7 +315,7 @@
               line-height-value (aget heap-f32 (+ u32-offset 29))
               letter-spacing-value (aget heap-f32 (+ u32-offset 30))
               font-id (fonts/uuid->font-id font-family-id-value)
-              font-style-value (text-editor-translate-font-style (text-editor-get-style-property font-style-state font-style-raw-value))
+              font-style-value (sr/untranslate-font-style (text-editor-get-style-property font-style-state font-style-raw-value))
               font-variant-id-computed (text-editor-compute-font-variant-id font-id font-weight-value font-style-value)
               ;; A font variant is defined by its family + weight + style, so it
               ;; is "mixed" when any of those is mixed. When the family itself is
@@ -387,11 +340,11 @@
               selected-colors (if (= multiple-fills 1) fills nil)
               fills (if (= multiple-fills 1) :multiple fills)
 
-              result {:vertical-align (text-editor-translate-vertical-align vertical-align)
-                      :text-align (text-editor-translate-text-align (text-editor-get-style-property text-align-state text-align-value))
-                      :text-direction (text-editor-translate-text-direction (text-editor-get-style-property text-direction-state text-direction-value))
-                      :text-decoration (text-editor-translate-text-decoration (text-editor-get-style-property text-decoration-state text-decoration-value))
-                      :text-transform (text-editor-translate-text-transform (text-editor-get-style-property text-transform-state text-transform-value))
+              result {:vertical-align (sr/untranslate-vertical-align vertical-align)
+                      :text-align (sr/untranslate-text-align (text-editor-get-style-property text-align-state text-align-value))
+                      :text-direction (sr/untranslate-text-direction (text-editor-get-style-property text-direction-state text-direction-value))
+                      :text-decoration (sr/untranslate-text-decoration (text-editor-get-style-property text-decoration-state text-decoration-value))
+                      :text-transform (sr/untranslate-text-transform (text-editor-get-style-property text-transform-state text-transform-value))
                       :line-height (text-editor-get-style-property line-height-state line-height-value)
                       :letter-spacing (text-editor-get-style-property letter-spacing-state letter-spacing-value)
                       :font-size (text-editor-get-style-property font-size-state font-size-value)


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10944

### Summary

`text-editor-translate-text-align` only handled 0/1/2 (left/center/right) and had no case for 3 (justify). The raw enums coming from `text_editor_get_current_styles` were decoded with a `case` that returned the raw number when it did not match. Justify had no case, so a justified text put `:text-align 3` in the editor styles and the options sidebar threw on the `radio-buttons*` props validation ('selected' should be a string) as soon as the text was edited
