### PR TITLE
:bug: Fix organization dropdown alignment

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.scss
+++ b/frontend/src/app/main/ui/dashboard/sidebar.scss
@@ -699,12 +699,13 @@
   grid-template-columns: 1fr auto auto;
   gap: var(--sp-s);
   height: 100%;
-  padding: 0 px2rem(10);
+  padding: 0 0 0 px2rem(10);
   width: 100%;
 }
 
 .current-organization-no-options {
   gap: 0;
+  padding: 0 px2rem(8) 0 px2rem(10);
 }
 
 .current-organization .arrow-icon {
@@ -734,11 +735,15 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: $sz-48;
-  height: $sz-48;
+  width: $sz-28;
+  height: 100%;
+  padding: 0;
+  border-radius: 0 $br-8 $br-8 0;
 
   &:hover {
     --icon-stroke: var(--color-accent-primary);
+
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26722

### Summary

Buttons from organization selector are now aligned with team selector's.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
