### PR TITLE
:bug: Add size limit and rate limiting to send-user-feedback endpoint

### DIFF
--- a/backend/resources/climit.edn
+++ b/backend/resources/climit.edn
@@ -39,4 +39,10 @@
  {:permits 3}
 
  :create-file-snapshot/by-profile
- {:permits 1 :queue 2 :timeout 60000}}
+ {:permits 1 :queue 2 :timeout 60000}
+
+ :send-user-feedback/global
+ {:permits 4}
+
+ :send-user-feedback/by-profile
+ {:permits 1 :queue 3}}

--- a/backend/src/app/rpc/commands/feedback.clj
+++ b/backend/src/app/rpc/commands/feedback.clj
@@ -14,22 +14,25 @@
    [app.db :as db]
    [app.email :as eml]
    [app.rpc :as-alias rpc]
+   [app.rpc.climit :as-alias climit]
    [app.rpc.commands.profile :as profile]
    [app.rpc.doc :as-alias doc]
    [app.util.services :as sv]))
 
 (declare ^:private send-user-feedback!)
 
-(def ^:private schema:send-user-feedback
+(def schema:send-user-feedback
   [:map {:title "send-user-feedback"}
    [:subject [:string {:max 500}]]
    [:content [:string {:max 2500}]]
    [:type {:optional true} :string]
    [:error-href {:optional true} [:string {:max 2500}]]
-   [:error-report {:optional true} :string]])
+   [:error-report {:optional true} [:string {:max 1048576}]]])
 
 (sv/defmethod ::send-user-feedback
-  {::doc/added "1.18"
+  {::climit/id [[:send-user-feedback/by-profile ::rpc/profile-id]
+                [:send-user-feedback/global]]
+   ::doc/added "1.18"
    ::sm/params schema:send-user-feedback}
   [{:keys [::db/pool]} {:keys [::rpc/profile-id] :as params}]
   (when-not (contains? cf/flags :user-feedback)

--- a/backend/test/backend_tests/rpc_feedback_test.clj
+++ b/backend/test/backend_tests/rpc_feedback_test.clj
@@ -1,0 +1,39 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns backend-tests.rpc-feedback-test
+  (:require
+   [app.common.schema :as sm]
+   [app.rpc.commands.feedback :as feedback]
+   [clojure.test :as t]))
+
+(t/deftest send-user-feedback-schema-validation
+  (let [schema feedback/schema:send-user-feedback]
+
+    (t/testing "accepts valid feedback with all fields"
+      (let [params {:subject "Test subject"
+                    :content "Test content"
+                    :type "bug"
+                    :error-href "https://example.com/error"
+                    :error-report "Error details here"}]
+        (t/is (sm/valid? schema params))))
+
+    (t/testing "accepts feedback without optional fields"
+      (let [params {:subject "Test subject"
+                    :content "Test content"}]
+        (t/is (sm/valid? schema params))))
+
+    (t/testing "accepts error-report up to 1MiB"
+      (let [params {:subject "Test subject"
+                    :content "Test content"
+                    :error-report (apply str (repeat 1048576 "x"))}]
+        (t/is (sm/valid? schema params))))
+
+    (t/testing "rejects error-report exceeding 1MiB"
+      (let [params {:subject "Test subject"
+                    :content "Test content"
+                    :error-report (apply str (repeat 1048577 "x"))}]
+        (t/is (not (sm/valid? schema params)))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Added 1MiB size limit to the `error-report` field in the send-user-feedback schema (previously unlimited)
- Added rate limiting via climit: per-profile (1 permit, queue 3) and global (4 permits)
- Made schema public to enable direct testing

## Why

The send-user-feedback endpoint allowed authenticated users to send arbitrarily large error reports and had no rate limiting, enabling email bombing attacks against Penpot's internal support channel.

## How

- **Schema constraint:** Added `:max 1048576` to `error-report` field, matching the pattern of other fields in the schema
- **Rate limiting:** Added `::climit/id` metadata with by-profile and global limits, configured in `climit.edn` following existing patterns (similar to `submit-audit-events`)
- **Tests:** Added schema validation tests covering the new size limit

Closes #10979
