### PR TITLE
:lipstick: Change nitrate error message

### DIFF
--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -425,7 +425,7 @@
 
         nitrate-toast-message
         (condp = params-subscription
-          dnt/nitrate-checkout-finish-error-token (tr "subscription.error.nitrate.checkout-finish-failed")
+          dnt/nitrate-checkout-finish-error-token (tr "subscription.error.nitrate.checkout-failed")
           dnt/nitrate-checkout-cancelled-token    (tr "subscription.error.nitrate.checkout-cancelled")
           nil)
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6073,12 +6073,6 @@ msgstr ""
 "The payment was not completed. Please try again. "
 "If the problem persists, contact us: support@penpot.app."
 
-#: src/app/main/ui/settings/subscription.cljs:407
-msgid "subscription.error.nitrate.checkout-finish-failed"
-msgstr ""
-"We couldn’t confirm your subscription. Please check your subscription "
-"status on the Subscription page. You may try again if needed."
-
 #: src/app/main/ui/settings/sidebar.cljs:114, src/app/main/ui/settings/subscription.cljs:505, src/app/main/ui/settings/subscription.cljs:565
 msgid "subscription.labels"
 msgstr "Subscription"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5937,13 +5937,6 @@ msgstr ""
 "No hemos podido iniciar el proceso de pago. Inténtalo de nuevo. Si el "
 "problema persiste, contáctanos: support@penpot.app."
 
-#: src/app/main/ui/settings/subscription.cljs:407
-msgid "subscription.error.nitrate.checkout-finish-failed"
-msgstr ""
-"No hemos podido confirmar tu suscripción. Revisa el estado de tu "
-"suscripción en la página de Suscripciones. Puedes volver a intentarlo si lo "
-"necesitas."
-
 #: src/app/main/ui/settings/sidebar.cljs:114, src/app/main/ui/settings/subscription.cljs:505, src/app/main/ui/settings/subscription.cljs:565
 msgid "subscription.labels"
 msgstr "Suscripción"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26664

### Summary

Change the error message on nitrate licenses buy process failure

### Steps to reproduce 

See taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
