### PR TITLE
:bug: Repair the create-font-variant ownership test and lint warning

### DIFF
--- a/backend/src/app/rpc/commands/fonts.clj
+++ b/backend/src/app/rpc/commands/fonts.clj
@@ -144,7 +144,7 @@
                 [:process-font/global]]
    ::webhooks/event? true
    ::sm/params schema:create-font-variant}
-  [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id team-id font-id uploads] :as params}]
+  [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id team-id font-id] :as params}]
   (teams/check-edition-permissions! pool profile-id team-id)
   (check-font-team-ownership! pool team-id font-id)
   (quotes/check! cfg {::quotes/id ::quotes/font-variants-per-team

--- a/backend/test/backend_tests/rpc_font_test.clj
+++ b/backend/test/backend_tests/rpc_font_test.clj
@@ -623,27 +623,29 @@
                       (io/read*))]
 
       ;; prof1 creates a font variant in team1 with font-id
-      (let [params {::th/type :create-font-variant
+      (let [session-id (upload-font-chunked! prof1 data "font/ttf" (* 4 1024 1024))
+            params {::th/type :create-font-variant
                     ::rpc/profile-id (:id prof1)
                     :team-id     team1
                     :font-id     font-id
                     :font-family "SharedFont"
                     :font-weight 400
                     :font-style  "normal"
-                    :data        {"font/ttf" data}}
+                    :uploads     {"font/ttf" session-id}}
             out    (th/command! params)]
         (t/is (nil? (:error out))))
 
       ;; prof2 tries to create a variant using the same font-id but
-      ;; in team2 — must be rejected because font-id belongs to team1
-      (let [params {::th/type :create-font-variant
+      ;; in team2, which must be rejected because font-id belongs to team1
+      (let [session-id (upload-font-chunked! prof2 data "font/ttf" (* 4 1024 1024))
+            params {::th/type :create-font-variant
                     ::rpc/profile-id (:id prof2)
                     :team-id     team2
                     :font-id     font-id
                     :font-family "SharedFont"
                     :font-weight 700
                     :font-style  "normal"
-                    :data        {"font/ttf" data}}
+                    :uploads     {"font/ttf" session-id}}
             out    (th/command! params)]
         (t/is (some? (:error out)))
         (t/is (= :not-found (-> out :error ex-data :type)))


### PR DESCRIPTION
_This work was produced with the help of language models._

### Related Ticket

Fallout from #11014, found while running CI on another branch.

### Summary

Two fixes in `create-font-variant`. Both arrived with #11014, and between them they stop the Backend workflow reaching a green state on any branch based on `develop`. Neither is related to any feature of mine.

**The `create-font-variant-rejects-foreign-font-id` regression test never exercised the control it guards.** It is the N2-07 regression test for the BOLA finding, and it sends `:data`, a param that no longer exists: `aeedb96260` (#10767) removed it on 5 August, in favour of the upload sessions the chunked-upload API returns. Both of the test's requests are therefore rejected by params validation, before `check-font-team-ownership!` is ever called.

That is worth stating plainly, because the shape of the failure is misleading. Of the test's four assertions, three fail and **one passes for the wrong reason**: `(t/is (some? (:error out)))` is satisfied by the validation rejection just as well as by the ownership rejection it was written for. A reader skimming the diff sees a security test present and asserting; what runs is a test that cannot distinguish a working control from a missing one.

The test now uploads through `upload-font-chunked!`, the helper the rest of the namespace already uses, and passes the session id in `:uploads`. With that, the assertions execute against the control for the first time and it holds: `prof1` creates the variant in `team1`, `prof2` is refused the same `font-id` in `team2` with `:not-found` / `:object-not-found`, raised by `check-font-team-ownership!`.

**`clj-kondo` fails the Lint step.** `create-font-variant` destructures `uploads` and never reads it, because the handler passes the whole `params` map to `prepare-font-data-from-uploads`. `clj-kondo` exits 2 on the unused binding. The Lint step runs before the tests, so the backend suite does not run at all.

### Why neither has been reported

`develop` has not run the Backend workflow since these landed.

| event | time (UTC) | ref |
|---|---|---|
| #11014 opened, `:data` still live | 2026-08-03 16:33 | — |
| `:data` removed from the schema | 2026-08-05 07:41 | `aeedb96260` (#10767) |
| #11014 merged into `staging`, still sending `:data` | 2026-08-06 16:32 | `0702363b5c` |
| `staging` merged into `develop` | 2026-08-06 18:55 | `88697794ce` |
| last Backend run on `develop` | 2026-08-06 14:13 | `38b990ef90` |

The merge into `develop` triggered no Backend run, so the first execution of this code anywhere was on a downstream branch.

### Verifications

| check | before | after |
|---|---|---|
| `clj-kondo --parallel --lint ../common/src/ src/` | 1 warning, exit 2 | 0 warnings |
| `cljfmt check --parallel=true src/ test/` | clean | clean |
| `backend-tests.rpc-font-test` | 16 tests, 168 assertions, 3 failures | 16 tests, 172 assertions, 0 failures |
| `check-font-team-ownership!` reached by the test | no | yes |

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. *(nothing visible)*
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable. *(repairs an existing backend test)*
- [x] Refactor any modified SCSS files following the refactor guide. *(no SCSS touched)*
- [x] Check CI passes successfully. *(Backend Tests green; this branch touches only `backend/`, so the other suites are not triggered)*

AI-assisted-by: mixed models
