### PR TITLE
:bug: Use random UUIDs for share link IDs

### DIFF
--- a/backend/src/app/rpc/commands/files_share.clj
+++ b/backend/src/app/rpc/commands/files_share.clj
@@ -43,7 +43,7 @@
   [conn {:keys [profile-id file-id pages who-comment who-inspect]}]
   (let [pages (db/create-array conn "uuid" pages)
         slink (db/insert! conn :share-link
-                          {:id (uuid/next)
+                          {:id (uuid/random)
                            :file-id file-id
                            :who-comment who-comment
                            :who-inspect who-inspect


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Share link IDs are now generated with UUIDv4 (cryptographically random) instead of UUIDv8 (predictable)
- Share links function as capability secrets — anyone possessing the ID can read a file without authentication

## Why

The previous UUIDv8 scheme uses 56 bits fixed per process plus a 48-bit timestamp, making share-link IDs substantially more predictable than genuine random UUIDs. Since the share-id is the sole access control mechanism for shared file links, it requires genuine unpredictability.

## How

- Changed `uuid/next` to `uuid/random` in `create-share-link` (`backend/src/app/rpc/commands/files_share.clj`)
- Existing share-links are unaffected; only newly created share-links use UUIDv4

Closes #11116
