### PR TITLE
fix: allow invitation-based registration when disable-registration is set (#5178)

### DIFF
--- a/backend/src/app/rpc/commands/auth.clj
+++ b/backend/src/app/rpc/commands/auth.clj
@@ -208,20 +208,22 @@
 (defn- validate-register-attempt!
   [cfg params]
 
-  (when (or (not (contains? cf/flags :registration))
-            (not (contains? cf/flags :login-with-password)))
-    (ex/raise :type :restriction
-              :code :registration-disabled
-              :hint "registration disabled"))
-
-  (when (contains? params :invitation-token)
+  (if (contains? params :invitation-token)
+    ;; Invitations bypass the disable-registration flag per documentation.
+    ;; Validate the invitation token and verify the email matches.
     (let [invitation (tokens/verify cfg
                                     {:token (:invitation-token params)
                                      :iss :team-invitation})]
       (when-not (= (:email params) (:member-email invitation))
         (ex/raise :type :restriction
                   :code :email-does-not-match-invitation
-                  :hint "email should match the invitation"))))
+                  :hint "email should match the invitation")))
+    ;; No invitation token — enforce the registration-disabled flag.
+    (when (or (not (contains? cf/flags :registration))
+              (not (contains? cf/flags :login-with-password)))
+      (ex/raise :type :restriction
+                :code :registration-disabled
+                :hint "registration disabled")))
 
   (when (and (email.blacklist/enabled? cfg)
              (email.blacklist/contains? cfg (:email params)))

--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -343,11 +343,12 @@
                             "no invitation associated with the token")))
 
         ;; If we have not logged-in user, and invitation comes with member-id we
-        ;; redirect user to login, if no member-id is present and  in the invitation
-        ;; token and registration is enabled, we redirect user the the register page.
+        ;; redirect user to login. If no member-id is present this is an invitation
+        ;; for a new user — send them to the register page. Invitations bypass
+        ;; the disable-registration flag per documentation.
         {:invitation-token token
          :iss :team-invitation
-         :redirect-to (if (or member-id registration-disabled?) :auth-login :auth-register)
+         :redirect-to (if member-id :auth-login :auth-register)
          :state :pending}))))
 
 ;; --- Default


### PR DESCRIPTION
## Problem

Per [documentation](https://help.penpot.app/technical-guide/configuration/#flags), the `disable-registration` flag:

> disables registration (still enabled for invitations only)

However, two separate bugs prevented invited users from actually registering:

**Bug 1 — `verify_token.clj`:** When processing a team-invitation token for a non-logged-in user with no `member-id` (a new account invitation), the redirect condition was:

```clojure
:redirect-to (if (or member-id registration-disabled?) :auth-login :auth-register)
```

With `disable-registration` set, `registration-disabled?` is `true`, so invited users are sent to the login page instead of the register page. They cannot create an account.

**Bug 2 — `auth.clj`:** Even if the user somehow reached the register page, `validate-register-attempt!` checked the registration-disabled flag _before_ the invitation token:

```clojure
(when (or (not (contains? cf/flags :registration)) ...)
  (ex/raise ... :code :registration-disabled ...))

(when (contains? params :invitation-token)
  ; validate email match
  ...)
```

The first `when` fires unconditionally, rejecting the RPC regardless of invitation.

## Fix

**`verify_token.clj`:** Remove `registration-disabled?` from the redirect condition. When `member-id` is absent this is a new-user invitation — send them to `:auth-register` unconditionally; invitations are documented to bypass the flag.

```clojure
:redirect-to (if member-id :auth-login :auth-register)
```

**`auth.clj`:** Restructure as an `if`/`else`: with an invitation token, validate the token and skip the flag check; without one, enforce the flag as before.

```clojure
(if (contains? params :invitation-token)
  ;; validate invitation token (bypasses registration-disabled)
  (let [invitation ...] ...)
  ;; no invitation — enforce flag
  (when (or (not (contains? cf/flags :registration)) ...) ...))
```

Fixes #5178