### PR TITLE
:bug: Fix selrect collapsing after undo (v3)

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -1329,7 +1329,16 @@
                 finalize-save-undo-first?
                 (if (and finalize? (or (not new-shape?) (not content-has-text?)))
                   false
-                  effective-save-undo?)]
+                  effective-save-undo?)
+
+                ;; Whether any content-changing edit happened this editing session.
+                session-touched? (some? (get-in state [:workspace-text-session-geom id]))
+                ;; A finalize on an existing shape that wasn't edited must not create any undo entry
+                ;; (exception being newly created shapes)
+                finalize-no-op?  (and finalize?
+                                      (not new-shape?)
+                                      content-has-text?
+                                      (not session-touched?))]
 
             (rx/concat
              (rx/of
@@ -1360,7 +1369,8 @@
                 :undo-group (when new-shape? id)})
 
               ;; Push the auto-grow geometry to WASM/app state; the commit persists it via `resize-geom`.
-              (when (some? resize-modifiers)
+              ;; Skipped for a no-op finalize: applying it would record an undo transaction.
+              (when (and (some? resize-modifiers) (not finalize-no-op?))
                 (dwm/apply-wasm-modifiers resize-modifiers {:undo-group (when new-shape? id)})))
 
              (when finalize?
@@ -1378,7 +1388,7 @@
                           (dwsh/delete-shapes #{id})))
                   (rx/empty))
                 (rx/concat
-                 (if content-has-text?
+                 (if (and content-has-text? (not finalize-no-op?))
                    (rx/of
                     (dch/commit-changes
                      (build-finalize-commit-changes it state id


### PR DESCRIPTION
### Related Ticket

Fix #11048 

### Summary

This fixes undo entries / committing changes when the edit on a shape is a no op.

### Steps to reproduce 

See [this comment](https://github.com/penpot/penpot/issues/11048#issuecomment-5255480528) on the issue itself.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor/ any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
