### PR TITLE
:bug: Fix selrect not being recalculated after pasting properties

### DIFF
--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -703,22 +703,38 @@
       ptk/WatchEvent
       (watch [_ state _]
         (let [features (get state :features)
-              selected (dsh/lookup-selected state)]
+              objects  (dsh/lookup-page-objects state)
+              selected (dsh/lookup-selected state)
+
+              ;; With WASM, pasted props change the text content but not the
+              ;; selrect, so auto-grow text shapes need an explicit relayout.
+              text-ids (into []
+                             (comp (filter #(cfh/text-shape? (get objects %)))
+                                   (filter #(not= :fixed (:grow-type (get objects %)))))
+                             selected)]
 
           (when (paste-data-valid? pdata)
             (cfeat/check-paste-features! features (:features pdata))
             (case (:type pdata)
               :copied-props
-
-              (rx/concat
-               (->> (rx/of pdata)
-                    (rx/mapcat (partial upload-images (:current-file-id state)))
-                    (rx/map
-                     #(dwsh/update-shapes
-                       selected
-                       (fn [shape objects] (cts/patch-props shape (:props pdata) objects))
-                       {:with-objects? true})))
-               (rx/of (ptk/data-event :layout/update {:ids selected})))
+              ;; Wrap in a single undo transaction so the async wasm text
+              ;; resize is bundled with the props change (one undo step).
+              (let [undo-id       (js/Symbol)
+                    resize-texts? (and (features/active-feature? state "render-wasm/v1")
+                                       (seq text-ids))]
+                (rx/concat
+                 (rx/of (dwu/start-undo-transaction undo-id))
+                 (->> (rx/of pdata)
+                      (rx/mapcat (partial upload-images (:current-file-id state)))
+                      (rx/map
+                       #(dwsh/update-shapes
+                         selected
+                         (fn [shape objects] (cts/patch-props shape (:props pdata) objects))
+                         {:with-objects? true})))
+                 (rx/of (ptk/data-event :layout/update {:ids selected}))
+                 (if resize-texts?
+                   (rx/of (dwwt/resize-wasm-text-all text-ids {:undo-id undo-id}))
+                   (rx/of (dwu/commit-undo-transaction undo-id)))))
               ;;
               (rx/empty))))))))
 

--- a/frontend/src/app/main/data/workspace/wasm_text.cljs
+++ b/frontend/src/app/main/data/workspace/wasm_text.cljs
@@ -224,21 +224,23 @@
 
 (defn resize-wasm-text-all
   "Resize all text shapes (auto-width/auto-height) from a collection of ids."
-  [ids]
-  (ptk/reify ::resize-wasm-text-all
-    ptk/WatchEvent
-    (watch [_ state stream]
-      (let [resize-stream
-            (->> (rx/from ids)
-                 (rx/map resize-wasm-text-debounce))]
-        (if (::dwsh/update-shapes-buffer state)
-          ;; If we're in the middle of a token propagation we wait until is finished to
-          ;; recalculate the text sizes. The shapes stay pending for that whole wait,
-          ;; since the per-shape debounce only marks them once dispatched.
-          (wrf/with-pending
-            :text-resize ids
-            (->> stream
-                 (rx/filter (ptk/type? ::dwsh/update-shapes-buffer-commit))
-                 (rx/take 1)
-                 (rx/mapcat (constantly resize-stream))))
-          resize-stream)))))
+  ([ids]
+   (resize-wasm-text-all ids nil))
+  ([ids opts]
+   (ptk/reify ::resize-wasm-text-all
+     ptk/WatchEvent
+     (watch [_ state stream]
+       (let [resize-stream
+             (->> (rx/from ids)
+                  (rx/map #(resize-wasm-text-debounce % opts)))]
+         (if (::dwsh/update-shapes-buffer state)
+           ;; If we're in the middle of a token propagation we wait until is finished to
+           ;; recalculate the text sizes. The shapes stay pending for that whole wait,
+           ;; since the per-shape debounce only marks them once dispatched.
+           (wrf/with-pending
+             :text-resize ids
+             (->> stream
+                  (rx/filter (ptk/type? ::dwsh/update-shapes-buffer-commit))
+                  (rx/take 1)
+                  (rx/mapcat (constantly resize-stream))))
+           resize-stream))))))


### PR DESCRIPTION
### Related Ticket

Fixes #10840 

### Summary

This fixes the selrect of a text shape not being recalculated after pasting props.

[Screencast from 2026-07-30 12-44-26.webm](https://github.com/user-attachments/assets/cace8b08-4be8-49cb-80c5-17a960847509)

_Note: We tried fixing it at commit level but it introduced a performance cost, so we're keeping the initial approach of resizing selrects adhoc_.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ x Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add/ or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
