### PR TITLE
:bug: Fix plugin modal z index

### DIFF
--- a/plugins/apps/composable-test-suite/package.json
+++ b/plugins/apps/composable-test-suite/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "composable-test-suite",
-  "private": true,
-  "version": "1.0.0",
-  "type": "module",
-  "scripts": {
-    "start": "vite build --watch",
-    "init": "pnpm run build && pnpm run start",
-    "build": "tsc && vite build",
-    "build:headless": "vite build --config vite.config.headless.ts",
-    "test:ci": "pnpm run build:headless && tsx ci/run-ci.ts",
-    "preview": "vite preview",
-    "bootstrap": "pnpm install --ignore-workspace && pnpm run build && pnpm run start",
-    "types:check": "tsc --noEmit",
-    "fmt": "prettier --write src ci index.html",
-    "clean": "rm -rf dist/"
-  },
-  "dependencies": {
-    "@penpot/plugin-styles": "1.4.2",
-    "@penpot/plugin-types": "1.4.2"
-  },
-  "devDependencies": {
-    "playwright": "^1.62.1",
-    "prettier": "^3.9.6",
-    "typescript": "^5.9.3",
-    "vite": "^8.2.0",
-    "vite-live-preview": "^0.4.0"
-  },
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
+    "name": "composable-test-suite",
+    "private": true,
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "vite build --watch",
+        "init": "pnpm run build && pnpm run start",
+        "build": "tsc && vite build",
+        "build:headless": "vite build --config vite.config.headless.ts",
+        "test:ci": "pnpm run build:headless && tsx ci/run-ci.ts",
+        "preview": "vite preview",
+        "bootstrap": "pnpm install --ignore-workspace && pnpm run build && pnpm run start",
+        "types:check": "tsc --noEmit",
+        "fmt": "prettier --write src ci index.html",
+        "clean": "rm -rf dist/"
+    },
+    "dependencies": {
+        "@penpot/plugin-styles": "1.4.2",
+        "@penpot/plugin-types": "1.4.2"
+    },
+    "devDependencies": {
+        "playwright": "^1.62.1",
+        "prettier": "^3.9.6",
+        "typescript": "^5.9.3",
+        "vite": "^8.2.0",
+        "vite-live-preview": "^0.4.0"
+    },
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
 }

--- a/plugins/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
+++ b/plugins/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
@@ -6,7 +6,8 @@ import { dragHandler } from '../drag-handler.js';
 import modalCss from './plugin.modal.css?inline';
 import { resizeModal } from '../create-modal.js';
 
-const MIN_Z_INDEX = 3;
+const MIN_Z_INDEX = 300;
+const Z_INDEX_VAR = '--z-index-set';
 
 export class PluginModalElement extends HTMLElement {
   constructor() {
@@ -43,7 +44,16 @@ export class PluginModalElement extends HTMLElement {
         return Number(modal.style.zIndex);
       });
 
-    const maxZIndex = Math.max(...zIndexModals, MIN_Z_INDEX);
+    // Read the application z-index scale via the inherited CSS custom property
+    // `--z-index-set` (defined on :root). Custom properties pierce shadow DOM
+    // boundaries, so the value is available even though the modal uses a Shadow
+    // root. Falls back to MIN_Z_INDEX when the variable is unset or unparseable
+    // (e.g. when the runtime is used outside the Penpot app shell).
+    const declared = getComputedStyle(this).getPropertyValue(Z_INDEX_VAR).trim();
+    const parsed = Number(declared);
+    const baseZIndex = Number.isFinite(parsed) && parsed > 0 ? parsed : MIN_Z_INDEX;
+
+    const maxZIndex = Math.max(...zIndexModals, baseZIndex);
 
     this.style.zIndex = (maxZIndex + 1).toString();
   }

--- a/plugins/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
+++ b/plugins/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
@@ -49,9 +49,12 @@ export class PluginModalElement extends HTMLElement {
     // boundaries, so the value is available even though the modal uses a Shadow
     // root. Falls back to MIN_Z_INDEX when the variable is unset or unparseable
     // (e.g. when the runtime is used outside the Penpot app shell).
-    const declared = getComputedStyle(this).getPropertyValue(Z_INDEX_VAR).trim();
+    const declared = getComputedStyle(this)
+      .getPropertyValue(Z_INDEX_VAR)
+      .trim();
     const parsed = Number(declared);
-    const baseZIndex = Number.isFinite(parsed) && parsed > 0 ? parsed : MIN_Z_INDEX;
+    const baseZIndex =
+      Number.isFinite(parsed) && parsed > 0 ? parsed : MIN_Z_INDEX;
 
     const maxZIndex = Math.max(...zIndexModals, baseZIndex);
 


### PR DESCRIPTION
### Related Ticket

The plugins modal appears under left sidebar due harcoded z-index-value. 
I used the modal z-index value defined on the css and a default fallback value of 300. 

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
