### PR TITLE
:bug: Invalidate all sessions on profile deletion

### DIFF
--- a/backend/src/app/http/session.clj
+++ b/backend/src/app/http/session.clj
@@ -226,6 +226,14 @@
     (-> (db/exec-one! cfg [sql (:profile-id session) (:id session)])
         (db/get-update-count))))
 
+(defn invalidate-all
+  "Delete all sessions for a given profile. Used when a profile is deleted
+  to ensure immediate access revocation across all devices."
+  [cfg profile-id]
+  (let [sql "delete from http_session_v2 where profile_id = ?"]
+    (-> (db/exec-one! cfg [sql profile-id])
+        (db/get-update-count))))
+
 (def ^:private sql:clear-organization-sso-sessions
   (str "UPDATE http_session_v2 "
        "SET props = props #- ARRAY['~:sso', ?]::text[] "

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -534,6 +534,10 @@
                                 :deleted-at deleted-at
                                 :id profile-id}})
 
+    ;; Invalidate all sessions for this profile to ensure immediate
+    ;; access revocation across all devices
+    (session/invalidate-all cfg profile-id)
+
     (-> (rph/wrap nil)
         (rph/with-transform (session/delete-fn cfg)))))
 

--- a/backend/test/backend_tests/rpc_profile_test.clj
+++ b/backend/test/backend_tests/rpc_profile_test.clj
@@ -388,6 +388,31 @@
     (let [result (th/run-task! :objects-gc {:min-age 0})]
       (t/is (= 10 (:processed result))))))
 
+(t/deftest profile-deletion-invalidates-all-sessions
+  (let [prof (th/create-profile* 1)
+
+        ;; Insert 3 sessions for this profile directly into the database
+        session-ids (doall
+                     (for [i (range 3)]
+                       (let [sid (uuid/random)]
+                         (th/db-exec-one! ["INSERT INTO http_session_v2 (id, profile_id, user_agent) VALUES (?, ?, ?)"
+                                           sid (:id prof) (str "user-agent-" i)])
+                         sid)))]
+
+    ;; Verify sessions exist
+    (let [count-before (:count (th/db-exec-one! ["SELECT count(*) FROM http_session_v2 WHERE profile_id = ?" (:id prof)]))]
+      (t/is (= 3 count-before)))
+
+    ;; Request profile to be deleted
+    (let [params {::th/type :delete-profile
+                  ::rpc/profile-id (:id prof)}
+          out    (th/command! params)]
+      (t/is (nil? (:error out))))
+
+    ;; Verify ALL sessions were invalidated (not just one)
+    (let [count-after (:count (th/db-exec-one! ["SELECT count(*) FROM http_session_v2 WHERE profile_id = ?" (:id prof)]))]
+      (t/is (= 0 count-after)))))
+
 
 (t/deftest email-blacklist-1
   (t/is (false? (email.blacklist/enabled? th/*system*)))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- All active sessions for a profile are now invalidated when the account is deleted
- Previously, only the session that initiated the deletion was invalidated; other sessions on different devices remained functional

## Why

When a user deletes their account, the expectation is that access is immediately revoked across all devices. The previous behavior only invalidated the current session, leaving other sessions active until the background cleanup task eventually removed the profile data. This is inconsistent with the password change flow, which already correctly invalidates all other sessions.

## How

- **New helper**: Added `session/invalidate-all` in `app.http.session` that deletes all `http_session_v2` rows for a given `profile_id`
- **delete-profile**: Calls `session/invalidate-all` before the response transform, ensuring all sessions are removed regardless of which device initiated the deletion

Closes #11114
