### PR TITLE
:books: Fix the devenv backend-flags instructions

### DIFF
--- a/docs/technical-guide/developer/devenv.md
+++ b/docs/technical-guide/developer/devenv.md
@@ -419,16 +419,28 @@ After creating or modifying this file, **reload the browser** (no need to restar
 ### Backend flags via PENPOT_FLAGS
 
 Backend feature flags are controlled through the `PENPOT_FLAGS` environment
-variable using the same `enable-<flag>` / `disable-<flag>` format. You can set
-this in the `docker/devenv/docker-compose.yaml` file under the `main` service
-`environment` section:
+variable using the same `enable-<flag>` / `disable-<flag>` format. The devenv
+sets its own list in `backend/scripts/_env`.
 
-```yaml
-environment:
-  - PENPOT_FLAGS=enable-access-tokens enable-mcp
+To change that list for your checkout, create `backend/scripts/_env.local`.
+`backend/scripts/start-dev` sources it immediately after `_env`, and the file
+is gitignored, so your override never appears in `git status`:
+
+```bash
+export PENPOT_FLAGS="$PENPOT_FLAGS enable-access-tokens enable-mcp"
 ```
 
-This requires **restarting the backend** to take effect.
+Flags are applied left to right and the last entry wins, so appending to
+`$PENPOT_FLAGS` both adds flags and switches off ones that `_env` enables:
+`disable-demo-users` at the end turns off the demo users that `_env` enables
+earlier.
+
+Setting `PENPOT_FLAGS` in the container environment does not work for this,
+because `_env` expands the inherited value *before* its own list. Any flag it
+sets afterwards wins over yours.
+
+This requires **restarting the backend** to take effect: stop the process in
+the `backend` tmux window and run `./scripts/start-dev` again.
 
 > **Note**: Some features (e.g., access tokens, webhooks) need both frontend and
 > backend flags enabled to work end-to-end. The frontend flag enables the UI, while


### PR DESCRIPTION
## Why

`docs/technical-guide/developer/devenv.md` §"Backend flags via PENPOT_FLAGS" tells readers to set `PENPOT_FLAGS` in `docker/devenv/docker-compose.yaml`. That file was deleted by #9906, which split the devenv compose into `docker-compose.infra.yml` and `docker-compose.main.yml`. The same page already names both replacements in its architecture section, so only this one section was missed.

Following the current instructions also fails silently even if you find the right compose file. `backend/scripts/_env` builds `PENPOT_FLAGS` by expanding the inherited value *first* and appending the devenv list after it, and `flags/parse` applies flags left to right with the last entry winning. Anything set in the container environment is therefore overridden by `_env` for any flag the two have in common.

## What

Document the mechanism that works: `backend/scripts/_env.local`, which `backend/scripts/start-dev` sources immediately after `_env` and which `.gitignore` already covers. Because it is sourced last, appending to `$PENPOT_FLAGS` there can both add a flag and switch off one that `_env` enables.

Also spell out what "restarting the backend" means in the devenv, since the page never says.

No behaviour change, documentation only.
