### PR TITLE
fix: reorder watch handler steps to prevent sprite deletion (#6030)

### DIFF
--- a/frontend/scripts/watch-storybook.js
+++ b/frontend/scripts/watch-storybook.js
@@ -81,8 +81,8 @@ h.watch("translations", null, async function (path) {
 log.info("watch: assets (~)");
 h.watch(["resources/images", "resources/fonts"], null, async function (path) {
   log.info("changed:", path);
-  await h.compileSvgSprites();
   await h.copyAssets();
+  await h.compileSvgSprites();
   await h.compileTemplates();
 });
 

--- a/frontend/scripts/watch.js
+++ b/frontend/scripts/watch.js
@@ -101,8 +101,8 @@ h.watch("translations", null, async function (path) {
 log.info("watch: assets (~)");
 h.watch(["resources/images", "resources/fonts"], null, async function (path) {
   log.info("changed:", path);
-  await h.compileSvgSprites();
   await h.copyAssets();
+  await h.compileSvgSprites();
   await h.compileTemplates();
 });
 


### PR DESCRIPTION
## Problem

When a new SVG icon is added to `resources/images/icons/`, the `watch` handler in `watch.js` (and `watch-storybook.js`) runs three steps in the wrong order:

```js
await h.compileSvgSprites();  // writes resources/public/images/sprites/
await h.copyAssets();          // rsync --delete DELETES resources/public/images/sprites/ !
await h.compileTemplates();   // FAILS: cannot read resources/public/images/sprites/symbol/icons.svg
```

`copyAssets` runs `rsync -ar --delete resources/images/ resources/public/images/`. Because `sprites/` exists only under `resources/public/images/` (it is generated, not a source directory), rsync's `--delete` flag removes it — destroying the output of `compileSvgSprites` before `compileTemplates` can read it.

The **initial build** sequence (lines 65–70 of `watch.js`) already has the correct order:

```js
await h.copyAssets();
// ...
await h.compileSvgSprites();
await h.compileTemplates();
```

## Fix

Reorder both watch handlers to match the initial build sequence:

```js
await h.copyAssets();
await h.compileSvgSprites();
await h.compileTemplates();
```

This applies to `watch.js` (the main dev watch) and `watch-storybook.js` (same bug, same handler pattern).

Fixes #6030