### PR TITLE
:bug: Fix collapsed fills section on text shapes

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
@@ -84,8 +84,10 @@
         empty-fills?   (and (not multiple?)
                             (= 0 (count fills)))
 
-        open*          (mf/use-state has-fills?)
-        open?          (deref open*)
+        ;; Derive the open state from `has-fills?` on every render so it stays
+        ;; in sync even when the fills arrive after mount (editor v3)
+        open*          (mf/use-state true)
+        open?          (and has-fills? (deref open*))
 
         toggle-content (mf/use-fn #(swap! open* not))
         open-content   (mf/use-fn #(reset! open* true))


### PR DESCRIPTION
### Related Ticket

Fixes #10860 for editor v3

### Summary

The editor v3 produces the fill when the user types, so it bypasses the usual Add fill workflow. This listens to a change on fills to open the section.

### Steps to reproduce 

See #10860 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
