### PR TITLE
:bug: Fix MCP issues pertaining to connection handling and task dispatching via Redis

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -272,6 +272,7 @@ The Penpot MCP server can be configured using environment variables.
 | `PENPOT_MCP_REPL_PORT`                           | Port for the REPL server (development/debugging)                           | `4403`         |
 | `PENPOT_MCP_REMOTE_MODE`                         | Enable remote mode (disables file system access). Set to `true` to enable. | `false`        |
 | `PENPOT_MCP_DEVENV`                              | Enable Penpot development environment tools. Set to `true` to enable.      | `false`        |
+| `PENPOT_MCP_TOOL_TIMEOUT_S`                      | Timeout, in seconds, for tool calls dispatched to the Penpot plugin        | `120`          |
 | `PENPOT_MCP_EXPORT_SHAPE_MAX_PARALLEL_REQUESTS`  | Maximum number of parallel export shape requests (multi-user mode only).   | `0` (no limit) |
 | `PENPOT_MCP_REDIS_URI`                           | Redis connection URI (e.g. `redis://host:6379`) enabling multi-instance horizontal scaling via Redis pub/sub task routing (multi-user mode only). When unset, the server runs in single-instance mode, requiring the plugin and MCP client to connect to the same instance. | (unset)        |
 

--- a/mcp/packages/server/src/PenpotMcpServer.ts
+++ b/mcp/packages/server/src/PenpotMcpServer.ts
@@ -127,6 +127,7 @@ export class PenpotMcpServer {
         this.webSocketPort = parseInt(process.env.PENPOT_MCP_WEBSOCKET_PORT ?? "4402", 10);
         this.replPort = parseInt(process.env.PENPOT_MCP_REPL_PORT ?? "4403", 10);
         this.tenant = process.env.PENPOT_TENANT ?? "default";
+        const toolTimeoutSecs = parseInt(process.env.PENPOT_MCP_TOOL_TIMEOUT_S ?? "120", 10);
 
         this.configLoader = new ConfigurationLoader(process.cwd());
         this.apiDocs = new ApiDocs();
@@ -147,7 +148,7 @@ export class PenpotMcpServer {
             this.redisBridge = new RedisBridge(redisUri, this.tenant);
         }
 
-        this.pluginBridge = new PluginBridge(this, this.webSocketPort, this.redisBridge);
+        this.pluginBridge = new PluginBridge(this, this.webSocketPort, toolTimeoutSecs, this.redisBridge);
         this.replServer = new ReplServer(this.pluginBridge, this.replPort, this.host);
     }
 

