### PR TITLE
:bug: Fix serialization of constraints

### DIFF
--- a/frontend/src/app/render_wasm/api/shapes.cljs
+++ b/frontend/src/app/render_wasm/api/shapes.cljs
@@ -110,13 +110,9 @@
 
           blend-mode   (sr/translate-blend-mode (get shape :blend-mode))
           constraint-h (let [c (get shape :constraints-h)]
-                         (if (some? c)
-                           (sr/translate-constraint-h c)
-                           CONSTRAINT-NONE))
+                         (sr/translate-constraint-h c))
           constraint-v (let [c (get shape :constraints-v)]
-                         (if (some? c)
-                           (sr/translate-constraint-v c)
-                           CONSTRAINT-NONE))
+                         (sr/translate-constraint-v c))
 
           opacity      (d/nilv (get shape :opacity) 1.0)
           rotation     (d/nilv (get shape :rotation) 0.0)

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -116,13 +116,13 @@
 (defn translate-constraint-h
   [type]
   (let [values (unchecked-get wasm/serializers "constraint-h")
-        default 5] ;; TODO: fix code in rust so we have a proper None variant
+        default (unchecked-get values "none")]
     (d/nilv (unchecked-get values (d/name type)) default)))
 
 (defn translate-constraint-v
   [type]
   (let [values (unchecked-get wasm/serializers "constraint-v")
-        default 5] ;; TODO: fix code in rust so we have a proper None variant
+        default (unchecked-get values "none")]
     (d/nilv (unchecked-get values (d/name type)) default)))
 
 (defn translate-bool-type

--- a/render-wasm/src/wasm/layouts/constraints.rs
+++ b/render-wasm/src/wasm/layouts/constraints.rs
@@ -7,11 +7,12 @@ use crate::with_current_shape_mut;
 #[repr(u8)]
 #[allow(dead_code)]
 pub enum RawConstraintH {
-    Left = 0,
-    Right = 1,
-    Leftright = 2, // odd casing to comply with cljs value
-    Center = 3,
-    Scale = 4,
+    None = 0,
+    Left = 1,
+    Right = 2,
+    Leftright = 3, // odd casing to comply with cljs value
+    Center = 4,
+    Scale = 5,
 }
 
 impl From<u8> for RawConstraintH {
@@ -20,14 +21,15 @@ impl From<u8> for RawConstraintH {
     }
 }
 
-impl From<RawConstraintH> for ConstraintH {
+impl From<RawConstraintH> for Option<ConstraintH> {
     fn from(value: RawConstraintH) -> Self {
         match value {
-            RawConstraintH::Left => ConstraintH::Left,
-            RawConstraintH::Right => ConstraintH::Right,
-            RawConstraintH::Leftright => ConstraintH::LeftRight,
-            RawConstraintH::Center => ConstraintH::Center,
-            RawConstraintH::Scale => ConstraintH::Scale,
+            RawConstraintH::None => None,
+            RawConstraintH::Left => Some(ConstraintH::Left),
+            RawConstraintH::Right => Some(ConstraintH::Right),
+            RawConstraintH::Leftright => Some(ConstraintH::LeftRight),
+            RawConstraintH::Center => Some(ConstraintH::Center),
+            RawConstraintH::Scale => Some(ConstraintH::Scale),
         }
     }
 }
@@ -36,11 +38,12 @@ impl From<RawConstraintH> for ConstraintH {
 #[repr(u8)]
 #[allow(dead_code)]
 pub enum RawConstraintV {
-    Top = 0,
-    Bottom = 1,
-    Topbottom = 2, // odd casing to comply with cljs value
-    Center = 3,
-    Scale = 4,
+    None = 0,
+    Top = 1,
+    Bottom = 2,
+    Topbottom = 3, // odd casing to comply with cljs value
+    Center = 4,
+    Scale = 5,
 }
 
 impl From<u8> for RawConstraintV {
@@ -49,14 +52,15 @@ impl From<u8> for RawConstraintV {
     }
 }
 
-impl From<RawConstraintV> for ConstraintV {
+impl From<RawConstraintV> for Option<ConstraintV> {
     fn from(value: RawConstraintV) -> Self {
         match value {
-            RawConstraintV::Top => ConstraintV::Top,
-            RawConstraintV::Bottom => ConstraintV::Bottom,
-            RawConstraintV::Topbottom => ConstraintV::TopBottom,
-            RawConstraintV::Center => ConstraintV::Center,
-            RawConstraintV::Scale => ConstraintV::Scale,
+            RawConstraintV::None => None,
+            RawConstraintV::Top => Some(ConstraintV::Top),
+            RawConstraintV::Bottom => Some(ConstraintV::Bottom),
+            RawConstraintV::Topbottom => Some(ConstraintV::TopBottom),
+            RawConstraintV::Center => Some(ConstraintV::Center),
+            RawConstraintV::Scale => Some(ConstraintV::Scale),
         }
     }
 }
@@ -64,16 +68,16 @@ impl From<RawConstraintV> for ConstraintV {
 #[no_mangle]
 pub extern "C" fn set_shape_constraint_h(constraint: u8) {
     with_current_shape_mut!(state, |shape: &mut Shape| {
-        let constraint = RawConstraintH::from(constraint);
-        shape.set_constraint_h(Some(constraint.into()));
+        let constraint: Option<ConstraintH> = RawConstraintH::from(constraint).into();
+        shape.set_constraint_h(constraint);
     });
 }
 
 #[no_mangle]
 pub extern "C" fn set_shape_constraint_v(constraint: u8) {
     with_current_shape_mut!(state, |shape: &mut Shape| {
-        let constraint = RawConstraintV::from(constraint);
-        shape.set_constraint_v(Some(constraint.into()));
+        let constraint: Option<ConstraintV> = RawConstraintV::from(constraint).into();
+        shape.set_constraint_v(constraint);
     });
 }
 

--- a/render-wasm/src/wasm/shapes/base_props.rs
+++ b/render-wasm/src/wasm/shapes/base_props.rs
@@ -14,7 +14,6 @@ use super::RawShapeType;
 
 const FLAG_CLIP_CONTENT: u8 = 0b0000_0001;
 const FLAG_HIDDEN: u8 = 0b0000_0010;
-const CONSTRAINT_NONE: u8 = 0xFF;
 
 const RAW_BASE_PROPS_SIZE: usize = std::mem::size_of::<RawBasePropsData>();
 
@@ -87,19 +86,11 @@ impl RawBasePropsData {
     }
 
     fn constraint_h(&self) -> Option<ConstraintH> {
-        if self.constraint_h == CONSTRAINT_NONE {
-            None
-        } else {
-            Some(RawConstraintH::from(self.constraint_h).into())
-        }
+        RawConstraintH::from(self.constraint_h).into()
     }
 
     fn constraint_v(&self) -> Option<ConstraintV> {
-        if self.constraint_v == CONSTRAINT_NONE {
-            None
-        } else {
-            Some(RawConstraintV::from(self.constraint_v).into())
-        }
+        RawConstraintV::from(self.constraint_v).into()
     }
 }
 
@@ -219,10 +210,10 @@ mod tests {
         bytes[33] = FLAG_CLIP_CONTENT | FLAG_HIDDEN;
         // blend_mode = Overlay (15)
         bytes[34] = 15;
-        // constraint_h = Center (3)
-        bytes[35] = 3;
-        // constraint_v = Scale (4)
-        bytes[36] = 4;
+        // constraint_h = Center (4)
+        bytes[35] = 4;
+        // constraint_v = Scale (5)
+        bytes[36] = 5;
         // opacity
         bytes[40..44].copy_from_slice(&0.5_f32.to_le_bytes());
         // rotation


### PR DESCRIPTION
### Related Ticket

#11080 

### Summary

This introduces a proper `None` variant to the `RawConstraintH` and `RawConstraintV` and fixes a serialization bug due to working around this.

### Steps to reproduce 

Create a shape with constraints and check that it works as expected.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
