### PR TITLE
:bug: Enable SSRF check for organization SSO provider

### DIFF
--- a/backend/src/app/auth/oidc.clj
+++ b/backend/src/app/auth/oidc.clj
@@ -776,7 +776,7 @@
 
 (defn prepare-organization-sso-provider
   "Build an OIDC provider map dynamically from the Nitrate organization SSO config.
-  Uses OIDC discovery via :issuer when token/auth/user URIs are absent."
+   Uses OIDC discovery via :issuer when token/auth/user URIs are absent."
   [cfg {:keys [client-id client-secret issuer]}]
   (prepare-oidc-provider cfg
                          {:type             "oidc"
@@ -785,8 +785,7 @@
                           :base-uri         (some-> (non-blank-uri issuer)
                                                     (str/rtrim "/")
                                                     (str "/"))
-                          :scopes           default-oidc-scopes
-                          :skip-ssrf-check? true}))
+                          :scopes           default-oidc-scopes}))
 
 (defn build-organization-sso-auth-redirect-uri
   "Build the OIDC authorization redirect URI for an organization SSO config.

--- a/backend/test/backend_tests/auth_oidc_test.clj
+++ b/backend/test/backend_tests/auth_oidc_test.clj
@@ -518,3 +518,16 @@
               loc    (redirect-location result)]
           (t/is (= 302 (::yres/status result)))
           (t/is (.contains loc "error=unable-to-auth")))))))
+
+(t/deftest prepare-organization-sso-provider-does-not-skip-ssrf-check
+  (t/testing "organization SSO provider must use SSRF protection"
+    (let [captured-params (atom nil)]
+      (with-redefs [oidc/prepare-oidc-provider (fn [_cfg params]
+                                                 (reset! captured-params params)
+                                                 {:type "oidc" :id "test"})]
+        (#'oidc/prepare-organization-sso-provider {}
+                                                  {:client-id "test-client"
+                                                   :client-secret "test-secret"
+                                                   :issuer "https://idp.example.com"})
+        (t/is (not (true? (:skip-ssrf-check? @captured-params)))
+              "SSRF protection must be disabled for organization SSO")))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Removed `:skip-ssrf-check? true` from `prepare-organization-sso-provider` in `backend/src/app/auth/oidc.clj`
- Added test `prepare-organization-sso-provider-does-not-skip-ssrf-check` to verify SSRF protection is active

## Why

The `check-organization-sso` endpoint is protected by shared-key authentication (admin-console), not exposed to unauthenticated users. However, the explicit `:skip-ssrf-check? true` flag disabled SSRF protection for organization SSO validation, which is unnecessary and increases the attack surface.

Enabling SSRF protection provides defense-in-depth: if the shared key were ever compromised, an attacker could not use this endpoint to probe internal networks or access cloud metadata endpoints.

## How

- Removed `:skip-ssrf-check? true` from the provider map in `prepare-organization-sso-provider`
- Added a test that captures the params passed to `prepare-oidc-provider` and verifies `:skip-ssrf-check?` is not true

Closes #11064
