### PR TITLE
:bug: Show a specific error on nitrate reused activation code

### DIFF
--- a/backend/src/app/rpc/commands/nitrate.clj
+++ b/backend/src/app/rpc/commands/nitrate.clj
@@ -101,6 +101,7 @@
             (ex/raise :type :validation
                       :code (case status
                               410 :expired-activation-code
+                              409 :used-activation-code
                               :invalid-activation-code)
                       :cause cause)
             (throw cause)))))))

--- a/backend/test/backend_tests/rpc_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_nitrate_test.clj
@@ -7,6 +7,7 @@
 (ns backend-tests.rpc-nitrate-test
   (:require
    [app.auth.oidc :as oidc]
+   [app.common.exceptions :as ex]
    [app.common.json :as json]
    [app.common.time :as ct]
    [app.common.uuid :as uuid]
@@ -1123,3 +1124,45 @@
                               ::rpc/profile-id (:id profile)})]
         (t/is (not (th/success? out)))
         (t/is (th/ex-of-code? (:error out) :nitrate-identity-unavailable))))))
+
+(t/deftest redeem-nitrate-activation-code-used
+  (let [profile (th/create-profile* 1 {:is-active true})]
+    (with-redefs [cf/flags     (conj cf/flags :admin-console)
+                  nitrate/call (fn [_cfg method _params]
+                                 (t/is (= :redeem-activation-code method))
+                                 (ex/raise :type :nitrate-http-error
+                                           :status 409
+                                           :hint "activation code already used"))]
+      (let [out (th/command! {::th/type :redeem-nitrate-activation-code
+                              ::rpc/profile-id (:id profile)
+                              :activation-code "already-used-code"})]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-code? (:error out) :used-activation-code))))))
+
+(t/deftest redeem-nitrate-activation-code-expired
+  (let [profile (th/create-profile* 1 {:is-active true})]
+    (with-redefs [cf/flags     (conj cf/flags :admin-console)
+                  nitrate/call (fn [_cfg method _params]
+                                 (t/is (= :redeem-activation-code method))
+                                 (ex/raise :type :nitrate-http-error
+                                           :status 410
+                                           :hint "activation code expired"))]
+      (let [out (th/command! {::th/type :redeem-nitrate-activation-code
+                              ::rpc/profile-id (:id profile)
+                              :activation-code "expired-code"})]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-code? (:error out) :expired-activation-code))))))
+
+(t/deftest redeem-nitrate-activation-code-invalid
+  (let [profile (th/create-profile* 1 {:is-active true})]
+    (with-redefs [cf/flags     (conj cf/flags :admin-console)
+                  nitrate/call (fn [_cfg method _params]
+                                 (t/is (= :redeem-activation-code method))
+                                 (ex/raise :type :nitrate-http-error
+                                           :status 422
+                                           :hint "invalid activation code"))]
+      (let [out (th/command! {::th/type :redeem-nitrate-activation-code
+                              ::rpc/profile-id (:id profile)
+                              :activation-code "invalid-code"})]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-code? (:error out) :invalid-activation-code))))))

--- a/frontend/src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs
@@ -53,10 +53,10 @@
                           (modal/show {:type :nitrate-activation-success})
                           (dprof/refresh-profile))))
                      (fn [error]
-                       ;; TODO: "Already used" is not yet detectable (CC upserts on reuse).
                        (let [code (-> error ex-data :code)]
                          (reset! error* (case code
                                           :expired-activation-code (tr "nitrate.activation-code.expired-error")
+                                          :used-activation-code    (tr "nitrate.activation-code.used-error")
                                           (tr "nitrate.activation-code.invalid-error")))))))))))
 
         on-key-down

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -4377,6 +4377,9 @@ msgstr "This code has expired."
 msgid "nitrate.activation-code.invalid-error"
 msgstr "Invalid code."
 
+msgid "nitrate.activation-code.used-error"
+msgstr "This code has already been used."
+
 #: src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs:57
 msgid "nitrate.activation-success.active-until"
 msgstr "Your plan is active until %s."

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -4252,6 +4252,9 @@ msgstr "Este código ha caducado."
 msgid "nitrate.activation-code.invalid-error"
 msgstr "Código inválido."
 
+msgid "nitrate.activation-code.used-error"
+msgstr "Este código ya ha sido utilizado."
+
 #: src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs:57
 msgid "nitrate.activation-success.active-until"
 msgstr "Tu plan está activo hasta el %s."


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26678

### Summary

### What

- Redeeming an already-used activation code now shows a specific inline error (“This code has already been used.”) instead of the generic “Invalid code.”

### Why

- A well-formed code that is already redeemed was indistinguishable from a mistyped/invalid code, so the user had no way to understand why activation failed.

### Steps to reproduce 

See Taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
