### PR TITLE
:bug: Close comment input box on Escape key press

### DIFF
--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -734,6 +734,7 @@
       {:value @content
        :placeholder (tr "labels.reply.thread")
        :autofocus true
+       :on-esc on-cancel
        :on-ctrl-enter on-submit*
        :on-change on-change}]
      (when (exceeds-length? @content)
@@ -764,6 +765,7 @@
      [:> comment-input*
       {:value @content
        :autofocus true
+       :on-esc on-cancel
        :on-ctrl-enter on-submit*
        :on-change on-change}]
      (when (exceeds-length? @content)
@@ -1109,7 +1111,7 @@
             [:> comment-floating-thread-item* {:comment item}]])]
 
         [:> comment-reply-form* {:on-submit on-submit
-                                 :on-cancel (when (= origin :viewer) on-cancel)}]
+                                 :on-cancel on-cancel}]
 
         [:> mentions-panel*]])]))
 


### PR DESCRIPTION
## Summary

Pressing **Escape** while the comment input box is focused in the workspace now closes the comment thread, matching the click-away behavior.

**Root cause:** `comment-reply-form*` and `comment-edit-form*` did not pass `:on-esc` to `comment-input*`, so ESC key events in the textarea were unhandled. Additionally, the workspace variant of `comment-floating-thread*` did not pass `on-cancel` to the reply form (only the viewer did).

**Closes #11128**

## Changes

- Pass `:on-esc on-cancel` to `comment-input*` in both `comment-reply-form*` and `comment-edit-form*`
- Always pass `on-cancel` to `comment-reply-form*` (previously gated behind `(= origin :viewer)`)

## Test plan

- [ ] Open a file in the workspace
- [ ] Activate comments mode (press "C")
- [ ] Click on the canvas to place a new comment, type a message, and click "Post"
- [ ] With the comment input box still focused, press ESC
- [ ] Verify the comment thread closes
- [ ] Verify ESC still dismisses the mentions dropdown when it's open (existing behavior)
- [ ] Verify ESC during comment edit cancels the edit
- [ ] Verify the same behavior works in the Viewer