### PR TITLE
:bug: Fix text layer bounds clipping glyph

### DIFF
--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1071,10 +1071,15 @@ impl Shape {
     }
 
     fn own_extrect_bounds(&self) -> Bounds {
+        self.expand_own_bounds(self.own_base_bounds())
+    }
+
+    /// The shape's own geometry bounds, before stroke/shadow/blur margins.
+    fn own_base_bounds(&self) -> Bounds {
         let shape = self;
         let max_stroke = Stroke::max_bounds_width(shape.strokes.iter(), shape.is_open());
 
-        let mut bounds = match &shape.shape_type {
+        match &shape.shape_type {
             Type::Path(_) | Type::Bool(_) => {
                 if let Some(path) = shape.get_skia_path() {
                     let cap_margin = shape.cap_bounds_margin();
@@ -1091,9 +1096,12 @@ impl Shape {
                 text_content.calculate_bounds(shape, false)
             }
             _ => shape.calculate_bounds(false),
-        };
+        }
+    }
 
-        bounds = self.apply_stroke_bounds(bounds, max_stroke);
+    fn expand_own_bounds(&self, bounds: Bounds) -> Bounds {
+        let max_stroke = Stroke::max_bounds_width(self.strokes.iter(), self.is_open());
+        let mut bounds = self.apply_stroke_bounds(bounds, max_stroke);
         bounds = self.apply_shadow_bounds(bounds);
         bounds = self.apply_blur_bounds(bounds);
         bounds
@@ -1104,7 +1112,15 @@ impl Shape {
     /// first). Includes shadow/blur margins, so it is also a valid input bound
     /// for a layer whose paint carries an image filter.
     pub fn layer_bounds(&self) -> math::Rect {
-        self.own_extrect_bounds().to_rect()
+        let mut bounds = self.own_base_bounds();
+
+        if matches!(self.shape_type, Type::Text(_)) {
+            let mut rect = bounds.to_rect();
+            rect.join(self.selrect);
+            bounds = Bounds::from_rect(&rect);
+        }
+
+        self.expand_own_bounds(bounds).to_rect()
     }
 
     fn calculate_extrect_uncached(&self, shapes_pool: ShapesPoolRef, scale: f32) -> math::Rect {


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10046

### Summary

This PR fixes bounds affecting emoji with non auto-width setting

### Steps to reproduce 

- Import this file: [emoji_boards.zip](https://github.com/user-attachments/files/30828486/emoji_boards.zip)
- Enable `enable-wasm-export` penpot flag and `enable-feature-wasm-export` config flag
- Export the file to PDF
- The "check" emoji should not be clipped

<img width="1566" height="1148" alt="image" src="https://github.com/user-attachments/assets/6783913e-6ba7-49a2-80ed-5301df61ff67" />
 
