### PR TITLE
:bug: Keep comment bubbles from painting over the rulers

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -363,7 +363,8 @@
                                       :page-id page-id
                                       :file-id file-id
                                       :vport vport
-                                      :zoom zoom}])
+                                      :zoom zoom
+                                      :show-rulers show-rulers?}])
 
       (when picking-color?
         [:> pixel-overlay/pixel-overlay* {:vport vport

--- a/frontend/src/app/main/ui/workspace/viewport/comments.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/comments.cljs
@@ -13,6 +13,7 @@
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.comments :as cmt]
+   [app.main.ui.workspace.viewport.rulers :as rulers]
    [rumext.v2 :as mf]))
 
 ;; Pin transform for the bubble's frame so it follows the frame during a drag,
@@ -70,7 +71,7 @@
 
 (mf/defc comments-layer*
   {::mf/wrap [mf/memo]}
-  [{:keys [vbox vport zoom file-id page-id]}]
+  [{:keys [vbox vport zoom file-id page-id show-rulers]}]
   (let [vbox-x      (dm/get-prop vbox :x)
         vbox-y      (dm/get-prop vbox :y)
         vport-w     (dm/get-prop vport :width)
@@ -114,7 +115,15 @@
       {:id "comments"
        :class (stl/css :workspace-comments-container)
        :style {:width (dm/str vport-w "px")
-               :height (dm/str vport-h "px")}}
+               :height (dm/str vport-h "px")
+               ;; This layer sits above the canvas, so without clipping the
+               ;; bubbles paint over the rulers as they pan past them. Keep
+               ;; them out of the ruler bars, like `clip-handlers` does for
+               ;; the selection handlers.
+               :clip-path (when show-rulers
+                            (dm/fmt "inset(%px 0 0 %px)"
+                                    rulers/ruler-area-size
+                                    rulers/ruler-area-size))}}
       [:div {:class (stl/css :threads)
              :style {:transform (dm/fmt "translate(%px, %px)" pos-x pos-y)}}
 

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -666,7 +666,8 @@
                                       :page-id page-id
                                       :file-id file-id
                                       :vport vport
-                                      :zoom zoom}])
+                                      :zoom zoom
+                                      :show-rulers show-rulers?}])
 
       (when picking-color?
         [:> pixel-overlay/pixel-overlay-wasm* {:viewport-ref viewport-ref


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

Fixes #11163.

## Root cause

The comments layer renders inside `.viewport-overlays`, which is `position: absolute` with `z-index: 1` (`viewport.scss:29-35`), and its own container adds `z-index: 1000` (`viewport/comments.scss:9-19`). The rulers are drawn by the canvas underneath. So although the overlays appear *before* the canvas in DOM order, they are lifted above it, and a bubble panned into the ruler bars paints over the ticks and numbers.

Confirmed in the workspace with `document.elementFromPoint` at a point inside the horizontal ruler, with a comment positioned there:

```
main_ui_comments__avatar-mask
 └ main_ui_comments__floating-preview-wrapper
   └ main_ui_workspace_viewport_comments__threads
```

## Fix

Clip the comments container to the area outside the ruler bars while the rulers are shown, reusing `rulers/ruler-area-size` rather than repeating the constant.

This is the approach already used for the same problem elsewhere: `viewport.cljs` defines a `clip-handlers` clip path "so the handlers are not over the rulers", and `rulers-clip-path*` is documented as keeping overlays from painting over the rulers.

Clipping `#comments` specifically — rather than `.viewport-overlays` — matters: the overlays also host the text editing layer, and clipping that could affect editing a text shape near the top-left of the viewport. Only the comments container is touched.

`.threads` itself is a zero-size anchor whose bubbles overflow it, so it is not a usable clip target; `#comments` is the full-viewport, comments-only container.

## Verification

Live in the devenv, comment thread placed so its bubble sits inside the horizontal ruler, same point before and after:

| | topmost element at that point |
|---|---|
| before | `main_ui_comments__avatar-mask` (the comment avatar) |
| after | `rect.cursor-resize-ns-0` inside `g.guides` (the ruler layer) |

The bubble keeps its layout position (unchanged at the same coordinates) — only its painting is clipped, so nothing moves or disappears outside the ruler bars. With rulers hidden no clip is applied at all.

`clj-kondo` 0 errors / 0 warnings, `cljfmt` clean, shadow-cljs `:main` recompiled with 0 warnings.