--- a/mcp/packages/server/src/PluginBridge.ts
+++ b/mcp/packages/server/src/PluginBridge.ts
@@ -20,6 +20,8 @@ interface ClientConnection {
  * over these connections.
  */
 export class PluginBridge {
+    public static readonly MULTIUSER_CONNECTION_ERROR_MESSAGE = `No Penpot instance connected for user token. Please ensure that Penpot is connected and that the MCP client connection is using the correct token.`;
+
     private readonly logger = createLogger("PluginBridge");
     private readonly wsServer: WebSocketServer;
     private readonly connectedClients: Map<WebSocket, ClientConnection> = new Map();
@@ -190,6 +192,35 @@ export class PluginBridge {
     }
 
     /**
+     * Rejects a still-pending task with the given error, releasing its correlation state.
+     *
+     * Clears the task's timeout (if armed) and removes the task from the pending-task
+     * index before rejecting its promise. Safe to call for a task that has already been
+     * settled (e.g. by a response or a timeout), in which case nothing happens.
+     *
+     * @param taskId - The ID of the task to reject
+     * @param error - The error with which to reject the task
+     * @returns Whether the task was still pending and has been rejected
+     */
+    private rejectPendingTask(taskId: string, error: Error): boolean {
+        const pendingTask = this.pendingTasks.get(taskId);
+        if (!pendingTask) {
+            return false;
+        }
+
+        const timeoutHandle = this.taskTimeouts.get(taskId);
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+            this.taskTimeouts.delete(taskId);
+        }
+        this.pendingTasks.delete(taskId);
+
+        pendingTask.rejectWithError(error);
+        this.logger.info(`Task ${taskId} rejected: ${error.message}`);
+        return true;
+    }
+
+    /**
      * Determines the client connection to use for executing a task.
      *
      * In single-user mode, returns the single connected client.
@@ -207,9 +238,7 @@ export class PluginBridge {
 
             const connection = this.clientsByToken.get(sessionContext.userToken);
             if (!connection) {
-                throw new Error(
-                    `No plugin instance connected for user token. Please ensure the plugin is running and connected with the correct token.`
-                );
+                throw new Error(PluginBridge.MULTIUSER_CONNECTION_ERROR_MESSAGE);
             }
 
             return connection;
@@ -257,6 +286,10 @@ export class PluginBridge {
      * `resolveWithResult`/`rejectWithError` methods. The same correlation and timeout
      * handling therefore applies regardless of the transport.
      *
+     * When routing via Redis, the task is rejected immediately (rather than timing out)
+     * if the published request reached no instance, i.e. if no instance holds a plugin
+     * connection for the session's user token, or if publishing fails outright.
+     *
      * @param task - The task to dispatch
      * @param useRedis - Whether to route the request via Redis (multi-instance) rather
      *   than directly over the local WebSocket connection
@@ -279,9 +312,17 @@ export class PluginBridge {
 
             // register the task for result correlation, then publish the request via Redis
             this.pendingTasks.set(task.id, task);
-            void redisBridge.sendTaskRequest(userToken, task.toRequest(), (response) =>
-                this.handlePluginTaskResponse(response)
-            );
+            void redisBridge
+                .sendTaskRequest(userToken, task.toRequest(), (response) => this.handlePluginTaskResponse(response))
+                .then((receiverCount) => {
+                    // fail fast when no instance received the request (no connection with matching user token in any instance)
+                    if (receiverCount === 0) {
+                        this.rejectPendingTask(task.id, new Error(PluginBridge.MULTIUSER_CONNECTION_ERROR_MESSAGE));
+                    }
+                })
+                .catch((error) => {
+                    this.rejectPendingTask(task.id, error instanceof Error ? error : new Error(String(error)));
+                });
 
             // on timeout, release the response-channel subscription, since no response
             // will arrive to trigger its self-unsubscribe.
@@ -300,14 +341,13 @@ export class PluginBridge {
 
         // Set up a timeout to reject the task if no response is received
         const timeoutHandle = setTimeout(() => {
-            const pendingTask = this.pendingTasks.get(task.id);
-            if (pendingTask) {
-                this.pendingTasks.delete(task.id);
-                this.taskTimeouts.delete(task.id);
-                onTimeout?.();
-                pendingTask.rejectWithError(
+            if (
+                this.rejectPendingTask(
+                    task.id,
                     new Error(`Task ${task.id} timed out after ${this.taskTimeoutSecs} seconds`)
-                );
+                )
+            ) {
+                onTimeout?.();
             }
         }, this.taskTimeoutSecs * 1000);
 

--- a/mcp/packages/server/src/PluginBridge.ts
+++ b/mcp/packages/server/src/PluginBridge.ts
@@ -24,6 +24,7 @@ export class PluginBridge {
 
     private readonly logger = createLogger("PluginBridge");
     private readonly wsServer: WebSocketServer;
+
     private readonly connectedClients: Map<WebSocket, ClientConnection> = new Map();
     private readonly clientsByToken: Map<string, ClientConnection> = new Map();
     private readonly pendingTasks: Map<string, AbstractPluginTask<any, any>> = new Map();
@@ -39,12 +40,13 @@ export class PluginBridge {
      *   holding the relevant plugin's WebSocket connection (which may be this same
      *   instance) via Redis, rather than dispatched directly over a local socket.
      * @param taskTimeoutSecs - Timeout, in seconds, for plugin task execution
+     *   (defaults to {@link DEFAULT_TASK_TIMEOUT_SECS})
      */
     constructor(
         public readonly mcpServer: PenpotMcpServer,
         private port: number,
-        private readonly redisBridge?: RedisBridge,
-        private taskTimeoutSecs: number = 30
+        private readonly taskTimeoutSecs: number,
+        private readonly redisBridge?: RedisBridge
     ) {
         this.wsServer = new WebSocketServer({ port: port });
         this.setupWebSocketHandlers();

--- a/mcp/packages/server/src/PluginBridge.ts
+++ b/mcp/packages/server/src/PluginBridge.ts
@@ -133,9 +133,10 @@ export class PluginBridge {
     /**
      * Removes a client connection and releases all resources associated with it.
      *
-     * Clears the per-connection keep-alive interval and removes the connection
-     * from both the socket-keyed and token-keyed indexes. Safe to call with a
-     * socket that is not (or no longer) registered.
+     * Clears the per-connection keep-alive interval and removes the connection from the
+     * socket-keyed index. The token-keyed index entry (and, in multi-instance mode, the
+     * token's Redis task subscription) is removed only if it is owned by the given
+     * connection. Safe to call with a socket that is not (or no longer) registered.
      *
      * @param ws - The WebSocket whose connection state should be removed
      */
@@ -147,12 +148,18 @@ export class PluginBridge {
         clearInterval(connection.pingInterval);
         this.connectedClients.delete(ws);
         if (connection.userToken) {
-            this.clientsByToken.delete(connection.userToken);
+            // Perform the token-keyed cleanup only if this connection owns the token registration.
+            // A connection rejected as a duplicate carries the same token but must not remove token associations.
+            if (this.clientsByToken.get(connection.userToken) !== connection) {
+                this.logger.debug("Removed connection does not own its token registration; skipping token cleanup");
+            } else {
+                this.clientsByToken.delete(connection.userToken);
 
-            if (this.redisBridge) {
-                this.redisBridge
-                    .unsubscribeFromTasks(connection.userToken)
-                    .catch((error) => this.logger.error(error, "Failed to unsubscribe from Redis task channel"));
+                if (this.redisBridge) {
+                    this.redisBridge
+                        .unsubscribeFromTasks(connection.userToken)
+                        .catch((error) => this.logger.error(error, "Failed to unsubscribe from Redis task channel"));
+                }
             }
         }
     }

--- a/mcp/packages/server/src/RedisBridge.ts
+++ b/mcp/packages/server/src/RedisBridge.ts
@@ -91,12 +91,16 @@ export class RedisBridge {
      * @param userToken - The user token identifying the target plugin's request channel
      * @param request - The serialized plugin task request, passed through verbatim
      * @param onResponse - Handler invoked with the response when it arrives
+     * @returns The number of instances that received the request. A count of 0 means no
+     *   instance is subscribed to the token's request channel (i.e. the plugin is not
+     *   connected anywhere); the request was dropped, no response will ever arrive, and
+     *   the response subscription has already been released.
      */
     async sendTaskRequest(
         userToken: string,
         request: PluginTaskRequest,
         onResponse: TaskResponseHandler
-    ): Promise<void> {
+    ): Promise<number> {
         const responseChannel = this.responseChannel(request.id);
         const requestChannel = this.requestChannel(userToken);
 
@@ -113,7 +117,19 @@ export class RedisBridge {
 
         await this.subscriber.subscribe(responseChannel);
         // publish only once the response subscription is confirmed
-        await this.publisher.publish(requestChannel, JSON.stringify(request));
+        let receiverCount: number;
+        try {
+            receiverCount = await this.publisher.publish(requestChannel, JSON.stringify(request));
+        } catch (error) {
+            // the request was never delivered, so no response can arrive
+            await this.unsubscribeFromResponse(request.id);
+            throw error;
+        }
+        if (receiverCount === 0) {
+            // no subscriber received the request, so no response can arrive
+            await this.unsubscribeFromResponse(request.id);
+        }
+        return receiverCount;
     }
 
     /**


### PR DESCRIPTION
# Summary

This PR resolves several issues in the MCP server:

* #10958  
  In multi-instance mode (where tasks are dispatched via Redis), the case where a connection from Penpot was no longer present was not correctly handled, resulting in a timeout instead of an immediate failure indicating no connected instances.
* #10961  
  Rejection of multiple connections for the same token was incorrectly handled: Removal of the duplicate connection also incorrectly removed entries for the original connection (token association, Redis association).
* #10953  
  Tool executions via the plugin connection used a timeout of 30 seconds, which was insufficient for some longer-running tasks. The timeout is now configurable via an env. variable and the default was raised to 120 seconds.
  
Additional issue which is likely fixed by these changes: #10753

NOTE: These are 3 logically separate changes, so squashing not recommended.