### PR TITLE
:bug: Fix organization invitation schema validation for logo URI

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -17,6 +17,7 @@
    [app.common.types.organization :as cto]
    [app.common.types.profile :refer [schema:profile, schema:basic-profile]]
    [app.common.types.team :refer [schema:team]]
+   [app.common.uri :as u]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.db :as db]
@@ -499,7 +500,7 @@ RETURNING id, deleted_at;")
     {:id            id
      :name          name
      :initials      (if logo-id "" (d/get-initials name))
-     :logo          (when logo-id (files/resolve-public-uri logo-id))
+     :logo          (when logo-id (u/uri (files/resolve-public-uri logo-id)))
      :avatar-bg-url (when-not logo-id avatar-bg-url)
      :sso-active    (true? sso-active)}))
 

--- a/backend/test/backend_tests/rpc_management_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_management_nitrate_test.clj
@@ -178,7 +178,7 @@
           (t/is (th/success? out))
           (t/is (= "Trusted Organization" (:name organization)))
           (t/is (= "" (:initials organization)))
-          (t/is (str/ends-with? (:logo organization)
+          (t/is (str/ends-with? (str (:logo organization))
                                 (str "/assets/by-id/" logo-id)))
           (t/is (nil? (:avatar-bg-url organization)))
           (t/is (true? (:sso-active organization))))))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26720

### Summary

The `get-invitation-organization` function returned a string for the logo field, but the schema expected a URI object. This caused schema validation to fail when inviting users to organizations with custom logos.

Wrap the `resolve-public-uri` result with `u/uri` to convert the string to a proper URI object that passes `::sm/uri` validation.

### Steps to reproduce 

1. Have an organization with a logo.
2. Try to invite someone via Admin console.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
