### PR TITLE
:bug: Fix Firefox not inserting emoji from MacOS Character Viewer

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -421,9 +421,15 @@
 
         on-blur
         (mf/use-fn
-         (fn [^js _event]
-           (sync-wasm-text-editor-content! {:finalize? true})
-           (wasm.api/text-editor-blur)))
+         (fn [^js event]
+           ;; MacOS Character Viewer on Firefox fires a `blur` when it opens.
+           ;; To avoid losing the selected character, we need guard against
+           ;; `activeElement` being the surface itself.
+           (when-not (and (some? event)
+                          (= (.-activeElement js/document)
+                             (mf/ref-val contenteditable-ref)))
+             (sync-wasm-text-editor-content! {:finalize? true})
+             (wasm.api/text-editor-blur))))
 
         style #js {:pointerEvents "all"
                    "--editor-container-width" (dm/str width "px")


### PR DESCRIPTION
### Related Ticket

Fixes #11030 

### Summary

MacOS Character Viewer on Firefox triggers a `blur` event, which was messing with our teardown code.

https://github.com/user-attachments/assets/afd49226-ee13-43ae-9c85-4e5f00d9dc80

### Steps to reproduce 

See #11030 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
