### PR TITLE
:bug: Use constant-time comparison for shared key authentication

### DIFF
--- a/backend/src/app/http/middleware.clj
+++ b/backend/src/app/http/middleware.clj
@@ -24,7 +24,8 @@
   (:import
    io.undertow.server.RequestTooBigException
    java.io.InputStream
-   java.io.OutputStream))
+   java.io.OutputStream
+   java.security.MessageDigest))
 
 (set! *warn-on-reflection* true)
 
@@ -329,6 +330,11 @@
   {:name ::auth
    :compile (constantly wrap-auth)})
 
+(defn- constant-time-eq?
+  "Compare strings in constant time to prevent timing attacks."
+  [^String a ^String b]
+  (MessageDigest/isEqual (.getBytes a "UTF-8") (.getBytes b "UTF-8")))
+
 (defn- wrap-shared-key-auth
   [handler keys]
   (if (seq keys)
@@ -338,7 +344,7 @@
         (let [key-id (-> key-id str/lower keyword)]
           (if (and (string? key)
                    (contains? keys key-id)
-                   (= key (get keys key-id)))
+                   (constant-time-eq? key (get keys key-id)))
             (-> request
                 (assoc ::http/auth-key-id key-id)
                 (handler))


### PR DESCRIPTION
## What

- Replace timing-vulnerable string comparison with constant-time comparison in shared key authentication middleware

## Why

The shared key authentication middleware used the standard `=` operator which terminates on the first mismatch, making it theoretically vulnerable to timing attacks. While exploitation requires high-precision timing measurements and many samples, this is a well-documented vulnerability class.

## How

- Added `constant-time-eq?` helper using `java.security.MessageDigest/isEqual`
- Replaced `=` comparison in `wrap-shared-key-auth` with the new helper

Closes #11121