### PR TITLE
:bug: Fix crash on drag-and-drop of selected text in Draft.js editor

### DIFF
--- a/frontend/packages/draft-js/package.json
+++ b/frontend/packages/draft-js/package.json
@@ -8,7 +8,7 @@
   "author": "Andrey Antukh",
   "license": "MPL-2.0",
   "dependencies": {
-    "draft-js": "penpot/draft-js.git#ba3b26ed63a01227a3560e440531b69d79c03f35",
+    "draft-js": "penpot/draft-js.git#c58ebd9429a6359d72a88cff87e078aaf6fe285d",
     "immutable": "^5.1.9"
   },
   "peerDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
   packages/draft-js:
     dependencies:
       draft-js:
-        specifier: penpot/draft-js.git#ba3b26ed63a01227a3560e440531b69d79c03f35
-        version: https://codeload.github.com/penpot/draft-js/tar.gz/ba3b26ed63a01227a3560e440531b69d79c03f35(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: penpot/draft-js.git#c58ebd9429a6359d72a88cff87e078aaf6fe285d
+        version: https://codeload.github.com/penpot/draft-js/tar.gz/c58ebd9429a6359d72a88cff87e078aaf6fe285d(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       immutable:
         specifier: ^5.1.9
         version: 5.1.9
@@ -2895,8 +2895,8 @@ packages:
     resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
     engines: {node: '>=20.19.0'}
 
-  draft-js@https://codeload.github.com/penpot/draft-js/tar.gz/ba3b26ed63a01227a3560e440531b69d79c03f35:
-    resolution: {gitHosted: true, integrity: sha512-IN2r8sw36jcH32WPP9eBFXNglirhkFIsqgoKzwwSDxiCbeipumeKXjYB3vw82CxYRwKc+oRTMcZ5jNnCWnmnBw==, tarball: https://codeload.github.com/penpot/draft-js/tar.gz/ba3b26ed63a01227a3560e440531b69d79c03f35}
+  draft-js@https://codeload.github.com/penpot/draft-js/tar.gz/c58ebd9429a6359d72a88cff87e078aaf6fe285d:
+    resolution: {gitHosted: true, integrity: sha512-Ji/UoFEm11scM7Zbp1O+7f498Ly5zkGRCJNvxR8BRL0xhqEs1ubgckZdmopjNxi+xjepHopa5hIv9pJTRaQOgg==, tarball: https://codeload.github.com/penpot/draft-js/tar.gz/c58ebd9429a6359d72a88cff87e078aaf6fe285d}
     version: 0.11.7
     peerDependencies:
       react: '>=0.14.0'
@@ -8249,7 +8249,7 @@ snapshots:
       domelementtype: 3.0.0
       domhandler: 6.0.1
 
-  draft-js@https://codeload.github.com/penpot/draft-js/tar.gz/ba3b26ed63a01227a3560e440531b69d79c03f35(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  draft-js@https://codeload.github.com/penpot/draft-js/tar.gz/c58ebd9429a6359d72a88cff87e078aaf6fe285d(encoding@0.1.13)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       fbjs: 3.0.5(encoding@0.1.13)
       immutable: 3.8.3

--- a/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
@@ -221,7 +221,12 @@
                   state                (-> (ted/insert-text state text style)
                                            (handle-change))]
               (st/emit! (dwt/update-editor-state shape state))))
-          "handled")]
+          "handled")
+
+        handle-drop
+        (fn [_ _ drag-type]
+          (when (= drag-type "internal")
+            "handled"))]
 
     (mf/use-layout-effect on-mount)
 
@@ -246,6 +251,7 @@
        :handle-return handle-return
        :strip-pasted-styles true
        :handle-pasted-text handle-pasted-text
+       :handle-drop handle-drop
        :custom-style-fn (partial styles-fn shape)
        :block-renderer-fn #(render-block % shape)
        :ref on-editor


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

The Draft.js text editor crashes with `TypeError: Cannot read properties of undefined (reading 'getCharacterList')` when the user drags and drops selected text internally. The crash happens because after `removeRange` modifies the block map, the drop target's `SelectionState` still references block keys from the pre-removal DOM that no longer exist.

## Why

In `DraftModifier.moveText`, the flow is: extract fragment → `removeRange` → `replaceWithFragment`. The `targetRange` is computed from the DOM (via `getSelectionForEvent`) before removal happens. After `removeRange` merges or deletes blocks, the `targetRange` can point to stale keys. When `removeEntitiesAtEdges` or `insertFragmentIntoContentState` looks up these keys, it gets `undefined` and crashes calling `.getCharacterList()` on it.

This is the same class of stale-selection-key bug fixed in `c64044d265` (harden draft-js block-data helpers against nil block), but in a different code path.

## How

Two layers of defense:

1. **Event-level fix** (`editor.cljs`): Added a `handle-drop` callback that returns `"handled"` for internal drag operations, preventing Draft.js from ever calling its default `moveText` handler.

2. **Defensive fix in Draft.js fork** (`external/draft-js/lib/DraftModifier.js`): Guarded `moveText` to validate that `targetRange` keys exist in `afterRemoval`'s block map before calling `replaceWithFragment`. Returns `afterRemoval` (no-op) if keys are stale.

Fixes #10954
