### PR TITLE
:bug: Fix confusing copy for feams in organizations

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1243,7 +1243,7 @@ msgstr "Your project has been moved successfully"
 
 #, unused
 msgid "dashboard.team-belong-organization"
-msgstr "This team now belongs to %s"
+msgstr "This team is now part of the organization %s"
 
 #: src/app/main/ui/dashboard/team.cljs:1602
 msgid "dashboard.team-info"
@@ -1255,7 +1255,7 @@ msgstr "Team members"
 
 #, unused
 msgid "dashboard.team-no-longer-belong-organization"
-msgstr "This team no longer belongs to the organization %s"
+msgstr "This team is no longer part of the organization %s"
 
 #: src/app/main/ui/dashboard/team.cljs:1609
 msgid "dashboard.team-organization"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1254,7 +1254,7 @@ msgstr "Tu proyecto ha sido movido con éxito"
 
 #, unused
 msgid "dashboard.team-belong-organization"
-msgstr "Este equipo ahora pertenece a la organización %s"
+msgstr "Este equipo ahora es parte de la organización %s"
 
 #: src/app/main/ui/dashboard/team.cljs:1602
 msgid "dashboard.team-info"
@@ -1266,7 +1266,7 @@ msgstr "Integrantes del equipo"
 
 #, unused
 msgid "dashboard.team-no-longer-belong-organization"
-msgstr "Este equipo ya no pertenece a la organización %s"
+msgstr "Este equipo ya no es parte de la organización %s"
 
 #: src/app/main/ui/dashboard/team.cljs:1609
 msgid "dashboard.team-organization"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26721

### Summary

Updated confusing copys for organization movements.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
