### PR TITLE
:bug: Fix crash after changing typography options (v2 and v3)

### DIFF
--- a/frontend/src/app/render_wasm/text_editor.cljs
+++ b/frontend/src/app/render_wasm/text_editor.cljs
@@ -345,10 +345,15 @@
                       :text-direction (sr/untranslate-text-direction (text-editor-get-style-property text-direction-state text-direction-value))
                       :text-decoration (sr/untranslate-text-decoration (text-editor-get-style-property text-decoration-state text-decoration-value))
                       :text-transform (sr/untranslate-text-transform (text-editor-get-style-property text-transform-state text-transform-value))
-                      :line-height (text-editor-get-style-property line-height-state line-height-value)
-                      :letter-spacing (text-editor-get-style-property letter-spacing-state letter-spacing-value)
-                      :font-size (text-editor-get-style-property font-size-state font-size-value)
-                      :font-weight (text-editor-get-style-property font-weight-state font-weight-value)
+                      ;; WASM reports size/weight as numbers, but the rest of Penpot (and the backend schema) expects strings.
+                      :line-height (let [height (text-editor-get-style-property line-height-state line-height-value)]
+                                     (if (= height :multiple) height (str height)))
+                      :letter-spacing (let [spacing (text-editor-get-style-property letter-spacing-state letter-spacing-value)]
+                                        (if (= spacing :multiple) spacing (str spacing)))
+                      :font-size (let [size (text-editor-get-style-property font-size-state font-size-value)]
+                                   (if (= size :multiple) size (str size)))
+                      :font-weight (let [weight (text-editor-get-style-property font-weight-state font-weight-value)]
+                                     (if (= weight :multiple) weight (str weight)))
                       :font-style font-style-value
                       :font-family (text-editor-get-style-property font-family-id-state font-id)
                       :font-id (text-editor-get-style-property font-family-id-state font-id)


### PR DESCRIPTION
### Related Ticket

Fixes #11046 

### Summary

This fixes a crash on text shapes due to Rust returning numeric values as numbers, and our schemas requiring them to be strings.

### Steps to reproduce 

See #11046. Note that this happens with both v2 and v3.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
