### PR TITLE
:bug: Fix nitrate organization sso expiration

### DIFF
--- a/backend/src/app/auth/oidc.clj
+++ b/backend/src/app/auth/oidc.clj
@@ -620,9 +620,6 @@
       (some? (:external-session-id state))
       (assoc :external-session-id (:external-session-id state))
 
-      (some? (:token/expires-in tdata))
-      (assoc :sso-token-exp (ct/in-future {:seconds (:token/expires-in tdata)}))
-
       ;; If state token comes with props, merge them. The state token
       ;; props can contain pm_ and utm_ prefixed query params.
       (map? (:props state))
@@ -904,9 +901,9 @@
       (let [organization-id (:organization-id state)
             sso             (nitrate/call cfg :get-organization-sso {:organization-id organization-id})
             provider        (prepare-organization-sso-provider cfg sso)
-            info            (get-info cfg provider state code)
+            _info           (get-info cfg provider state code)
             session         (session/get-session request)
-            exp             (or (:sso-token-exp info) (ct/in-future {:hours 48}))]
+            exp             (ct/in-future {:minutes 15})]
         (when (and session organization-id)
           (let [props (-> (or (:props session) {})
                           (update :sso assoc organization-id exp))]


### PR DESCRIPTION
### Related Ticket

Related with https://tree.taiga.io/project/penpot-nitrate/issue/26682

### Summary

Change nitrate organization sso expiration to 15 minutes


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
