### PR TITLE
Don't show duplicate cursor when selection cannot be alt-duplicated (#11165)

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -130,6 +130,12 @@
                                (into [] (keep (d/getf objects-modified)))
                                (not-empty))
 
+        ;; True when at least one selected shape can be alt-duplicated.
+        ;; Inner shapes of component copies are excluded by ctk/allow-duplicate?
+        can-alt-duplicate? (mf/with-memo [selected base-objects]
+                             (some #(ctk/allow-duplicate? base-objects %)
+                                   (map (d/getf base-objects) selected)))
+
         ;; STATE
         alt?               (mf/use-state false)
         shift?             (mf/use-state false)
@@ -311,7 +317,7 @@
 
     (hooks/setup-dom-events zoom disable-paste-ref in-viewport-ref read-only? drawing-tool path-drawing?)
     (hooks/setup-viewport-size vport viewport-ref)
-    (hooks/setup-cursor cursor alt? mod? space? panning drawing-tool path-drawing? path-editing? z? read-only?)
+    (hooks/setup-cursor cursor alt? mod? space? panning drawing-tool path-drawing? path-editing? z? read-only? can-alt-duplicate?)
     (hooks/setup-keyboard alt? mod? space? z? shift?)
     (hooks/setup-hover-shapes page-id move-stream base-objects selected mod? hover measure-hover
                               hover-ids hover-top-frame-id @hover-disabled? focus zoom show-measures? read-only? transform)

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -91,9 +91,9 @@
       (when (not= size vport)
         (st/emit! (dw/initialize-viewport (dom/get-client-size prnt)))))))
 
-(defn setup-cursor [cursor alt? mod? space? panning drawing-tool drawing-path? path-editing? z? workspace-read-only?]
+(defn setup-cursor [cursor alt? mod? space? panning drawing-tool drawing-path? path-editing? z? workspace-read-only? can-alt-duplicate?]
   (mf/use-effect
-   (mf/deps @cursor @alt? @mod? @space? panning drawing-tool drawing-path? path-editing? z? workspace-read-only?)
+   (mf/deps @cursor @alt? @mod? @space? panning drawing-tool drawing-path? path-editing? z? workspace-read-only? can-alt-duplicate?)
    (fn []
      (let [show-pen? (or (= drawing-tool :path)
                          (and drawing-path?
@@ -120,7 +120,8 @@
              (and
               @alt?
               (not path-editing?)
-              (not workspace-read-only?))    (utils/get-cursor :duplicate)
+              (not workspace-read-only?)
+              can-alt-duplicate?)            (utils/get-cursor :duplicate)
              :else                           (utils/get-cursor :pointer-inner))]
 
        (when (not= @cursor new-cursor)


### PR DESCRIPTION
## Problem

When pressing Alt and dragging a shape that is **inside a component copy** (but is not the copy root), Penpot shows the `:duplicate` cursor — indicating that alt-drag will clone the shape. However, `duplicate-shapes` filters those shapes out via `ctk/allow-duplicate?` (inner shapes of component copies are intentionally excluded to protect component structure), so the operation silently falls back to a plain move. The cursor was lying.

## Root cause

`setup-cursor` showed the duplicate cursor whenever:
- Alt is held
- Not path-editing
- Not read-only workspace

It had no knowledge of whether the current selection could actually be duplicated.

## Fix

- In `viewport.cljs`: compute `can-alt-duplicate?` using `ctk/allow-duplicate?` against the current selection and base-objects. It is truthy when at least one selected shape is eligible for duplication.
- Pass `can-alt-duplicate?` to `setup-cursor` as a new parameter.
- In `hooks.cljs`: gate the `:duplicate` cursor branch on `can-alt-duplicate?`. When the entire selection is non-duplicatable (e.g. selecting an inner shape of a library component copy), the cursor falls through to `:pointer-inner`, honestly indicating that only a move will happen.

No behaviour change to duplication itself — only the cursor state is corrected.

Fixes #11165