### PR TITLE
:bug: Add timeout to plugin manifest fetch

### DIFF
--- a/frontend/src/app/main/data/plugins.cljs
+++ b/frontend/src/app/main/data/plugins.cljs
@@ -39,6 +39,7 @@
                     :uri plugin-url
                     :omit-default-headers true
                     :response-type :json})
+       (rx/timeout 15000)
        (rx/map :body)
        (rx/map #(preg/parse-manifest plugin-url %))))
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Plugin manifest fetch now times out after 15 seconds instead of hanging indefinitely

## Why

If a user enters a URL that accepts the connection but never responds, the plugin installation flow would hang until the user manually closed the modal.

## How

- Added `rx/timeout 15000` to the `fetch-manifest` observable chain in `frontend/src/app/main/data/plugins.cljs`
- The existing error handling already displays a user-facing error message for network failures

Closes #11119
