### PR TITLE
:bug: Use a single translation key for the Mixed values label

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
@@ -723,7 +723,7 @@
                                 :id id
                                 :class inner-class
                                 :placeholder (if is-multiple?
-                                               (tr "labels.mixed-values")
+                                               (tr "settings.multiple")
                                                placeholder)
                                 :default-value (fmt/format-number (or (mf/ref-val last-value*) value))
                                 :on-blur handle-blur

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -296,7 +296,7 @@
         (if mixed-state
           [:div  {:class (stl/css :first-row)}
            [:span {:class (stl/css :mixed-label)}
-            (tr "labels.mixed-values")]
+            (tr "settings.multiple")]
            [:> icon-button* {:variant "ghost"
                              :aria-label (tr "workspace.options.blur-options.remove-blur")
                              :on-click handle-delete-all


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

Fixes #11148.

## The split

Two keys name the same concept. `settings.multiple` is used across the sidebar (measures, stroke, color, layout, typography, exports — ~18 call sites) and ships a translation in **33** locale files. `labels.mixed-values` had only **2** call sites and exists in **17**.

| | call sites | locale files |
|---|---|---|
| `settings.multiple` | ~18 | 33 |
| `labels.mixed-values` | 2 | 17 |

Because both read "Mixed" in English the split is invisible in the default locale, but elsewhere it shows. Spot-checked against the `.po` files:

- **pl** — `labels.mixed-values` is absent entirely, `settings.multiple` is `"Mieszane"`. The missing string falls back to the default language (`i18n.cljs:178`), so the blur label and every numeric input rendered the English "Mixed" beside sections showing the Polish word.
- **fr** — `"Divers"` vs `"Mélangé"`; **ru** — `"Смешаный"` vs `"Смешать"`. Same sidebar, same concept, two names.

## Fix

Point the two outliers — `ds/controls/numeric_input.cljs` and `options/menus/blur.cljs` — at `settings.multiple`. Nothing else changes, and `labels.mixed-values` is now unused in `src/`.

I did **not** hand-edit the `.po` files to drop the now-unused key: translations are managed externally, so removing the entry belongs to that tooling rather than to this PR. Say the word if you would prefer it stripped here.

## Verification

Live in the devenv with the profile language set to **Polski**, two rectangles selected with different widths so the inputs go mixed — before and after the change in the same session:

| | DS numeric input placeholder |
|---|---|
| before | `Mixed` (English fallback) |
| after | `Mieszane` |

`clj-kondo` 0 errors / 0 warnings, `cljfmt` clean, shadow-cljs `:main` recompiled with 0 warnings.
