### PR TITLE
:bug: Fix text align shown as left in v3 editor

### DIFF
--- a/frontend/src/app/main/data/workspace/texts_v3.cljs
+++ b/frontend/src/app/main/data/workspace/texts_v3.cljs
@@ -15,8 +15,11 @@
   (ptk/reify ::v3-update-text-editor-styles
     ptk/UpdateEvent
     (update [_ state]
-      (let [merged-styles (merge (txt/get-default-text-attrs)
-                                 (fonts/valid-default-font
-                                  (get-in state [:workspace-global :default-font]))
-                                 new-styles)]
-        (update-in state [:workspace-wasm-editor-styles id] (fnil merge {}) merged-styles)))))
+      (if (not= id (get-in state [:workspace-local :edition]))
+        state
+        (let [defaults (merge (txt/get-default-text-attrs)
+                              (fonts/valid-default-font
+                               (get-in state [:workspace-global :default-font])))]
+          (update-in state [:workspace-wasm-editor-styles id]
+                     (fn [current-styles]
+                       (merge defaults current-styles new-styles))))))))


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10928

### Summary

The v3 editor styles are the source the options sidebar reads for text shapes, but they were also written when the shape was not being edited, and every write merged the default attributes on top of the stored ones, wo a centered paragraph show up as left aligned after changing any property.

### Steps to reproduce

[screen-recorder-thu-jul-30-2026-16-05-54.webm](https://github.com/user-attachments/assets/0b66456c-3489-4715-a686-ac13d7c22571)