### PR TITLE
:bug: Prevent MCP tokens from being used as access tokens

### DIFF
--- a/backend/src/app/rpc/commands/access_token.clj
+++ b/backend/src/app/rpc/commands/access_token.clj
@@ -37,7 +37,8 @@
   (let [token-id   (uuid/next)
         expires-at (some-> expiration (ct/in-future))
         created-at (ct/now)
-        token      (tokens/generate cfg {:iss "access-token"
+        token-iss  (if (= type "mcp") "urn:penpot:mcp-token" "access-token")
+        token      (tokens/generate cfg {:iss token-iss
                                          :uid profile-id
                                          :iat created-at
                                          :tid token-id})

--- a/backend/test/backend_tests/rpc_access_tokens_test.clj
+++ b/backend/test/backend_tests/rpc_access_tokens_test.clj
@@ -9,6 +9,7 @@
    [app.common.uuid :as uuid]
    [app.db :as db]
    [app.http :as http]
+   [app.http.access-token :as actoken]
    [app.rpc :as-alias rpc]
    [app.storage :as sto]
    [backend-tests.helpers :as th]
@@ -205,3 +206,29 @@
           (t/is (not (contains? all-ids (:id first-mcp))))
           (t/is (not (contains? all-ids (:id second-mcp))))
           (t/is (contains? all-ids (:id third-mcp))))))))
+
+(t/deftest mcp-tokens-cannot-be-used-as-access-tokens
+  (let [prof (th/create-profile* 1 {:is-active true})
+        cfg  th/*system*]
+
+    (t/testing "MCP tokens use different issuer claim"
+      (let [{:keys [result]} (th/command! {::th/type :create-access-token
+                                           ::rpc/profile-id (:id prof)
+                                           :type "mcp"
+                                           :name "mcp token"})
+            mcp-token (:token result)
+
+            ;; Try to decode as access token (should fail)
+            decoded (actoken/decode-token cfg mcp-token)]
+        (t/is (nil? decoded))))
+
+    (t/testing "Regular access tokens use access-token issuer claim"
+      (let [{:keys [result]} (th/command! {::th/type :create-access-token
+                                           ::rpc/profile-id (:id prof)
+                                           :name "regular token"})
+            access-token (:token result)
+
+            ;; Should decode successfully
+            decoded (actoken/decode-token cfg access-token)]
+        (t/is (some? decoded))
+        (t/is (= (:id prof) (:uid decoded)))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance as part of the Penpot self-improvement initiative.

## What

- MCP tokens can no longer be used as API access tokens
- Attempting to authenticate an API request with an MCP token now fails JWT validation

## Why

MCP tokens were created with the same JWT issuer claim (`access-token`) as regular access tokens, making them interchangeable. MCP tokens are designed only for identifying users in the MCP server's WebSocket connections and should not grant API access.

## How

- **Token creation**: MCP tokens now use a distinct JWT issuer claim (`urn:penpot:mcp-token`) instead of `access-token`
- **Validation**: Existing `decode-token` already only accepts `:iss "access-token"`, so MCP tokens naturally fail validation when presented as access tokens — no changes needed to the validation layer

Fixes #10960
