### PR TITLE
:bug: Normalize error response on duplicate file ID

### DIFF
--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -748,9 +748,17 @@
     (fmigr/upsert-migrations! conn file))
 
   (let [file (encode-file cfg file)]
-    (db/insert! conn :file
-                (file->params file)
-                (assoc opts ::db/return-keys false))
+    (try
+      (db/insert! conn :file
+                  (file->params file)
+                  (assoc opts ::db/return-keys false))
+      (catch org.postgresql.util.PSQLException cause
+        (if (db/duplicate-key-error? cause)
+          (ex/raise :type :not-found
+                    :code :object-not-found
+                    :hint "file already exists"
+                    :cause cause)
+          (throw cause))))
 
     (->> (file->file-data-params file)
          (fdata/upsert! cfg))

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -141,6 +141,31 @@
         (let [result (:result out)]
           (t/is (= 0 (count result))))))))
 
+(t/deftest create-file-with-duplicate-id
+  (let [prof    (th/create-profile* 1 {:is-active true})
+        proj-id (:default-project-id prof)
+        file-id (uuid/next)]
+
+    (t/testing "create file with specific id"
+      (let [data {::th/type :create-file
+                  ::rpc/profile-id (:id prof)
+                  :project-id proj-id
+                  :id file-id
+                  :name "first-file"}
+            out  (th/command! data)]
+        (t/is (nil? (:error out)))))
+
+    (t/testing "create file with duplicate id returns normalized error"
+      (let [data {::th/type :create-file
+                  ::rpc/profile-id (:id prof)
+                  :project-id proj-id
+                  :id file-id
+                  :name "duplicate-file"}
+            out  (th/command! data)
+            err  (:error out)]
+        (t/is (th/ex-info? err))
+        (t/is (th/ex-of-type? err :not-found))))))
+
 (t/deftest file-gc-with-fragments
   (let [profile (th/create-profile* 1)
         file    (th/create-file* 1 {:profile-id (:id profile)


### PR DESCRIPTION
## What

Normalize error response when attempting to create a file with a duplicate ID.

## Why

Duplicate file ID errors returned an inconsistent error response format that differed from other error responses in the system, making error handling more difficult for clients and potentially exposing file existence information.

## How

- Capture unique constraint violation in `insert-file!`
- Return generic `:not-found` error instead of propagating raw PostgreSQL exception
- Prevent file existence oracle by returning consistent error format

Closes #11045

Note: This is an error response normalization that does not affect normal file creation workflows.